### PR TITLE
Fix the Material color scheme for docs

### DIFF
--- a/doc/css/custom.css
+++ b/doc/css/custom.css
@@ -3,7 +3,7 @@ img#mim-readme-logo {
     margin-bottom: 1em;
 }
 
-:root {
+[data-md-color-scheme] {
   --md-primary-fg-color: #459bb6;
   --md-accent-fg-color: #0554b8;
 }


### PR DESCRIPTION
The scheme needs to appear in the CSS selector for Material 8.3.3

Tested locally with `mkdocs serve`, and the colors are broken before the change, and fixed after the change.

