### PR TITLE
Drop the obsolete notion of option scope from the docs

### DIFF
--- a/doc/authentication-methods/dummy.md
+++ b/doc/authentication-methods/dummy.md
@@ -15,13 +15,11 @@ where `Base` is `base_time` and `Variance` is `variance`, as configured below.
 ## Configuration
 
 ### `auth.dummy.base_time`
-* **Scope:** local
 * **Syntax:** non-negative integer
 * **Default:** 50
 * **Example:** `base_time = 5`
 
 ### `auth.dummy.variance`
-* **Scope:** local
 * **Syntax:** positive integer
 * **Default:** 450
 * **Example:** `variance = 10`

--- a/doc/authentication-methods/rdbms.md
+++ b/doc/authentication-methods/rdbms.md
@@ -7,7 +7,6 @@ This authentication method stores user accounts in a relational database, e.g. M
 The `rdbms` method uses an outgoing connection pool of type `rdbms` with the `default` tag - it has to be defined in the `outgoing_pools` section.
 
 ### `auth.rdbms.users_number_estimate`
-* **Scope:** local
 * **Syntax:** boolean
 * **Default:** false
 * **Example:** `users_number_estimate = true`

--- a/doc/configuration/Services.md
+++ b/doc/configuration/Services.md
@@ -5,7 +5,6 @@ only once with global configuration.
 Currently, three modules are categorised as "service providers".
 Eventually the modules which are not specific for a host type will be refactored to be services.
 
-* **Scope:** global
 * **Syntax:** Each service is specified in its own `services.*` section. 
 * **Default:** None - each service needs to be enabled explicitly.
 Typical services are already specified in the example configuration file.

--- a/doc/configuration/access.md
+++ b/doc/configuration/access.md
@@ -1,6 +1,5 @@
 The `access` section is used to define **access rules** which return specific values for specific access classes.
 
-* **Scope:** global
 * **Syntax:** each access rule is a key-value pair, where:
     * Key is the name of the rule,
     * Value is a TOML array of rule clauses - TOML tables, whose format is described below.

--- a/doc/configuration/acl.md
+++ b/doc/configuration/acl.md
@@ -1,6 +1,5 @@
 The `acl` section is used to define **access classes** to which the connecting users are assigned. These classes are used in [access rules](access.md).
 
-* **Scope:** global
 * **Syntax:** each access class is a key-value pair, where:
     * Key is the name of the access class,
     * Value is a TOML array of patterns - TOML tables, whose format is described below.

--- a/doc/configuration/configuration-files.md
+++ b/doc/configuration/configuration-files.md
@@ -26,14 +26,11 @@ The file is divided into the following sections:
 
 The section names above are links to the detailed documentation of each section.
 
-### Option scope
+!!! Warning
+    It is recommended to use the same configuration file for all nodes in the cluster, but there is no protection against using different option values for each node, because it can happen in two cases:
 
-Each configuration option has its **scope**, which is one of the following:
-
-* **local** - configured separately for each node in the cluster - each node can have a different value,
-* **global** - configured for the entire cluster - all nodes share the same value.
-
-The scope of each option is defined in the documentation above - either at the top of the section page or for each option individually.
+    * During a [rolling upgrade](../../operation-and-maintenance/Rolling-upgrade) procedure, when nodes are restarted one by one with new configuration.
+    * When you need different network-specific parameters (e.g. listening IP addresses) for each node.
 
 ## vm.args
 

--- a/doc/configuration/general.md
+++ b/doc/configuration/general.md
@@ -16,7 +16,6 @@ All options are described below.
 These are the basic settings that you should configure before running your MongooseIM server.
 
 ### `general.loglevel`
-* **Scope:** local
 * **Syntax:** string, one of `"none"`, `"emergency"`, `"alert"`, `"critical"`, `"error"`, `"warning"`, `"notice"`, `"info"`, `"debug"`, `"all"`.
 * **Default:** `"warning"`
 * **Example:** `loglevel = "error"`
@@ -24,7 +23,6 @@ These are the basic settings that you should configure before running your Mongo
 Verbosity level of the logger. Values recommended for production systems are `"error"` and `"warning"`. The `"debug"` level is good for development.
 
 ### `general.hosts`
-* **Scope:** global
 * **Syntax:** array of strings representing the domain names.
 * **Default:** none. If omitted, at least one host type has to be defined in `general.host_types`.
 * **Example:** `hosts = ["localhost", "domain2"]`
@@ -40,7 +38,6 @@ In order to configure these hosts independently, use the [`host_config` section]
     When increasing the number of domains, please make sure you have enough resources available (e.g. connection limit set in the DBMS).
 
 ### `general.host_types`
-* **Scope:** global
 * **Syntax:** array of strings the names for host types.
 * **Default:** none. If omitted, at least one hast has to be defined in `general.hosts`.
 * **Example:** `host_types = ["first type", "second type"]`
@@ -63,7 +60,6 @@ Moreover, [`s2s`](s2s.md) as well as XMPP components (XEP-0114), as configured i
     When increasing the number of host types, please make sure you have enough resources available (e.g. connection limit set in the DBMS).
 
 ### `general.default_server_domain`
-* **Scope:** global
 * **Syntax:** a string
 * **Default:** none, this option is mandatory.
 * **Example:** `default_server_domain = "my-xmpp-domain.com"`
@@ -71,7 +67,6 @@ Moreover, [`s2s`](s2s.md) as well as XMPP components (XEP-0114), as configured i
 This domain is used as a default when one cannot be determined, for example when sending XMPP stream errors to unauthenticated clients.
 
 ### `general.language`
-* **Scope:** global
 * **Syntax:** string representing the two-letter language code.
 * **Default:** `"en"`
 * **Example:** `language = "pl"`
@@ -84,7 +79,6 @@ RDBMS connection pools are set using [outgoing connections configuration](./outg
 There are some additional options that influence all database connections in the server:
 
 ### `general.rdbms_server_type`
-* **Scope:** local
 * **Syntax:** string, `"mssql"` or `"pgsql"`
 * **Default:** not set
 * **Example:** `rdbms_server_type = "mssql"`
@@ -96,7 +90,6 @@ When using MSSQL or PostgreSQL databases, this option allows MongooseIM to optim
 User access rules are configured mainly in the [`acl`](acl.md) and [`access`](access.md) sections. Here you can find some additional options.
 
 ### `general.mongooseimctl_access_commands`
-* **Scope:** local
 * **Syntax:** TOML table, whose **keys** are the names of the access rules defined in the [`access`](access.md) config section and **values** specify allowed administration commands. Each value is a table with the following nested options:
     * `commands`: optional, a list of strings representing the allowed commands. When not specified, all commands are allowed.
     * `argument_restrictions`: optional, a table whose keys are the argument names, and the values are strings representing the allowed values. When not specified, there are no restrictions.
@@ -127,7 +120,6 @@ The `local` rule needs to be defined in the `access` section.
 Here you can find some additional options related to system security.
 
 ### `general.registration_timeout`
-* **Scope:** local
 * **Syntax:** the string `"infinity"` or a number of seconds (positive integer)
 * **Default:** `600`
 * **Example:** `registration_timeout = "infinity"`
@@ -135,7 +127,6 @@ Here you can find some additional options related to system security.
 Limits the registration frequency from a single IP address. The special value `infinity` means no limit.
 
 ### `general.hide_service_name`
-* **Scope:** local
 * **Syntax:** boolean
 * **Default:** `false`
 * **Example:** `hide_service_name = true`
@@ -147,7 +138,6 @@ According to RFC 6210, even when a client sends invalid data after opening a con
 These options can be used to configure the way MongooseIM manages user sessions.
 
 ### `general.sm_backend`
-* **Scope:** global
 * **Syntax:** string, `"mnesia"` or `"redis"`
 * **Default:** `"mnesia"`
 * **Example:** `sm_backend = "redis"`
@@ -157,7 +147,6 @@ Mnesia is sufficient in most cases, use Redis only in large deployments when you
 See the section about [redis connection setup](./outgoing-connections.md#redis-specific-options) for more information.
 
 ### `general.replaced_wait_timeout`
-* **Scope:** local
 * **Syntax:** positive integer, representing time in milliseconds
 * **Default:** `2000`
 * **Example:** `replaced_wait_timeout = 5000`
@@ -169,7 +158,6 @@ When a user's session is replaced (due to a full JID conflict) by a new one, thi
 The following options influence the way MongooseIM routes incoming messages to their recipients.
 
 ### `general.route_subdomains`
-* **Scope:** local
 * **Syntax:** string, the only accepted value is `"s2s"`
 * **Default:** not set
 * **Example:** `route_subdomains = "s2s"`
@@ -177,7 +165,6 @@ The following options influence the way MongooseIM routes incoming messages to t
 If a stanza is addressed to a subdomain of the served domain and this option is set to `s2s`, such a stanza will be transmitted over a server-to-server connection. Without it, MongooseIM will try to route the stanza to one of its internal services.
 
 ### `general.routing_modules`
-* **Scope:** local
 * **Syntax:** a list of strings representing the routing module names.
 * **Default:** `["mongoose_router_global", "mongoose_router_localdomain", "mongoose_router_external_localnode", "mongoose_router_external", "ejabberd_s2s"]`
 * **Example:** `routing_modules = ["mongoose_router_global", "mongoose_router_localdomain"]`
@@ -197,7 +184,6 @@ Allowed module names:
 The options listed below are used to configure more specific settings, that do not need to be changed in usual use cases.
 
 ### `general.all_metrics_are_global`
-* **Scope:** local
 * **Syntax:** boolean
 * **Default:** `false`
 * **Example:** `all_metrics_are_global = true`
@@ -205,7 +191,6 @@ The options listed below are used to configure more specific settings, that do n
 When enabled, all per-host metrics are merged into global equivalents. It means it is no longer possible to view individual host1, host2, host3, ... metrics, only sums are available. This option significantly reduces CPU and (especially) memory footprint in setups with exceptionally many domains (thousands, tens of thousands).
 
 ### `general.http_server_name`
-* **Scope:** local
 * **Syntax:** string
 * **Default:** `"Cowboy"`
 * **Example:** `http_server_name = "Apache"`
@@ -213,7 +198,6 @@ When enabled, all per-host metrics are merged into global equivalents. It means 
 Replaces [Cowboy](https://github.com/ninenines/cowboy)'s default name returned in the `server` HTTP response header. It may be used for extra security, as it makes it harder for the malicious user to learn what HTTP software is running under a specific port. This option applies to **all** configured HTTP listeners.
 
 ### `general.max_fsm_queue`
-* **Scope:** local
 * **Syntax:** positive integer
 * **Default:** not set
 * **Example:** `max_fsm_queue = 5000`
@@ -222,7 +206,6 @@ When specified, will terminate certain processes (e.g. client handlers) that hav
 This option is set for C2S, outgoing S2S and component connections and can be overridden for particular `s2s` or `service` listeners in their configurations. **Use with caution!**
 
 ### `general.domain_certfile`
-* **Scope:** local
 * **Syntax:** array of TOML tables with the following mandatory content:
     * `domain` - string, XMPP domain name. In case of dynamic domains it should be a host type instead.
     * `certfile` - string, path in the file system

--- a/doc/configuration/host_config.md
+++ b/doc/configuration/host_config.md
@@ -1,7 +1,6 @@
 The `host_config` section is used to configure options for specific XMPP domains or for host types, which are used to group multiple domains.
 For each domain or host type requiring such options, a `host_config` section needs to be created with the following format:
 
-* **Scope:** for each option the scope is the same as for the corresponding top-level option.
 * **Syntax:** domain subsection starts with `[[host_config]]` and contains the options listed below.
 * **Default:** none - all domain-level options need to be specified explicitly.
 * **Example:** see the examples for each section below.

--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -1,6 +1,5 @@
 The `listen` section specifies how MongooseIM handles incoming connections.
 
-* **Scope:** local
 * **Syntax:** Each listener is specified in a subsection starting with `[[listen.type]]` where `type` is one of the allowed listener types, handling different types of incoming connections:
 
     * `c2s` - client-to-server XMPP connections,

--- a/doc/configuration/s2s.md
+++ b/doc/configuration/s2s.md
@@ -9,7 +9,6 @@ The `s2s` section contains options configuring the server-to-server connections 
 These options affect both incoming and outgoing S2S connections.
 
 ### `s2s.default_policy`
-* **Scope:** local
 * **Syntax:** string, `"allow"` or `"deny"`
 * **Default:** `"allow"`
 * **Example:** `default_policy = "deny"`
@@ -17,7 +16,6 @@ These options affect both incoming and outgoing S2S connections.
 Default policy for opening new S2S connections to/from remote servers.
 
 ### `s2s.host_policy`
-* **Scope:** local
 * **Syntax:** array of TOML tables with the following mandatory content:
     * `host` - string, host name
     * `policy` - string, `"allow"` or `"deny"`
@@ -34,7 +32,6 @@ Default policy for opening new S2S connections to/from remote servers.
 Policy for opening new connections to/from specific remote servers.
 
 ### `s2s.use_starttls`
-* **Scope:** local
 * **Syntax:** string, one of `"false"`, `"optional"`, `"required"`, `"required_trusted"`
 * **Default:** `"false"`
 * **Example:** `use_starttls = "required"`
@@ -47,7 +44,6 @@ Allows to configure StartTLS for incoming and outgoing S2S connections:
 - `required_trusted` - StartTLS is supported and enforced with certificate verification.
 
 ### `s2s.certfile`
-* **Scope:** local
 * **Syntax:** string, path in the file system
 * **Default:** not set
 * **Example:** `certfile = "cert.pem"`
@@ -55,7 +51,6 @@ Allows to configure StartTLS for incoming and outgoing S2S connections:
 Path to the X509 PEM file with a certificate and a private key inside (not protected by any password). Required if `use_starttls` is not `false`.
 
 ### `s2s.shared`
-* **Scope:** local
 * **Syntax:** string
 * **Default:** 10 strong random bytes, hex-encoded
 * **Example:** `shared = "82gc8b23ct7824"`
@@ -67,7 +62,6 @@ S2S shared secret used in the [Server Dialback](https://xmpp.org/extensions/xep-
 The options listed below affect only the outgoing S2S connections.
 
 ### `s2s.address`
-* **Scope:** local
 * **Syntax:** array of TOML tables with the following content:
     * `host` - string, mandatory, host name
     * `ip_address` - string, mandatory, IP address
@@ -85,7 +79,6 @@ The options listed below affect only the outgoing S2S connections.
 This option defines IP addresses and port numbers for specific non-local XMPP domains, allowing to override the DNS lookup for outgoing S2S connections.
 
 ### `s2s.ciphers`
-* **Scope:** local
 * **Syntax:** string
 * **Default:** `"TLSv1.2:TLSv1.3"`
 * **Example:** `ciphers = "TLSv1.2"`
@@ -94,7 +87,6 @@ Defines a list of accepted SSL ciphers for outgoing S2S connections.
 Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/apps/ciphers.html) for the cipher string format.
 
 ### `s2s.max_retry_delay`
-* **Scope:** local
 * **Syntax:** positive integer
 * **Default:** `300`
 * **Example:** `max_retry_delay = 300`
@@ -102,7 +94,6 @@ Please refer to the [OpenSSL documentation](http://www.openssl.org/docs/apps/cip
 Specifies the maximum time in seconds that MongooseIM will wait until the next attempt to connect to a remote XMPP server. The delays between consecutive attempts will be doubled until this limit is reached.
 
 ### `s2s.outgoing.port`
-* **Scope:** local
 * **Syntax:** integer, port number
 * **Default:** `5269`
 * **Example:** `outgoing.port = 5270`
@@ -110,7 +101,6 @@ Specifies the maximum time in seconds that MongooseIM will wait until the next a
 Defines the port to be used for outgoing S2S connections.
 
 ### `s2s.outgoing.ip_versions`
-* **Scope:** local
 * **Syntax:** array of integers (IP versions): `4` or `6`
 * **Default:** `[4, 6]`
 * **Example:** `outgoing.ip_versions = [6]`
@@ -118,7 +108,6 @@ Defines the port to be used for outgoing S2S connections.
 Specifies the order of IP address families to try when establishing an outgoing S2S connection.
 
 ### `s2s.outgoing.connection_timeout`
-* **Scope:** local
 * **Syntax:** positive integer or the string `"infinity"`
 * **Default:** `10_000`
 * **Example:** `outgoing.connection_timeout = 5000`
@@ -126,7 +115,6 @@ Specifies the order of IP address families to try when establishing an outgoing 
 Timeout (in milliseconds) for establishing an outgoing S2S connection.
 
 ### `s2s.dns.timeout`
-* **Scope:** local
 * **Syntax:** positive integer
 * **Default:** `10`
 * **Example:** `dns.timeout = 30`
@@ -134,7 +122,6 @@ Timeout (in milliseconds) for establishing an outgoing S2S connection.
 Timeout (in seconds) for DNS lookups when opening an outgoing S2S connection.
 
 ### `s2s.dns.retries`
-* **Scope:** local
 * **Syntax:** positive integer
 * **Default:** `2`
 * **Example:** `dns.retries = 1`

--- a/doc/configuration/shaper.md
+++ b/doc/configuration/shaper.md
@@ -1,6 +1,5 @@
 The `shaper` section specifies **traffic shapers** used to limit the incoming XMPP traffic, providing a safety valve to protect the server. It can be used to prevent DoS attacks or to calm down too noisy clients.
 
-* **Scope:** global
 * **Syntax:** each shaper is specified in a subsection starting with `[shaper.name]` where `name` is used to uniquely identify the shaper.
 * **Default:** no default - each shaper needs to be specified explicitly.
 * **Example:** the `normal` shaper is used for the C2S connections.


### PR DESCRIPTION
Now all options are set per node.
There are no clustered options anymore.