### PR TITLE
Mongoose acc pipelining

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -3311,8 +3311,8 @@ element_to_origin_accum(El, StateData = #state{sid = SID, jid = JID}) ->
         _ToBin -> BaseParams
     end,
     Acc = new_acc(StateData, Params),
-    Acc1 = mongoose_acc:set_permanent(c2s, origin_sid, SID, Acc),
-    mongoose_acc:set_permanent(c2s, origin_jid, JID, Acc1).
+    C2S = [{origin_sid, SID}, {origin_jid, JID}],
+    mongoose_acc:set_permanent(c2s, C2S, Acc).
 
 -spec hibernate() -> hibernate | infinity.
 hibernate() ->

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -213,11 +213,10 @@ set(NS, K, V, #{ mongoose_acc := true } = Acc) ->
     Acc#{ {NS, K} => V }.
 
 -spec set(Namespace :: any(), [{K :: any(), V :: any()}], Acc :: t()) -> t().
-set(_, [], Acc) ->
-    Acc;
-set(NS, [{K, V} | T], Acc) ->
-    NewAcc = set(NS, K, V, Acc),
-    set(NS, T, NewAcc).
+set(NS, KVs, #{ mongoose_acc := true } = Acc) ->
+    NSKVs = [ {{NS, K}, V} || {K, V} <- KVs ],
+    Input = maps:from_list(NSKVs),
+    maps:merge(Acc, Input).
 
 %% .. while these are not.
 -spec set_permanent(Namespace :: any(), K :: any(), V :: any(), Acc :: t()) -> t().

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -279,11 +279,10 @@ delete(NS, K, #{ mongoose_acc := true, non_strippable := NonStrippable } = Acc0)
     Acc1#{ non_strippable => lists:delete(Key, NonStrippable) }.
 
 -spec delete_many(Namespace :: any(), [K :: any()], Acc :: t()) -> t().
-delete_many(_, [], Acc) ->
-    Acc;
-delete_many(NS, [K | T], Acc) ->
-    NewAcc = delete(NS, K, Acc),
-    delete_many(NS, T, NewAcc).
+delete_many(NS, Keys, #{ mongoose_acc := true, non_strippable := NonStrippable } = Acc0) ->
+    KVs = [{NS, K} || K <- Keys],
+    Acc1 = maps:without(KVs, Acc0),
+    Acc1#{ non_strippable := lists:subtract(NonStrippable, KVs) }.
 
 -spec delete(Namespace :: any(), Acc :: t()) -> t().
 delete(NS, Acc) ->

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -54,7 +54,7 @@
 % Strip with or without stanza replacement
 -export([strip/1, strip/2]).
 
--ignore_xref([delete/2, ref/1, set/3]).
+-ignore_xref([delete/2, ref/1]).
 
 %% Note about 'undefined' to_jid and from_jid: these are the special cases when JID may be
 %% truly unknown: before a client is authorized.

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -229,7 +229,7 @@ set(NSKVs, #{ mongoose_acc := true } = Acc) ->
 set_permanent(NS, K, V, #{ mongoose_acc := true, non_strippable := NonStrippable } = Acc) ->
     Key = {NS, K},
     NewNonStrippable = [Key | lists:delete(Key, NonStrippable)],
-    Acc#{ Key => V, non_strippable => NewNonStrippable }.
+    Acc#{ Key => V, non_strippable := NewNonStrippable }.
 
 -spec set_permanent(Namespace :: any(), [{K :: any(), V :: any()}], Acc :: t()) -> t().
 set_permanent(NS, KVs, #{mongoose_acc := true, non_strippable := NonStrippable} = Acc) ->
@@ -276,7 +276,7 @@ get(NS, K, Default, #{ mongoose_acc := true } = Acc) ->
 delete(NS, K, #{ mongoose_acc := true, non_strippable := NonStrippable } = Acc0) ->
     Key = {NS, K},
     Acc1 = maps:remove(Key, Acc0),
-    Acc1#{ non_strippable => lists:delete(Key, NonStrippable) }.
+    Acc1#{ non_strippable := lists:delete(Key, NonStrippable) }.
 
 -spec delete_many(Namespace :: any(), [K :: any()], Acc :: t()) -> t().
 delete_many(NS, Keys, #{ mongoose_acc := true, non_strippable := NonStrippable } = Acc0) ->

--- a/src/mongoose_iq.erl
+++ b/src/mongoose_iq.erl
@@ -49,16 +49,14 @@ update_acc_info(Acc0) ->
         CurrentRef ->
             El = mongoose_acc:element(Acc0),
             IQ = jlib:iq_query_or_response_info(El),
-            Acc1 = mongoose_acc:set(iq, record, IQ, Acc0),
             {XMLNS, Command} = case IQ of
                                    #iq{ xmlns = XMLNS0, sub_el = SubEl } ->
                                        {XMLNS0, sub_el_to_command(SubEl)};
                                    _ ->
                                        {undefined, undefined}
                                end,
-            Acc2 = mongoose_acc:set(iq, xmlns, XMLNS, Acc1),
-            Acc3 = mongoose_acc:set(iq, command, Command, Acc2),
-            mongoose_acc:set(iq, ref, CurrentRef, Acc3)
+            IqData = [{record, IQ}, {xmlns, XMLNS}, {command, Command}, {ref, CurrentRef}],
+            mongoose_acc:set(iq, IqData, Acc0)
     end.
 
 %% update_and_get updates only when it is actually necessary


### PR DESCRIPTION
A few tiny optimisations to setting fields in the accumulator, together with places where they can be used, and some microbenchmarkings below. The main optimisation is on generating less garbage to collect later, mainly intermediate maps: adding a key to a map creates a new map that copies lots of parts from the previous, and so adding a list of keys one by one copies the map every time.

Instead, putting all new keys on a map using maps:from_list, and then doing maps:merge, generates no intermediate mongoose_acc map only the temporary map with the new keys, regardless of the number of entries being inserted. Then the resulting map after the merge is the final mongoose_acc.

```
Compiling 1 file (.erl)
Operating System: Linux
CPU Information: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
Number of Available Cores: 12
Available memory: 30.98 GB
Elixir 1.13.4
Erlang 25.0.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 5 s
reduction time: 0 ns
parallel: 12
inputs: macc
Estimated total run time: 24 s

Benchmarking p_set_n with input macc ...
Benchmarking p_set with input macc ...

##### With input macc #####
Name           ips        average  deviation         median         99th %
p_set_n    608.75 K        1.64 μs  ±2525.21%        1.36 μs        1.98 μs
p_set      498.05 K        2.01 μs  ±1968.16%        1.64 μs        2.41 μs

Comparison:
p_set_n    608.75 K
p_set      498.05 K - 1.22x slower +0.37 μs

Memory usage statistics:

Name    Memory usage
p_set_n       0.68 KB
p_set         1.10 KB - 1.62x memory usage +0.42 KB


##### With input macc #####
Name            ips        average  deviation         median         99th %
set_n      922.05 K        1.08 μs  ±3182.45%        0.89 μs        1.12 μs
set        588.95 K        1.70 μs  ±2604.34%        1.44 μs        1.72 μs

Comparison:
set_n      922.05 K
set        588.95 K - 1.57x slower +0.61 μs

Memory usage statistics:

Name     Memory usage
set_n           496 B
set             696 B - 1.40x memory usage +200 B
```