### PR TITLE
Add affiliation change REST API for muc lights

### DIFF
--- a/doc/rest-api/Administration-backend_swagger.yml
+++ b/doc/rest-api/Administration-backend_swagger.yml
@@ -536,6 +536,44 @@ paths:
       responses:
         204:
           description: Message was sent to the MUC Light room
+  /muc-lights/{XMPPMUCHost}/{roomName}/{user}/affiliation:
+    parameters:
+      - $ref: '#/parameters/MUCServer'
+      - $ref: '#/parameters/roomName'
+      - name: user
+        in: path
+        description: User's JID (f.e. alice@wonderland.lit)
+        required: true
+        type: string
+        format: JID
+    put:
+      tags:
+        - "MUC-light management"
+      description: Changes a MUC light member affiliation
+      consumes:
+        - application/json
+      parameters:
+        - name: roomDetails
+          in: body
+          description: Details for the affiliation update
+          required: true
+          schema:
+            title: userDetails
+            type: object
+            properties:
+              target:
+                type: string
+                description: |
+                  The user JID whose affiliation we want to change
+                example: "alice@wonderland.lit"
+              affiliation:
+                type: string
+                description: The new target affiliation
+                enum: ["none", "member", "owner"]
+                example: "none"
+      responses:
+        204:
+          description: The MUC-light room affiliation was updated.
   /muc-lights/{XMPPMUCHost}/{roomName}/{user}/management:
     parameters:
       - $ref: '#/parameters/MUCServer'

--- a/doc/rest-api/Administration-backend_swagger.yml
+++ b/doc/rest-api/Administration-backend_swagger.yml
@@ -553,12 +553,12 @@ paths:
       consumes:
         - application/json
       parameters:
-        - name: roomDetails
+        - name: affiliationDetails
           in: body
           description: Details for the affiliation update
           required: true
           schema:
-            title: userDetails
+            title: affiliationDetails
             type: object
             properties:
               target:

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -156,7 +156,23 @@ commands() ->
        [{domain, binary},
         {name, binary},
         {owner, binary}]},
-      {result, ok}]
+      {result, ok}],
+
+      [{name, change_affiliation},
+        {category, <<"muc-lights">>},
+        {subcategory, <<"affiliation">>},
+        {desc, <<"Changes a MUC light member affiliation">>},
+        {module, ?MODULE},
+        {function, change_affiliation},
+        {action, update},
+        {identifiers, [domain, name, owner]},
+        {args,
+          [{domain, binary},
+            {name, binary},
+            {owner, binary},
+            {target, binary},
+            {affiliation, binary}]},
+        {result, ok}]
     ].
 
 


### PR DESCRIPTION
Muc-light APIs were missing a way to update participants
affiliations. Now this exposes an API to allow just for that.

Swagger documentation was updated.

Tests are missing, unfortunately I'm not really used to Erlang
and Erlang tests
