### PR TITLE
Install a hook to filter messages being buffered

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2969,8 +2969,10 @@ flush_stream_mgmt_buffer(#state{stream_mgmt = StreamMgmt})
 flush_stream_mgmt_buffer(#state{stream_mgmt_buffer = Buffer} = State) ->
     re_route_packets(Buffer, State).
 
-re_route_packets(Buffer, StateData) ->
-    [reroute(Acc, StateData) || Acc <- lists:reverse(Buffer)],
+re_route_packets(Buffer, #state{jid = Jid, host_type = HostType} = StateData) ->
+    OrderedBuffer = lists:reverse(Buffer),
+    FilteredBuffer = mongoose_hooks:filter_unacknowledged_messages(HostType, Jid, OrderedBuffer),
+    [reroute(Acc, StateData) || Acc <- FilteredBuffer],
     ok.
 
 reroute(Acc, StateData) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -33,6 +33,7 @@
          session_cleanup/5,
          set_vcard/3,
          unacknowledged_message/2,
+         filter_unacknowledged_messages/3,
          unregister_command/1,
          unregister_subhost/1,
          user_available_hook/2,
@@ -423,6 +424,14 @@ unacknowledged_message(Acc, JID) ->
     Args = [JID],
     ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     run_hook_for_host_type(unacknowledged_message, HostType, Acc, ParamsWithLegacyArgs).
+
+-spec filter_unacknowledged_messages(HostType, Jid, Buffer) -> Result when
+    HostType :: mongooseim:host_type(),
+    Jid :: jid:jid(),
+    Buffer :: [mongoose_acc:t()],
+    Result :: [mongoose_acc:t()].
+filter_unacknowledged_messages(HostType, Jid, Buffer) ->
+    run_fold(filter_unacknowledged_messages, HostType, Buffer, #{jid => Jid}).
 
 %%% @doc The `unregister_command' hook is called when a command
 %%% is unregistered from `mongoose_commands'.


### PR DESCRIPTION
This can be used to insert handlers that would filter out stanzas with a
`no-copy` hint, or any other desired condition. The handler will have
access to the full buffer and can return an entirely new one,
preferably, by only filtering whichever stanza is to be undesired.
