### PR TITLE
Use 'format_items = map' by default for config sections

### DIFF
--- a/include/mongoose_config_spec.hrl
+++ b/include/mongoose_config_spec.hrl
@@ -15,7 +15,7 @@
 
 -record(list, {items :: mongoose_config_spec:config_node(),
                validate = any :: mongoose_config_validator:list_validator(),
-               format_items = none :: mongoose_config_spec:format_items(),
+               format_items = list :: mongoose_config_spec:format_items(),
                process :: undefined | mongoose_config_parser_toml:list_processor(),
                wrap = default :: mongoose_config_spec:wrapper()}).
 

--- a/include/mongoose_config_spec.hrl
+++ b/include/mongoose_config_spec.hrl
@@ -6,7 +6,7 @@
                   validate_keys = any :: mongoose_config_validator:validator(),
                   required = [] :: [mongoose_config_parser_toml:toml_key()] | all,
                   validate = any :: mongoose_config_validator:section_validator(),
-                  format_items = none :: mongoose_config_spec:format_items(),
+                  format_items = map :: mongoose_config_spec:format_items(),
                   process :: undefined | mongoose_config_parser_toml:list_processor(),
                   defaults = #{} :: #{mongoose_config_parser_toml:toml_key() =>
                                          mongoose_config_parser_toml:config_part()},

--- a/src/admin_extra/service_admin_extra.erl
+++ b/src/admin_extra/service_admin_extra.erl
@@ -60,8 +60,7 @@ config_spec() ->
                                                         validate = {enum, ?SUBMODS}},
                                         validate = unique}
                 },
-       defaults = #{<<"submods">> => ?SUBMODS},
-       format_items = map
+       defaults = #{<<"submods">> => ?SUBMODS}
       }.
 
 mod_name(ModAtom) ->

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -93,8 +93,7 @@ config_spec() ->
                                            validate = {enum, [sasl_anon, login_anon, both]}}
                 },
        defaults = #{<<"allow_multiple_connections">> => false,
-                    <<"protocol">> => sasl_anon},
-       format_items = map
+                    <<"protocol">> => sasl_anon}
       }.
 
 %% @doc Return true if multiple connections have been allowed in the config file

--- a/src/auth/ejabberd_auth_dummy.erl
+++ b/src/auth/ejabberd_auth_dummy.erl
@@ -47,8 +47,7 @@ config_spec() ->
                  <<"variance">> => #option{type = integer,
                                            validate = positive}},
        defaults = #{<<"base_time">> => 50,
-                    <<"variance">> => 450},
-       format_items = map
+                    <<"variance">> => 450}
       }.
 
 authorize(Creds) ->

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -80,8 +80,7 @@ config_spec() ->
                                           validate = non_empty}
                 },
        required = [<<"program">>],
-       defaults = #{<<"instances">> => 1},
-       format_items = map
+       defaults = #{<<"instances">> => 1}
       }.
 
 -spec check_cache_last_options(mongooseim:host_type()) -> 'cache' | 'no_cache'.

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -51,10 +51,7 @@ stop(_HostType) ->
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
-    #section{
-       items = #{<<"basic_auth">> => #option{type = string}},
-       format_items = map
-      }.
+    #section{items = #{<<"basic_auth">> => #option{type = string}}}.
 
 -spec supports_sasl_module(mongooseim:host_type(), cyrsasl:sasl_module()) -> boolean().
 supports_sasl_module(_HostType, cyrsasl_plain) -> true;

--- a/src/auth/ejabberd_auth_jwt.erl
+++ b/src/auth/ejabberd_auth_jwt.erl
@@ -70,8 +70,7 @@ config_spec() ->
                  <<"username_key">> => #option{type = atom,
                                                validate = non_empty}
                 },
-       required = all,
-       format_items = map
+       required = all
       }.
 
 jwt_secret_config_spec() ->
@@ -81,6 +80,7 @@ jwt_secret_config_spec() ->
                  <<"env">> => #option{type = string,
                                       validate = non_empty},
                  <<"value">> => #option{type = string}},
+       format_items = none,
        process = fun ?MODULE:process_jwt_secret/1
       }.
 

--- a/src/auth/ejabberd_auth_jwt.erl
+++ b/src/auth/ejabberd_auth_jwt.erl
@@ -80,7 +80,7 @@ jwt_secret_config_spec() ->
                  <<"env">> => #option{type = string,
                                       validate = non_empty},
                  <<"value">> => #option{type = string}},
-       format_items = none,
+       format_items = list,
        process = fun ?MODULE:process_jwt_secret/1
       }.
 

--- a/src/auth/ejabberd_auth_rdbms.erl
+++ b/src/auth/ejabberd_auth_rdbms.erl
@@ -88,8 +88,7 @@ stop(_HostType) ->
 config_spec() ->
     #section{
        items = #{<<"users_number_estimate">> => #option{type = boolean}},
-       defaults = #{<<"users_number_estimate">> => false},
-       format_items = map
+       defaults = #{<<"users_number_estimate">> => false}
       }.
 
 -spec supports_sasl_module(mongooseim:host_type(), cyrsasl:sasl_module()) -> boolean().

--- a/src/auth/ejabberd_auth_riak.erl
+++ b/src/auth/ejabberd_auth_riak.erl
@@ -55,8 +55,7 @@ config_spec() ->
     #section{
        items = #{<<"bucket_type">> => #option{type = binary,
                                               validate = non_empty}},
-       defaults = #{<<"bucket_type">> => <<"users">>},
-       format_items = map
+       defaults = #{<<"bucket_type">> => <<"users">>}
       }.
 
 -spec supports_sasl_module(mongooseim:host_type(), cyrsasl:sasl_module()) -> boolean().

--- a/src/auth/mongoose_gen_auth.erl
+++ b/src/auth/mongoose_gen_auth.erl
@@ -135,8 +135,7 @@ stop(Mod, HostType) ->
 config_spec(Mod) ->
     case is_exported(Mod, config_spec, 0) of
         true -> Mod:config_spec();
-        false -> #section{items = #{},
-                          format_items = map}
+        false -> #section{}
     end.
 
 -spec supports_sasl_module(ejabberd_auth:authmodule(), mongooseim:host_type(),

--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -128,6 +128,8 @@ parse_list(Path, L, #list{items = ItemSpec}) ->
                   end, L).
 
 -spec handle(path(), toml_value(), mongoose_config_spec:config_node()) -> [config_part()].
+handle(Path, Value, Spec = #option{}) ->
+    handle(Path, Value, Spec, [parse, validate, process, wrap]);
 handle(Path, Value, Spec) ->
     handle(Path, Value, Spec, [parse, validate, format_items, process, wrap]).
 
@@ -184,15 +186,14 @@ validate_keys(#section{validate_keys = Validator}, Section) ->
 
 -spec format_items_spec(mongoose_config_spec:config_node()) -> mongoose_config_spec:format_items().
 format_items_spec(#section{format_items = FormatItems}) -> FormatItems;
-format_items_spec(#list{format_items = FormatItems}) -> FormatItems;
-format_items_spec(#option{}) -> none.
+format_items_spec(#list{format_items = FormatItems}) -> FormatItems.
 
 -spec format_items(config_part(), mongoose_config_spec:format_items()) -> config_part().
 format_items(KVs, map) ->
     Keys = lists:map(fun({K, _}) -> K end, KVs),
     mongoose_config_validator:validate_list(Keys, unique),
     maps:from_list(KVs);
-format_items(Value, none) ->
+format_items(Value, list) when is_list(Value) ->
     Value.
 
 -spec validate(config_part(), mongoose_config_spec:config_node()) -> any().

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -112,7 +112,8 @@ root() ->
                 },
        required = [<<"general">>],
        process = fun ?MODULE:process_root/1,
-       wrap = none
+       wrap = none,
+       format_items = none
       }.
 
 %% path: host_config[]
@@ -146,7 +147,8 @@ host_config() ->
                  <<"access">> => access(),
                  <<"s2s">> => s2s()
                 },
-       wrap = none
+       wrap = none,
+       format_items = none
       }.
 
 %% path: general
@@ -192,6 +194,7 @@ general() ->
                                                    wrap = host_config},
                  <<"mongooseimctl_access_commands">> => #section{
                                                            items = #{default => ctl_access_rule()},
+                                                           format_items = none,
                                                            wrap = global_config},
                  <<"routing_modules">> => #list{items = #option{type = atom,
                                                                 validate = module},
@@ -205,7 +208,8 @@ general() ->
                                                 format_items = map,
                                                 wrap = global_config}
                 },
-       wrap = none
+       wrap = none,
+       format_items = none
       }.
 
 general_defaults() ->
@@ -226,9 +230,12 @@ ctl_access_rule() ->
     #section{
        items = #{<<"commands">> => #list{items = #option{type = string}},
                  <<"argument_restrictions">> => #section{
-                                                   items = #{default => #option{type = string}}
+                                                   items = #{default => #option{type = string}},
+                                                   format_items = none
                                                   }
                 },
+       defaults = #{<<"commands">> => all,
+                    <<"argument_restrictions">> => []},
        process = fun ?MODULE:process_ctl_access_rule/1,
        wrap = prepend_key
       }.
@@ -241,7 +248,6 @@ domain_cert() ->
                  <<"certfile">> => #option{type = string,
                                            validate = filename}},
        required = all,
-       format_items = map,
        process = fun ?MODULE:process_domain_cert/1
       }.
 
@@ -252,7 +258,8 @@ listen() ->
        items = maps:from_list([{atom_to_binary(Key), #list{items = listener(Key), wrap = none}}
                                || Key <- Keys]),
        process = fun mongoose_listener_config:verify_unique_listeners/1,
-       wrap = global_config
+       wrap = global_config,
+       format_items = none
       }.
 
 %% path: listen.*[]
@@ -269,7 +276,6 @@ listener_common() ->
                        <<"ip_version">> => #option{type = integer,
                                                    validate = {enum, [4, 6]}}
                       },
-             format_items = map,
              required = [<<"port">>],
              defaults = #{<<"proto">> => tcp},
              process = fun ?MODULE:process_listener/2
@@ -301,8 +307,7 @@ xmpp_listener_common() ->
                           <<"proxy_protocol">> => false,
                           <<"hibernate_after">> => 0,
                           <<"max_stanza_size">> => infinity,
-                          <<"num_acceptors">> => 100},
-             format_items = map
+                          <<"num_acceptors">> => 100}
             }.
 
 xmpp_listener_extra(c2s) ->
@@ -320,8 +325,7 @@ xmpp_listener_extra(c2s) ->
                                  validate = unique},
                        <<"tls">> => c2s_tls()},
              defaults = #{<<"access">> => all,
-                          <<"shaper">> => none},
-             format_items = map
+                          <<"shaper">> => none}
             };
 xmpp_listener_extra(s2s) ->
     TLSSection = tls([server], [fast_tls]),
@@ -329,8 +333,7 @@ xmpp_listener_extra(s2s) ->
                                                validate = non_empty},
                        <<"tls">> => TLSSection#section{include = always,
                                                        process = fun ?MODULE:process_fast_tls/1}},
-             defaults = #{<<"shaper">> => none},
-             format_items = map
+             defaults = #{<<"shaper">> => none}
             };
 xmpp_listener_extra(service) ->
     #section{items = #{<<"access">> => #option{type = atom,
@@ -351,8 +354,7 @@ xmpp_listener_extra(service) ->
                           <<"shaper_rule">> => none,
                           <<"check_from">> => true,
                           <<"hidden_components">> => false,
-                          <<"conflict_behaviour">> => disconnect},
-             format_items = map
+                          <<"conflict_behaviour">> => disconnect}
             }.
 
 %% path: listen.c2s[].tls
@@ -367,7 +369,6 @@ c2s_tls_extra() ->
                       },
              defaults = #{<<"module">> => fast_tls,
                           <<"mode">> => starttls},
-             format_items = map,
              process = fun ?MODULE:process_c2s_tls/1}.
 
 %% path: listen.http[].transport
@@ -378,7 +379,6 @@ http_transport() ->
                  <<"max_connections">> => #option{type = int_or_infinity,
                                                   validate = non_negative}
                 },
-       format_items = map,
        defaults = #{<<"num_acceptors">> => 100,
                     <<"max_connections">> => 1024},
        include = always
@@ -388,7 +388,6 @@ http_transport() ->
 http_protocol() ->
     #section{
        items = #{<<"compress">> => #option{type = boolean}},
-       format_items = map,
        defaults = #{<<"compress">> => false},
        include = always
       }.
@@ -409,7 +408,6 @@ auth() ->
                                                 validate = {module, cyrsasl},
                                                 process = fun ?MODULE:process_sasl_mechanism/1}}
                      },
-       format_items = map,
        defaults = #{<<"sasl_external">> => [standard],
                     <<"sasl_mechanisms">> => cyrsasl:default_modules()},
        process = fun ?MODULE:process_auth/1,
@@ -429,7 +427,6 @@ auth_password() ->
                  <<"scram_iterations">> => #option{type = integer,
                                                    validate = positive}
                 },
-       format_items = map,
        defaults = #{<<"format">> => scram,
                     <<"scram_iterations">> => mongoose_scram:iterations()},
        include = always
@@ -441,8 +438,10 @@ outgoing_pools() ->
                  <<"rabbit">>, <<"rdbms">>, <<"redis">>, <<"riak">>],
     Items = [{Type, #section{items = #{default => outgoing_pool(Type)},
                              validate_keys = non_empty,
-                             wrap = none}} || Type <- PoolTypes],
+                             wrap = none,
+                             format_items = none}} || Type <- PoolTypes],
     #section{items = maps:from_list(Items),
+             format_items = none,
              wrap = global_config,
              include = always}.
 
@@ -469,8 +468,7 @@ wpool(ExtraDefaults) ->
                       },
              defaults = maps:merge(#{<<"workers">> => 10,
                                      <<"strategy">> => best_worker,
-                                     <<"call_timeout">> => 5000}, ExtraDefaults),
-             format_items = map}.
+                                     <<"call_timeout">> => 5000}, ExtraDefaults)}.
 
 outgoing_pool_extra(Type) ->
     #section{items = #{<<"scope">> => #option{type = atom,
@@ -480,7 +478,6 @@ outgoing_pool_extra(Type) ->
                        <<"connection">> => outgoing_pool_connection(Type)
                       },
              process = fun ?MODULE:process_pool/2,
-             format_items = map,
              defaults = #{<<"scope">> => global}
             }.
 
@@ -492,11 +489,9 @@ outgoing_pool_connection(<<"cassandra">>) ->
                  <<"keyspace">> => #option{type = atom,
                                            validate = non_empty},
                  <<"auth">> => #section{items = #{<<"plain">> => cassandra_auth_plain()},
-                                        required = all,
-                                        format_items = map},
+                                        required = all},
                  <<"tls">> => tls([client], [just_tls])
                 },
-       format_items = map,
        include = always,
        defaults = #{<<"servers">> => [#{host => "localhost", port => 9042}],
                     <<"keyspace">> => mongooseim}
@@ -508,7 +503,6 @@ outgoing_pool_connection(<<"elastic">>) ->
                  <<"port">> => #option{type = integer,
                                        validate = port}
                 },
-       format_items = map,
        include = always,
        defaults = #{<<"host">> => <<"localhost">>,
                     <<"port">> => 9200}
@@ -523,7 +517,6 @@ outgoing_pool_connection(<<"http">>) ->
                                                   validate = non_negative},
                  <<"tls">> => tls([client], [just_tls])
                 },
-       format_items = map,
        include = always,
        required = [<<"host">>],
        defaults = #{<<"path_prefix">> => <<"/">>,
@@ -541,7 +534,6 @@ outgoing_pool_connection(<<"ldap">>) ->
                                                    validate = positive},
                  <<"tls">> => tls([client], [just_tls])
                 },
-       format_items = map,
        include = always,
        defaults = #{<<"servers">> => ["localhost"],
                     <<"root_dn">> => <<>>,
@@ -563,7 +555,6 @@ outgoing_pool_connection(<<"rabbit">>) ->
                  <<"max_worker_queue_len">> => #option{type = int_or_infinity,
                                                        validate = non_negative}
                 },
-       format_items = map,
        include = always,
        defaults = #{<<"host">> => "localhost",
                     <<"port">> => 5672,
@@ -599,8 +590,7 @@ outgoing_pool_connection(<<"rdbms">>) ->
                 },
        required = [<<"driver">>],
        defaults = #{<<"max_start_interval">> => 30},
-       process = fun mongoose_rdbms:process_options/1,
-       format_items = map
+       process = fun mongoose_rdbms:process_options/1
       };
 outgoing_pool_connection(<<"redis">>) ->
     #section{
@@ -612,7 +602,6 @@ outgoing_pool_connection(<<"redis">>) ->
                                            validate = non_negative},
                  <<"password">> => #option{type = string}
                 },
-       format_items = map,
        include = always,
        defaults = #{<<"host">> => "127.0.0.1",
                     <<"port">> => 6379,
@@ -630,8 +619,7 @@ outgoing_pool_connection(<<"riak">>) ->
                                        validate = port},
                  <<"credentials">> => riak_credentials(),
                  <<"tls">> => TLSSection},
-       required = [<<"address">>, <<"port">>],
-       format_items = map
+       required = [<<"address">>, <<"port">>]
       }.
 
 cassandra_server() ->
@@ -641,8 +629,7 @@ cassandra_server() ->
                  <<"port">> => #option{type = integer,
                                        validate = port}},
        required = [<<"host">>],
-       defaults = #{<<"port">> => 9042},
-       format_items = map
+       defaults = #{<<"port">> => 9042}
       }.
 
 %% path: outgoing_pools.cassandra.*.connection.auth.plain
@@ -650,8 +637,7 @@ cassandra_auth_plain() ->
     #section{
        items = #{<<"username">> => #option{type = binary},
                  <<"password">> => #option{type = binary}},
-       required = all,
-       format_items = map
+       required = all
       }.
 
 %% path: outgoing_pools.riak.*.connection.credentials
@@ -661,8 +647,7 @@ riak_credentials() ->
                                        validate = non_empty},
                  <<"password">> => #option{type = string,
                                            validate = non_empty}},
-       required = all,
-       format_items = map
+       required = all
     }.
 
 %% path: outgoing_pools.rdbms.*.connection.tls
@@ -670,8 +655,7 @@ sql_tls() ->
     mongoose_config_utils:merge_sections(tls([client], [just_tls]), sql_tls_extra()).
 
 sql_tls_extra() ->
-    #section{items = #{<<"required">> => #option{type = boolean}},
-             format_items = map}.
+    #section{items = #{<<"required">> => #option{type = boolean}}}.
 
 %% TLS options
 
@@ -688,36 +672,30 @@ tls(common, common) ->
                                                    validate = filename},
                        <<"ciphers">> => #option{type = string}
                       },
-             defaults = #{<<"verify_mode">> => peer},
-             format_items = map};
+             defaults = #{<<"verify_mode">> => peer}};
 tls(common, fast_tls) ->
     #section{items = #{<<"protocol_options">> => #list{items = #option{type = string,
-                                                                       validate = non_empty}}},
-             format_items = map};
+                                                                       validate = non_empty}}}};
 tls(common, just_tls) ->
     #section{items = #{<<"keyfile">> => #option{type = string,
                                                 validate = filename},
                        <<"password">> => #option{type = string},
-                       <<"versions">> => #list{items = #option{type = atom}}},
-             format_items = map};
+                       <<"versions">> => #list{items = #option{type = atom}}}};
 tls(server, common) ->
     #section{items = #{<<"dhfile">> => #option{type = string,
-                                               validate = filename}},
-             format_items = map};
+                                               validate = filename}}};
 tls(server, fast_tls) ->
-    #section{format_items = map};
+    #section{};
 tls(server, just_tls) ->
     #section{items = #{<<"disconnect_on_failure">> => #option{type = boolean},
                        <<"crl_files">> => #list{items = #option{type = string,
-                                                                validate = filename}}},
-             format_items = map};
+                                                                validate = filename}}}};
 tls(client, common) ->
-    #section{format_items = map};
+    #section{};
 tls(client, fast_tls) ->
-    #section{format_items = map};
+    #section{};
 tls(client, just_tls) ->
-    #section{items = #{<<"server_name_indication">> => server_name_indication()},
-             format_items = map}.
+    #section{items = #{<<"server_name_indication">> => server_name_indication()}}.
 
 server_name_indication() ->
     #section{items = #{<<"enabled">> => #option{type = boolean},
@@ -728,7 +706,6 @@ server_name_indication() ->
                       },
              defaults = #{<<"enabled">> => true,
                           <<"protocol">> => default},
-             format_items = map,
              include = always}.
 
 %% path: (host_config[].)services
@@ -737,7 +714,6 @@ services() ->
                 || Service <- configurable_services()],
     #section{
        items = maps:from_list(Services),
-       format_items = map,
        wrap = global_config,
        include = always
       }.
@@ -753,9 +729,8 @@ modules() ->
                || Module <- configurable_modules()],
     Items = maps:from_list(Modules),
     #section{
-       items = Items#{default => #section{items = #{}, format_items = map}},
+       items = Items#{default => #section{}},
        validate_keys = module,
-       format_items = map,
        wrap = host_config
       }.
 
@@ -810,12 +785,8 @@ iqdisc() ->
        process = fun ?MODULE:process_iqdisc/1
       }.
 
-process_iqdisc(KVs) ->
-    {[[{type, Type}]], WorkersOpts} = proplists:split(KVs, [type]),
-    iqdisc(Type, WorkersOpts).
-
-iqdisc(queues, [{workers, N}]) -> {queues, N};
-iqdisc(Type, []) -> Type.
+process_iqdisc(#{type := Type, workers := N}) -> {queues = Type, N};
+process_iqdisc(#{type := Type}) -> Type.
 
 %% path: shaper
 shaper() ->
@@ -824,12 +795,10 @@ shaper() ->
                      #section{
                         items = #{<<"max_rate">> => #option{type = integer,
                                                             validate = positive}},
-                        required = all,
-                        format_items = map
+                        required = all
                        }
                 },
        validate_keys = non_empty,
-       format_items = map,
        wrap = global_config
       }.
 
@@ -837,7 +806,6 @@ shaper() ->
 acl() ->
     #section{
        items = #{default => #list{items = acl_item()}},
-       format_items = map,
        wrap = host_config
       }.
 
@@ -859,15 +827,13 @@ acl_item() ->
                  <<"server_glob">> => Cond,
                  <<"resource_glob">> => Cond
                 },
-       defaults = #{<<"match">> => current_domain},
-       format_items = map
+       defaults = #{<<"match">> => current_domain}
       }.
 
 %% path: (host_config[].)access
 access() ->
     #section{
        items = #{default => #list{items = access_rule_item()}},
-       format_items = map,
        wrap = host_config
       }.
 
@@ -878,8 +844,7 @@ access_rule_item() ->
                                       validate = non_empty},
                  <<"value">> => #option{type = int_or_atom}
                 },
-       required = all,
-       format_items = map
+       required = all
       }.
 
 %% path: (host_config[].)s2s
@@ -907,7 +872,6 @@ s2s() ->
                     <<"use_starttls">> => false,
                     <<"ciphers">> => mongoose_tls:default_ciphers(),
                     <<"max_retry_delay">> => 300},
-       format_items = map,
        wrap = host_config
       }.
 
@@ -918,7 +882,6 @@ s2s_dns() ->
                                           validate = positive},
                  <<"retries">> => #option{type = integer,
                                           validate = positive}},
-       format_items = map,
        include = always,
        defaults = #{<<"timeout">> => 10,
                     <<"retries">> => 2}
@@ -936,7 +899,6 @@ s2s_outgoing() ->
                  <<"connection_timeout">> => #option{type = int_or_infinity,
                                                      validate = positive}
                 },
-       format_items = map,
        include = always,
        defaults = #{<<"port">> => 5269,
                     <<"ip_versions">> => [4, 6],
@@ -952,7 +914,6 @@ s2s_host_policy() ->
                                          validate = {enum, [allow, deny]}}
                 },
        required = all,
-       format_items = map,
        process = fun ?MODULE:process_s2s_host_policy/1
       }.
 
@@ -967,7 +928,6 @@ s2s_address() ->
                                        validate = port}
                 },
        required = [<<"host">>, <<"ip_address">>],
-       format_items = map,
        process = fun ?MODULE:process_s2s_address/1
       }.
 
@@ -1015,9 +975,7 @@ is_host_type_item({{_, HostType}, _}, HostTypes) ->
 is_host_type_item(_, _) ->
     false.
 
-process_ctl_access_rule(KVs) ->
-    Commands = proplists:get_value(commands, KVs, all),
-    ArgRestrictions = proplists:get_value(argument_restrictions, KVs, []),
+process_ctl_access_rule(#{commands := Commands, argument_restrictions := ArgRestrictions}) ->
     {Commands, ArgRestrictions}.
 
 process_host(Host) ->

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -65,7 +65,7 @@
 
 %% This option allows to put list/section items in a map
 -type format_items() ::
-        none         % keep the processed items unchanged
+        list         % keep the processed items in a list
       | map.         % convert the processed items (which have to be a KV list) to a map
 
 -export_type([config_node/0, config_section/0, config_list/0, config_option/0,
@@ -113,7 +113,7 @@ root() ->
        required = [<<"general">>],
        process = fun ?MODULE:process_root/1,
        wrap = none,
-       format_items = none
+       format_items = list
       }.
 
 %% path: host_config[]
@@ -148,7 +148,7 @@ host_config() ->
                  <<"s2s">> => s2s()
                 },
        wrap = none,
-       format_items = none
+       format_items = list
       }.
 
 %% path: general
@@ -194,7 +194,7 @@ general() ->
                                                    wrap = host_config},
                  <<"mongooseimctl_access_commands">> => #section{
                                                            items = #{default => ctl_access_rule()},
-                                                           format_items = none,
+                                                           format_items = list,
                                                            wrap = global_config},
                  <<"routing_modules">> => #list{items = #option{type = atom,
                                                                 validate = module},
@@ -209,7 +209,7 @@ general() ->
                                                 wrap = global_config}
                 },
        wrap = none,
-       format_items = none
+       format_items = list
       }.
 
 general_defaults() ->
@@ -231,7 +231,7 @@ ctl_access_rule() ->
        items = #{<<"commands">> => #list{items = #option{type = string}},
                  <<"argument_restrictions">> => #section{
                                                    items = #{default => #option{type = string}},
-                                                   format_items = none
+                                                   format_items = list
                                                   }
                 },
        defaults = #{<<"commands">> => all,
@@ -259,7 +259,7 @@ listen() ->
                                || Key <- Keys]),
        process = fun mongoose_listener_config:verify_unique_listeners/1,
        wrap = global_config,
-       format_items = none
+       format_items = list
       }.
 
 %% path: listen.*[]
@@ -439,9 +439,9 @@ outgoing_pools() ->
     Items = [{Type, #section{items = #{default => outgoing_pool(Type)},
                              validate_keys = non_empty,
                              wrap = none,
-                             format_items = none}} || Type <- PoolTypes],
+                             format_items = list}} || Type <- PoolTypes],
     #section{items = maps:from_list(Items),
-             format_items = none,
+             format_items = list,
              wrap = global_config,
              include = always}.
 

--- a/src/domain/mongoose_domain_handler.erl
+++ b/src/domain/mongoose_domain_handler.erl
@@ -37,7 +37,6 @@
 config_spec() ->
     #section{items = #{<<"username">> => #option{type = binary},
                        <<"password">> => #option{type = binary}},
-             format_items = map,
              process = fun ?MODULE:process_config/1}.
 
 process_config(Opts) ->

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -65,8 +65,7 @@ config_spec() ->
                       },
              defaults = #{<<"event_cleaning_interval">> => 1800, % 30 minutes
                           <<"event_max_age">> => 7200, % 2 hours
-                          <<"db_pool">> => global},
-             format_items = map}.
+                          <<"db_pool">> => global}}.
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).

--- a/src/event_pusher/mod_event_pusher.erl
+++ b/src/event_pusher/mod_event_pusher.erl
@@ -70,8 +70,7 @@ stop(HostType) ->
 config_spec() ->
     BackendItems = [{atom_to_binary(B, utf8),
                      (backend_module(B)):config_spec()} || B <- all_backends()],
-    #section{items = maps:from_list(BackendItems),
-             format_items = map}.
+    #section{items = maps:from_list(BackendItems)}.
 
 -spec config_metrics(mongooseim:host_type()) -> [{gen_mod:opt_key(), gen_mod:opt_value()}].
 config_metrics(HostType) ->

--- a/src/event_pusher/mod_event_pusher_http.erl
+++ b/src/event_pusher/mod_event_pusher_http.erl
@@ -65,8 +65,7 @@ stop(_HostType) ->
 config_spec() ->
     #section{items = #{<<"handlers">> => #list{items = handler_config_spec(),
                                               validate = unique}},
-             defaults = #{<<"handlers">> => []},
-             format_items = map}.
+             defaults = #{<<"handlers">> => []}}.
 
 handler_config_spec() ->
     #section{items = #{<<"pool_name">> => #option{type = atom,
@@ -78,8 +77,7 @@ handler_config_spec() ->
                 },
              defaults = #{<<"pool_name">> => http_pool,
                           <<"path">> => <<>>,
-                          <<"callback_module">> => mod_event_pusher_http_defaults},
-             format_items = map
+                          <<"callback_module">> => mod_event_pusher_http_defaults}
             }.
 
 push_event(Acc, #chat_event{direction = Dir, from = From, to = To, packet = Packet}) ->

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -103,8 +103,7 @@ config_spec() ->
         defaults = #{<<"iqdisc">> => one_queue,
                      <<"backend">> => mnesia,
                      <<"plugin_module">> => mod_event_pusher_push_plugin:default_plugin_module(),
-                     <<"virtual_pubsub_hosts">> => []},
-        format_items = map
+                     <<"virtual_pubsub_hosts">> => []}
     }.
 
 wpool_spec() ->

--- a/src/event_pusher/mod_event_pusher_rabbit.erl
+++ b/src/event_pusher/mod_event_pusher_rabbit.erl
@@ -66,8 +66,7 @@ stop(_HostType) ->
 config_spec() ->
     #section{items = #{<<"presence_exchange">> => exchange_spec(<<"presence">>),
                        <<"chat_msg_exchange">> => msg_exchange_spec(<<"chat_msg">>),
-                       <<"groupchat_msg_exchange">> => msg_exchange_spec(<<"groupchat_msg">>)},
-             format_items = map}.
+                       <<"groupchat_msg_exchange">> => msg_exchange_spec(<<"groupchat_msg">>)}}.
 
 msg_exchange_spec(Name) ->
     Spec = #section{items = Items, defaults = Defaults} = exchange_spec(Name),
@@ -77,7 +76,6 @@ msg_exchange_spec(Name) ->
                                                             validate = non_empty}},
                  defaults = Defaults#{<<"sent_topic">> => <<Name/binary, "_sent">>,
                                       <<"recv_topic">> => <<Name/binary, "_recv">>},
-                 format_items = map,
                  include = always
                 }.
 
@@ -88,7 +86,6 @@ exchange_spec(Name) ->
                                              validate = non_empty}},
              defaults = #{<<"name">> => Name,
                           <<"type">> => <<"topic">>},
-             format_items = map,
              include = always}.
 
 push_event(Acc, #user_status_event{jid = UserJID, status = Status}) ->

--- a/src/event_pusher/mod_event_pusher_sns.erl
+++ b/src/event_pusher/mod_event_pusher_sns.erl
@@ -94,8 +94,7 @@ config_spec() ->
                     <<"pool_size">> => 100,
                     <<"publish_retry_count">> => 2,
                     <<"publish_retry_time_ms">> => 50
-                   },
-       format_items = map
+                   }
     }.
 
 push_event(Acc, #user_status_event{jid = UserJID, status = Status}) ->

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -92,7 +92,6 @@ config_spec() ->
         required = [<<"global_host">>, <<"local_host">>],
         defaults = #{<<"message_ttl">> => 4,
                      <<"hosts_refresh_interval">> => 3000},
-        format_items = map,
         process = fun ?MODULE:process_opts/1
     }.
 
@@ -114,7 +113,6 @@ connections_spec() ->
                      <<"endpoint_refresh_interval">> => 60,
                      <<"endpoint_refresh_interval_when_empty">> => 3,
                      <<"disabled_gc_interval">> => 60},
-        format_items = map,
         include = always
     }.
 
@@ -126,7 +124,6 @@ endpoint_spec() ->
                                         validate = port}
         },
         required = all,
-        format_items = map,
         process = fun ?MODULE:process_endpoint/1
     }.
 
@@ -146,7 +143,6 @@ redis_spec() ->
         defaults = #{<<"pool">> => global_distrib,
                      <<"expire_after">> => 120,
                      <<"refresh_after">> => 60},
-        format_items = map,
         include = always
     }.
 
@@ -165,7 +161,6 @@ cache_spec() ->
                      <<"jid_lifetime_seconds">> => 5,
                      <<"max_jids">> => 10000
                     },
-        format_items = map,
         include = always
     }.
 
@@ -180,7 +175,6 @@ bounce_spec() ->
         defaults = #{<<"enabled">> => true,
                      <<"resend_after_ms">> => 200,
                      <<"max_retries">> => 4},
-        format_items = map,
         include = always
     }.
 

--- a/src/http_upload/mod_http_upload.erl
+++ b/src/http_upload/mod_http_upload.erl
@@ -112,8 +112,7 @@ config_spec() ->
                      <<"token_bytes">> => 32,
                      <<"max_file_size">> => ?DEFAULT_MAX_FILE_SIZE
         },
-        required = [<<"s3">>],
-        format_items = map
+        required = [<<"s3">>]
     }.
 
 s3_spec() ->
@@ -126,8 +125,7 @@ s3_spec() ->
                   <<"secret_access_key">> => #option{type = binary}
         },
         defaults = #{<<"add_acl">> => false},
-        required = [<<"bucket_url">>, <<"region">>, <<"access_key_id">>, <<"secret_access_key">>],
-        format_items = map
+        required = [<<"bucket_url">>, <<"region">>, <<"access_key_id">>, <<"secret_access_key">>]
     }.
 
 -spec supported_features() -> [atom()].

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -142,15 +142,13 @@ config_spec() ->
                      <<"reset_markers">> => [<<"displayed">>],
                      <<"iqdisc">> => no_queue
                     },
-        process = fun ?MODULE:process_inbox_boxes/1,
-        format_items = map
+        process = fun ?MODULE:process_inbox_boxes/1
     }.
 
 async_config_spec() ->
     #section{
        items = #{<<"pool_size">> => #option{type = integer, validate = non_negative}},
        defaults = #{<<"pool_size">> => 2 * erlang:system_info(schedulers_online)},
-       format_items = map,
        include = always
       }.
 

--- a/src/jingle_sip/mod_jingle_sip.erl
+++ b/src/jingle_sip/mod_jingle_sip.erl
@@ -100,7 +100,6 @@ config_spec() ->
                                              validate = {enum, ["udp", "tcp"]}},
                   <<"username_to_phone">> => #list{items = username_to_phone_spec()}
         },
-        format_items = map,
         defaults = #{<<"proxy_host">> => "localhost",
                      <<"proxy_port">> => 5060,
                      <<"listen_port">> => 5600,
@@ -115,7 +114,6 @@ username_to_phone_spec() ->
         items = #{<<"username">> => #option{type = binary},
                   <<"phone">> => #option{type = binary}},
         required = all,
-        format_items = map,
         process = fun process_u2p/1
     }.
 

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -60,7 +60,6 @@ config_spec() ->
                     <<"cache_users">> => true,
                     <<"default_result_limit">> => 50,
                     <<"max_result_limit">> => 50},
-       format_items = map,
        process = fun ?MODULE:remove_unused_backend_opts/1
       }.
 
@@ -69,13 +68,11 @@ remove_unused_backend_opts(Opts) -> maps:remove(riak, Opts).
 
 pm_config_spec() ->
     #section{items = maps:merge(common_config_items(), pm_config_items()),
-             format_items = map,
              defaults = #{<<"archive_groupchats">> => false,
                           <<"same_mam_id_for_peers">> => false}}.
 
 muc_config_spec() ->
     #section{items = maps:merge(common_config_items(), muc_config_items()),
-             format_items = map,
              defaults = #{<<"host">> => mod_muc:default_host()}}.
 
 root_config_items() ->
@@ -139,8 +136,7 @@ async_config_spec() ->
        defaults = #{<<"enabled">> => true,
                     <<"flush_interval">> => 2000,
                     <<"batch_size">> => 30,
-                    <<"pool_size">> => 4 * erlang:system_info(schedulers_online)},
-       format_items = map
+                    <<"pool_size">> => 4 * erlang:system_info(schedulers_online)}
       }.
 
 riak_config_spec() ->
@@ -151,7 +147,6 @@ riak_config_spec() ->
                                               validate = non_empty}},
        defaults = #{<<"search_index">> => <<"mam">>,
                     <<"bucket_type">> => <<"mam_yz">>},
-       format_items = map,
        include = always
       }.
 

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -93,8 +93,7 @@ config_spec() ->
        items = #{<<"report_commands_node">> => #option{type = boolean},
                  <<"iqdisc">> => mongoose_config_spec:iqdisc()},
        defaults = #{<<"report_commands_node">> => false,
-                    <<"iqdisc">> => one_queue},
-       format_items = map
+                    <<"iqdisc">> => one_queue}
       }.
 
 -spec supported_features() -> [atom()].

--- a/src/mod_auth_token.erl
+++ b/src/mod_auth_token.erl
@@ -107,8 +107,7 @@ config_spec() ->
                  <<"validity_period">> => validity_periods_spec(),
                  <<"iqdisc">> => mongoose_config_spec:iqdisc()},
        defaults = #{<<"backend">> => rdbms,
-                    <<"iqdisc">> => no_queue},
-       format_items = map
+                    <<"iqdisc">> => no_queue}
       }.
 
 validity_periods_spec() ->
@@ -117,7 +116,6 @@ validity_periods_spec() ->
                  <<"refresh">> => validity_period_spec()},
        defaults = #{<<"access">> => #{value => 1, unit => hours},
                     <<"refresh">> => #{value => 25, unit => days}},
-       format_items = map,
        include = always
       }.
 
@@ -128,8 +126,7 @@ validity_period_spec() ->
                  <<"unit">> => #option{type = atom,
                                        validate = {enum, [days, hours, minutes, seconds]}}
                 },
-       required = all,
-       format_items = map
+       required = all
       }.
 
 -spec commands() -> [ejabberd_commands:cmd()].

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -112,8 +112,8 @@ config_spec() ->
                           <<"inactivity">> => 30, % seconds
                           <<"max_wait">> => infinity, % seconds
                           <<"server_acks">> => false,
-                          <<"max_pause">> => 120}, % seconds
-             format_items = map}.
+                          <<"max_pause">> => 120} % seconds
+            }.
 
 -spec supported_features() -> [atom()].
 supported_features() ->

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -121,8 +121,7 @@ config_spec() ->
                                                    validate = positive}
                  },
         defaults = #{<<"cache_size">> => 1000,
-                     <<"cache_life_time">> => timer:hours(24) div 1000},
-        format_items = map
+                     <<"cache_life_time">> => timer:hours(24) div 1000}
        }.
 
 supported_features() -> [dynamic_domains].

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -97,10 +97,8 @@ hooks(HostType) ->
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
-    #section{
-       format_items = map,
-       items = #{<<"iqdisc">> => mongoose_config_spec:iqdisc()},
-       defaults = #{<<"iqdisc">> => no_queue}}.
+    #section{items = #{<<"iqdisc">> => mongoose_config_spec:iqdisc()},
+             defaults = #{<<"iqdisc">> => no_queue}}.
 
 -spec disco_local_features(mongoose_disco:feature_acc()) -> mongoose_disco:feature_acc().
 disco_local_features(Acc = #{node := <<>>}) ->

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -52,7 +52,6 @@ config_spec() ->
     #section{
        items = #{<<"buffer_max">> => #option{type = int_or_infinity,
                                              validate = non_negative}},
-       format_items = map,
        defaults = #{<<"buffer_max">> => 20}
     }.
 

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -99,8 +99,7 @@ config_spec() ->
        defaults = #{<<"extra_domains">> => [],
                     <<"server_info">> => [],
                     <<"users_can_see_hidden_services">> => true,
-                    <<"iqdisc">> => one_queue},
-       format_items = map
+                    <<"iqdisc">> => one_queue}
       }.
 
 server_info_spec() ->
@@ -112,8 +111,7 @@ server_info_spec() ->
                  <<"modules">> => #list{items = #option{type = atom,
                                                         validate = module}}
                 },
-       required = [<<"name">>, <<"urls">>],
-       format_items = map
+       required = [<<"name">>, <<"urls">>]
       }.
 
 supported_features() -> [dynamic_domains].

--- a/src/mod_dynamic_domains_test.erl
+++ b/src/mod_dynamic_domains_test.erl
@@ -25,8 +25,8 @@ config_spec() ->
                                    process = fun mongoose_subdomain_utils:make_subdomain_pattern/1},
                        <<"namespace">> =>
                            #option{type = binary,
-                                   validate = non_empty}},
-             format_items = map}.
+                                   validate = non_empty}}
+            }.
 
 supported_features() -> [dynamic_domains].
 

--- a/src/mod_extdisco.erl
+++ b/src/mod_extdisco.erl
@@ -46,8 +46,7 @@ config_spec() ->
     #section{items = #{<<"iqdisc">> => mongoose_config_spec:iqdisc(),
                        <<"service">> => #list{items = service_config_spec()}},
              defaults = #{<<"iqdisc">> => no_queue,
-                          <<"service">> => []},
-             format_items = map}.
+                          <<"service">> => []}}.
 
 service_config_spec() ->
     #section{items = #{<<"type">> => #option{type = atom,
@@ -63,8 +62,7 @@ service_config_spec() ->
                        <<"password">> => #option{type = binary,
                                                  validate = non_empty}
                       },
-             required = [<<"type">>, <<"host">>],
-             format_items = map}.
+             required = [<<"type">>, <<"host">>]}.
 
 -spec process_iq(mongoose_acc:t(), jid:jid(), jid:jid(), jlib:iq(), map()) ->
     {mongoose_acc:t(), jlib:iq()}.

--- a/src/mod_keystore.erl
+++ b/src/mod_keystore.erl
@@ -80,8 +80,7 @@ config_spec() ->
                                       format_items = map}
         },
         defaults = #{<<"ram_key_size">> => ?DEFAULT_RAM_KEY_SIZE,
-                     <<"keys">> => #{}},
-        format_items = map
+                     <<"keys">> => #{}}
     }.
 
 keys_spec() ->
@@ -94,7 +93,6 @@ keys_spec() ->
                                         validate = filename}
         },
         required = [<<"name">>, <<"type">>],
-        format_items = map,
         process = fun ?MODULE:process_key/1
     }.
 

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -113,7 +113,6 @@ config_spec() ->
        defaults = #{<<"iqdisc">> => one_queue,
                     <<"backend">> => mnesia
                    },
-       format_items = map,
        process = fun ?MODULE:remove_unused_backend_opts/1
       }.
 
@@ -125,8 +124,7 @@ riak_config_spec() ->
                                                     validate = non_empty}
                       },
              defaults = #{<<"bucket_type">> => <<"last">>},
-             include = always,
-             format_items = map
+             include = always
             }.
 
 supported_features() -> [dynamic_domains].

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -198,7 +198,6 @@ assert_server_running(HostType) ->
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
     #section{
-       format_items = map,
        items = #{<<"backend">> => #option{type = atom,
                                           validate = {module, mod_muc}},
                  <<"host">> => #option{type = string,
@@ -281,7 +280,6 @@ keys_as_atoms(Map) ->
 
 default_room_config_spec() ->
     #section{
-       format_items = map,
        items = #{<<"title">> => #option{type = binary},
                  <<"description">> => #option{type = binary},
                  <<"allow_change_subj">> => #option{type = boolean},
@@ -352,9 +350,7 @@ default_room_affiliations_spec() ->
        process = fun ?MODULE:process_room_affiliation/1
       }.
 
-process_room_affiliation(KVs) ->
-    {[[{user, User}], [{server, Server}], [{resource, Res}], [{affiliation, Aff}]], []} =
-        proplists:split(KVs, [user, server, resource, affiliation]),
+process_room_affiliation(#{user := User, server := Server, resource := Res, affiliation := Aff}) ->
     {{User, Server, Res}, Aff}.
 
 stop_gen_server(HostType) ->

--- a/src/mod_muc_log.erl
+++ b/src/mod_muc_log.erl
@@ -129,7 +129,6 @@ supported_features() ->
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
     #section{
-       format_items = map,
        items = #{<<"outdir">> => #option{type = string,
                                          validate = dirname},
                  <<"access_log">> => #option{type = atom,
@@ -171,8 +170,7 @@ top_link_config_spec() ->
        process = fun ?MODULE:process_top_link/1
       }.
 
-process_top_link(KVs) ->
-    {[[{target, Target}], [{text, Text}]], []} = proplists:split(KVs, [target, text]),
+process_top_link(#{target := Target, text := Text}) ->
     {Target, Text}.
 
 -spec add_to_log(mongooseim:host_type(), Type :: any(), Data :: any(), mod_muc:room(),

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -134,8 +134,7 @@ config_spec() ->
                     <<"timeout_action">> => none,
                     <<"ping_req_timeout">> => ?DEFAULT_PING_REQ_TIMEOUT,
                     <<"iqdisc">> => no_queue
-                   },
-       format_items = map
+                   }
       }.
 
 supported_features() -> [dynamic_domains].

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -98,7 +98,6 @@ config_spec() ->
                  <<"riak">> => riak_config_spec()},
        defaults = #{<<"iqdisc">> => one_queue,
                     <<"backend">> => rdbms},
-       format_items = map,
        process = fun ?MODULE:remove_unused_backend_opts/1
     }.
 
@@ -111,8 +110,7 @@ riak_config_spec() ->
                                               validate = non_empty}
                 },
        defaults = #{<<"bucket_type">> => <<"private">>},
-       include = always,
-       format_items = map
+       include = always
       }.
 
 %% ------------------------------------------------------------------

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -72,8 +72,7 @@ config_spec() ->
                 },
        defaults = #{<<"pool_name">> => undefined,
                     <<"api_version">> => <<"v3">>,
-                    <<"max_http_connections">> => 100},
-       format_items = map
+                    <<"max_http_connections">> => 100}
       }.
 
 %%--------------------------------------------------------------------

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -95,7 +95,6 @@ config_spec() ->
                                                     validate = non_negative},
                  <<"ip_access">> => #list{items = ip_access_spec()}
                 },
-       format_items = map,
        defaults = #{<<"iqdisc">> => one_queue,
                     <<"access">> => all,
                     <<"registration_watchers">> => [],
@@ -109,7 +108,6 @@ welcome_message_spec() ->
                   <<"subject">> => #option{type = string}},
         defaults = #{<<"body">> => "",
                      <<"subject">> => ""},
-        format_items = map,
         process = fun ?MODULE:process_welcome_message/1
     }.
 
@@ -121,7 +119,6 @@ ip_access_spec() ->
                                           validate = {enum, [allow, deny]}}
                 },
         required = all,
-        format_items = map,
         process = fun ?MODULE:process_ip_access/1
     }.
 

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -155,7 +155,6 @@ config_spec() ->
                                           validate = {module, mod_roster}},
                  <<"riak">> => riak_config_spec()
                 },
-       format_items = map,
        defaults = #{<<"iqdisc">> => one_queue,
                     <<"versioning">> => false,
                     <<"store_current_id">> => false,
@@ -169,7 +168,6 @@ riak_config_spec() ->
                        <<"version_bucket_type">> => #option{type = binary,
                                                             validate = non_empty}},
              include = always,
-             format_items = map,
              defaults = #{<<"bucket_type">> => <<"rosters">>,
                           <<"version_bucket_type">> => <<"roster_versions">>}
     }.

--- a/src/mod_sic.erl
+++ b/src/mod_sic.erl
@@ -72,8 +72,7 @@ iq_handlers() ->
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
     #section{items = #{<<"iqdisc">> => mongoose_config_spec:iqdisc()},
-             defaults = #{<<"iqdisc">> => one_queue},
-             format_items = map}.
+             defaults = #{<<"iqdisc">> => one_queue}}.
 
 -spec supported_features() -> [atom()].
 supported_features() -> [dynamic_domains].

--- a/src/mod_time.erl
+++ b/src/mod_time.erl
@@ -41,8 +41,7 @@ supported_features() ->
 config_spec() ->
     #section{
        items = #{<<"iqdisc">> => mongoose_config_spec:iqdisc()},
-       defaults = #{<<"iqdisc">> => one_queue},
-       format_items = map
+       defaults = #{<<"iqdisc">> => one_queue}
     }.
 
 process_local_iq(Acc, _From, _To, #iq{type = set, sub_el = SubEl} = IQ, _Extra) ->

--- a/src/mod_version.erl
+++ b/src/mod_version.erl
@@ -36,8 +36,7 @@ config_spec() ->
                  <<"os_info">> => #option{type = boolean}
                 },
        defaults = #{<<"iqdisc">> => no_queue,
-                    <<"os_info">> => false},
-       format_items = map
+                    <<"os_info">> => false}
       }.
 
 -spec process_iq(mongoose_acc:t(), jid:jid(), jid:jid(), jlib:iq(), any()) ->

--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -75,8 +75,7 @@ config_spec() ->
                                                         validate = positive},
                        <<"service">> => mongoose_config_spec:xmpp_listener_extra(service)},
              defaults = #{<<"timeout">> => 60000,
-                          <<"max_stanza_size">> => infinity},
-             format_items = map
+                          <<"max_stanza_size">> => infinity}
             }.
 
 %%--------------------------------------------------------------------

--- a/src/mongoose_api.erl
+++ b/src/mongoose_api.erl
@@ -69,8 +69,7 @@ config_spec() ->
                                                                validate = {enum, HandlerModules}},
                                                validate = unique_non_empty}
                       },
-             defaults = #{<<"handlers">> => HandlerModules},
-             format_items = map}.
+             defaults = #{<<"handlers">> => HandlerModules}}.
 
 -spec routes(handler_options()) -> mongoose_http_handler:routes().
 routes(#{path := BasePath, handlers := HandlerModules}) ->

--- a/src/mongoose_api_admin.erl
+++ b/src/mongoose_api_admin.erl
@@ -58,7 +58,6 @@
 config_spec() ->
     #section{items = #{<<"username">> => #option{type = binary},
                        <<"password">> => #option{type = binary}},
-             format_items = map,
              process = fun ?MODULE:process_config/1}.
 
 -spec process_config(handler_options()) -> handler_options().

--- a/src/mongoose_client_api/mongoose_client_api.erl
+++ b/src/mongoose_client_api/mongoose_client_api.erl
@@ -36,8 +36,7 @@ config_spec() ->
                                                validate = unique},
                        <<"docs">> => #option{type = boolean}},
              defaults = #{<<"handlers">> => HandlerModules,
-                          <<"docs">> => true},
-             format_items = map}.
+                          <<"docs">> => true}}.
 
 -spec routes(handler_options()) -> mongoose_http_handler:routes().
 routes(Opts = #{path := BasePath}) ->

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -31,7 +31,7 @@ config_spec() ->
                             || Module <- configurable_handler_modules()]),
     #section{items = Items#{default => #list{items = common_handler_config_spec(),
                                              wrap = none}},
-             format_items = none,
+             format_items = list,
              validate_keys = module,
              include = always}.
 

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -31,6 +31,7 @@ config_spec() ->
                             || Module <- configurable_handler_modules()]),
     #section{items = Items#{default => #list{items = common_handler_config_spec(),
                                              wrap = none}},
+             format_items = none,
              validate_keys = module,
              include = always}.
 
@@ -46,7 +47,6 @@ common_handler_config_spec() ->
                        <<"path">> => #option{type = string}
                       },
              required = [<<"host">>, <<"path">>],
-             format_items = map,
              process = fun ?MODULE:process_config/2}.
 
 process_config([item, HandlerType | _], Opts) ->

--- a/src/mongoose_ldap_config.erl
+++ b/src/mongoose_ldap_config.erl
@@ -23,8 +23,7 @@ spec() ->
                   <<"filter">> => #option{type = binary}},
         defaults = #{<<"pool_tag">> => default,
                      <<"deref">> => never,
-                     <<"filter">> => <<>>},
-        format_items = map
+                     <<"filter">> => <<>>}
     }.
 
 uids() ->
@@ -32,8 +31,7 @@ uids() ->
        items = #{<<"attr">> => #option{type = binary},
                  <<"format">> => #option{type = binary}},
        process = fun ?MODULE:process_uids/1,
-       required = [<<"attr">>],
-       format_items = map
+       required = [<<"attr">>]
       }.
 
 dn_filter() ->
@@ -44,8 +42,7 @@ dn_filter() ->
                 },
        required = [<<"filter">>],
        defaults = #{<<"attributes">> => []},
-       process = fun ?MODULE:process_dn_filter/1,
-       format_items = map
+       process = fun ?MODULE:process_dn_filter/1
       }.
 
 local_filter() ->
@@ -58,8 +55,7 @@ local_filter() ->
                                        validate = non_empty}
                 },
        required = all,
-       process = fun ?MODULE:process_local_filter/1,
-       format_items = map
+       process = fun ?MODULE:process_local_filter/1
       }.
 
 process_uids(#{attr := Attr, format := Format}) -> {Attr, Format};

--- a/src/mongoose_user_cache.erl
+++ b/src/mongoose_user_cache.erl
@@ -45,8 +45,7 @@ config_spec() ->
        defaults = #{<<"module">> => internal,
                     <<"strategy">> => fifo,
                     <<"time_to_live">> => 480,
-                    <<"number_of_segments">> => 3},
-       format_items = map
+                    <<"number_of_segments">> => 3}
       }.
 
 %% If an external module is provided, disallow any other configuration key

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -244,8 +244,7 @@ config_spec() ->
                     <<"max_occupants">> => ?DEFAULT_MAX_OCCUPANTS,
                     <<"rooms_per_page">> => ?DEFAULT_ROOMS_PER_PAGE,
                     <<"rooms_in_rosters">> => ?DEFAULT_ROOMS_IN_ROSTERS,
-                    <<"config_schema">> => default_schema()},
-       format_items = map
+                    <<"config_schema">> => default_schema()}
       }.
 
 config_schema_spec() ->
@@ -258,8 +257,7 @@ config_schema_spec() ->
                  <<"internal_key">> => #option{type = atom,
                                                validate = non_empty}
                 },
-       required = [<<"field">>],
-       format_items = map
+       required = [<<"field">>]
       }.
 
 -spec process_config_schema([map()]) -> mod_muc_light_room_config:schema().

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -132,18 +132,14 @@ config_spec() ->
                      <<"store_groupchat_messages">> => false,
                      <<"backend">> => mnesia
                     },
-        format_items = map,
-        process = fun ?MODULE:remove_unused_backend_opts/1
-        }.
+        process = fun ?MODULE:remove_unused_backend_opts/1}.
 
 riak_config_spec() ->
     #section{
         items = #{<<"bucket_type">> => #option{type = binary,
                                                validate = non_empty}},
         defaults = #{<<"bucket_type">> => <<"offline">>},
-        format_items = map,
-        include = always
-        }.
+        include = always}.
 
 -spec remove_unused_backend_opts(gen_mod:module_opts()) -> gen_mod:module_opts().
 remove_unused_backend_opts(Opts = #{backend := riak}) -> Opts;

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -101,8 +101,7 @@ config_spec() ->
                  },
         defaults = #{<<"store_groupchat_messages">> => false,
                      <<"backend">> => rdbms
-                    },
-        format_items = map
+                    }
         }.
 
 remove_user(Acc, User, Server) ->

--- a/src/privacy/mod_privacy.erl
+++ b/src/privacy/mod_privacy.erl
@@ -85,7 +85,6 @@ config_spec() ->
                                           validate = {module, mod_privacy}},
                  <<"riak">> => riak_config_spec()},
        defaults = #{<<"backend">> => mnesia},
-       format_items = map,
        process = fun ?MODULE:remove_unused_backend_opts/1
       }.
 
@@ -101,7 +100,6 @@ riak_config_spec() ->
        defaults = #{<<"defaults_bucket_type">> => <<"privacy_defaults">>,
                     <<"names_bucket_type">> => <<"privacy_lists_names">>,
                     <<"bucket_type">> => <<"privacy_lists">>},
-       format_items = map,
        include = always
       }.
 

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -301,8 +301,7 @@ config_spec() ->
                     <<"pep_mapping">> => #{},
                     <<"default_node_config">> => [],
                     <<"item_publisher">> => false,
-                    <<"sync_broadcast">> => false},
-       format_items = map
+                    <<"sync_broadcast">> => false}
       }.
 
 pep_mapping_config_spec() ->
@@ -312,7 +311,6 @@ pep_mapping_config_spec() ->
                  <<"node">> => #option{type = binary,
                                        validate = non_empty}},
        required = all,
-       format_items = map,
        process = fun ?MODULE:process_pep_mapping/1
       }.
 
@@ -343,7 +341,8 @@ default_node_config_spec() ->
                  <<"send_last_published_item">> => #option{type = atom,
                                                            validate = non_empty},
                  <<"subscribe">> => #option{type = boolean}
-                }
+                },
+       format_items = none
       }.
 
 process_pep_mapping(#{namespace := NameSpace, node := Node}) ->

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -342,7 +342,7 @@ default_node_config_spec() ->
                                                            validate = non_empty},
                  <<"subscribe">> => #option{type = boolean}
                 },
-       format_items = none
+       format_items = list
       }.
 
 process_pep_mapping(#{namespace := NameSpace, node := Node}) ->

--- a/src/smart_markers/mod_smart_markers.erl
+++ b/src/smart_markers/mod_smart_markers.erl
@@ -120,15 +120,13 @@ config_spec() ->
                  <<"iqdisc">> => mongoose_config_spec:iqdisc()},
        defaults = #{<<"keep_private">> => false,
                     <<"backend">> => rdbms,
-                    <<"iqdisc">> => no_queue},
-       format_items = map
+                    <<"iqdisc">> => no_queue}
     }.
 
 async_config_spec() ->
     #section{
        items = #{<<"pool_size">> => #option{type = integer, validate = non_negative}},
        defaults = #{<<"pool_size">> => 2 * erlang:system_info(schedulers_online)},
-       format_items = map,
        include = always
       }.
 

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -77,7 +77,6 @@ config_spec() ->
                   <<"stale_h">> => stale_h_config_spec()
                  },
         process = fun ?MODULE:process_buffer_and_ack/1,
-        format_items = map,
         defaults = #{<<"backend">> => mnesia,
                      <<"buffer">> => true,
                      <<"buffer_max">> => 100,
@@ -110,7 +109,6 @@ stale_h_config_spec() ->
                                                 validate = positive},
                   <<"geriatric">> => #option{type = integer,
                                              validate = positive}},
-        format_items = map,
         include = always,
         defaults = #{<<"enabled">> => false,
                      <<"repeat_after">> => 1800, % seconds

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -72,8 +72,7 @@ config_spec() ->
                                               validate = non_empty}
                 },
        defaults = #{<<"initial_report">> => timer:minutes(5),
-                    <<"periodic_report">> => timer:hours(3)},
-       format_items = map
+                    <<"periodic_report">> => timer:hours(3)}
       }.
 
 -spec start_link(mongoose_service:options()) -> {ok, pid()}.

--- a/src/vcard/mod_vcard.erl
+++ b/src/vcard/mod_vcard.erl
@@ -230,7 +230,6 @@ config_spec() ->
                     <<"backend">> => mnesia,
                     <<"matches">> => 30
        },
-       format_items = map,
        process = fun remove_unused_backend_opts/1
       }.
 
@@ -298,24 +297,17 @@ riak_config_spec() ->
                                                 validate = non_empty}
                 },
         include = always,
-        format_items = map,
         defaults = #{<<"bucket_type">> => <<"vcard">>,
                      <<"search_index">> => <<"vcard">>}
     }.
 
-process_map_spec(KVs) ->
-    {[[{vcard_field, VF}], [{ldap_pattern, LP}], [{ldap_field, LF}]], []} =
-        proplists:split(KVs, [vcard_field, ldap_pattern, ldap_field]),
+process_map_spec(#{vcard_field := VF, ldap_pattern := LP, ldap_field := LF}) ->
     {VF, LP, [LF]}.
 
-process_search_spec(KVs) ->
-    {[[{search_field, SF}], [{ldap_field, LF}]], []} =
-        proplists:split(KVs, [search_field, ldap_field]),
+process_search_spec(#{search_field := SF, ldap_field := LF}) ->
     {SF, LF}.
 
-process_search_reported_spec(KVs) ->
-    {[[{search_field, SF}], [{vcard_field, VF}]], []} =
-        proplists:split(KVs, [search_field, vcard_field]),
+process_search_reported_spec(#{search_field := SF, vcard_field := VF}) ->
     {SF, VF}.
 
 remove_unused_backend_opts(Opts = #{backend := riak}) -> maps:remove(ldap, Opts);


### PR DESCRIPTION
Clean up item formatting:
- For sections, use `format_items = map` by default.
- For lists, use `format_items = list` by default.

Remove explicit `format_items = map` for all sections.
For sections that are formatted as lists, use `format_items = list`. Trivial cases are converted to maps in this PR.