### PR TITLE
Enable dialyzer for both OTP 24 and OTP 25

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -695,7 +695,14 @@ workflows:
           build_prod: false
       # ============= DIALYZER =============
       - dialyzer:
-          name: dialyzer
+          name: dialyzer_24
+          executor: otp_24
+          context: mongooseim-org
+          requires:
+            - otp_24_docker
+          filters: *all_tags
+      - dialyzer:
+          name: dialyzer_25
           executor: otp_25
           context: mongooseim-org
           requires:
@@ -860,6 +867,7 @@ workflows:
             - pgsql_mnesia_24
             - riak_mnesia_24
             - dynamic_domains_pgsql_mnesia_24
+            - dialyzer_24
 
             - small_tests_25
             - internal_mnesia_25
@@ -871,8 +879,8 @@ workflows:
             - dynamic_domains_pgsql_mnesia_25
             - dynamic_domains_mysql_redis_25
             - dynamic_domains_mssql_mnesia_25
+            - dialyzer_25
 
-            - dialyzer
             - xref
             - edoc
           filters: *all_tags

--- a/src/async_pools/mongoose_aggregator_worker.erl
+++ b/src/async_pools/mongoose_aggregator_worker.erl
@@ -21,7 +21,7 @@
                     mongoose_async_pools:pool_extra()) ->
     {ok, mongoose_async_pools:task()} | {error, term()}.
 -callback request(mongoose_async_pools:task(), mongoose_async_pools:pool_extra()) ->
-    reference().
+    gen_server:request_id().
 -callback verify(term(), mongoose_async_pools:task(), mongoose_async_pools:pool_extra()) ->
     term().
 -optional_callbacks([verify/3]).


### PR DESCRIPTION
There are some dialyzer errors caught only on OTP 24, and not on OTP 25, because e.g. some types have changed. We support both, so let's run Dialyzer checks for both.

One type spec fixed to make it pass on OTP 24.
