### PR TITLE
Access commands in maps

### DIFF
--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -253,9 +253,6 @@ wrap(_Path, V, item) ->
     [V];
 wrap(_Path, _V, remove) ->
     [];
-wrap([Key|_], V, prepend_key) ->
-    L = [b2a(Key) | tuple_to_list(V)],
-    [list_to_tuple(L)];
 wrap(_Path, V, none) when is_list(V) ->
     V.
 

--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -218,9 +218,8 @@ process(Args) ->
     Code.
 
 
--spec process2(Args :: [string()],
-               AccessCommands :: [ejabberd_commands:access_cmd()]
-               ) -> {String::string(), Code::integer()}.
+-spec process2(Args :: [string()],  AccessCommands :: ejabberd_commands:access_commands()) ->
+          {String::string(), Code::integer()}.
 process2(["--auth", User, Server, Pass | Args], AccessCommands) ->
     process2(Args, {list_to_binary(User), list_to_binary(Server), list_to_binary(Pass)},
              AccessCommands);
@@ -245,7 +244,7 @@ process2(Args, Auth, AccessCommands) ->
     end.
 
 
--spec get_accesscommands() -> [char() | tuple()].
+-spec get_accesscommands() -> ejabberd_commands:access_commands().
 get_accesscommands() ->
     mongoose_config:get_opt(mongooseimctl_access_commands).
 
@@ -256,7 +255,7 @@ get_accesscommands() ->
 
 -spec try_run_ctp(Args :: [string()],
                   Auth :: ejabberd_commands:auth(),
-                  AccessCommands :: [ejabberd_commands:access_cmd()]
+                  AccessCommands :: ejabberd_commands:access_commands()
                  ) -> string() | integer() | {string(), integer()} | {string(), wrong_command_arguments}.
 try_run_ctp(Args, Auth, AccessCommands) ->
     try mongoose_hooks:ejabberd_ctl_process(false, Args) of
@@ -281,7 +280,7 @@ try_run_ctp(Args, Auth, AccessCommands) ->
 
 -spec try_call_command(Args :: [string()],
                        Auth :: ejabberd_commands:auth(),
-                       AccessCommands :: [ejabberd_commands:access_cmd()]
+                       AccessCommands :: ejabberd_commands:access_commands()
                       ) -> string() | integer() | {string(), integer()} | {string(), wrong_command_arguments}.
 try_call_command(Args, Auth, AccessCommands) ->
     try call_command(Args, Auth, AccessCommands) of
@@ -297,7 +296,7 @@ try_call_command(Args, Auth, AccessCommands) ->
 
 -spec call_command(Args :: [string()],
                    Auth :: ejabberd_commands:auth(),
-                   AccessCommands :: [ejabberd_commands:access_cmd()]
+                   AccessCommands :: ejabberd_commands:access_commands()
                    ) -> string() | integer() | {string(), integer()}
                      | {string(), wrong_command_arguments} | {error, command_unknown}.
 call_command([CmdString | Args], Auth, AccessCommands) ->

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -17,7 +17,7 @@ options("host_types") ->
      {language, <<"en">>},
      {listen, []},
      {loglevel, warning},
-     {mongooseimctl_access_commands, []},
+     {mongooseimctl_access_commands, #{}},
      {outgoing_pools, []},
      {rdbms_server_type, generic},
      {registration_timeout, 600},
@@ -78,7 +78,8 @@ options("miscellaneous") ->
                })]},
      {loglevel, warning},
      {mongooseimctl_access_commands,
-      [{local, ["join_cluster"], [{node, "mongooseim@prime"}]}]},
+      #{local => #{commands => [join_cluster],
+                   argument_restrictions => #{node => "mongooseim@prime"}}}},
      {outgoing_pools, []},
      {rdbms_server_type, mssql},
      {registration_timeout, 600},
@@ -109,7 +110,7 @@ options("modules") ->
      {language, <<"en">>},
      {listen, []},
      {loglevel, warning},
-     {mongooseimctl_access_commands, []},
+     {mongooseimctl_access_commands, #{}},
      {outgoing_pools, []},
      {rdbms_server_type, generic},
      {registration_timeout, 600},
@@ -240,7 +241,7 @@ options("mongooseim-pgsql") ->
       ]},
      {loglevel, warning},
      {max_fsm_queue, 1000},
-     {mongooseimctl_access_commands, []},
+     {mongooseimctl_access_commands, #{}},
      {outgoing_pools,
       lists:map(
         fun pool_config/1,
@@ -318,7 +319,7 @@ options("outgoing_pools") ->
      {language, <<"en">>},
      {listen, []},
      {loglevel, warning},
-     {mongooseimctl_access_commands, []},
+     {mongooseimctl_access_commands, #{}},
      {outgoing_pools,
       lists:map(
         fun pool_config/1,
@@ -389,7 +390,7 @@ options("s2s_only") ->
      {language, <<"en">>},
      {listen, []},
      {loglevel, warning},
-     {mongooseimctl_access_commands, []},
+     {mongooseimctl_access_commands, #{}},
      {outgoing_pools, []},
      {rdbms_server_type, generic},
      {registration_timeout, 600},
@@ -1072,6 +1073,8 @@ extra_service_listener_config() ->
       hidden_components => false,
       conflict_behaviour => disconnect}.
 
+default_config([general, mongooseimctl_access_commands, _Key]) ->
+    #{commands => all, argument_restrictions => #{}};
 default_config([listen, http]) ->
     (common_listener_config())#{module => ejabberd_cowboy,
                                 transport => default_config([listen, http, transport]),

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -408,26 +408,17 @@ route_subdomains(_Config) ->
     ?errh(#{<<"general">> => #{<<"route_subdomains">> => <<"c2s">>}}).
 
 mongooseimctl_access_commands(_Config) ->
-    ?cfg(mongooseimctl_access_commands, [], #{}), % default
-    AccessRule = #{<<"commands">> => [<<"join_cluster">>],
-                   <<"argument_restrictions">> => #{<<"node">> => <<"mim1@host1">>}},
-    ?cfg(mongooseimctl_access_commands, [{local, ["join_cluster"], [{node, "mim1@host1"}]}],
-         #{<<"general">> => #{<<"mongooseimctl_access_commands">> =>
-                                  #{<<"local">> => AccessRule}}}),
-    ?cfg(mongooseimctl_access_commands, [{local, all, [{node, "mim1@host1"}]}],
-         #{<<"general">> => #{<<"mongooseimctl_access_commands">> =>
-                                  #{<<"local">> => maps:remove(<<"commands">>, AccessRule)}}}),
-    ?cfg(mongooseimctl_access_commands, [{local, ["join_cluster"], []}],
-         #{<<"general">> => #{<<"mongooseimctl_access_commands">> =>
-                                  #{<<"local">> => maps:remove(<<"argument_restrictions">>,
-                                                               AccessRule)}}}),
-    ?cfg(mongooseimctl_access_commands, [{local, all, []}],
-         #{<<"general">> => #{<<"mongooseimctl_access_commands">> => #{<<"local">> => #{}}}}),
-    ?err(#{<<"general">> => #{<<"mongooseimctl_access_commands">> =>
-                                  #{<<"local">> => #{<<"commands">> => <<"all">>}}}}),
-    ?err(#{<<"general">> => #{<<"mongooseimctl_access_commands">> =>
-                                  #{<<"local">> => #{<<"argument_restrictions">> =>
-                                                         [<<"none">>]}}}}).
+    ?cfg(mongooseimctl_access_commands, #{}, #{}), % default
+    P = [mongooseimctl_access_commands, local],
+    T = fun(Opts) ->
+                #{<<"general">> => #{<<"mongooseimctl_access_commands">> => #{<<"local">> => Opts}}}
+        end,
+    ?cfg(P, default_config([general, mongooseimctl_access_commands, local]), T(#{})),
+    ?cfg(P ++ [commands], [join_cluster], T(#{<<"commands">> => [<<"join_cluster">>]})),
+    ?cfg(P ++ [argument_restrictions], #{node => "mim1@host1"},
+         T(#{<<"argument_restrictions">> => #{<<"node">> => <<"mim1@host1">>}})),
+    ?err(T(#{<<"commands">> => [<<>>]})),
+    ?err(T(#{<<"argument_restrictions">> => #{<<"node">> => 1}})).
 
 routing_modules(_Config) ->
     ?cfg(routing_modules, mongoose_router:default_routing_modules(), #{}), % default

--- a/test/mongoose_config_SUITE.erl
+++ b/test/mongoose_config_SUITE.erl
@@ -180,7 +180,7 @@ minimal_config_opts() ->
      {language, <<"en">>},
      {listen, []},
      {loglevel, warning},
-     {mongooseimctl_access_commands, []},
+     {mongooseimctl_access_commands, #{}},
      {outgoing_pools, []},
      {rdbms_server_type, generic},
      {registration_timeout, 600},


### PR DESCRIPTION
Convert the configuration of command access rules to use maps with defaults.

This allows to remove the temporary `prepend_key` wrapper.

