### PR TITLE
Use a different issue for collecting error comments

### DIFF
--- a/tools/circle-publish-github-summary-comment.sh
+++ b/tools/circle-publish-github-summary-comment.sh
@@ -28,7 +28,7 @@ function post_new_comment
         -H "Authorization: token $COMMENTER_GITHUB_TOKEN" \
         -H "Content-Type: application/json" \
         -X POST -d "$POST_BODY" \
-        https://api.github.com/repos/$REPO_SLUG/issues/3360/comments
+        https://api.github.com/repos/$REPO_SLUG/issues/3685/comments
 }
 
 BODY=$(make_body)


### PR DESCRIPTION
This PR addresses "No more space for comments, reached 2500".


Proposed changes include:
* Post comments there instead https://github.com/esl/MongooseIM/issues/3685