### PR TITLE
Use maps for mongoose_wpool options

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -310,9 +310,8 @@
   scope = \"global\"
   workers = 5
   connection.port = 3636
-  connection.rootdn = \"cn=admin,dc=esl,dc=com\"
+  connection.root_dn = \"cn=admin,dc=esl,dc=com\"
   connection.password = \"mongooseim_secret\"
-  connection.encrypt = \"tls\"
   connection.tls.versions = [\"tlsv1.2\"]
   connection.tls.verify_peer = true
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
@@ -322,7 +321,6 @@
   scope = \"global\"
   workers = 5
   connection.port = 3636
-  connection.encrypt = \"tls\"
   connection.tls.versions = [\"tlsv1.2\"]
   connection.tls.verify_peer = true
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
@@ -369,7 +367,7 @@
 [outgoing_pools.cassandra.default]
   scope = \"global\"
   workers = 20
-  connection.servers = [{ip_address = \"localhost\", port = 9142}]
+  connection.servers = [{host = \"localhost\", port = 9142}]
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.verify_peer = true
 [outgoing_pools.elastic.default]

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -126,16 +126,12 @@ init_per_suite(Config) ->
     catch mongoose_push_mock:stop(),
     mongoose_push_mock:start(Config),
     Port = mongoose_push_mock:port(),
-
     PoolOpts = #{strategy => available_worker, workers => 20},
-    HTTPOpts = #{server => "https://localhost:" ++ integer_to_list(Port), path_prefix => "/",
-                 request_timeout => 2000},
-    rpc(?RPC_SPEC, mongoose_wpool, start_configured_pools,
-        [[#{type => http, scope => global, tag => mongoose_push_http, opts => PoolOpts,
-           conn_opts => HTTPOpts}]]),
+    ConnOpts = #{host => "https://localhost:" ++ integer_to_list(Port), request_timeout => 2000},
+    Pool = config([outgoing_pools, http, mongoose_push_http], #{opts => PoolOpts, conn_opts => ConnOpts}),
+    [{ok, _Pid}] = rpc(?RPC_SPEC, mongoose_wpool, start_configured_pools, [[Pool]]),
     ConfigWithModules = dynamic_modules:save_modules(domain(), Config),
     escalus:init_per_suite(ConfigWithModules).
-
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),

--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -75,9 +75,51 @@ For example:
 
 #### `outgoing_pools.rdbms.*.connection.driver`
 * **Syntax:** string, one of `"pgsql"`, `"mysql"` or `"odbc"` (a supported driver)
+* **Default:** none - this option is mandatory
 * **Example:** `driver = "psgql"`
 
 Selects the driver for RDBMS connection. The choice of a driver impacts the set of available options.
+
+#### `outgoing_pools.rdbms.*.connection.keepalive_interval`
+* **Syntax:** positive integer
+* **Default:** not set - disabled by default
+* **Example:** `keepalive_interval = 30`
+
+When enabled, MongooseIM will send `SELECT 1 `query through every DB connection at given interval to keep them open. This option should be used to ensure that database connections are restarted after they became broken (e.g. due to a database restart or a load balancer dropping connections). Currently, not every network-related error returned from a database driver to a regular query will imply a connection restart.
+
+#### `outgoing_pools.rdbms.*.connection.max_start_interval`
+* **Syntax:** positive integer
+* **Default:** 30
+* **Example:** `max_start_interval = 30`
+
+When MongooseIM fails to connect to the DB, it retries with an exponential backoff. This option limits the backoff time for faster reconnection when the DB becomes reachable again.
+
+### Options for `pgsql` and `mysql`
+
+#### `outgoing_pools.rdbms.*.connection.host`
+* **Syntax:** string
+* **Default:** no default; required for `pgsql` and `mysql`
+* **Example:** `host = "localhost"`
+
+#### `outgoing_pools.rdbms.*.connection.port`
+* **Syntax:** string
+* **Default:** `5432` for `pgsql`; `3306` for `mysql`
+* **Example:** `port = 5343`
+
+#### `outgoing_pools.rdbms.*.connection.database`
+* **Syntax:** string
+* **Default:** no default; required for `pgsql` and `mysql`
+* **Example:** `database = "mim-db"`
+
+#### `outgoing_pools.rdbms.*.connection.username`
+* **Syntax:** string
+* **Default:** no default; required for `pgsql` and `mysql`
+* **Example:** `username = "mim-user"`
+
+#### `outgoing_pools.rdbms.*.connection.password`
+* **Syntax:** string
+* **Default:** no default; required for `pgsql` and `mysql`
+* **Example:** `password = "mim-password"`
 
 ### ODBC options
 
@@ -107,35 +149,11 @@ sslmode     = verify-full
 sslrootcert = /path/to/ca/cert
 ```
 
-### Other RDBMS backends
-
-#### `outgoing_pools.rdbms.*.connection.host`
-* **Syntax:** string
-* **Example:** `host = "localhost"`
-
-#### `outgoing_pools.rdbms.*.connection.database`
-* **Syntax:** string
-* **Example:** `database = "mim-db"`
-
-#### `outgoing_pools.rdbms.*.connection.username`
-* **Syntax:** string
-* **Example:** `username = "mim-user"`
-
-#### `outgoing_pools.rdbms.*.connection.password`
-* **Syntax:** string
-* **Example:** `password = "mim-password"`
-
-#### `outgoing_pools.rdbms.*.connection.keepalive_interval`
-* **Syntax:** positive integer
-* **Default:** undefined (keep-alive not activated)
-* **Example:** `keepalive_interval = 30`
-
-When enabled, MongooseIM will send SELECT 1 query through every DB connection at given interval to keep them open. This option should be used to ensure that database connections are restarted after they became broken (e.g. due to a database restart or a load balancer dropping connections). Currently, not every network-related error returned from a database driver to a regular query will imply a connection restart.
-
 ## HTTP options
 
 ### `outgoing_pools.http.*.connection.host`
 * **Syntax:** `"http[s]://string[:integer]"`
+* **Default:** no default; this option is mandatory
 * **Example:** `host = "https://server.com:879"`
 
 ### `outgoing_pools.http.*.connection.path_prefix`
@@ -156,7 +174,7 @@ HTTP also supports all TLS-specific options described in the TLS section.
 
 ## Redis-specific options
 
-Redis can be used as a session manager backend. 
+Redis can be used as a session manager backend.
 Global distribution (implemented in `mod_global_distrib`) requires Redis pool.
 
 There are two important limitations:
@@ -195,10 +213,12 @@ Currently, only one Riak connection pool can exist for each supported XMPP host 
 
 ### `outgoing_pools.riak.*.connection.address`
 * **Syntax:** string
+* **Default:** none, this option is mandatory
 * **Example:** `address = "127.0.0.1"`
 
 ### `outgoing_pools.riak.*.connection.port`
 * **Syntax:** integer
+* **Default:** none, this option is mandatory
 * **Example:** `port = 8087`
 
 ### `outgoing_pools.riak.*.connection.credentials`
@@ -213,9 +233,9 @@ Riak also supports all TLS-specific options described in the TLS section.
 ## Cassandra options
 
 ### `outgoing_pools.cassandra.*.connection.servers`
-* **Syntax:** a TOML array of tables containing keys `"ip_adddress"` and `"port"`
-* **Default:** `[{ip_address = "localhost", port = 9042}]`
-* **Example:** `servers = [{ip_address = "host_one", port = 9042}, {ip_address = "host_two", port = 9042}]`
+* **Syntax:** a TOML array of tables containing keys `"host"` and `"port"`
+* **Default:** `[{host = "localhost", port = 9042}]`
+* **Example:** `servers = [{host = "host_one", port = 9042}, {host = "host_two", port = 9042}]`
 
 ### `outgoing_pools.cassandra.*.connection.keyspace`
 * **Syntax:** string
@@ -226,10 +246,12 @@ To use plain text authentication (using cqerl_auth_plain_handler module):
 
 ### `outgoing_pools.cassandra.*.connection.auth.plain.username`
 * **Syntax:** string
+* **Default:** none, this option is mandatory
 * **Example:** `username = "auser"`
 
 ### `outgoing_pools.cassandra.*.connection.auth.plain.password`
 * **Syntax:** string
+* **Default:** none, this option is mandatory
 * **Example:** `password = "somesecretpassword"`
 
 Support for other authentication modules may be added in the future.
@@ -241,7 +263,7 @@ Cassandra also supports all TLS-specific options described in the TLS section.
 Currently, only one pool tagged `default` can be used.
 
 ### `outgoing_pools.elastic.default.connection.host`
-* **Syntax:** string
+* **Syntax:** non-empty string
 * **Default:** `"localhost"`
 * **Example:** `host = "otherhost"`
 
@@ -286,25 +308,25 @@ The `Tag` parameter must be set to `event_pusher` in order to be able to use
 the pool for [`mod_event_pusher_rabbit`](../modules/mod_event_pusher_rabbit.md).
 Any other `Tag` can be used for other purposes.
 
-### `outgoing_pools.rabbit.*.connection.amqp_host`
+### `outgoing_pools.rabbit.*.connection.host`
 * **Syntax:** string
 * **Default:** `"localhost"`
-* **Example:** `amqp_host = "anotherhost"`
+* **Example:** `host = "anotherhost"`
 
-### `outgoing_pools.rabbit.*.connection.amqp_port`
+### `outgoing_pools.rabbit.*.connection.port`
 * **Syntax:** integer
 * **Default:** `5672`
-* **Example:** `amqp_port = 4561`
+* **Example:** `port = 4561`
 
-### `outgoing_pools.rabbit.*.connection.amqp_username`
+### `outgoing_pools.rabbit.*.connection.username`
 * **Syntax:** string
 * **Default:** `"guest"`
-* **Example:** `amqp_username = "corpop"`
+* **Example:** `username = "corpop"`
 
-### `outgoing_pools.rabbit.*.connection.amqp_password`
+### `outgoing_pools.rabbit.*.connection.password`
 * **Syntax:** string
 * **Default:** `"guest"`
-* **Example:** `amqp_password = "guest"`
+* **Example:** `password = "guest"`
 
 ### `outgoing_pools.rabbit.*.connection.confirms_enabled`
 * **Syntax:** boolean
@@ -329,13 +351,13 @@ Sets a limit of messages in a worker's mailbox above which the worker starts dro
 
 ### `outgoing_pools.ldap.*.connection.port`
 * **Syntax:** integer
-* **Default:** `389` (or `636` if encryption is enabled)
+* **Default:** `389` (or `636` if TLS is enabled)
 * **Example:** `port = 800`
 
-### `outgoing_pools.ldap.*.connection.rootdn`
+### `outgoing_pools.ldap.*.connection.root_dn`
 * **Syntax:** string
-* **Default:** empty string 
-* **Example:** `rootdn = "cn=admin,dc=example,dc=com"`
+* **Default:** empty string
+* **Example:** `root_dn = "cn=admin,dc=example,dc=com"`
 
 Leaving out this option makes it an anonymous connection, which most likely is what you want.
 
@@ -345,18 +367,14 @@ Leaving out this option makes it an anonymous connection, which most likely is w
 * **Example:** `password = "topsecret"`
 
 ### `outgoing_pools.ldap.*.connection.connect_interval`
-* **Syntax:** integer
+* **Syntax:** positive integer
 * **Default:** `10000`
 * **Example:** `connect_interval = 20000`
 
 Reconnect interval after a failed connection.
 
-### `outgoing_pools.ldap.*.connection.encrypt`
-* **Syntax:** string, one of: `"none"` or `"tls"`
-* **Default:** `"none"`
-* **Example:** `encrypt = "tls"`
-
-LDAP also supports all TLS-specific options described in the TLS section (provided `encrypt` is set to `tls`).
+LDAP also supports all TLS-specific options described in the TLS section.
+To enable TLS, you need to include the `tls` subsection (it can be empty).
 
 ## TLS options
 

--- a/doc/migrations/5.0.0_5.1.0.md
+++ b/doc/migrations/5.0.0_5.1.0.md
@@ -18,6 +18,15 @@ See the description of [`current_domain`](../configuration/acl.md#aclmatch) for 
 
 See the [auth configuration](../configuration/auth.md) for details.
 
+### Section `outgoing_pools`
+
+A few options of the outgoing connection pools were changed for consistency:
+
+* [Cassandra servers](../configuration/outgoing-connections.md#outgoing_poolscassandraconnectionservers): `ip_address` was renamed to `host`,
+* [RabbitMQ](../configuration/outgoing-connections.md#rabbitmq-options): the `amqp_` option prefix was removed,
+* [LDAP](../configuration/outgoing-connections.md#ldap-options): `rootdn` was renamed to `root_dn`;
+`encrypt` was removed (the `tls` option should be used instead).
+
 ### Section `s2s`
 
 * All options can be set globally or inside `host_config`.

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -108,11 +108,8 @@ config_spec() ->
     }.
 
 wpool_spec() ->
-    WpoolDefaults = mongoose_config_spec:wpool_defaults(),
-    #section{items = mongoose_config_spec:wpool_items(),
-             defaults = WpoolDefaults#{<<"strategy">> := available_worker},
-             format_items = map,
-             include = always}.
+    Wpool = mongoose_config_spec:wpool(#{<<"strategy">> => available_worker}),
+    Wpool#section{include = always}.
 
 %%--------------------------------------------------------------------
 %% mod_event_pusher callbacks

--- a/src/mongoose_amqp.erl
+++ b/src/mongoose_amqp.erl
@@ -23,7 +23,7 @@
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 
--export([network_params/0, network_params/1, exchange_declare/2,
+-export([network_params/1, exchange_declare/2,
          exchange_declare_ok/0, exchange_delete/1, basic_publish/2,
          confirm_select/0, confirm_select_ok/0, message/1]).
 
@@ -53,13 +53,9 @@
 %%% API
 %%%===================================================================
 
--spec network_params() -> network_params().
-network_params() ->
-    network_params([]).
-
--spec network_params(proplists:proplist()) -> #amqp_params_network{}.
-network_params(Opts) ->
-    network_params(Opts, #amqp_params_network{}).
+-spec network_params(map()) -> #amqp_params_network{}.
+network_params(#{host := Host, port := Port, username := UserName, password := Password}) ->
+    #amqp_params_network{host = Host, port = Port, username = UserName, password = Password}.
 
 -spec exchange_declare(Exchange :: binary(), Type :: binary()) -> method().
 exchange_declare(Exchange, Type) ->
@@ -88,15 +84,3 @@ confirm_select_ok() ->
 -spec message(Payload :: binary()) -> message().
 message(Payload) ->
     #amqp_msg{payload = Payload}.
-
-%%%===================================================================
-%%% Helpers
-%%%===================================================================
-
-network_params(Opts, #amqp_params_network{host = Host, username = UserName,
-                                          password = Password}) ->
-    #amqp_params_network{
-       host = proplists:get_value(host, Opts, Host),
-       port = proplists:get_value(port, Opts, ?DEFAULT_PORT),
-       username = proplists:get_value(username, Opts, UserName),
-       password = proplists:get_value(password, Opts, Password)}.

--- a/src/mongoose_rabbit_worker.erl
+++ b/src/mongoose_rabbit_worker.erl
@@ -112,7 +112,7 @@ terminate(_Reason, #{connection := Connection, channel := Channel,
 %%%===================================================================
 
 do_init(Opts) ->
-    Host = proplists:get_value(host, Opts),
+    Host = proplists:get_value(host_type, Opts),
     PoolTag = proplists:get_value(pool_tag, Opts),
     AMQPClientOpts = proplists:get_value(amqp_client_opts, Opts),
     {Connection, Channel} =

--- a/src/rdbms/mongoose_rdbms_backend.erl
+++ b/src/rdbms/mongoose_rdbms_backend.erl
@@ -16,12 +16,13 @@
 
 -define(MAIN_MODULE, mongoose_rdbms).
 
+-type options() :: mongoose_rdbms:options().
 
 -callback escape_binary(binary()) -> mongoose_rdbms:sql_query_part().
 -callback escape_string(binary()|list()) -> mongoose_rdbms:sql_query_part().
 
 -callback unescape_binary(binary()) -> binary().
--callback connect(Args :: any(), QueryTimeout :: non_neg_integer()) ->
+-callback connect(options(), QueryTimeout :: non_neg_integer()) ->
     {ok, Connection :: term()} | {error, Reason :: any()}.
 -callback disconnect(Connection :: term()) -> any().
 -callback query(Connection :: term(), Query :: any(), Timeout :: infinity | non_neg_integer()) ->
@@ -51,10 +52,10 @@ unescape_binary(Binary) ->
     Args = [Binary],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec connect(Settings :: tuple(), QueryTimeout :: non_neg_integer()) ->
+-spec connect(options(), QueryTimeout :: non_neg_integer()) ->
     {ok, Connection :: term()} | {error, Reason :: any()}.
-connect(Settings, QueryTimeout) ->
-    Args = [Settings, QueryTimeout],
+connect(Options, QueryTimeout) ->
+    Args = [Options, QueryTimeout],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
 -spec disconnect(Connection :: term()) -> any().

--- a/src/rdbms/mongoose_rdbms_mysql.erl
+++ b/src/rdbms/mongoose_rdbms_mysql.erl
@@ -18,9 +18,12 @@
 -author('konrad.zemek@erlang-solutions.com').
 -behaviour(mongoose_rdbms_backend).
 
--include("mongoose.hrl").
-
--define(MYSQL_PORT, 3306).
+-type options() :: #{host := string(),
+                     port := inet:port(),
+                     database := string(),
+                     username := string(),
+                     password := string(),
+                     atom() => any()}.
 
 -export([escape_binary/1, unescape_binary/1, connect/2, disconnect/1,
          query/3, prepare/5, execute/4]).
@@ -35,10 +38,10 @@ escape_binary(Bin) when is_binary(Bin) ->
 unescape_binary(Bin) when is_binary(Bin) ->
     Bin.
 
--spec connect(Args :: any(), QueryTimeout :: non_neg_integer()) ->
+-spec connect(options(), QueryTimeout :: non_neg_integer()) ->
                      {ok, Connection :: term()} | {error, Reason :: any()}.
-connect(Settings, QueryTimeout) ->
-    case mysql:start_link([{query_timeout, QueryTimeout} | db_opts(Settings)]) of
+connect(Options, QueryTimeout) ->
+    case mysql:start_link([{query_timeout, QueryTimeout} | db_opts(Options)]) of
         {ok, Ref} ->
             mysql:query(Ref, <<"set names 'utf8mb4';">>),
             mysql:query(Ref, <<"SET SESSION query_cache_type=1;">>),
@@ -70,32 +73,14 @@ execute(Connection, StatementRef, Params, _Timeout) ->
 
 %% Helpers
 
--spec db_opts(Settings :: term()) -> list().
-db_opts({mysql, Server, DB, User, Pass}) ->
-    db_opts({mysql, Server, ?MYSQL_PORT, DB, User, Pass});
-db_opts({mysql, Server, Port, DB, User, Pass}) when is_integer(Port) ->
-    get_db_basic_opts({Server, Port, DB, User, Pass});
-db_opts({mysql, Server, DB, User, Pass, SSLConnOpts}) ->
-    db_opts({mysql, Server, ?MYSQL_PORT, DB, User, Pass, SSLConnOpts});
-db_opts({mysql, Server, Port, DB, User, Pass, SSLConnOpts})
-  when is_integer(Port) ->
-    DBBasicOpts = get_db_basic_opts({Server, Port, DB, User, Pass}),
-    extend_db_opts_with_ssl(DBBasicOpts, SSLConnOpts).
+-spec db_opts(options()) -> [mysql:option()].
+db_opts(Options) ->
+    FilteredOpts = maps:with([host, port, database, username, password, tls], Options),
+    [{found_rows, true} | lists:map(fun process_opt/1, maps:to_list(FilteredOpts))].
 
--spec get_db_basic_opts(Settings :: term()) -> [term()].
-get_db_basic_opts({Server, Port, DB, User, Pass}) ->
-    [
-     {host, Server},
-     {port, Port},
-     {user, User},
-     {password, Pass},
-     {database, DB},
-     {found_rows, true}
-    ].
-
--spec extend_db_opts_with_ssl(Opts :: [term()], SSLConnOpts :: [term()]) -> [term()].
-extend_db_opts_with_ssl(Opts, SSLConnOpts) ->
-    Opts ++ [{ssl, SSLConnOpts}].
+process_opt({tls, TLSOpts}) -> {ssl, TLSOpts};
+process_opt({username, UserName}) -> {user, UserName};
+process_opt(Opt) -> Opt.
 
 %% @doc Convert MySQL query result to Erlang RDBMS result formalism
 -spec mysql_to_rdbms(mysql:query_result(), Conn :: term()) -> mongoose_rdbms:query_result().

--- a/src/rdbms/mongoose_rdbms_odbc.erl
+++ b/src/rdbms/mongoose_rdbms_odbc.erl
@@ -25,6 +25,8 @@
 
 -type tabcol() :: {binary(), binary()}.
 
+-type options() :: #{settings := string(), atom() => any()}.
+
 %% API
 
 -spec escape_binary(binary()) -> iodata().
@@ -39,9 +41,9 @@ escape_string(Iolist) ->
 unescape_binary(Bin) when is_binary(Bin) ->
     base16:decode(Bin).
 
--spec connect(Args :: any(), QueryTimeout :: non_neg_integer()) ->
+-spec connect(options(), QueryTimeout :: non_neg_integer()) ->
                      {ok, Connection :: term()} | {error, Reason :: any()}.
-connect(Settings, _QueryTimeout) when is_list(Settings) ->
+connect(#{settings := Settings}, _QueryTimeout) when is_list(Settings) ->
     %% We need binary_strings=off to distinguish between:
     %% - UTF-16 encoded NVARCHARs - encoded as binaries.
     %% - Binaries/regular strings - encoded as list of small integers.

--- a/src/system_metrics/mongoose_system_metrics_collector.erl
+++ b/src/system_metrics/mongoose_system_metrics_collector.erl
@@ -166,7 +166,7 @@ extract_tls_options(#{tls := Opts}) ->
 extract_tls_options(_) -> [].
 
 get_outgoing_pools() ->
-    OutgoingPools = mongoose_config:get_opt(outgoing_pools, []),
+    OutgoingPools = mongoose_config:get_opt(outgoing_pools),
     [#{report_name => outgoing_pools,
        key => type,
        value => Type} || #{type := Type} <- OutgoingPools].

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -90,10 +90,10 @@
 -type callback_fun() :: init | start | is_supported_strategy | stop.
 
 -callback init() -> ok | {error, term()}.
--callback start(scope(), tag(), WPoolOpts :: pool_opts(), ConnOpts :: conn_opts()) ->
+-callback start(host_type_or_global(), tag(), WPoolOpts :: pool_opts(), ConnOpts :: conn_opts()) ->
     {ok, {pid(), proplists:proplist()}} | {ok, pid()} | {error, Reason :: term()}.
 -callback is_supported_strategy(Strategy :: wpool:strategy()) -> boolean().
--callback stop(scope(), tag()) -> ok.
+-callback stop(host_type_or_global(), tag()) -> ok.
 
 -optional_callbacks([is_supported_strategy/1]).
 
@@ -118,7 +118,7 @@ ensure_started() ->
     end.
 
 start_configured_pools() ->
-    Pools = mongoose_config:get_opt(outgoing_pools, []),
+    Pools = mongoose_config:get_opt(outgoing_pools),
     start_configured_pools(Pools).
 
 start_configured_pools(PoolsIn) ->
@@ -227,7 +227,7 @@ stop(PoolType, HostType, Tag) ->
 
 -spec is_configured(pool_type()) -> boolean().
 is_configured(PoolType) ->
-    Pools = mongoose_config:get_opt(outgoing_pools, []),
+    Pools = mongoose_config:get_opt(outgoing_pools),
     lists:any(fun(#{type := Type}) -> Type =:= PoolType end, Pools).
 
 -spec get_worker(pool_type()) -> worker_result().

--- a/src/wpool/mongoose_wpool_cassandra.erl
+++ b/src/wpool/mongoose_wpool_cassandra.erl
@@ -7,17 +7,20 @@
 
 %% --------------------------------------------------------------
 %% mongoose_wpool callbacks
+-spec init() -> ok.
 init() ->
     {ok, []} = application:ensure_all_started(cqerl),
     application:set_env(cqerl, maps, true).
 
-start(HostType, Tag, WpoolOptsIn, CqerlOpts) ->
+-spec start(mongooseim:host_type_or_global(), mongoose_wpool:tag(),
+            mongoose_wpool:pool_opts(), mongoose_wpool:conn_opts()) -> {ok, pid()} | {error, any()}.
+start(HostType, Tag, WpoolOptsIn, ConnOpts) ->
     PoolSize = proplists:get_value(workers, WpoolOptsIn),
     application:set_env(cqerl, num_clients, PoolSize),
-    ExtConfig = extend_config(CqerlOpts),
-    Servers = proplists:get_value(servers, ExtConfig),
-    set_cluster_config(Tag, Servers, ExtConfig),
-    Res = cqerl_cluster:add_nodes(Tag, Servers, ExtConfig),
+    Servers = prepare_cqerl_servers(ConnOpts),
+    CqerlOpts = prepare_cqerl_opts(ConnOpts),
+    set_cluster_config(Tag, Servers, CqerlOpts),
+    Res = cqerl_cluster:add_nodes(Tag, Servers, CqerlOpts),
     case lists:keyfind(error, 1, Res) of
         false ->
             ok;
@@ -29,14 +32,31 @@ start(HostType, Tag, WpoolOptsIn, CqerlOpts) ->
     WpoolOpts = [{worker, Worker} | WpoolOptsIn],
     mongoose_wpool:start_sup_pool(cassandra, Name, WpoolOpts).
 
+-spec stop(mongooseim:host_type_or_global(), mongoose_wpool:tag()) -> ok.
 stop(_, _) ->
     ok.
 
 %% --------------------------------------------------------------
 %% Internal functions
-extend_config(PoolConfig) ->
-    ConfigMap = maps:merge(#{tcp_opts => [{keepalive, true}]}, PoolConfig),
-    maps:to_list(ConfigMap).
+prepare_cqerl_servers(#{servers := Servers}) ->
+    [cqerl_server(Server) || Server <- Servers].
+
+cqerl_server(#{host := Host, port := Port}) -> {Host, Port};
+cqerl_server(#{host := Host}) -> Host.
+
+prepare_cqerl_opts(ConnOpts) ->
+    lists:flatmap(fun(Opt) -> cqerl_opts(Opt, ConnOpts) end, [keyspace, auth, tcp, tls]).
+
+cqerl_opts(keyspace, #{keyspace := Keyspace}) ->
+    [{keyspace, Keyspace}];
+cqerl_opts(auth, #{auth := #{plain := #{username := UserName, password := Password}}}) ->
+    [{cqerl_auth_plain_handler, [{UserName, Password}]}];
+cqerl_opts(tcp, #{}) ->
+    [{tcp_opts, [{keepalive, true}]}]; % always set
+cqerl_opts(tls, #{tls := TLSOpts}) ->
+    [{ssl, TLSOpts}];
+cqerl_opts(_Opt, #{}) ->
+    [].
 
 %% make the config survive the restart of 'cqerl_cluster' in case of a network failure
 set_cluster_config(Tag, Servers, ExtConfig) ->

--- a/src/wpool/mongoose_wpool_elastic.erl
+++ b/src/wpool/mongoose_wpool_elastic.erl
@@ -7,19 +7,21 @@
 
 %% --------------------------------------------------------------
 %% mongoose_wpool callbacks
+-spec init() -> ok.
 init() ->
     tirerl:start(),
     ok.
 
-start(HostType, Tag, WpoolOptsIn, #{host := ElasticHost, port := Port}) ->
+-spec start(mongooseim:host_type_or_global(), mongoose_wpool:tag(),
+            mongoose_wpool:pool_opts(), mongoose_wpool:conn_opts()) -> {ok, pid()} | {error, any()}.
+start(HostType, Tag, WpoolOptsIn, ConnOpts) ->
     ProcName = mongoose_wpool:make_pool_name(elastic, HostType, Tag),
-    Opts = [{host, list_to_binary(ElasticHost)}, {port, Port}],
     WPoolOptions  = [{overrun_warning, infinity},
                      {overrun_handler, {error_logger, warning_report}},
-                     {worker, {tirerl_worker, Opts}}
+                     {worker, {tirerl_worker, maps:to_list(ConnOpts)}}
                     | WpoolOptsIn],
     mongoose_wpool:start_sup_pool(elastic, ProcName, WPoolOptions).
 
+-spec stop(mongooseim:host_type_or_global(), mongoose_wpool:tag()) -> ok.
 stop(_, _) ->
     ok.
-

--- a/src/wpool/mongoose_wpool_http.erl
+++ b/src/wpool/mongoose_wpool_http.erl
@@ -18,6 +18,7 @@
 
 %% --------------------------------------------------------------
 %% mongoose_wpool callbacks
+-spec init() -> ok.
 init() ->
     case ets:info(?MODULE) of
         undefined ->
@@ -32,11 +33,12 @@ init() ->
             ok
     end.
 
+-spec start(mongooseim:host_type_or_global(), mongoose_wpool:tag(),
+            mongoose_wpool:pool_opts(), mongoose_wpool:conn_opts()) -> {ok, pid()} | {error, any()}.
 start(HostType, Tag, WpoolOptsIn, ConnOpts) ->
     Name = mongoose_wpool:make_pool_name(http, HostType, Tag),
     WpoolOpts = wpool_spec(WpoolOptsIn, ConnOpts),
-    PathPrefix = list_to_binary(maps:get(path_prefix, ConnOpts)),
-    RequestTimeout = maps:get(request_timeout, ConnOpts),
+    #{path_prefix := PathPrefix, request_timeout := RequestTimeout} = ConnOpts,
     case mongoose_wpool:start_sup_pool(http, Name, WpoolOpts) of
         {ok, Pid} ->
             ets:insert(?MODULE, {{HostType, Tag}, PathPrefix, RequestTimeout}),
@@ -45,6 +47,7 @@ start(HostType, Tag, WpoolOptsIn, ConnOpts) ->
             Other
     end.
 
+-spec stop(mongooseim:host_type_or_global(), mongoose_wpool:tag()) -> ok.
 stop(HostType, Tag) ->
     true = ets:delete(?MODULE, {HostType, Tag}),
     ok.
@@ -65,9 +68,7 @@ get_params(HostType, Tag) ->
 %% --------------------------------------------------------------
 %% Internal functions
 
-wpool_spec(WpoolOptsIn, ConnOpts) ->
-    TargetServer = maps:get(server, ConnOpts),
-    HttpOpts = maps:get(http_opts, ConnOpts, []),
-    Worker = {fusco, {TargetServer, [{connect_options, HttpOpts}]}},
+wpool_spec(WpoolOptsIn, #{host := Host} = ConnOpts) ->
+    HTTPOpts = maps:get(tls, ConnOpts, []),
+    Worker = {fusco, {Host, [{connect_options, HTTPOpts}]}},
     [{worker, Worker} | WpoolOptsIn].
-

--- a/src/wpool/mongoose_wpool_ldap.erl
+++ b/src/wpool/mongoose_wpool_ldap.erl
@@ -6,13 +6,17 @@
 
 %% --------------------------------------------------------------
 %% mongoose_wpool callbacks
+-spec init() -> ok.
 init() ->
     ok.
 
+-spec start(mongooseim:host_type_or_global(), mongoose_wpool:tag(),
+            mongoose_wpool:pool_opts(), mongoose_wpool:conn_opts()) -> {ok, pid()} | {error, any()}.
 start(HostType, Tag, WpoolOpts, ConnOpts) ->
     WorkerSpec = {mongoose_ldap_worker, ConnOpts},
     ProcName = mongoose_wpool:make_pool_name(ldap, HostType, Tag),
     mongoose_wpool:start_sup_pool(ldap, ProcName, [{worker, WorkerSpec} | WpoolOpts]).
 
+-spec stop(mongooseim:host_type_or_global(), mongoose_wpool:tag()) -> ok.
 stop(_HostType, _Tag) ->
     ok.

--- a/src/wpool/mongoose_wpool_rabbit.erl
+++ b/src/wpool/mongoose_wpool_rabbit.erl
@@ -5,25 +5,24 @@
 -export([start/4]).
 -export([stop/2]).
 
+-spec init() -> ok | {error, any()}.
 init() ->
     application:ensure_all_started(amqp_client).
 
-start(Host, Tag, WpoolOptsIn,
-    AMQPOpts = #{confirms_enabled := Confirms, max_worker_queue_len := MaxQueueLen}) ->
-    PoolName = mongoose_wpool:make_pool_name(rabbit, Host, Tag),
+-spec start(mongooseim:host_type_or_global(), mongoose_wpool:tag(),
+            mongoose_wpool:pool_opts(), mongoose_wpool:conn_opts()) -> {ok, pid()} | {error, any()}.
+start(HostType, Tag, WpoolOptsIn, ConnOpts) ->
+    #{confirms_enabled := Confirms, max_worker_queue_len := MaxQueueLen} = ConnOpts,
+    PoolName = mongoose_wpool:make_pool_name(rabbit, HostType, Tag),
     Worker = {mongoose_rabbit_worker,
-              [{amqp_client_opts, amqp_client_opts(AMQPOpts)},
-               {host, Host},
+              [{amqp_client_opts, mongoose_amqp:network_params(ConnOpts)},
+               {host_type, HostType},
                {pool_tag, Tag},
                {confirms, Confirms},
                {max_queue_len, MaxQueueLen}]},
     WpoolOpts = [{worker, Worker} | WpoolOptsIn],
     mongoose_wpool:start_sup_pool(rabbit, PoolName, WpoolOpts).
 
+-spec stop(mongooseim:host_type_or_global(), mongoose_wpool:tag()) -> ok.
 stop(_, _) ->
     ok.
-
-amqp_client_opts(AMQPOpts) ->
-    AMQPNetworkOpts = maps:with([amqp_host, amqp_port, amqp_username, amqp_password], AMQPOpts),
-    KVOpts = maps:to_list(AMQPNetworkOpts),
-    mongoose_amqp:network_params(KVOpts).

--- a/src/wpool/mongoose_wpool_redis.erl
+++ b/src/wpool/mongoose_wpool_redis.erl
@@ -8,14 +8,18 @@
 
 %% --------------------------------------------------------------
 %% mongoose_wpool callbacks
+-spec init() -> ok.
 init() ->
     ok.
 
+-spec start(mongooseim:host_type_or_global(), mongoose_wpool:tag(),
+            mongoose_wpool:pool_opts(), mongoose_wpool:conn_opts()) -> {ok, pid()} | {error, any()}.
 start(HostType, Tag, WpoolOptsIn, ConnOpts) ->
     ProcName = mongoose_wpool:make_pool_name(redis, HostType, Tag),
     WpoolOpts = wpool_spec(WpoolOptsIn, ConnOpts),
     mongoose_wpool:start_sup_pool(redis, ProcName, WpoolOpts).
 
+-spec stop(mongooseim:host_type_or_global(), mongoose_wpool:tag()) -> ok.
 stop(_, _) ->
     ok.
 

--- a/test/config_parser_SUITE_data/outgoing_pools.toml
+++ b/test/config_parser_SUITE_data/outgoing_pools.toml
@@ -55,8 +55,8 @@
 
   [outgoing_pools.cassandra.default.connection]
     servers = [
-      {ip_address = "cassandra_server1.example.com", port = 9042},
-      {ip_address = "cassandra_server2.example.com", port = 9042}
+      {host = "cassandra_server1.example.com", port = 9042},
+      {host = "cassandra_server2.example.com", port = 9042}
     ]
     keyspace = "big_mongooseim"
 
@@ -69,10 +69,10 @@
   workers = 20
 
   [outgoing_pools.rabbit.event_pusher.connection]
-    amqp_host = "localhost"
-    amqp_port = 5672
-    amqp_username = "guest"
-    amqp_password = "guest"
+    host = "localhost"
+    port = 5672
+    username = "guest"
+    password = "guest"
     confirms_enabled = true
     max_worker_queue_len = 100
 
@@ -82,5 +82,5 @@
 
   [outgoing_pools.ldap.default.connection]
     servers = ["ldap-server.example.com"]
-    rootdn = "cn=admin,dc=example,dc=com"
+    root_dn = "cn=admin,dc=example,dc=com"
     password = "ldap-admin-password"

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -2,20 +2,16 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
--include("ejabberd_c2s.hrl").
--include("mongoose.hrl").
 -include_lib("jid/include/jid.hrl").
 -include_lib("session.hrl").
 -compile([export_all, nowarn_export_all]).
 
-
--define(_eq(E, I), ?_assertEqual(E, I)).
 -define(eq(E, I), ?assertEqual(E, I)).
--define(ne(E, I), ?assert(E =/= I)).
 
 -define(B(C), (proplists:get_value(backend, C))).
 -define(MAX_USER_SESSIONS, 2).
 
+-import(config_parser_helper, [default_config/1]).
 
 all() -> [{group, mnesia}, {group, redis}].
 
@@ -76,8 +72,7 @@ init_redis_group(true, Config) ->
                   register(test_helper, self()),
                   mongoose_wpool:ensure_started(),
                   % This would be started via outgoing_pools in normal case
-                  PoolConf = #{type => redis, scope => global, tag => default},
-                  Pool = config_parser_helper:merge_with_default_pool_config(PoolConf),
+                  Pool = default_config([outgoing_pools, redis, default]),
                   mongoose_wpool:start_configured_pools([Pool], []),
                   Self ! ready,
                   receive stop -> ok end

--- a/test/mongoose_config_SUITE.erl
+++ b/test/mongoose_config_SUITE.erl
@@ -181,6 +181,7 @@ minimal_config_opts() ->
      {listen, []},
      {loglevel, warning},
      {mongooseimctl_access_commands, []},
+     {outgoing_pools, []},
      {rdbms_server_type, generic},
      {registration_timeout, 600},
      {routing_modules, mongoose_router:default_routing_modules()},

--- a/test/mongoose_rdbms_SUITE.erl
+++ b/test/mongoose_rdbms_SUITE.erl
@@ -59,13 +59,15 @@ init_per_testcase(does_backoff_increase_to_a_point, Config) ->
     meck_db(DbType),
     meck_connection_error(DbType),
     meck_rand(),
-    [{db_opts, [{server, server(DbType)}, {keepalive_interval, 2}, {start_interval, 10}]} | Config];
+    ServerOpts = server_opts(DbType),
+    [{db_opts, ServerOpts#{keepalive_interval => 2, max_start_interval => 10}} | Config];
 init_per_testcase(_, Config) ->
     DbType = ?config(db_type, Config),
     set_opts(),
     meck_db(DbType),
-    [{db_opts, [{server, server(DbType)}, {keepalive_interval, ?KEEPALIVE_INTERVAL},
-                {start_interval, ?MAX_INTERVAL}]} | Config].
+    ServerOpts = server_opts(DbType),
+    [{db_opts, ServerOpts#{keepalive_interval => ?KEEPALIVE_INTERVAL,
+                           max_start_interval => ?MAX_INTERVAL}} | Config].
 
 end_per_testcase(does_backoff_increase_to_a_point, Config) ->
     meck_unload_rand(),
@@ -211,9 +213,11 @@ a(mysql) ->
 a(pgsql) ->
     ['_', [?KEEPALIVE_QUERY]].
 
-server(odbc) ->
-    "fake-connection-string";
-server(mysql) ->
-    {mysql, "fake-host", "fake-db", "fake-user", "fake-pass"};
-server(pgsql) ->
-    {pgsql, "fake-host", "fake-db", "fake-user", "fake-pass"}.
+server_opts(odbc) ->
+    #{driver => odbc, settings => "fake-connection-string"};
+server_opts(mysql) ->
+    #{driver => mysql, host => "fake-host", port => 3306,
+      database => "fake-db", username => "fake-user", password => "fake-pass"};
+server_opts(pgsql) ->
+    #{driver => pgsql, host => "fake-host", port => 5432,
+      database => "fake-db", username => "fake-user", password => "fake-pass"}.


### PR DESCRIPTION
The main goal is to keep the configuration options for outgoing pools in maps in the `mongoose_wpool_*` modules. The benefit is that they don't have to be converted to an intermediate format and then converted again to the format expected by the specific connection libraries.

Other main changes:
- Store RDBMS backend options in maps as well.
- Rename some options for improved consistency and less post-processing.
- Fix some bugs (e.g. Rabbit options were not working because the `amqp_` option prefix was not expected by `mongoose_amqp`
- Amend config parser tests for outgoing pools to use the new convention of testing individual paths instead of whole structures at once. Some missing tests were added as well. The `compare_nodes` logic was cleaned up.
- Make the `config/2` helper recursive by default, so there is no more need to use custom helpers to merge nested configs with defaults.

Omitted on purpose:
- As the team agreed, there is no preparation of library-specific options that could be stored in the maps as well. This would save some processing when each pool worker is started, but the difference would be negligible. It looks like the clarity and brevity of simple options in maps wins here.
