### PR TITLE
Pre-build metric prefixes and fetch-or-rebuild when needed

### DIFF
--- a/big_tests/tests/metrics_helper.erl
+++ b/big_tests/tests/metrics_helper.erl
@@ -15,8 +15,7 @@ get_counter_value(CounterName) ->
     get_counter_value(domain_helper:host_type(mim), CounterName).
 
 get_counter_value(HostType, Metric) ->
-    HostTypeName = make_host_type_name(HostType),
-    case rpc(mim(), mongoose_metrics, get_metric_value, [HostTypeName, Metric]) of
+    case rpc(mim(), mongoose_metrics, get_metric_value, [HostType, Metric]) of
         {ok, [{count, Total}, {one, _}]} ->
             {value, Total};
         {ok, [{value, Value} | _]} when is_integer(Value) ->
@@ -34,8 +33,7 @@ assert_counter(Value, CounterName) ->
     assert_counter(domain_helper:host_type(mim), Value, CounterName).
 
 assert_counter(HostType, Value, CounterName) ->
-    HostTypeName = make_host_type_name(HostType),
-    {value, Value} = get_counter_value(HostTypeName, CounterName).
+    {value, Value} = get_counter_value(HostType, CounterName).
 
 -spec prepare_by_all_metrics_are_global(Config :: list(), UseAllMetricsAreGlobal :: boolean()) ->
     list().

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -108,7 +108,7 @@ ensure_db_pool_metric({rdbms, Host, Tag} = Name) ->
                   {function, mongoose_metrics, get_rdbms_data_stats, [[Name]], proplist,
                    [workers | ?INET_STATS]}).
 
--spec update(HostType :: mongooseim:host_type() | global, Name :: term() | list(),
+-spec update(HostType :: mongooseim:host_type_or_global(), Name :: term() | list(),
              Change :: term()) -> any().
 update(HostType, Name, Change) when is_list(Name) ->
     exometer:update(name_by_all_metrics_are_global(HostType, Name), Change);
@@ -208,16 +208,16 @@ prepare_prefixes() ->
 all_metrics_are_global() ->
     mongoose_config:get_opt(all_metrics_are_global).
 
-get_host_type_prefix(HostType) when is_atom(HostType) ->
-    HostType;
+get_host_type_prefix(global) ->
+    global;
 get_host_type_prefix(HostType) when is_binary(HostType) ->
     case persistent_term:get(?PREFIXES, #{}) of
         #{HostType := HostTypePrefix} -> HostTypePrefix;
         #{} -> make_host_type_prefix(HostType)
     end.
 
-make_host_type_prefix(HT) when is_atom(HT) ->
-    HT;
+make_host_type_prefix(global) ->
+    global;
 make_host_type_prefix(HT) when is_binary(HT) ->
     binary:replace(HT, <<" ">>, <<"_">>, [global]).
 

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -48,7 +48,7 @@
               remove_host_type_metrics/1, get_report_interval/0,
               sample_metric/1]).
 
--define(PREFIXES, {?MODULE, prefixes}).
+-define(PREFIXES, mongoose_metrics_prefixes).
 -define(DEFAULT_REPORT_INTERVAL, 60000). %%60s
 
 -type use_or_skip() :: use | skip.
@@ -216,8 +216,6 @@ get_host_type_prefix(HostType) when is_binary(HostType) ->
         #{} -> make_host_type_prefix(HostType)
     end.
 
-make_host_type_prefix(global) ->
-    global;
 make_host_type_prefix(HT) when is_binary(HT) ->
     binary:replace(HT, <<" ">>, <<"_">>, [global]).
 

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -196,9 +196,13 @@ remove_all_metrics() ->
 %% ---------------------------------------------------------------------
 
 prepare_prefixes() ->
-    PrefixesList = [ {HT, make_host_type_prefix(HT)} || HT <- ?ALL_HOST_TYPES ],
-    PrefixesMap = maps:from_list(PrefixesList),
-    persistent_term:put(?PREFIXES, PrefixesMap).
+    Prebuilt = maps:from_list([begin
+                                   Prefix = make_host_type_prefix(HT),
+                                   {Prefix, Prefix}
+                               end || HT <- ?ALL_HOST_TYPES ]),
+    Prefixes = maps:from_list([ {HT, make_host_type_prefix(HT)}
+                                || HT <- ?ALL_HOST_TYPES ]),
+    persistent_term:put(?PREFIXES, maps:merge(Prebuilt, Prefixes)).
 
 -spec all_metrics_are_global() -> boolean().
 all_metrics_are_global() ->

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -48,6 +48,7 @@
               remove_host_type_metrics/1, get_report_interval/0,
               sample_metric/1]).
 
+-define(PREFIXES, {?MODULE, prefixes}).
 -define(DEFAULT_REPORT_INTERVAL, 60000). %%60s
 
 -type use_or_skip() :: use | skip.
@@ -62,6 +63,7 @@
 
 -spec init() -> ok.
 init() ->
+    prepare_prefixes(),
     create_global_metrics(),
     lists:foreach(
         fun(HostType) ->
@@ -138,7 +140,7 @@ sample_metric(Metric) ->
     exometer:sample(Metric).
 
 get_host_type_metric_names(HostType) ->
-    HostTypeName = make_host_type_name(HostType),
+    HostTypeName = get_host_type_prefix(HostType),
     [MetricName || {[_HostTypeName | MetricName], _, _} <- exometer:find_entries([HostTypeName])].
 
 get_global_metric_names() ->
@@ -182,24 +184,43 @@ get_mnesia_running_db_nodes_count() ->
     {value, length(mnesia:system_info(running_db_nodes))}.
 
 remove_host_type_metrics(HostType) ->
-    HostTypeName = make_host_type_name(HostType),
+    HostTypeName = get_host_type_prefix(HostType),
     lists:foreach(fun remove_metric/1, exometer:find_entries([HostTypeName])).
 
 remove_all_metrics() ->
+    persistent_term:erase(?PREFIXES),
     lists:foreach(fun remove_metric/1, exometer:find_entries([])).
 
 %% ---------------------------------------------------------------------
 %% Internal functions
 %% ---------------------------------------------------------------------
 
+prepare_prefixes() ->
+    PrefixesList = [ {HT, make_host_type_prefix(HT)} || HT <- ?ALL_HOST_TYPES ],
+    PrefixesMap = maps:from_list(PrefixesList),
+    persistent_term:put(?PREFIXES, PrefixesMap).
+
 -spec all_metrics_are_global() -> boolean().
 all_metrics_are_global() ->
     mongoose_config:get_opt(all_metrics_are_global).
 
+get_host_type_prefix(HostType) when is_atom(HostType) ->
+    HostType;
+get_host_type_prefix(HostType) when is_binary(HostType) ->
+    case persistent_term:get(?PREFIXES, #{}) of
+        #{HostType := HostTypePrefix} -> HostTypePrefix;
+        #{} -> make_host_type_prefix(HostType)
+    end.
+
+make_host_type_prefix(HT) when is_atom(HT) ->
+    HT;
+make_host_type_prefix(HT) when is_binary(HT) ->
+    binary:replace(HT, <<" ">>, <<"_">>, [global]).
+
 pick_prefix_by_all_metrics_are_global(HostType) ->
     case all_metrics_are_global() of
         true -> global;
-        false -> make_host_type_name(HostType)
+        false -> get_host_type_prefix(HostType)
     end.
 
 pick_by_all_metrics_are_global(WhenGlobal, WhenNot) ->
@@ -469,11 +490,6 @@ subscribe_to_all(Reporter, Interval) ->
     HostTypePrefixes = pick_by_all_metrics_are_global([], ?ALL_HOST_TYPES),
     lists:foreach(
       fun(Prefix) ->
-              UnspacedPrefix = make_host_type_name(Prefix),
+              UnspacedPrefix = get_host_type_prefix(Prefix),
               start_metrics_subscriptions(Reporter, [UnspacedPrefix], Interval)
       end, [global | HostTypePrefixes]).
-
-make_host_type_name(HT) when is_atom(HT) ->
-    HT;
-make_host_type_name(HT) when is_binary(HT) ->
-    binary:replace(HT, <<" ">>, <<"_">>, [global]).


### PR DESCRIPTION
This PR addresses the fact that metric prefixes are sanitised every single time a metric is going to be updated, which happens potentially hundreds of times per message, turning into an important waste. Here we instead build all host-type prefixes early on and store them on a persistent term, and fetch these values when updating the metrics. If a prefix wasn't built at that point, we can only then rebuild it.