### PR TITLE
Fix invalid clause for case for issue 3690

### DIFF
--- a/src/auth/ejabberd_auth_jwt.erl
+++ b/src/auth/ejabberd_auth_jwt.erl
@@ -100,7 +100,7 @@ authorize(Creds) ->
                      Password :: binary()) -> boolean().
 check_password(HostType, LUser, LServer, Password) ->
     Key = case persistent_term:get({?MODULE, HostType, jwt_secret}) of
-              Key1 when is_binary(Key1) -> Key1;
+              Key1 -> list_to_binary(Key1);
               {env, Var} -> list_to_binary(os:getenv(Var))
           end,
     BinAlg = mongoose_config:get_opt([{auth, HostType}, jwt, algorithm]),


### PR DESCRIPTION

This PR addresses [Issue 3690](https://github.com/esl/MongooseIM/issues/3690) 

Proposed changes include:
Remove `is_binary` for checking string, it will always fail, instead convert to binary. 

