### PR TITLE
Use OTP 24.3.4 for CircleCI

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  - &OTP24 cimg/elixir:1.12.3  # Contains Erlang 24.0.5
+  - &OTP24 chrzaszcz/cimg-erlang:24.3.4
   - &OTP23 cimg/elixir:1.11.4  # Contains Erlang 23.1
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days


### PR DESCRIPTION
The goal is to use the latest OTP 24 for CI tests. Details in commit messages:

- [Use OTP 24.3 for CircleCI](https://github.com/esl/MongooseIM/pull/3661/commits/169c70911a8ab44debb6d54c9709f1c8d2215b38)
- [Get dist metrics using 'tls_sender' to make it work for OTP 24.3.4](https://github.com/esl/MongooseIM/pull/3661/commits/a9ffb2d496b111f794963973b9d12bc054988bf0)


