### PR TITLE
Test GraphQL CLI for accounts

### DIFF
--- a/big_tests/tests/graphql_account_SUITE.erl
+++ b/big_tests/tests/graphql_account_SUITE.erl
@@ -6,7 +6,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
--import(graphql_helper, [execute/3, execute_auth/2, get_listener_port/1,
+-import(graphql_helper, [execute/3, execute_auth/2, execute_command/4, get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_msg/1]).
 
 -define(NOT_EXISTING_JID, <<"unknown987@unknown">>).
@@ -16,17 +16,19 @@ suite() ->
 
 all() ->
     [{group, user_account_handler},
-     {group, admin_account_handler}].
+     {group, admin_account_handler},
+     {group, admin_account_cli}].
 
 groups() ->
-    [{user_account_handler, [parallel], user_account_handler()},
-     {admin_account_handler, [], admin_account_handler()}].
+    [{user_account_handler, [parallel], user_account_tests()},
+     {admin_account_handler, [], admin_account_tests()},
+     {admin_account_cli, [], admin_account_tests()}].
 
-user_account_handler() ->
+user_account_tests() ->
     [user_unregister,
      user_change_password].
 
-admin_account_handler() ->
+admin_account_tests() ->
     [admin_list_users,
      admin_count_users,
      admin_check_password,
@@ -43,27 +45,37 @@ admin_account_handler() ->
 init_per_suite(Config) ->
     Config1 = [{ctl_auth_mods, mongoose_helper:auth_modules()} | Config],
     Config2 = escalus:init_per_suite(Config1),
-    dynamic_modules:save_modules(domain_helper:host_type(), Config2).
+    Config3 = ejabberd_node_utils:init(mim(), Config2),
+    dynamic_modules:save_modules(domain_helper:host_type(), Config3).
 
 end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
 init_per_group(admin_account_handler, Config) ->
-    Config1 = escalus:create_users(Config, escalus:get_users([alice])),
-    graphql_helper:init_admin_handler(Config1);
+    graphql_helper:init_admin_handler(init_users(Config));
+init_per_group(admin_account_cli, Config) ->
+    graphql_helper:init_admin_cli(init_users(Config));
 init_per_group(user_account_handler, Config) ->
     [{schema_endpoint, user} | Config];
 init_per_group(_, Config) ->
     Config.
 
 end_per_group(admin_account_handler, Config) ->
-    escalus_fresh:clean(),
-    escalus:delete_users(Config, escalus:get_users([alice]));
+    clean_users(Config);
+end_per_group(admin_account_cli, Config) ->
+    clean_users(Config);
 end_per_group(user_account_handler, _Config) ->
     escalus_fresh:clean();
 end_per_group(_, _Config) ->
     ok.
+
+init_users(Config) ->
+    escalus:create_users(Config, escalus:get_users([alice])).
+
+clean_users(Config) ->
+    escalus_fresh:clean(),
+    escalus:delete_users(Config, escalus:get_users([alice])).
 
 init_per_testcase(admin_register_user = C, Config) ->
     Config1 = [{user, {<<"gql_admin_registration_test">>, domain_helper:domain()}} | Config],
@@ -110,7 +122,7 @@ user_unregister_story(Config, Alice) ->
     AllUsers = rpc(mim(), mongoose_account_api, list_users, [domain_helper:domain()]),
     LAliceJID = jid:to_binary(jid:to_lower((jid:binary_to_bare(BinJID)))),
     ?assertNot(lists:member(LAliceJID, AllUsers)).
-    
+
 user_change_password(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_change_password_story/2).
 
@@ -128,23 +140,23 @@ user_change_password_story(Config, Alice) ->
 
 admin_list_users(Config) ->
     % An unknown domain
-    Resp = execute_auth(list_users_body(<<"unknown-domain">>), Config),
+    Resp = list_users(<<"unknown-domain">>, Config),
     ?assertEqual([], get_ok_value([data, account, listUsers], Resp)),
     % A domain with users
     Domain = domain_helper:domain(),
     Username = jid:nameprep(escalus_users:get_username(Config, alice)),
     JID = <<Username/binary, "@", Domain/binary>>,
-    Resp2 = execute_auth(list_users_body(Domain), Config),
+    Resp2 = list_users(Domain, Config),
     Users = get_ok_value([data, account, listUsers], Resp2),
     ?assert(lists:member(JID, Users)).
-    
+
 admin_count_users(Config) ->
     % An unknown domain
-    Resp = execute_auth(count_users_body(<<"unknown-domain">>), Config),
+    Resp = count_users(<<"unknown-domain">>, Config),
     ?assertEqual(0, get_ok_value([data, account, countUsers], Resp)),
     % A domain with at least one user
     Domain = domain_helper:domain(),
-    Resp2 = execute_auth(count_users_body(Domain), Config),
+    Resp2 = count_users(Domain, Config),
     ?assert(0 < get_ok_value([data, account, countUsers], Resp2)).
 
 admin_check_password(Config) ->
@@ -152,24 +164,24 @@ admin_check_password(Config) ->
     BinJID = escalus_users:get_jid(Config, alice),
     Path = [data, account, checkPassword],
     % A correct password
-    Resp1 = execute_auth(check_password_body(BinJID, Password), Config),
+    Resp1 = check_password(BinJID, Password, Config),
     ?assertMatch(#{<<"correct">> := true, <<"message">> := _}, get_ok_value(Path, Resp1)),
     % An incorrect password
-    Resp2 = execute_auth(check_password_body(BinJID, <<"incorrect_pw">>), Config),
+    Resp2 = check_password(BinJID, <<"incorrect_pw">>, Config),
     ?assertMatch(#{<<"correct">> := false, <<"message">> := _}, get_ok_value(Path, Resp2)),
     % A non-existing user
-    Resp3 = execute_auth(check_password_body(?NOT_EXISTING_JID, Password), Config),
-    ?assertEqual(null, get_ok_value(Path, Resp3)).
+    Resp3 = check_password(?NOT_EXISTING_JID, Password, Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp3), <<"not exist">>)).
 
 admin_check_password_hash(Config) ->
     UserSCRAM = escalus_users:get_jid(Config, alice),
     EmptyHash = list_to_binary(get_md5(<<>>)),
     Method = <<"md5">>,
     % SCRAM password user
-    Resp1 = execute_auth(check_password_hash_body(UserSCRAM, EmptyHash, Method), Config),
+    Resp1 = check_password_hash(UserSCRAM, EmptyHash, Method, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp1), <<"SCRAM password">>)),
     % A non-existing user
-    Resp2 = execute_auth(check_password_hash_body(?NOT_EXISTING_JID, EmptyHash, Method), Config),
+    Resp2 = check_password_hash(?NOT_EXISTING_JID, EmptyHash, Method, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp2), <<"not exist">>)).
 
 admin_check_plain_password_hash(Config) ->
@@ -180,23 +192,23 @@ admin_check_plain_password_hash(Config) ->
     WrongHash = list_to_binary(get_md5(<<"wrong password">>)),
     Path = [data, account, checkPasswordHash],
     % A correct hash
-    Resp = execute_auth(check_password_hash_body(UserJID, Hash, Method), Config),
+    Resp = check_password_hash(UserJID, Hash, Method, Config),
     ?assertMatch(#{<<"correct">> := true, <<"message">> := _}, get_ok_value(Path, Resp)),
     % An incorrect hash
-    Resp2 = execute_auth(check_password_hash_body(UserJID, WrongHash, Method), Config),
+    Resp2 = check_password_hash(UserJID, WrongHash, Method, Config),
     ?assertMatch(#{<<"correct">> := false, <<"message">> := _}, get_ok_value(Path, Resp2)),
     % A not-supported hash method
-    Resp3 = execute_auth(check_password_hash_body(UserJID, Hash, <<"a">>), Config),
+    Resp3 = check_password_hash(UserJID, Hash, <<"a">>, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp3), <<"not supported">>)).
 
 admin_check_user(Config) ->
     BinJID = escalus_users:get_jid(Config, alice),
     Path = [data, account, checkUser],
     % An existing user
-    Resp1 = execute_auth(check_user_body(BinJID), Config),
+    Resp1 = check_user(BinJID, Config),
     ?assertMatch(#{<<"exist">> := true, <<"message">> := _}, get_ok_value(Path, Resp1)),
     % A non-existing user
-    Resp2 = execute_auth(check_user_body(?NOT_EXISTING_JID), Config),
+    Resp2 = check_user(?NOT_EXISTING_JID, Config),
     ?assertMatch(#{<<"exist">> := false, <<"message">> := _}, get_ok_value(Path, Resp2)).
 
 admin_register_user(Config) ->
@@ -204,10 +216,10 @@ admin_register_user(Config) ->
     {Username, Domain} = proplists:get_value(user, Config),
     Path = [data, account, registerUser, message],
     % Register a new user
-    Resp1 = execute_auth(register_user_body(Domain, Username, Password), Config),
+    Resp1 = register_user(Domain, Username, Password, Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Resp1), <<"successfully registered">>)),
     % Try to register a user with existing name
-    Resp2 = execute_auth(register_user_body(Domain, Username, Password), Config),
+    Resp2 = register_user(Domain, Username, Password, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp2), <<"already registered">>)).
 
 admin_register_random_user(Config) ->
@@ -215,7 +227,7 @@ admin_register_random_user(Config) ->
     Domain = domain_helper:domain(),
     Path = [data, account, registerUser],
     % Register a new user
-    Resp1 = execute_auth(register_user_body(Domain, null, Password), Config),
+    Resp1 = register_random_user(Domain, Password, Config),
     #{<<"message">> := Msg, <<"jid">> := JID} = get_ok_value(Path, Resp1),
     {Username, Server} = jid:to_lus(jid:from_binary(JID)),
 
@@ -223,14 +235,14 @@ admin_register_random_user(Config) ->
     {ok, _} = rpc(mim(), mongoose_account_api, unregister_user, [Username, Server]).
 
 admin_remove_non_existing_user(Config) ->
-    Resp = execute_auth(remove_user_body(?NOT_EXISTING_JID), Config),
+    Resp = remove_user(?NOT_EXISTING_JID, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp), <<"not exist">>)).
 
 admin_remove_existing_user(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
         Path = [data, account, removeUser, message],
         BinJID = escalus_client:full_jid(Alice),
-        Resp4 = execute_auth(remove_user_body(BinJID), Config),
+        Resp4 = remove_user(BinJID, Config),
         ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Resp4),
                                               <<"successfully unregister">>))
     end).
@@ -239,12 +251,12 @@ admin_ban_user(Config) ->
     Path = [data, account, banUser, message],
     Reason = <<"annoying">>,
     % Ban not existing user
-    Resp1 = execute_auth(ban_user_body(?NOT_EXISTING_JID, Reason), Config),
+    Resp1 = ban_user(?NOT_EXISTING_JID, Reason, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp1), <<"not allowed">>)),
     % Ban an existing user
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
         BinJID = escalus_client:full_jid(Alice),
-        Resp2 = execute_auth(ban_user_body(BinJID, Reason), Config),
+        Resp2 = ban_user(BinJID, Reason, Config),
         ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Resp2), <<"successfully banned">>))
     end).
 
@@ -252,15 +264,16 @@ admin_change_user_password(Config) ->
     Path = [data, account, changeUserPassword, message],
     NewPassword = <<"new password">>,
     % Change password of not existing user
-    Resp1 = execute_auth(change_user_password_body(?NOT_EXISTING_JID, NewPassword), Config),
+
+    Resp1 = change_user_password(?NOT_EXISTING_JID, NewPassword, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp1), <<"not allowed">>)),
     % Set an empty password
-    Resp2 = execute_auth(change_user_password_body(?NOT_EXISTING_JID, <<>>), Config),
+    Resp2 = change_user_password(?NOT_EXISTING_JID, <<>>, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp2), <<"Empty password">>)),
     % Change password of an existing user
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
         BinJID = escalus_client:full_jid(Alice),
-        Resp3 = execute_auth(change_user_password_body(BinJID, NewPassword), Config),
+        Resp3 = change_user_password(BinJID, NewPassword, Config),
         ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Resp3), <<"Password changed">>))
     end).
 
@@ -270,70 +283,49 @@ get_md5(AccountPass) ->
     lists:flatten([io_lib:format("~.16B", [X])
                    || X <- binary_to_list(crypto:hash(md5, AccountPass))]).
 
-%% Request bodies
+%% Admin commands
 
-list_users_body(Domain) ->
-    Query = <<"query Q1($domain: String!) { account { listUsers(domain: $domain) } }">>,
-    OpName = <<"Q1">>,
+list_users(Domain, Config) ->
     Vars = #{<<"domain">> => Domain},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"account">>, <<"listUsers">>, Vars, Config).
 
-count_users_body(Domain) ->
-    Query = <<"query Q1($domain: String!) { account { countUsers(domain: $domain) } }">>,
-    OpName = <<"Q1">>,
+count_users(Domain, Config) ->
     Vars = #{<<"domain">> => Domain},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"account">>, <<"countUsers">>, Vars, Config).
 
-check_password_body(User, Password) ->
-    Query = <<"query Q1($user: JID!, $password: String!) 
-              { account { checkPassword(user: $user, password: $password) {correct message} } }">>,
-    OpName = <<"Q1">>,
+check_password(User, Password, Config) ->
     Vars = #{<<"user">> => User, <<"password">> => Password},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"account">>, <<"checkPassword">>, Vars, Config).
 
-check_password_hash_body(User, PasswordHash, HashMethod) ->
-    Query = <<"query Q1($user: JID!, $hash: String!, $method: String!)
-              { account { checkPasswordHash(user: $user, passwordHash: $hash, hashMethod: $method)
-              {correct message} } }">>,
-    OpName = <<"Q1">>,
-    Vars = #{<<"user">> => User, <<"hash">> => PasswordHash, <<"method">> => HashMethod},
-    #{query => Query, operationName => OpName, variables => Vars}.
+check_password_hash(User, PasswordHash, HashMethod, Config) ->
+    Vars = #{<<"user">> => User, <<"passwordHash">> => PasswordHash, <<"hashMethod">> => HashMethod},
+    execute_command(<<"account">>, <<"checkPasswordHash">>, Vars, Config).
 
-check_user_body(User) ->
-    Query = <<"query Q1($user: JID!) 
-              { account { checkUser(user: $user) {exist message} } }">>,
-    OpName = <<"Q1">>,
+check_user(User, Config) ->
     Vars = #{<<"user">> => User},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"account">>, <<"checkUser">>, Vars, Config).
 
-register_user_body(Domain, Username, Password) ->
-    Query = <<"mutation M1($domain: String!, $username: String, $password: String!)
-              { account { registerUser(domain: $domain, username: $username, password: $password) 
-              { jid message } } }">>,
-    OpName = <<"M1">>,
+register_user(Domain, Username, Password, Config) ->
     Vars = #{<<"domain">> => Domain, <<"username">> => Username, <<"password">> => Password},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"account">>, <<"registerUser">>, Vars, Config).
 
-remove_user_body(User) ->
-    Query = <<"mutation M1($user: JID!) 
-              { account { removeUser(user: $user) { jid message } } }">>,
-    OpName = <<"M1">>,
+register_random_user(Domain, Password, Config) ->
+    Vars = #{<<"domain">> => Domain, <<"password">> => Password},
+    execute_command(<<"account">>, <<"registerUser">>, Vars, Config).
+
+remove_user(User, Config) ->
     Vars = #{<<"user">> => User},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"account">>, <<"removeUser">>, Vars, Config).
 
-ban_user_body(JID, Reason) ->
-    Query = <<"mutation M1($user: JID!, $reason: String!) 
-              { account { banUser(user: $user, reason: $reason) { jid message } } }">>,
-    OpName = <<"M1">>,
+ban_user(JID, Reason, Config) ->
     Vars = #{<<"user">> => JID, <<"reason">> => Reason},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"account">>, <<"banUser">>, Vars, Config).
 
-change_user_password_body(JID, NewPassword) ->
-    Query = <<"mutation M1($user: JID!, $newPassword: String!) 
-              { account { changeUserPassword(user: $user, newPassword: $newPassword) { jid message } } }">>,
-    OpName = <<"M1">>,
+change_user_password(JID, NewPassword, Config) ->
     Vars = #{<<"user">> => JID, <<"newPassword">> => NewPassword},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"account">>, <<"changeUserPassword">>, Vars, Config).
+
+%% Request bodies
 
 user_change_password_body(NewPassword) ->
     Query = <<"mutation M1($newPassword: String!)

--- a/big_tests/tests/graphql_account_SUITE.erl
+++ b/big_tests/tests/graphql_account_SUITE.erl
@@ -264,7 +264,6 @@ admin_change_user_password(Config) ->
     Path = [data, account, changeUserPassword, message],
     NewPassword = <<"new password">>,
     % Change password of not existing user
-
     Resp1 = change_user_password(?NOT_EXISTING_JID, NewPassword, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp1), <<"not allowed">>)),
     % Set an empty password

--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -25,7 +25,8 @@ execute_command(Category, Command, Args, Config) ->
     execute_command(Category, Command, Args, Config, Protocol).
 
 execute_command(Category, Command, Args, Config, http) ->
-    {ok, Doc} = rpc(mim(), mongoose_graphql_commands, find_document, [Category, Command]),
+    #{Category := #{Command := #{doc := Doc}}} =
+        rpc(mim(), mongoose_graphql_commands, get_specs, []),
     execute_auth(#{query => Doc, variables => Args}, Config);
 execute_command(Category, Command, Args, Config, cli) ->
     VarsJSON = jiffy:encode(Args),

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -1,37 +1,7 @@
 -module(rest_helper).
 -author("bartekgorny").
 
-%% API
--export([
-    assert_inlist/2,
-    assert_notinlist/2,
-    assert_status/2,
-    decode_maplist/1,
-    gett/2,
-    gett/3,
-    post/3,
-    post/4,
-    putt/3,
-    putt/4,
-    delete/2,
-    delete/3,
-    delete/4,
-    make_request/1,
-    simple_request/2,
-    simple_request/3,
-    simple_request/4,
-    maybe_enable_mam/3,
-    maybe_skip_mam_test_cases/3,
-    fill_archive/2,
-    fill_room_archive/3,
-    make_timestamp/2,
-    change_admin_creds/1,
-    make_msg_stanza_with_props/2,
-    make_malformed_msg_stanza_with_props/2,
-    make_msg_stanza_with_thread_and_parent/4,
-    make_msg_stanza_with_thread/3,
-    make_msg_stanza_without_thread/2
-]).
+-compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0,
                              subhost_pattern/1,

--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -230,7 +230,10 @@ process(Args) ->
 handle_graphql_result({ok, Result}) ->
     JSONResult = mongoose_graphql_response:term_to_pretty_json(Result),
     ?PRINT("~s\n", [JSONResult]),
-    ?STATUS_SUCCESS;
+    case Result of
+        #{errors := _} -> ?STATUS_ERROR;
+        _ -> ?STATUS_SUCCESS
+    end;
 handle_graphql_result({error, Reason}) ->
     {_Code, Error} = mongoose_graphql_errors:format_error(Reason),
     JSONResult = jiffy:encode(#{errors => [Error]}, [pretty]),

--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -179,7 +179,8 @@ process(["mnesia", Arg]) when is_list(Arg) ->
     ?STATUS_SUCCESS;
 process(["graphql", Arg]) when is_list(Arg) ->
     Doc = list_to_binary(Arg),
-    Result = mongoose_graphql_commands:execute(Doc, #{}), % TODO Support vars?
+    Ep = mongoose_graphql:get_endpoint(admin),
+    Result = mongoose_graphql:execute(Ep, undefined, Doc),
     handle_graphql_result(Result);
 process(["graphql" | _]) ->
     ?PRINT("This command requires one string type argument!\n", []),
@@ -213,19 +214,33 @@ process(["help" | Mode]) ->
             print_usage_commands(CmdStringU, MaxC, ShCode),
             ?STATUS_SUCCESS
     end;
-process([CategoryStr, CommandStr, VarsStr] = Args) ->
-    Category = list_to_binary(CategoryStr),
-    Command = list_to_binary(CommandStr),
-    case mongoose_graphql_commands:find_document(Category, Command) of
-        {ok, Doc} ->
-            Vars = jiffy:decode(VarsStr, [return_maps]),
-            Result = mongoose_graphql_commands:execute(Doc, Vars),
-            handle_graphql_result(Result);
-        {error, not_found} ->
-            run_command(Args)
-    end;
 process(Args) ->
-    run_command(Args).
+    case mongoose_graphql_commands:process(Args) of
+        {error, #{reason := Reason}} when Reason =:= no_args;
+                                          Reason =:= unknown_category ->
+            run_command(Args); % Fallback to the old commands
+        {error, #{reason := unknown_command, category := Category, cat_spec := CatSpec,
+                  command := Command}} ->
+            ?PRINT("Unknown command '~s'. Available commands in category '~s':~n",
+                   [Command, Category]),
+            [?PRINT("  ~s~n", [Cmd]) || Cmd <- lists:sort(maps:keys(CatSpec))],
+            ?STATUS_ERROR;
+        {error, #{reason := no_command, category := Category, cat_spec := CatSpec}} ->
+            ?PRINT("No command was specified. Available commands in category '~s':~n", [Category]),
+            [?PRINT("  ~s~n", [Cmd]) || Cmd <- lists:sort(maps:keys(CatSpec))],
+            ?STATUS_ERROR;
+        {error, #{reason := invalid_vars}} ->
+            ?PRINT("Could not parse command variables from JSON~n", []),
+            ?STATUS_ERROR;
+        {error, #{reason := no_vars}} ->
+            ?PRINT("This command requires variables in JSON~n", []),
+            ?STATUS_ERROR;
+        {error, #{reason := too_many_args}} ->
+            ?PRINT("Too many arguments~n", []),
+            ?STATUS_ERROR;
+        Result ->
+            handle_graphql_result(Result)
+    end.
 
 handle_graphql_result({ok, Result}) ->
     JSONResult = mongoose_graphql_response:term_to_pretty_json(Result),


### PR DESCRIPTION
- Reuse the existing test code for the HTTP API - now there is a 'protocol' option per test group, that can be 'http' or 'cli'.
- Test the basic `mongooseimctl` cases, including errors.

The main drawback is that client API tests look different than admin API tests. This could be theoretically solved with precomputing docs for the client (and domain) endpoints as well, but they are not needed on the server side. We can change this later, if needed.

Also: added `export_all` for helpers, as this is convenient and useful when debugging tests, and we do it for other helpers anyway.

To do in separate stories:
- Test other categories.
- Support unions.
- Display more detailed usage information including category list.
- Document.
- Finally: remove redundant commands replaced by the GraphQL ones.

### Example
```
$ _build/mim1/rel/mongooseim/bin/mongooseimctl account
No command was specified. Available commands in category 'account':
  banUser
  changeUserPassword
  checkPassword
  checkPasswordHash
  checkUser
  countUsers
  listUsers
  registerUser
  removeUser

$ _build/mim1/rel/mongooseim/bin/mongooseimctl account listUsers
This command requires variables in JSON

$ _build/mim1/rel/mongooseim/bin/mongooseimctl account listUsers {}
{
  "errors" : [
    {
      "path" : [
        "..",
        "domain"
      ],
      "message" : "The parameter is non-null, but was undefined in parameter list",
      "extensions" : {
        "code" : "missing_non_null_param"
      }
    }
  ]
}

$ _build/mim1/rel/mongooseim/bin/mongooseimctl account listUsers '{"domain":"localhost"}'
{
  "data" : {
    "account" : {
      "listUsers" : [
        
      ]
    }
  }
}
```