### PR TITLE
GraphQL - Implement last category

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -28,6 +28,7 @@
 {suites, "tests", graphql_SUITE}.
 {suites, "tests", graphql_account_SUITE}.
 {suites, "tests", graphql_domain_SUITE}.
+{suites, "tests", graphql_last_SUITE}.
 {suites, "tests", graphql_muc_SUITE}.
 {suites, "tests", graphql_muc_light_SUITE}.
 {suites, "tests", graphql_private_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -44,6 +44,7 @@
 {suites, "tests", graphql_SUITE}.
 {suites, "tests", graphql_account_SUITE}.
 {suites, "tests", graphql_domain_SUITE}.
+{suites, "tests", graphql_last_SUITE}.
 {suites, "tests", graphql_muc_SUITE}.
 {suites, "tests", graphql_muc_light_SUITE}.
 {suites, "tests", graphql_private_SUITE}.

--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -5,7 +5,7 @@
 -export([execute/3, execute_auth/2, execute_domain_auth/2, execute_user/3]).
 -export([init_admin_handler/1, init_domain_admin_handler/1, end_domain_admin_handler/1]).
 -export([get_listener_port/1, get_listener_config/1]).
--export([get_ok_value/2, get_err_msg/1, get_err_msg/2, make_creds/1,
+-export([get_ok_value/2, get_err_msg/1, get_err_msg/2, get_err_code/1, make_creds/1,
          user_to_bin/1, user_to_full_bin/1, user_to_jid/1, user_to_lower_jid/1]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -77,6 +77,9 @@ get_listener_opts(EpName) ->
     #{handlers := [Opts]} = get_listener_config(EpName),
     Opts.
 
+get_err_code(Resp) ->
+    get_ok_value([errors, 1, extensions, code], Resp).
+
 -spec get_err_msg(#{errors := [#{message := binary()}]}) -> binary().
 get_err_msg(Resp) ->
     get_ok_value([errors, 1, message], Resp).
@@ -100,7 +103,8 @@ user_to_full_bin(#client{} = Client) -> escalus_client:full_jid(Client);
 user_to_full_bin(Bin) when is_binary(Bin) -> Bin.
 
 user_to_bin(#client{} = Client) -> escalus_client:short_jid(Client);
-user_to_bin(Bin) when is_binary(Bin) -> Bin.
+user_to_bin(Bin) when is_binary(Bin) -> Bin;
+user_to_bin(null) -> null.
 
 user_to_jid(#client{jid = JID}) -> jid:to_bare(jid:from_binary(JID));
 user_to_jid(Bin) when is_binary(Bin) -> jid:to_bare(jid:from_binary(Bin)).

--- a/big_tests/tests/graphql_last_SUITE.erl
+++ b/big_tests/tests/graphql_last_SUITE.erl
@@ -55,13 +55,12 @@ init_per_suite(Config) ->
     HostType = domain_helper:host_type(),
     SecHostType = domain_helper:secondary_host_type(),
     Config1 = escalus:init_per_suite(Config),
-    Config2 = dynamic_modules:save_modules(HostType, Config1),
-    Config3 = dynamic_modules:save_modules(SecHostType, Config2),
+    Config2 = dynamic_modules:save_modules([HostType, SecHostType], Config1),
     Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
     SecBackend = mongoose_helper:get_backend_mnesia_rdbms_riak(SecHostType),
     dynamic_modules:ensure_modules(HostType, required_modules(Backend)),
     dynamic_modules:ensure_modules(SecHostType, required_modules(SecBackend)),
-    escalus:init_per_suite(Config3).
+    escalus:init_per_suite(Config2).
 
 end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),

--- a/big_tests/tests/graphql_last_SUITE.erl
+++ b/big_tests/tests/graphql_last_SUITE.erl
@@ -1,0 +1,207 @@
+-module(graphql_last_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(graphql_helper, [execute_user/3, execute_auth/2, user_to_bin/1,
+                         get_ok_value/2, get_err_msg/1, get_err_code/1]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(assertErrMsg(Res, ContainsPart), assert_err_msg(ContainsPart, Res)).
+-define(assertErrCode(Res, Code), assert_err_code(Code, Res)).
+
+-define(NONEXISTENT_JID, <<"user@user.com">>).
+-define(DEFAULT_DT, <<"2022-04-17T12:58:30.000000Z">>).
+
+suite() ->
+    require_rpc_nodes([mim]) ++ escalus:suite().
+
+all() ->
+    [{group, user_last},
+     {group, admin_last}].
+
+groups() ->
+    [{user_last, [parallel], user_last_handler()},
+     {admin_last, [parallel], admin_last_handler()}].
+
+user_last_handler() ->
+    [mock].
+
+admin_last_handler() ->
+    [admin_set_last,
+     admin_try_set_nonexistent_user_last,
+     admin_get_last,
+     admin_get_nonexistent_user_last,
+     admin_try_get_nonexistent_last,
+     admin_count_active_users,
+     admin_try_count_nonexistent_domain_active_users].
+
+init_per_suite(Config) ->
+    Config1 = escalus:init_per_suite(Config),
+    Config2 = dynamic_modules:save_modules(domain_helper:host_type(), Config1),
+    HostType = domain_helper:host_type(),
+    Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
+    dynamic_modules:ensure_modules(HostType, required_modules(Backend)),
+    escalus:init_per_suite([{backend, Backend} | Config2]).
+
+
+end_per_suite(Config) ->
+    dynamic_modules:restore_modules(Config),
+    escalus:end_per_suite(Config).
+
+init_per_group(admin_last, Config) ->
+    graphql_helper:init_admin_handler(Config);
+init_per_group(user_last, Config) ->
+    [{schema_endpoint, user} | Config].
+
+end_per_group(admin_last, _Config) ->
+    escalus_fresh:clean();
+end_per_group(user_last, _Config) ->
+    escalus_fresh:clean().
+
+init_per_testcase(CaseName, Config) ->
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(CaseName, Config) ->
+    escalus:end_per_testcase(CaseName, Config).
+
+required_modules(riak) ->
+    [{mod_last, #{backend => riak,
+                  iqdisc => one_queue,
+                  riak => #{bucket_type => <<"last">>}}}];
+required_modules(Backend) ->
+    [{mod_last, #{backend => Backend,
+                  iqdisc => one_queue}}].
+
+%% Admin test cases
+
+admin_set_last(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_set_last/2).
+
+admin_set_last(Config, Alice) ->
+    Status = <<"First status">>,
+    JID = escalus_utils:jid_to_lower(user_to_bin(Alice)),
+    % With timestamp provided
+    Res = execute_auth(admin_set_last_body(Alice, Status, ?DEFAULT_DT), Config),
+    #{<<"user">> := JID, <<"status">> := Status, <<"timestamp">> := ?DEFAULT_DT} =
+        get_ok_value(p(setLast), Res),
+    % Without timestamp
+    Status2 = <<"Second status">>,
+    Res2 = execute_auth(admin_set_last_body(Alice, Status2, null), Config),
+    #{<<"user">> := JID, <<"status">> := Status2, <<"timestamp">> := DateTime2} =
+        get_ok_value(p(setLast), Res2),
+    ?assert(os:system_time(second) - dt_to_unit(DateTime2, second) < 2).
+
+admin_try_set_nonexistent_user_last(Config) ->
+    Res = execute_auth(admin_set_last_body(?NONEXISTENT_JID, <<"status">>, null), Config),
+    ?assertErrMsg(Res, <<"not exist">>),
+    ?assertErrCode(Res, user_does_not_exist).
+
+admin_get_last(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_get_last/2).
+
+admin_get_last(Config, Alice) ->
+    Status = <<"I love ducks">>,
+    JID = escalus_utils:jid_to_lower(user_to_bin(Alice)),
+    execute_auth(admin_set_last_body(Alice, Status, ?DEFAULT_DT), Config),
+    Res = execute_auth(admin_get_last_body(Alice), Config),
+    #{<<"user">> := JID, <<"status">> := Status, <<"timestamp">> := ?DEFAULT_DT} =
+        get_ok_value(p(getLast), Res).
+
+admin_get_nonexistent_user_last(Config) ->
+    Res = execute_auth(admin_get_last_body(?NONEXISTENT_JID), Config),
+    ?assertErrMsg(Res, <<"not exist">>),
+    ?assertErrCode(Res, user_does_not_exist).
+
+admin_try_get_nonexistent_last(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_try_get_nonexistent_last/2).
+
+admin_try_get_nonexistent_last(Config, Alice) ->
+    Res = execute_auth(admin_get_last_body(Alice), Config),
+    ?assertErrMsg(Res, <<"not found">>),
+    ?assertErrCode(Res, last_not_found).
+
+admin_count_active_users(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_count_active_users/3).
+
+admin_count_active_users(Config, Alice, Bob) ->
+    Domain = domain_helper:domain(),
+    execute_auth(admin_set_last_body(Alice, <<"a">>, now_dt_with_offset(5)), Config),
+    execute_auth(admin_set_last_body(Bob, <<"b">>, now_dt_with_offset(10)), Config),
+    Res = execute_auth(admin_count_active_users_body(Domain, null), Config),
+    ?assertEqual(2, get_ok_value(p(countActiveUsers), Res)),
+    Res2 = execute_auth(admin_count_active_users_body(Domain, now_dt_with_offset(30)), Config),
+    ?assertEqual(0, get_ok_value(p(countActiveUsers), Res2)).
+
+admin_try_count_nonexistent_domain_active_users(Config) ->
+    Res = execute_auth(admin_count_active_users_body(<<"unknown-domain.com">>, null), Config),
+    ?assertErrMsg(Res, <<"not found">>),
+    ?assertErrCode(Res, domain_not_found).
+
+%% User test cases
+
+%% Helpers
+
+assert_err_msg(Contains, Res) ->
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), Contains)).
+
+assert_err_code(Code, Res) ->
+    ?assertEqual(atom_to_binary(Code), get_err_code(Res)).
+
+p(Cmd) when is_atom(Cmd) ->
+    [data, last, Cmd];
+p(Path) when is_list(Path) ->
+    [data, last] ++ Path.
+
+now_dt_with_offset(SecondsOffset) ->
+    Seconds = erlang:system_time(second) + SecondsOffset,
+    list_to_binary(calendar:system_time_to_rfc3339(Seconds, [{unit, second}, {offset, "Z"}])).
+
+dt_to_unit(ISODateTime, Unit) ->
+    calendar:rfc3339_to_system_time(binary_to_list(ISODateTime), [{unit, Unit}]).
+
+%% Request bodies
+
+admin_set_last_body(User, Status, DateTime) ->
+    Query = <<"mutation M1($user: JID!, $timestamp: DateTime, $status: String!)
+              { last { setLast (user: $user, timestamp: $timestamp, status: $status)
+              { user timestamp status } } }">>,
+    OpName = <<"M1">>,
+    Vars = #{user => user_to_bin(User), timestamp => DateTime, status => Status},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_get_last_body(User) ->
+    Query = <<"query Q1($user: JID!)
+              { last { getLast(user: $user)
+              { user timestamp status } } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{user => user_to_bin(User)},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+admin_count_active_users_body(Domain, Timestamp) ->
+    Query = <<"query Q1($domain: String!, $timestamp: DateTime)
+              { last { countActiveUsers(domain: $domain, timestamp: $timestamp) } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{domain => Domain, timestamp => Timestamp},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+user_set_last_body(DateTime, Status) ->
+    Query = <<"mutation M1($timestamp: DateTime, $status: String!)
+              { last { setLast (timestamp: $timestamp, status: $status)
+              { user timestamp status } } }">>,
+    OpName = <<"M1">>,
+    Vars = #{timestamp => DateTime, status => Status},
+    #{query => Query, operationName => OpName, variables => Vars}.
+
+user_get_last_body(User) ->
+    Query = <<"query Q1($user: JID)
+              { last { getLast(user: $user)
+              { user timestamp status } } }">>,
+    OpName = <<"Q1">>,
+    Vars = #{user => user_to_bin(User)},
+    #{query => Query, operationName => OpName, variables => Vars}.

--- a/priv/graphql/schemas/admin/account.gql
+++ b/priv/graphql/schemas/admin/account.gql
@@ -5,14 +5,8 @@ type AccountAdminQuery @protected{
   "List users per domain"
   listUsers(domain: String!): [String!]!
     @protected(type: DOMAIN, args: ["domain"])
-  "List users that didn't log in the last days or have never logged in. Globally or for a specified domain"
-  listOldUsers(domain: String, days: Int!): [String!]!
-    @protected(type: DOMAIN, args: ["domain"])
   "Get number of users per domain"
   countUsers(domain: String!): Int!
-    @protected(type: DOMAIN, args: ["domain"])
-  "Get number of users active in last days"
-  countActiveUsers(domain: String!, days: Int!): Int
     @protected(type: DOMAIN, args: ["domain"])
   "Check if a password is correct"
   checkPassword(user: JID!, password: String!): CheckPasswordPayload
@@ -35,26 +29,12 @@ type AccountAdminMutation @protected{
   "Remove a user"
   removeUser(user: JID!): UserPayload
     @protected(type: DOMAIN, args: ["user"])
-  """
-  Delete users that didn't log in the last days or have never logged in. Globally or for a specified domain.
-  Please use listOldUsers to check which users will be deleted
-  """
-  removeOldUsers(domain: String, days: Int!): OldUsersPayload
-    @protected(type: DOMAIN, args: ["domain"])
   "Ban an account: kick sessions and set a random password"
   banUser(user: JID!, reason: String!): UserPayload 
     @protected(type: DOMAIN, args: ["user"])
   "Change the password of a user"
   changeUserPassword(user: JID!, newPassword: String!): UserPayload 
     @protected(type: DOMAIN, args: ["user"])
-}
-
-"Remove old users payload"
-type OldUsersPayload{
-  "Removed users"
-  users: [JID!]!
-  "Result message"
-  message: String!
 }
 
 "Modify user payload"

--- a/priv/graphql/schemas/admin/admin_schema.gql
+++ b/priv/graphql/schemas/admin/admin_schema.gql
@@ -10,18 +10,20 @@ Only an authenticated admin can execute these queries.
 type AdminQuery{
   "Check authorization status"
   checkAuth: AdminAuthInfo
-  "Domain management"
-  domains: DomainAdminQuery
   "Account management"
   account: AccountAdminQuery
-  "Session management"
-  session: SessionAdminQuery
-  "Stanza management"
-  stanza: StanzaAdminQuery
+  "Domain management"
+  domains: DomainAdminQuery
+  "Last activity management"
+  last: LastAdminQuery
   "MUC room management"
   muc: MUCAdminQuery
   "MUC Light room management"
   muc_light: MUCLightAdminQuery
+  "Session management"
+  session: SessionAdminQuery
+  "Stanza management"
+  stanza: StanzaAdminQuery
   "Roster/Contacts management"
   roster: RosterAdminQuery
   "Vcard management"
@@ -39,14 +41,16 @@ type AdminMutation @protected{
   account: AccountAdminMutation
   "Domain management"
   domains: DomainAdminMutation
-  "Session management"
-  session: SessionAdminMutation
-  "Stanza management"
-  stanza: StanzaAdminMutation
+  "Last activity management"
+  last: LastAdminMutation
   "MUC room management"
   muc: MUCAdminMutation
   "MUC Light room management"
   muc_light: MUCLightAdminMutation
+  "Session management"
+  session: SessionAdminMutation
+  "Stanza management"
+  stanza: StanzaAdminMutation
   "Roster/Contacts management"
   roster: RosterAdminMutation
   "Vcard management"

--- a/priv/graphql/schemas/admin/last.gql
+++ b/priv/graphql/schemas/admin/last.gql
@@ -8,6 +8,12 @@ type LastAdminQuery @protected{
   "Get the number of users active from the given timestamp"
   countActiveUsers(domain: String!, timestamp: DateTime): Int
     @protected(type: DOMAIN, args: ["domain"])
+  """
+  List users that didn't log in the last days or have never logged in.
+  Globally or for a specified domain
+  """
+  listOldUsers(domain: String, timestamp: DateTime!): [OldUser!]
+    @protected(type: DOMAIN, args: ["domain"])
 }
 
 """
@@ -17,4 +23,21 @@ type LastAdminMutation @protected{
   "Set user's last activity information"
   setLast(user: JID!, timestamp: DateTime, status: String!): LastActivity
     @protected(type: DOMAIN, args: ["user"])
+  """
+  Delete users that didn't log in the last days or have never logged in.
+  Globally or for a specified domain. Please use listOldUsers to check which users will be deleted
+  """
+  removeOldUsers(domain: String, timestamp: DateTime!): [OldUser!]
+    @protected(type: DOMAIN, args: ["domain"])
+}
+
+"""
+The user is considered old when never registered activity in `mod_last`, or the latest registered
+activity is older than the given timestamp.
+"""
+type OldUser{
+  "The user's JID"
+  jid: JID!
+  "The latest recorded user activity DateTime"
+  timestamp: DateTime
 }

--- a/priv/graphql/schemas/admin/last.gql
+++ b/priv/graphql/schemas/admin/last.gql
@@ -1,0 +1,20 @@
+"""
+Allow admin to manage last activity.
+"""
+type LastAdminQuery @protected{
+  "Get the user's last activity information"
+  getLast(user: JID!): LastActivity
+    @protected(type: DOMAIN, args: ["user"])
+  "Get the number of users active from the given timestamp"
+  countActiveUsers(domain: String!, timestamp: DateTime): Int
+    @protected(type: DOMAIN, args: ["domain"])
+}
+
+"""
+Allow admin to get information about last activity.
+"""
+type LastAdminMutation @protected{
+  "Set user's last activity information"
+  setLast(user: JID!, timestamp: DateTime, status: String!): LastActivity
+    @protected(type: DOMAIN, args: ["user"])
+}

--- a/priv/graphql/schemas/global/last.gql
+++ b/priv/graphql/schemas/global/last.gql
@@ -1,0 +1,5 @@
+type LastActivity{
+  user: JID!
+  timestamp: DateTime!
+  status: String!
+}

--- a/priv/graphql/schemas/global/last.gql
+++ b/priv/graphql/schemas/global/last.gql
@@ -1,5 +1,8 @@
 type LastActivity{
+  "The user's JID"
   user: JID!
+  "The activity DateTime"
   timestamp: DateTime!
+  "The status text"
   status: String!
 }

--- a/priv/graphql/schemas/user/last.gql
+++ b/priv/graphql/schemas/user/last.gql
@@ -1,0 +1,15 @@
+"""
+Allow user to manage last activity.
+"""
+type LastUserQuery @protected{
+  "Get the user's last activity information"
+  getLast(user: JID): LastActivity
+}
+
+"""
+Allow user to get information about last activity.
+"""
+type LastUserMutation @protected{
+  "Set user's last activity information"
+  setLast(timestamp: DateTime, status: String!): LastActivity
+}

--- a/priv/graphql/schemas/user/user_schema.gql
+++ b/priv/graphql/schemas/user/user_schema.gql
@@ -12,6 +12,8 @@ type UserQuery{
   checkAuth: UserAuthInfo
   "Account management"
   account: AccountUserQuery
+  "Last activity management"
+  last: LastUserQuery
   "MUC room management"
   muc: MUCUserQuery
   "MUC Light room management"
@@ -35,6 +37,8 @@ Only an authenticated user can execute these mutations.
 type UserMutation @protected{
   "Account management"
   account: AccountUserMutation
+  "Last activity management"
+  last: LastUserMutation
   "MUC room management"
   muc: MUCUserMutation
   "MUC Light room management"

--- a/src/admin_extra/service_admin_extra_accounts.erl
+++ b/src/admin_extra/service_admin_extra_accounts.erl
@@ -157,5 +157,5 @@ days_to_timestamp(Days) ->
     erlang:system_time(second) - Days * 86400.
 
 format_deleted_users(Users) ->
-    Users2 = [jid:to_binary(JID) || {JID, _} <- Users],
-    io_lib:format("Deleted ~p users: ~p", [length(Users), Users2]).
+    Users2 = lists:join(", ", [jid:to_binary(JID) || {JID, _} <- Users]),
+    io_lib:format("Deleted ~p users: ~s", [length(Users), Users2]).

--- a/src/admin_extra/service_admin_extra_accounts.erl
+++ b/src/admin_extra/service_admin_extra_accounts.erl
@@ -122,25 +122,40 @@ check_account(User, Host) ->
 check_password_hash(User, Host, PasswordHash, HashMethod) ->
     mongoose_account_api:check_password_hash(User, Host, PasswordHash, HashMethod).
 
--spec num_active_users(jid:lserver(), integer()) -> {ok | cannot_count, string()}.
+-spec num_active_users(jid:lserver(), integer()) -> {ok | domain_not_found, iolist()}.
 num_active_users(Domain, Days) ->
-    case mongoose_account_api:num_active_users(Domain, Days) of
+    Timestamp2 = days_to_timestamp(Days),
+    case mod_last_api:count_active_users(Domain, Timestamp2) of
         {ok, Num} -> {ok, integer_to_list(Num)};
         Res -> Res
     end.
 
--spec delete_old_users(integer()) -> mongoose_account_api:delete_old_users_result().
+-spec delete_old_users(integer()) -> {ok, iolist()}.
 delete_old_users(Days) ->
-    {Res, _} = mongoose_account_api:delete_old_users(Days),
-    Res.
+    Timestamp = days_to_timestamp(Days),
+    OldUsers = mod_last_api:remove_old_users(Timestamp),
+    {ok, format_deleted_users(OldUsers)}.
 
--spec delete_old_users_for_domain(jid:server(), integer()) ->
-    mongoose_account_api:delete_old_users().
+-spec delete_old_users_for_domain(jid:server(), integer()) -> {ok | domain_not_found, iolist()}.
 delete_old_users_for_domain(Domain, Days) ->
-    {Res, _} = mongoose_account_api:delete_old_users_for_domain(Domain, Days),
-    Res.
+    Timestamp = days_to_timestamp(Days),
+    case mod_last_api:remove_old_users(Domain, Timestamp) of
+        {ok, OldUsers} ->
+            {ok, format_deleted_users(OldUsers)};
+        Error ->
+            Error
+    end.
 
 -spec ban_account(jid:user(), jid:server(), binary() | string()) ->
     mongoose_account_api:change_password_result().
 ban_account(User, Host, ReasonText) ->
     mongoose_account_api:ban_account(User, Host, ReasonText).
+
+%% Internal
+
+days_to_timestamp(Days) ->
+    erlang:system_time(second) - Days * 86400.
+
+format_deleted_users(Users) ->
+    Users2 = [jid:to_binary(JID) || {JID, _} <- Users],
+    io_lib:format("Deleted ~p users: ~p", [length(Users), Users2]).

--- a/src/admin_extra/service_admin_extra_last.erl
+++ b/src/admin_extra/service_admin_extra_last.erl
@@ -63,14 +63,11 @@ commands() ->
 -spec set_last(jid:user(), jid:server(), _, _) -> {Res, string()} when
     Res :: ok | user_does_not_exist.
 set_last(User, Server, Timestamp, Status) ->
-    JID = jid:make(User, Server, <<>>),
-    case ejabberd_auth:does_user_exist(JID) of
-        true ->
-            {ok, HostType} = mongoose_domain_api:get_host_type(JID#jid.lserver),
-            mod_last:store_last_info(HostType, JID#jid.luser, JID#jid.lserver, Timestamp, Status),
+    JID = jid:make_bare(User, Server),
+    case mod_last_api:set_last(JID, Timestamp, Status) of
+        {ok, #{timestamp := Timestamp, status := Status}} ->
             {ok, io_lib:format("Last activity for user ~s is set as ~B with status ~s",
                                [jid:to_binary(JID), Timestamp, Status])};
-        false ->
-            String = io_lib:format("User ~s@~s does not exist", [User, Server]),
-            {user_does_not_exist, String}
+        Error ->
+            Error
     end.

--- a/src/graphql/admin/mongoose_graphql_account_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_account_admin_mutation.erl
@@ -13,8 +13,6 @@ execute(_Ctx, _Obj, <<"registerUser">>, Args) ->
     register_user(Args);
 execute(_Ctx, _Obj, <<"removeUser">>, Args) ->
     remove_user(Args);
-execute(_Ctx, _Obj, <<"removeOldUsers">>, Args) ->
-    remove_old_users(Args);
 execute(_Ctx, _Obj, <<"banUser">>, Args) ->
     ban_user(Args);
 execute(_Ctx, _Obj, <<"changeUserPassword">>, Args) ->
@@ -41,14 +39,6 @@ remove_user(#{<<"user">> := JID}) ->
     Result = mongoose_account_api:unregister_user(JID),
     format_user_payload(Result, JID).
 
--spec remove_old_users(map()) -> {ok, map()} | {error, resolver_error()}.
-remove_old_users(#{<<"domain">> := null, <<"days">> := Days}) ->
-    {{ok, Msg}, JIDs} = mongoose_account_api:delete_old_users(Days),
-    {ok, make_old_users_payload(Msg, JIDs)};
-remove_old_users(#{<<"domain">> := Domain, <<"days">> := Days}) ->
-    {{ok, Msg}, JIDs} = mongoose_account_api:delete_old_users_for_domain(Domain, Days),
-    {ok, make_old_users_payload(Msg, JIDs)}.
-
 -spec ban_user(map()) -> {ok, map()} | {error, resolver_error()}.
 ban_user(#{<<"user">> := JID, <<"reason">> := Reason}) ->
     Result = mongoose_account_api:ban_account(JID, Reason),
@@ -71,8 +61,3 @@ format_user_payload(InResult, JID) ->
 -spec make_user_payload(string(), jid:literal_jid()) -> map().
 make_user_payload(Msg, JID) ->
     #{<<"message">> => iolist_to_binary(Msg), <<"jid">> => JID}.
-
--spec make_old_users_payload(string(), [jid:literal_jid()]) -> map().
-make_old_users_payload(Msg, JIDs) ->
-    Users = lists:map(fun(U) -> {ok, U} end, JIDs),
-    #{<<"message">> => iolist_to_binary(Msg), <<"users">> => Users}.

--- a/src/graphql/admin/mongoose_graphql_account_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_account_admin_query.erl
@@ -11,12 +11,8 @@
 
 execute(_Ctx, _Obj, <<"listUsers">>, Args) ->
     list_users(Args);
-execute(_Ctx, _Obj, <<"listOldUsers">>, Args) ->
-    list_old_users(Args);
 execute(_Ctx, _Obj, <<"countUsers">>, Args) ->
     count_users(Args);
-execute(_Ctx, _Obj, <<"countActiveUsers">>, Args) ->
-    get_active_users_number(Args);
 execute(_Ctx, _Obj, <<"checkPassword">>, Args) ->
     check_password(Args);
 execute(_Ctx, _Obj, <<"checkPasswordHash">>, Args) ->
@@ -32,24 +28,9 @@ list_users(#{<<"domain">> := Domain}) ->
     Users2 = lists:map(fun(U) -> {ok, U} end, Users),
     {ok, Users2}.
 
--spec list_old_users(map()) -> {ok, [{ok, binary()}]}.
-list_old_users(#{<<"domain">> := null, <<"days">> := Days}) ->
-    {ok, Users} = mongoose_account_api:list_old_users(Days),
-    Users2 = lists:map(fun(U) -> {ok, U} end, Users),
-    {ok, Users2};
-list_old_users(#{<<"domain">> := Domain, <<"days">> := Days}) ->
-    {ok, Users} = mongoose_account_api:list_old_users_for_domain(Domain, Days),
-    Users2 = lists:map(fun(U) -> {ok, U} end, Users),
-    {ok, Users2}.
-
 -spec count_users(map()) -> {ok, non_neg_integer()}.
 count_users(#{<<"domain">> := Domain}) ->
     {ok, mongoose_account_api:count_users(Domain)}.
-
--spec get_active_users_number(map()) -> {ok, non_neg_integer()} | {error, resolver_error()}.
-get_active_users_number(#{<<"domain">> := Domain, <<"days">> := Days}) ->
-    Result = mongoose_account_api:num_active_users(Domain, Days),
-    format_result(Result, #{domain => Domain}).
 
 -spec check_password(map()) -> {ok, map()} | {error, resolver_error()}.
 check_password(#{<<"user">> := JID, <<"password">> := Password}) ->

--- a/src/graphql/admin/mongoose_graphql_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_mutation.erl
@@ -7,21 +7,23 @@
 
 -include("../mongoose_graphql_types.hrl").
 
-execute(_Ctx, _Obj, <<"domains">>, _Args) ->
-    {ok, admin};
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
+execute(_Ctx, _Obj, <<"domains">>, _Args) ->
+    {ok, admin};
+execute(_Ctx, _Obj, <<"last">>, _Args) ->
+    {ok, last};
 execute(_Ctx, _Obj, <<"muc">>, _Args) ->
     {ok, muc};
 execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
     {ok, muc_light};
-execute(_Ctx, _Obj, <<"session">>, _Args) ->
-    {ok, session};
-execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
-    {ok, stanza};
 execute(_Ctx, _Obj, <<"private">>, _Args) ->
     {ok, private};
 execute(_Ctx, _Obj, <<"roster">>, _Args) ->
     {ok, roster};
+execute(_Ctx, _Obj, <<"session">>, _Args) ->
+    {ok, session};
+execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
+    {ok, stanza};
 execute(_Ctx, _Obj, <<"vcard">>, _Args) ->
     {ok, vcard}.

--- a/src/graphql/admin/mongoose_graphql_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_query.erl
@@ -7,23 +7,25 @@
 
 -include("../mongoose_graphql_types.hrl").
 
-execute(_Ctx, _Obj, <<"domains">>, _Args) ->
+execute(_Ctx, _Obj, <<"checkAuth">>, _Args) ->
     {ok, admin};
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
+execute(_Ctx, _Obj, <<"domains">>, _Args) ->
+    {ok, admin};
+execute(_Ctx, _Obj, <<"last">>, _Args) ->
+    {ok, last};
 execute(_Ctx, _Obj, <<"muc">>, _Args) ->
     {ok, muc};
 execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
     {ok, muc_light};
-execute(_Ctx, _Obj, <<"session">>, _Args) ->
-    {ok, session};
-execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
-    {ok, #{}};
 execute(_Ctx, _Obj, <<"private">>, _Args) ->
     {ok, private};
 execute(_Ctx, _Obj, <<"roster">>, _Args) ->
     {ok, roster};
-execute(_Ctx, _Obj, <<"checkAuth">>, _Args) ->
-    {ok, admin};
+execute(_Ctx, _Obj, <<"session">>, _Args) ->
+    {ok, session};
+execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
+    {ok, #{}};
 execute(_Ctx, _Obj, <<"vcard">>, _Args) ->
     {ok, vcard}.

--- a/src/graphql/admin/mongoose_graphql_last_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_last_admin_mutation.erl
@@ -1,0 +1,20 @@
+-module(mongoose_graphql_last_admin_mutation).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2]).
+
+-type last_info() :: mongoose_graphql_last_helper:last_info().
+-type args() :: mongoose_graphql:args().
+
+execute(_Ctx, last, <<"setLast">>, Args) ->
+   set_last(Args).
+
+-spec set_last(args()) -> {ok, last_info()} | {error, resolver_error()}.
+set_last(#{<<"user">> := JID, <<"timestamp">> := Timestamp, <<"status">> := Status}) ->
+    mongoose_graphql_last_helper:set_last(JID, Timestamp, Status).

--- a/src/graphql/admin/mongoose_graphql_last_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_last_admin_mutation.erl
@@ -8,13 +8,31 @@
 -include("../mongoose_graphql_types.hrl").
 
 -import(mongoose_graphql_helper, [make_error/2]).
+-import(mongoose_graphql_last_helper, [format_old_users/1]).
 
+-type old_users() :: mongoose_graphql_last_helper:old_users().
 -type last_info() :: mongoose_graphql_last_helper:last_info().
 -type args() :: mongoose_graphql:args().
 
 execute(_Ctx, last, <<"setLast">>, Args) ->
-   set_last(Args).
+   set_last(Args);
+execute(_Ctx, last, <<"removeOldUsers">>, Args) ->
+   remove_old_users(Args).
 
 -spec set_last(args()) -> {ok, last_info()} | {error, resolver_error()}.
 set_last(#{<<"user">> := JID, <<"timestamp">> := Timestamp, <<"status">> := Status}) ->
     mongoose_graphql_last_helper:set_last(JID, Timestamp, Status).
+
+-spec remove_old_users(args()) -> {ok, old_users()} | {error, resolver_error()}.
+remove_old_users(#{<<"domain">> := null, <<"timestamp">> := Timestamp}) ->
+    Timestamp2 = mongoose_graphql_last_helper:microseconds_to_seconds(Timestamp),
+    OldUsers = mod_last_api:remove_old_users(Timestamp2),
+    {ok, format_old_users(OldUsers)};
+remove_old_users(#{<<"domain">> := Domain, <<"timestamp">> := Timestamp}) ->
+    Timestamp2 = mongoose_graphql_last_helper:microseconds_to_seconds(Timestamp),
+    case mod_last_api:remove_old_users(Domain, Timestamp2) of
+        {ok, OldUsers} ->
+            {ok, format_old_users(OldUsers)};
+        Error ->
+            make_error(Error, #{domain => Domain})
+    end.

--- a/src/graphql/admin/mongoose_graphql_last_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_last_admin_query.erl
@@ -8,14 +8,18 @@
 -include("../mongoose_graphql_types.hrl").
 
 -import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2]).
+-import(mongoose_graphql_last_helper, [format_old_users/1]).
 
+-type old_users() :: mongoose_graphql_last_helper:old_users().
 -type last_info() :: mongoose_graphql_last_helper:last_info().
 -type args() :: mongoose_graphql:args().
 
 execute(_Ctx, last, <<"getLast">>, Args) ->
     get_last(Args);
 execute(_Ctx, last, <<"countActiveUsers">>, Args) ->
-    count_active_users(Args).
+    count_active_users(Args);
+execute(_Ctx, last, <<"listOldUsers">>, Args) ->
+    list_old_users(Args).
 
 -spec get_last(args()) -> {ok, last_info()} | {error, resolver_error()}.
 get_last(#{<<"user">> := JID}) ->
@@ -27,3 +31,17 @@ count_active_users(#{<<"domain">> := Domain, <<"timestamp">> := Timestamp}) ->
     TimestampSec = mongoose_graphql_last_helper:microseconds_to_seconds(DefTimestamp),
     Res = mod_last_api:count_active_users(Domain, TimestampSec),
     format_result(Res, #{domain => Domain}).
+
+-spec list_old_users(args()) -> {ok, old_users()} | {error, resolver_error()}.
+list_old_users(#{<<"domain">> := null, <<"timestamp">> := Timestamp}) ->
+    Timestamp2 = mongoose_graphql_last_helper:microseconds_to_seconds(Timestamp),
+    OldUsers = mod_last_api:list_old_users(Timestamp2),
+    {ok, format_old_users(OldUsers)};
+list_old_users(#{<<"domain">> := Domain, <<"timestamp">> := Timestamp}) ->
+    Timestamp2 = mongoose_graphql_last_helper:microseconds_to_seconds(Timestamp),
+    case mod_last_api:list_old_users(Domain, Timestamp2) of
+        {ok, OldUsers} ->
+            {ok, format_old_users(OldUsers)};
+        Error ->
+            make_error(Error, #{domain => Domain})
+    end.

--- a/src/graphql/admin/mongoose_graphql_last_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_last_admin_query.erl
@@ -1,0 +1,29 @@
+-module(mongoose_graphql_last_admin_query).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2]).
+
+-type last_info() :: mongoose_graphql_last_helper:last_info().
+-type args() :: mongoose_graphql:args().
+
+execute(_Ctx, last, <<"getLast">>, Args) ->
+    get_last(Args);
+execute(_Ctx, last, <<"countActiveUsers">>, Args) ->
+    count_active_users(Args).
+
+-spec get_last(args()) -> {ok, last_info()} | {error, resolver_error()}.
+get_last(#{<<"user">> := JID}) ->
+    mongoose_graphql_last_helper:get_last(JID).
+
+-spec count_active_users(args()) -> {ok, pos_integer()} | {error, resolver_error()}.
+count_active_users(#{<<"domain">> := Domain, <<"timestamp">> := Timestamp}) ->
+    DefTimestamp = null_to_default(Timestamp, os:system_time(microsecond)),
+    TimestampSec = mongoose_graphql_last_helper:microseconds_to_seconds(DefTimestamp),
+    Res = mod_last_api:count_active_users(Domain, TimestampSec),
+    format_result(Res, #{domain => Domain}).

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -136,6 +136,8 @@ admin_mapping_rules() ->
         'SessionAdminQuery' => mongoose_graphql_session_admin_query,
         'StanzaAdminMutation' => mongoose_graphql_stanza_admin_mutation,
         'StanzaAdminQuery' => mongoose_graphql_stanza_admin_query,
+        'LastAdminMutation' => mongoose_graphql_last_admin_mutation,
+        'LastAdminQuery' => mongoose_graphql_last_admin_query,
         'AccountAdminQuery' => mongoose_graphql_account_admin_query,
         'AccountAdminMutation' => mongoose_graphql_account_admin_mutation,
         'MUCAdminMutation' => mongoose_graphql_muc_admin_mutation,

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -173,6 +173,8 @@ user_mapping_rules() ->
         'RosterUserMutation' => mongoose_graphql_roster_user_mutation,
         'VcardUserMutation' => mongoose_graphql_vcard_user_mutation,
         'VcardUserQuery' => mongoose_graphql_vcard_user_query,
+        'LastUserMutation' => mongoose_graphql_last_user_mutation,
+        'LastUserQuery' => mongoose_graphql_last_user_query,
         'SessionUserQuery' => mongoose_graphql_session_user_query,
         'StanzaUserMutation' => mongoose_graphql_stanza_user_mutation,
         'StanzaUserQuery' => mongoose_graphql_stanza_user_query,

--- a/src/graphql/mongoose_graphql_last_helper.erl
+++ b/src/graphql/mongoose_graphql_last_helper.erl
@@ -1,0 +1,44 @@
+-module(mongoose_graphql_last_helper).
+
+-export([get_last/1, set_last/3]).
+
+-export([microseconds_to_seconds/1, seconds_to_microseconds/1]).
+
+-ignore_xref([microseconds_to_seconds/1, seconds_to_microseconds/1]).
+
+-include("mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, null_to_default/2]).
+
+-type last_info() :: map().
+-type timestamp() :: mod_last:timestamp() | null.
+-type status() :: mod_last:status().
+
+-export_type([last_info/0]).
+
+-spec get_last(jid:jid()) -> {ok, last_info()} | {error, resolver_error()}.
+get_last(JID) ->
+    case mod_last_api:get_last(JID) of
+        {ok, #{timestamp := T, status := S}} ->
+            {ok, #{<<"user">> => JID, <<"timestamp">> => seconds_to_microseconds(T),
+                   <<"status">> => S}};
+        Error ->
+            make_error(Error, #{user => jid:to_binary(JID)})
+    end.
+
+-spec set_last(jid:jid(), timestamp(), status()) -> {ok, last_info()} | {error, resolver_error()}.
+set_last(JID, Timestamp, Status) ->
+    DefTimestamp = microseconds_to_seconds(null_to_default(Timestamp, os:system_time(microsecond))),
+    case mod_last_api:set_last(JID, DefTimestamp, Status) of
+        {ok, #{timestamp := DefTimestamp, status := Status}} ->
+            {ok, #{<<"user">> => JID, <<"timestamp">> => seconds_to_microseconds(DefTimestamp),
+                   <<"status">> => Status}};
+        Error ->
+            make_error(Error, #{user => jid:to_binary(JID)})
+    end.
+
+microseconds_to_seconds(Timestamp) ->
+    Timestamp div 1000000.
+
+seconds_to_microseconds(Timestamp) ->
+    Timestamp * 1000000.

--- a/src/graphql/mongoose_graphql_permissions.erl
+++ b/src/graphql/mongoose_graphql_permissions.erl
@@ -181,10 +181,6 @@ arg_eq(Subdomain, Domain) when is_binary(Subdomain), is_binary(Domain) ->
     check_subdomain(Subdomain, Domain);
 arg_eq(#jid{lserver = Domain1}, Domain2) ->
     arg_eq(Domain1, Domain2);
-arg_eq(undefined, _) ->
-    % The arg is optional, and the value is not present, so we assume that
-    % the domain admin has access.
-    true;
 arg_eq(_, _) ->
     false.
 

--- a/src/graphql/user/mongoose_graphql_last_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_last_user_mutation.erl
@@ -1,0 +1,21 @@
+-module(mongoose_graphql_last_user_mutation).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [null_to_default/2]).
+
+-type last_info() :: map().
+-type args() :: mongoose_graphql:args().
+-type ctx() :: mongoose_graphql:ctx().
+
+execute(Ctx, last, <<"setLast">>, Args) ->
+   set_last(Ctx, Args).
+
+-spec set_last(ctx(), args()) -> {ok, last_info()} | {error, resolver_error()}.
+set_last(#{user := JID}, #{<<"timestamp">> := Timestamp, <<"status">> := Status}) ->
+    mongoose_graphql_last_helper:set_last(JID, Timestamp, Status).

--- a/src/graphql/user/mongoose_graphql_last_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_last_user_query.erl
@@ -1,0 +1,21 @@
+-module(mongoose_graphql_last_user_query).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+-import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_default/2]).
+
+-type last_info() :: mongoose_graphql_last_helper:last_info().
+-type args() :: mongoose_graphql:args().
+-type ctx() :: mongoose_graphql:ctx().
+
+execute(Ctx, last, <<"getLast">>, Args) ->
+    get_last(Ctx, Args).
+
+-spec get_last(ctx(), args()) -> {ok, last_info()} | {error, resolver_error()}.
+get_last(#{user := UserJID}, #{<<"user">> := JID}) ->
+    mongoose_graphql_last_helper:get_last(null_to_default(JID, UserJID)).

--- a/src/graphql/user/mongoose_graphql_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_user_mutation.erl
@@ -7,15 +7,17 @@
 
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
+execute(_Ctx, _Obj, <<"last">>, _Args) ->
+    {ok, last};
 execute(_Ctx, _Obj, <<"muc">>, _Args) ->
     {ok, muc};
 execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
     {ok, muc_light};
-execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
-    {ok, stanza};
 execute(_Ctx, _Obj, <<"private">>, _Args) ->
     {ok, private};
 execute(_Ctx, _Obj, <<"roster">>, _Args) ->
     {ok, roster};
+execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
+    {ok, stanza};
 execute(_Ctx, _Obj, <<"vcard">>, _Args) ->
     {ok, vcard}.

--- a/src/graphql/user/mongoose_graphql_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_user_query.erl
@@ -5,21 +5,23 @@
 
 -ignore_xref([execute/4]).
 
+execute(_Ctx, _Obj, <<"checkAuth">>, _Args) ->
+    {ok, user};
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
+execute(_Ctx, _Obj, <<"last">>, _Args) ->
+    {ok, last};
 execute(_Ctx, _Obj, <<"muc">>, _Args) ->
     {ok, muc};
 execute(_Ctx, _Obj, <<"muc_light">>, _Args) ->
     {ok, muc_light};
-execute(_Ctx, _Obj, <<"session">>, _Args) ->
-    {ok, session};
-execute(_Ctx, _Obj, <<"checkAuth">>, _Args) ->
-    {ok, user};
-execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
-    {ok, stanza};
 execute(_Ctx, _Obj, <<"private">>, _Args) ->
     {ok, private};
 execute(_Ctx, _Obj, <<"roster">>, _Args) ->
     {ok, roster};
+execute(_Ctx, _Obj, <<"session">>, _Args) ->
+    {ok, session};
+execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
+    {ok, stanza};
 execute(_Ctx, _Obj, <<"vcard">>, _Args) ->
     {ok, vcard}.

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -224,7 +224,7 @@ make_response(HostType, IQ, SubEl, JID, allow) ->
     end.
 
 -spec get_last_info(mongooseim:host_type(), jid:luser(), jid:lserver())
-        -> 'not_found' | {'ok', integer(), binary()}.
+        -> 'not_found' | {'ok', timestamp(), status()}.
 get_last_info(HostType, LUser, LServer) ->
     case get_last(HostType, LUser, LServer) of
         {error, _Reason} -> not_found;
@@ -240,7 +240,8 @@ remove_user(Acc, User, Server) ->
     mongoose_lib:log_if_backend_error(R, ?MODULE, ?LINE, {Acc, User, Server}),
     Acc.
 
--spec remove_domain(mongoose_hooks:simple_acc(), mongooseim:host_type(), jid:lserver()) -> mongoose_hooks:simple_acc().
+-spec remove_domain(mongoose_hooks:simple_acc(), mongooseim:host_type(), jid:lserver()) ->
+    mongoose_hooks:simple_acc().
 remove_domain(Acc, HostType, Domain) ->
     mod_last_backend:remove_domain(HostType, Domain),
     Acc.
@@ -263,7 +264,8 @@ store_last_info(Acc, LUser, LServer, Status) ->
     store_last_info(HostType, LUser, LServer, TimeStamp, Status),
     Acc.
 
--spec store_last_info(mongooseim:host_type(), jid:luser(), jid:lserver(), timestamp(), status()) -> ok.
+-spec store_last_info(mongooseim:host_type(), jid:luser(), jid:lserver(),
+                      timestamp(), status()) -> ok.
 store_last_info(HostType, LUser, LServer, TimeStamp, Status) ->
     case mod_last_backend:set_last_info(HostType, LUser, LServer, TimeStamp, Status) of
         {error, Reason} ->

--- a/src/mod_last_api.erl
+++ b/src/mod_last_api.erl
@@ -1,0 +1,51 @@
+%% @doc Provide an interface for frontends (like graphql or ctl) to manage last activity.
+-module(mod_last_api).
+
+-export([get_last/1, set_last/3, count_active_users/2]).
+
+-include("jlib.hrl").
+
+-type info() :: #{timestamp := mod_last:timestamp(), status := mod_last:status()}.
+-type timestamp() :: mod_last:timestamp().
+-type status() :: mod_last:status().
+
+-define(USER_NOT_FOUND_RESULT(User, Server),
+        {user_does_not_exist, io_lib:format("User ~s@~s does not exist", [User, Server])}).
+
+-spec set_last(jid:jid(), timestamp(), status()) -> {ok, info()} | {user_does_not_exist, iolist()}.
+set_last(#jid{luser = User, lserver = Server} = JID, Timestamp, Status) ->
+    case ejabberd_auth:does_user_exist(JID) of
+        true ->
+            {ok, HostType} = mongoose_domain_api:get_host_type(Server),
+            ok = mod_last:store_last_info(HostType, User, Server, Timestamp, Status),
+            {ok, #{timestamp => Timestamp, status => Status}};
+        false ->
+            ?USER_NOT_FOUND_RESULT(User, Server)
+    end.
+
+-spec get_last(jid:jid()) ->
+    {ok, info()} | {last_not_found | user_does_not_exist, iolist()}.
+get_last(#jid{luser = User, lserver = Server} = JID) ->
+    case ejabberd_auth:does_user_exist(JID) of
+        true ->
+            {ok, HostType} = mongoose_domain_api:get_host_type(Server),
+            case mod_last:get_last_info(HostType, User, Server) of
+                {ok, Timestamp, Status} ->
+                    {ok, #{timestamp => Timestamp, status => Status}};
+                not_found ->
+                    {last_not_found, "Given user's last info not found"}
+            end;
+        false ->
+            ?USER_NOT_FOUND_RESULT(User, Server)
+    end.
+
+-spec count_active_users(jid:server(), timestamp()) ->
+    {ok, pos_integer()} |{domain_not_found, iolist()}.
+count_active_users(Domain, Timestamp) ->
+    LDomain = jid:nameprep(Domain),
+    case mongoose_domain_api:get_host_type(LDomain) of
+        {ok, HostType} ->
+            {ok, mod_last:count_active_users(HostType, LDomain, Timestamp)};
+        {error, not_found} ->
+            {domain_not_found, "Domain not found"}
+    end.

--- a/src/mod_last_api.erl
+++ b/src/mod_last_api.erl
@@ -3,14 +3,20 @@
 
 -export([get_last/1, set_last/3, count_active_users/2]).
 
--include("jlib.hrl").
+-export([list_old_users/1, list_old_users/2,
+         remove_old_users/1, remove_old_users/2]).
 
+-include("jlib.hrl").
+-include("mongoose.hrl").
+
+-type old_user() :: {jid:jid(), null | timestamp()}.
 -type info() :: #{timestamp := mod_last:timestamp(), status := mod_last:status()}.
 -type timestamp() :: mod_last:timestamp().
 -type status() :: mod_last:status().
 
 -define(USER_NOT_FOUND_RESULT(User, Server),
         {user_does_not_exist, io_lib:format("User ~s@~s does not exist", [User, Server])}).
+-define(DOMAIN_NOT_FOUND_RESULT, {domain_not_found, "Domain not found"}).
 
 -spec set_last(jid:jid(), timestamp(), status()) -> {ok, info()} | {user_does_not_exist, iolist()}.
 set_last(#jid{luser = User, lserver = Server} = JID, Timestamp, Status) ->
@@ -40,12 +46,75 @@ get_last(#jid{luser = User, lserver = Server} = JID) ->
     end.
 
 -spec count_active_users(jid:server(), timestamp()) ->
-    {ok, pos_integer()} |{domain_not_found, iolist()}.
+    {ok, non_neg_integer()} |{domain_not_found, iolist()}.
 count_active_users(Domain, Timestamp) ->
     LDomain = jid:nameprep(Domain),
     case mongoose_domain_api:get_host_type(LDomain) of
         {ok, HostType} ->
             {ok, mod_last:count_active_users(HostType, LDomain, Timestamp)};
         {error, not_found} ->
-            {domain_not_found, "Domain not found"}
+            ?DOMAIN_NOT_FOUND_RESULT
     end.
+
+-spec list_old_users(timestamp()) -> [old_user()].
+list_old_users(Timestamp) ->
+    lists:append([list_old_users(HostType, Domain, Timestamp) ||
+                  HostType <- ?ALL_HOST_TYPES,
+                  Domain <- mongoose_domain_api:get_domains_by_host_type(HostType)]).
+
+-spec list_old_users(jid:server(), timestamp()) ->
+    {ok, [old_user()]} | {domain_not_found, iolist()}.
+list_old_users(Domain, Timestamp) ->
+    LDomain = jid:nameprep(Domain),
+    case mongoose_domain_api:get_host_type(LDomain) of
+        {ok, HostType} ->
+            {ok, list_old_users(HostType, LDomain, Timestamp)};
+        {error, not_found} ->
+            ?DOMAIN_NOT_FOUND_RESULT
+    end.
+
+-spec remove_old_users(timestamp()) -> [old_user()].
+remove_old_users(Timestamp) ->
+    OldUsers = list_old_users(Timestamp),
+    ok = remove_users(OldUsers),
+    OldUsers.
+
+-spec remove_old_users(jid:server(), timestamp()) ->
+    {ok, [old_user()]} | {domain_not_found, iolist()}.
+remove_old_users(Domain, Timestamp) ->
+    case list_old_users(Domain, Timestamp) of
+        {ok, OldUsers} ->
+            ok = remove_users(OldUsers),
+            {ok, OldUsers};
+        Error ->
+            Error
+    end.
+
+%% Internal
+
+-spec list_old_users(_, jid:lserver(), timestamp()) -> [old_user()].
+list_old_users(HostType, Domain, Timestamp) ->
+    Users = ejabberd_auth:get_vh_registered_users(Domain),
+    lists:filtermap(fun(U) -> prepare_old_user(HostType, U, Timestamp) end, Users).
+
+-spec prepare_old_user(mongooseim:host_type(), jid:simple_bare_jid(), timestamp()) ->
+    false | {true, old_user()}.
+prepare_old_user(HostType, {LU, LS}, Timestamp) ->
+    JID = jid:make_bare(LU, LS),
+    case ejabberd_sm:get_user_resources(JID) of
+        [] ->
+            case mod_last:get_last_info(HostType, LU, LS) of
+                {ok, UserTimestamp, _} when UserTimestamp < Timestamp ->
+                    {true, {JID, UserTimestamp}};
+                not_found ->
+                    {true, {JID, null}};
+                _ ->
+                    false
+            end;
+        _ ->
+            false
+    end.
+
+-spec remove_users([old_user()]) -> ok.
+remove_users(Users) ->
+    lists:foreach(fun({JID, _}) -> ok = ejabberd_auth:remove_user(JID) end, Users).

--- a/test/mongoose_graphql_SUITE.erl
+++ b/test/mongoose_graphql_SUITE.erl
@@ -542,8 +542,8 @@ check_field_list_arg_domain_permissions(Config) ->
 
 check_field_null_arg_domain_permissions(Config) ->
     [{_, Domain} | _] = ?config(domains, Config),
-    Doc = <<"{ domainProtectedField domainInputProtectedField }">>,
-    ?assertPermissionsSuccess(Config, Domain, Doc).
+    FDoc = <<"{ domainProtectedField domainInputProtectedField }">>,
+    ?assertDomainPermissionsFailed(Config, Domain, [<<"argA">>], FDoc).
 
 check_field_jid_arg_domain_permissions(Config) ->
     Domain = <<"my-domain.com">>,


### PR DESCRIPTION
This PR addresses [MIM-1647](https://erlangsolutions.atlassian.net/browse/MIM-1647) and adds the last category to the GraphQL API. Moreover, all the commends from the `account` category that need `mod_last` to work were moved to the `last` category. 

The commands `list_old_users`, `remove_old_users` and `count_active_users` take now a timestamp in ISO date-time format. All users with activity older than the given timestamp are considered old.

### Change in granting domain permissions

Domain admin shouldn't be able to execute a query containing fields with optional domain arguments without providing them. `null` domain argument means that the command should affect the global scope. Thus only global admin should be allowed to do it.
