### PR TITLE
Execute setup workflow for tags as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ references:
 # this allows you to use CircleCI's dynamic configuration feature
 setup: true
 
+filters: &all_tags
+  tags:
+    only: /^\d+\.\d+\.\d+([a-z0-9\-\+])*/
+
 # the continuation orb is required in order to use dynamic configuration
 orbs:
   continuation: circleci/continuation@0.2.0
@@ -56,4 +60,5 @@ commands:
 workflows:
   setup:
     jobs:
-      - setup
+      - setup:
+        filters: *all_tags


### PR DESCRIPTION
> `tags`
CircleCI does not run workflows for tags unless you explicitly specify tag filters. Additionally, if a job requires any other jobs (directly or indirectly), you must specify tag filters for those jobs.

https://circleci.com/docs/2.0/configuration-reference/#tags

This was probably lost when we built the setup stage for CircleCI jobs. Gustaw and I had the same problem a long time ago, I think for 3.6 or so, that we realise that by default CircleCI does not run workflows for tags. I just guess this is the reason again, specially after seeing CircleCI says there's no workflow to run after a setup, without errors:
<img width="669" alt="image" src="https://user-images.githubusercontent.com/27267603/172730125-858f6e6e-50c0-4baf-b007-374490de09b5.png">
