### PR TITLE
Support unions in GraphQL CLI

### DIFF
--- a/big_tests/tests/graphql_account_SUITE.erl
+++ b/big_tests/tests/graphql_account_SUITE.erl
@@ -15,13 +15,13 @@ suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
-    [{group, user_account_handler},
-     {group, admin_account_handler},
+    [{group, user_account},
+     {group, admin_account_http},
      {group, admin_account_cli}].
 
 groups() ->
-    [{user_account_handler, [parallel], user_account_tests()},
-     {admin_account_handler, [], admin_account_tests()},
+    [{user_account, [parallel], user_account_tests()},
+     {admin_account_http, [], admin_account_tests()},
      {admin_account_cli, [], admin_account_tests()}].
 
 user_account_tests() ->
@@ -52,20 +52,20 @@ end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-init_per_group(admin_account_handler, Config) ->
+init_per_group(admin_account_http, Config) ->
     graphql_helper:init_admin_handler(init_users(Config));
 init_per_group(admin_account_cli, Config) ->
     graphql_helper:init_admin_cli(init_users(Config));
-init_per_group(user_account_handler, Config) ->
+init_per_group(user_account, Config) ->
     [{schema_endpoint, user} | Config];
 init_per_group(_, Config) ->
     Config.
 
-end_per_group(admin_account_handler, Config) ->
+end_per_group(admin_account_http, Config) ->
     clean_users(Config);
 end_per_group(admin_account_cli, Config) ->
     clean_users(Config);
-end_per_group(user_account_handler, _Config) ->
+end_per_group(user_account, _Config) ->
     escalus_fresh:clean();
 end_per_group(_, _Config) ->
     ok.

--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -112,12 +112,12 @@ assert_response_code(ok, {exit_status, 0}) -> ok;
 assert_response_code(Type, Code) ->
     error(#{what => invalid_response_code, expected_type => Type, response_code => Code}).
 
-skip_null_values(M) when is_map(M) ->
+skip_null_fields(M) when is_map(M) ->
     M1 = maps:filter(fun(_K, V) -> V =/= null end, M),
-    maps:map(fun(_K, V) -> skip_null_values(V) end, M1);
-skip_null_values(L) when is_list(L) ->
-    [skip_null_values(Item) || Item <- L];
-skip_null_values(V) ->
+    maps:map(fun(_K, V) -> skip_null_fields(V) end, M1);
+skip_null_fields(L) when is_list(L) ->
+    [skip_null_fields(Item) || Item <- L];
+skip_null_fields(V) ->
     V.
 
 make_creds(#client{props = Props} = Client) ->

--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -29,7 +29,7 @@ execute_command(Category, Command, Args, Config, http) ->
         rpc(mim(), mongoose_graphql_commands, get_specs, []),
     execute_auth(#{query => Doc, variables => Args}, Config);
 execute_command(Category, Command, Args, Config, cli) ->
-    VarsJSON = jiffy:encode(Args),
+    VarsJSON = iolist_to_binary(jiffy:encode(Args)),
     {Result, Code} = mongooseimctl_helper:mongooseimctl(Category, [Command, VarsJSON], Config),
     {{exit_status, Code}, rest_helper:decode(Result, #{return_maps => true})}.
 
@@ -111,6 +111,14 @@ assert_response_code(error, {exit_status, 1}) -> ok;
 assert_response_code(ok, {exit_status, 0}) -> ok;
 assert_response_code(Type, Code) ->
     error(#{what => invalid_response_code, expected_type => Type, response_code => Code}).
+
+skip_null_values(M) when is_map(M) ->
+    M1 = maps:filter(fun(_K, V) -> V =/= null end, M),
+    maps:map(fun(_K, V) -> skip_null_values(V) end, M1);
+skip_null_values(L) when is_list(L) ->
+    [skip_null_values(Item) || Item <- L];
+skip_null_values(V) ->
+    V.
 
 make_creds(#client{props = Props} = Client) ->
     JID = escalus_utils:jid_to_lower(escalus_client:short_jid(Client)),

--- a/big_tests/tests/graphql_metric_SUITE.erl
+++ b/big_tests/tests/graphql_metric_SUITE.erl
@@ -6,8 +6,8 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [require_rpc_nodes/1, rpc/4]).
--import(graphql_helper, [execute_auth/2, init_admin_handler/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(graphql_helper, [execute_auth/2, execute_command/4, get_ok_value/2]).
 
 suite() ->
     MIM2NodeName = maps:get(node, distributed_helper:mim2()),
@@ -16,19 +16,21 @@ suite() ->
     require_rpc_nodes([mim, mim2]) ++ escalus:suite().
 
 all() ->
-     [{group, metrics}].
+     [{group, metrics_handler},
+      {group, metrics_cli}].
 
 groups() ->
-     [{metrics, [], metrics_handler()}].
+     [{metrics_handler, [parallel], metrics_tests()},
+      {metrics_cli, [parallel], metrics_tests()}].
 
-metrics_handler() ->
+metrics_tests() ->
     [get_all_metrics,
      get_all_metrics_check_by_type,
      get_by_name_global_erlang_metrics,
      get_process_queue_length,
      get_inet_stats,
      get_vm_stats_memory,
-     get_metrics_as_dicts,
+     get_all_metrics_as_dicts,
      get_by_name_metrics_as_dicts,
      get_metrics_as_dicts_with_key_one,
      get_cluster_metrics,
@@ -36,11 +38,20 @@ metrics_handler() ->
      get_mim2_cluster_metrics].
 
 init_per_suite(Config) ->
-    escalus:init_per_suite(init_admin_handler(Config)).
+    Config1 = ejabberd_node_utils:init(mim(), Config),
+    escalus:init_per_suite(Config1).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     escalus:end_per_suite(Config).
+
+init_per_group(metrics_handler, Config) ->
+    graphql_helper:init_admin_handler(Config);
+init_per_group(metrics_cli, Config) ->
+    graphql_helper:init_admin_cli(Config).
+
+end_per_group(_GroupName, _Config) ->
+    ok.
 
 init_per_testcase(CaseName, Config) ->
      escalus:init_per_testcase(CaseName, Config).
@@ -49,10 +60,8 @@ end_per_testcase(CaseName, Config) ->
      escalus:end_per_testcase(CaseName, Config).
 
 get_all_metrics(Config) ->
-    %% Get all metrics
-    Result = execute_auth(#{query => get_all_metrics_call(),
-                            variables => #{}, operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getMetrics">>, Result),
+    Result = get_metrics(Config),
+    ParsedResult = get_ok_value([data, metric, getMetrics], Result),
     Map = maps:from_list([{Name, X} || X = #{<<"name">> := Name} <- ParsedResult]),
     ReadsKey = [<<"global">>, <<"backends">>, <<"mod_roster">>, <<"read_roster_version">>],
     Reads = maps:get(ReadsKey, Map),
@@ -62,10 +71,8 @@ get_all_metrics(Config) ->
     #{<<"type">> := <<"histogram">>} = Reads.
 
 get_all_metrics_check_by_type(Config) ->
-    %% Get all metrics
-    Result = execute_auth(#{query => get_all_metrics_call(),
-                            variables => #{}, operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getMetrics">>, Result),
+    Result = get_metrics(Config),
+    ParsedResult = get_ok_value([data, metric, getMetrics], Result),
     lists:foreach(fun check_metric_by_type/1, ParsedResult).
 
 check_metric_by_type(#{<<"type">> := Type} = Map) ->
@@ -97,9 +104,8 @@ type_to_keys(<<"probe_queues">>) ->
 
 get_by_name_global_erlang_metrics(Config) ->
     %% Filter by name works
-    Result = execute_auth(#{query => get_metrics_call_with_args(<<"(name: [\"global\", \"erlang\"])">>),
-                            variables => #{}, operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getMetrics">>, Result),
+    Result = get_metrics([<<"global">>, <<"erlang">>], Config),
+    ParsedResult = get_ok_value([data, metric, getMetrics], Result),
     Map = maps:from_list([{Name, X} || X = #{<<"name">> := Name} <- ParsedResult]),
     Info = maps:get([<<"global">>, <<"erlang">>, <<"system_info">>], Map),
     %% VMSystemInfoMetric type
@@ -110,10 +116,8 @@ get_by_name_global_erlang_metrics(Config) ->
     undef = maps:get(ReadsKey, Map, undef).
 
 get_process_queue_length(Config) ->
-    Result = execute_auth(#{query => get_metrics_call_with_args(
-                                       <<"(name: [\"global\", \"processQueueLengths\"])">>),
-                            variables => #{}, operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getMetrics">>, Result),
+    Result = get_metrics([<<"global">>, <<"processQueueLengths">>], Config),
+    ParsedResult = get_ok_value([data, metric, getMetrics], Result),
     Map = maps:from_list([{Name, X} || X = #{<<"name">> := Name} <- ParsedResult]),
     Lens = maps:get([<<"global">>, <<"processQueueLengths">>], Map),
     %% ProbeQueuesMetric type
@@ -121,10 +125,8 @@ get_process_queue_length(Config) ->
     check_metric_by_type(Lens).
 
 get_inet_stats(Config) ->
-    Result = execute_auth(#{query => get_metrics_call_with_args(
-                                       <<"(name: [\"global\", \"data\", \"dist\"])">>),
-                            variables => #{}, operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getMetrics">>, Result),
+    Result = get_metrics([<<"global">>, <<"data">>, <<"dist">>], Config),
+    ParsedResult = get_ok_value([data, metric, getMetrics], Result),
     Map = maps:from_list([{Name, X} || X = #{<<"name">> := Name} <- ParsedResult]),
     Stats = maps:get([<<"global">>, <<"data">>, <<"dist">>], Map),
     %% MergedInetStatsMetric type
@@ -132,26 +134,22 @@ get_inet_stats(Config) ->
     check_metric_by_type(Stats).
 
 get_vm_stats_memory(Config) ->
-    Result = execute_auth(#{query => get_metrics_call_with_args(<<"(name: [\"global\"])">>),
-                            variables => #{}, operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getMetrics">>, Result),
+    Result = get_metrics([<<"global">>], Config),
+    ParsedResult = get_ok_value([data, metric, getMetrics], Result),
     Map = maps:from_list([{Name, X} || X = #{<<"name">> := Name} <- ParsedResult]),
     Mem = maps:get([<<"global">>, <<"erlang">>, <<"memory">>], Map),
     %% VMStatsMemoryMetric type
     #{<<"type">> := <<"vm_stats_memory">>} = Mem,
     check_metric_by_type(Mem).
 
-get_metrics_as_dicts(Config) ->
-    Result = execute_auth(#{query => get_all_metrics_as_dicts_call(), variables => #{},
-                            operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getMetricsAsDicts">>, Result),
+get_all_metrics_as_dicts(Config) ->
+    Result = get_metrics_as_dicts(Config),
+    ParsedResult = get_ok_value([data, metric, getMetricsAsDicts], Result),
     check_node_result_is_valid(ParsedResult, false).
 
 get_by_name_metrics_as_dicts(Config) ->
-    Args = <<"(name: [\"_\", \"xmppStanzaSent\"])">>,
-    Result = execute_auth(#{query => get_by_args_metrics_as_dicts_call(Args),
-                            variables => #{}, operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getMetricsAsDicts">>, Result),
+    Result = get_metrics_as_dicts_by_name([<<"_">>, <<"xmppStanzaSent">>], Config),
+    ParsedResult = get_ok_value([data, metric, getMetricsAsDicts], Result),
     [_|_] = ParsedResult,
     %% Only xmppStanzaSent type
     lists:foreach(fun(#{<<"dict">> := Dict, <<"name">> := [_, <<"xmppStanzaSent">>]}) ->
@@ -159,10 +157,8 @@ get_by_name_metrics_as_dicts(Config) ->
             end, ParsedResult).
 
 get_metrics_as_dicts_with_key_one(Config) ->
-    Result = execute_auth(#{query => get_all_metrics_as_dicts_with_key_one_call(),
-                            variables => #{},
-                            operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getMetricsAsDicts">>, Result),
+    Result = get_metrics_as_dicts_with_keys([<<"one">>], Config),
+    ParsedResult = get_ok_value([data, metric, getMetricsAsDicts], Result),
     Map = dict_objects_to_map(ParsedResult),
     SentName = [metric_host_type(), <<"xmppStanzaSent">>],
     [#{<<"key">> := <<"one">>, <<"value">> := One}] = maps:get(SentName, Map),
@@ -172,19 +168,15 @@ get_cluster_metrics(Config) ->
     %% We will have at least these two nodes
     Node1 = atom_to_binary(maps:get(node, distributed_helper:mim())),
     Node2 = atom_to_binary(maps:get(node, distributed_helper:mim2())),
-    Result = execute_auth(#{query => get_all_cluster_metrics_as_dicts_call(),
-                            variables => #{},
-                            operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getClusterMetricsAsDicts">>, Result),
+    Result = get_cluster_metrics_as_dicts(Config),
+    ParsedResult = get_ok_value([data, metric, getClusterMetricsAsDicts], Result),
     #{Node1 := Res1, Node2 := Res2} = node_objects_to_map(ParsedResult),
     check_node_result_is_valid(Res1, false),
     check_node_result_is_valid(Res2, true).
 
 get_by_name_cluster_metrics_as_dicts(Config) ->
-    Args = <<"(name: [\"_\", \"xmppStanzaSent\"])">>,
-    Result = execute_auth(#{query => get_by_args_cluster_metrics_as_dicts_call(Args),
-                            variables => #{}, operationName => <<"Q1">>}, Config),
-    NodeResult = ok_result(<<"metric">>, <<"getClusterMetricsAsDicts">>, Result),
+    Result = get_cluster_metrics_as_dicts_by_name([<<"_">>, <<"xmppStanzaSent">>], Config),
+    NodeResult = get_ok_value([data, metric, getClusterMetricsAsDicts], Result),
     Map = node_objects_to_map(NodeResult),
     %% Contains data for at least two nodes
     true = maps:size(Map) > 1,
@@ -197,10 +189,8 @@ get_by_name_cluster_metrics_as_dicts(Config) ->
 
 get_mim2_cluster_metrics(Config) ->
     Node = atom_to_binary(maps:get(node, distributed_helper:mim2())),
-    Result = execute_auth(#{query => get_node_cluster_metrics_as_dicts_call(Node),
-                            variables => #{},
-                            operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"metric">>, <<"getClusterMetricsAsDicts">>, Result),
+    Result = get_cluster_metrics_as_dicts_for_nodes([Node], Config),
+    ParsedResult = get_ok_value([data, metric, getClusterMetricsAsDicts], Result),
     [#{<<"node">> := Node, <<"result">> := ResList}] = ParsedResult,
     check_node_result_is_valid(ResList, true).
 
@@ -240,68 +230,38 @@ kv_objects_to_map(List) ->
     KV = [{Key, Value} || #{<<"key">> := Key, <<"value">> := Value} <- List],
     maps:from_list(KV).
 
-get_all_metrics_call() ->
-    get_metrics_call_with_args(<<>>).
+%% Admin commands
 
-get_metrics_call_with_args(Args) ->
-    <<"query Q1
-           {metric
-               {getMetrics", Args/binary, " {
-                     ... on HistogramMetric
-                     { name type n mean min max median p50 p75 p90 p95 p99 p999 }
-                     ... on CounterMetric
-                     { name type value ms_since_reset }
-                     ... on SpiralMetric
-                     { name type one count }
-                     ... on GaugeMetric
-                     { name type value }
-                     ... on MergedInetStatsMetric
-                     { name type connections recv_cnt recv_max recv_oct
-                       send_cnt send_max send_oct send_pend }
-                     ... on RDBMSStatsMetric
-                     { name type workers recv_cnt recv_max recv_oct
-                       send_cnt send_max send_oct send_pend }
-                     ... on VMStatsMemoryMetric
-                     { name type total processes_used atom_used binary ets system }
-                     ... on VMSystemInfoMetric
-                     { name type port_count port_limit process_count process_limit ets_limit }
-                     ... on ProbeQueuesMetric
-                     { name type fsm regular total }
-                 }
-               }
-           }">>.
+get_metrics(Config) ->
+    execute_command(<<"metric">>, <<"getMetrics">>, #{}, Config).
 
-get_all_metrics_as_dicts_call() ->
-    get_by_args_metrics_as_dicts_call(<<>>).
+get_metrics(Name, Config) ->
+    Vars = #{<<"name">> => Name},
+    execute_command(<<"metric">>, <<"getMetrics">>, Vars, Config).
 
-get_by_args_metrics_as_dicts_call(Args) ->
-    <<"query Q1
-           {metric
-               {getMetricsAsDicts", Args/binary, " { name dict { key value }}}}">>.
+get_metrics_as_dicts(Config) ->
+    execute_command(<<"metric">>, <<"getMetricsAsDicts">>, #{}, Config).
 
-get_all_metrics_as_dicts_with_key_one_call() ->
-    <<"query Q1
-           {metric
-               {getMetricsAsDicts(keys: [\"one\"]) { name dict { key value }}}}">>.
+get_metrics_as_dicts_by_name(Name, Config) ->
+    Vars = #{<<"name">> => Name},
+    execute_command(<<"metric">>, <<"getMetricsAsDicts">>, Vars, Config).
 
-get_all_cluster_metrics_as_dicts_call() ->
-    get_by_args_cluster_metrics_as_dicts_call(<<>>).
+get_metrics_as_dicts_with_keys(Keys, Config) ->
+    Vars = #{<<"keys">> => Keys},
+    execute_command(<<"metric">>, <<"getMetricsAsDicts">>, Vars, Config).
 
-get_by_args_cluster_metrics_as_dicts_call(Args) ->
-    <<"query Q1
-           {metric
-               {getClusterMetricsAsDicts", Args/binary,
-               " {node result { name dict { key value }}}}}">>.
+get_cluster_metrics_as_dicts(Config) ->
+    execute_command(<<"metric">>, <<"getClusterMetricsAsDicts">>, #{}, Config).
 
-get_node_cluster_metrics_as_dicts_call(NodeBin) ->
-    get_by_args_cluster_metrics_as_dicts_call(<<"(nodes: [\"", NodeBin/binary, "\"])">>).
+get_cluster_metrics_as_dicts_by_name(Name, Config) ->
+    Vars = #{<<"name">> => Name},
+    execute_command(<<"metric">>, <<"getClusterMetricsAsDicts">>, Vars, Config).
+
+get_cluster_metrics_as_dicts_for_nodes(Nodes, Config) ->
+    Vars = #{<<"nodes">> => Nodes},
+    execute_command(<<"metric">>, <<"getClusterMetricsAsDicts">>, Vars, Config).
 
 %% Helpers
-ok_result(What1, What2, {{<<"200">>, <<"OK">>}, #{<<"data">> := Data}}) ->
-    maps:get(What2, maps:get(What1, Data)).
-
-error_result(ErrorNumber, {{<<"200">>, <<"OK">>}, #{<<"errors">> := Errors}}) ->
-    lists:nth(ErrorNumber, Errors).
 
 check_spiral_dict(Dict) ->
     [#{<<"key">> := <<"count">>, <<"value">> := Count},

--- a/big_tests/tests/graphql_metric_SUITE.erl
+++ b/big_tests/tests/graphql_metric_SUITE.erl
@@ -7,7 +7,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
--import(graphql_helper, [execute_auth/2, execute_command/4, get_ok_value/2]).
+-import(graphql_helper, [execute_command/4, get_ok_value/2]).
 
 suite() ->
     MIM2NodeName = maps:get(node, distributed_helper:mim2()),
@@ -16,12 +16,12 @@ suite() ->
     require_rpc_nodes([mim, mim2]) ++ escalus:suite().
 
 all() ->
-     [{group, metrics_handler},
+     [{group, metrics_http},
       {group, metrics_cli}].
 
 groups() ->
-     [{metrics_handler, [parallel], metrics_tests()},
-      {metrics_cli, [parallel], metrics_tests()}].
+     [{metrics_http, [], metrics_tests()},
+      {metrics_cli, [], metrics_tests()}].
 
 metrics_tests() ->
     [get_all_metrics,
@@ -45,7 +45,7 @@ end_per_suite(Config) ->
     escalus_fresh:clean(),
     escalus:end_per_suite(Config).
 
-init_per_group(metrics_handler, Config) ->
+init_per_group(metrics_http, Config) ->
     graphql_helper:init_admin_handler(Config);
 init_per_group(metrics_cli, Config) ->
     graphql_helper:init_admin_cli(Config).

--- a/big_tests/tests/graphql_vcard_SUITE.erl
+++ b/big_tests/tests/graphql_vcard_SUITE.erl
@@ -2,26 +2,28 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [require_rpc_nodes/1]).
--import(graphql_helper, [execute_user/3, execute_auth/2, user_to_bin/1]).
+-import(distributed_helper, [require_rpc_nodes/1, mim/0]).
+-import(graphql_helper, [execute_user/3, execute_command/4, user_to_bin/1, get_ok_value/2,
+                         skip_null_values/1, get_err_msg/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("exml/include/exml.hrl").
--include_lib("escalus/include/escalus.hrl").
 -include_lib("../../include/mod_roster.hrl").
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
-    [{group, user_vcard}, {group, admin_vcard}].
+    [{group, user_vcard},
+     {group, admin_vcard_http},
+     {group, admin_vcard_cli}].
 
 groups() ->
-    [{user_vcard, [], user_vcard_handler()},
-     {admin_vcard, [], admin_vcard_handler()}].
+    [{user_vcard, [], user_vcard_tests()},
+     {admin_vcard_http, [], admin_vcard_tests()},
+     {admin_vcard_cli, [], admin_vcard_tests()}].
 
-user_vcard_handler() ->
+user_vcard_tests() ->
     [user_set_vcard,
      user_get_their_vcard,
      user_get_their_vcard_no_vcard,
@@ -29,7 +31,7 @@ user_vcard_handler() ->
      user_get_others_vcard_no_user,
      user_get_others_vcard_no_vcard].
 
-admin_vcard_handler() ->
+admin_vcard_tests() ->
     [admin_set_vcard,
      admin_set_vcard_incomplete_fields,
      admin_set_vcard_no_user,
@@ -42,7 +44,8 @@ init_per_suite(Config) ->
         true ->
             {skip, ldap_vcard_is_not_supported};
         _ ->
-            Config2 = escalus:init_per_suite(Config),
+            Config1 = escalus:init_per_suite(Config),
+            Config2 = ejabberd_node_utils:init(mim(), Config1),
             dynamic_modules:save_modules(domain_helper:host_type(), Config2)
     end.
 
@@ -50,14 +53,14 @@ end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-init_per_group(admin_vcard, Config) ->
+init_per_group(admin_vcard_http, Config) ->
     graphql_helper:init_admin_handler(Config);
+init_per_group(admin_vcard_cli, Config) ->
+    graphql_helper:init_admin_cli(Config);
 init_per_group(user_vcard, Config) ->
     [{schema_endpoint, user} | Config].
 
-end_per_group(admin_vcard, _Config) ->
-    escalus_fresh:clean();
-end_per_group(user_vcard, _Config) ->
+end_per_group(_GroupName, _Config) ->
     escalus_fresh:clean().
 
 init_per_testcase(CaseName, Config) ->
@@ -154,52 +157,28 @@ user_get_others_vcard_no_user(Config, Alice) ->
 %% Admin test cases
 
 admin_set_vcard(Config) ->
-    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+    Config1 = [{vcard, complete_vcard_input()} | Config],
+    escalus:fresh_story_with_config(Config1, [{alice, 1}, {bob, 1}],
+                                    fun admin_set_vcard/3).
+
+admin_set_vcard_incomplete_fields(Config) ->
+    Config1 = [{vcard, address_vcard_input()} | Config],
+    escalus:fresh_story_with_config(Config1, [{alice, 1}, {bob, 1}],
                                     fun admin_set_vcard/3).
 
 admin_set_vcard(Config, Alice, _Bob) ->
-    Vcard = complete_vcard_input(),
-    BodySet = set_vcard_body_admin(Vcard, user_to_bin(Alice)),
-    GraphQlRequestSet = execute_auth(BodySet, Config),
-    ParsedResultSet = ok_result(<<"vcard">>, <<"setVcard">>, GraphQlRequestSet),
-    ?assertEqual(Vcard, ParsedResultSet),
-    QueryGet = admin_get_full_vcard_as_result_query(),
-    VarsGet = #{user => user_to_bin(Alice)},
-    BodyGet = #{query => QueryGet, operationName => <<"Q1">>, variables => VarsGet},
-    GraphQlRequestGet = execute_auth(BodyGet, Config),
-    ParsedResultGet = ok_result(<<"vcard">>, <<"getVcard">>, GraphQlRequestGet),
-    ?assertEqual(Vcard, ParsedResultGet).
-
-admin_set_vcard_incomplete_fields(Config) ->
-    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
-                                    fun admin_set_vcard_incomplete_fields/3).
-
-admin_set_vcard_incomplete_fields(Config, Alice, _Bob) ->
-    QuerySet = admin_get_full_vcard_as_result_mutation(),
-    VcardInput = address_vcard_input(),
-    [VcardAddress] = maps:get(<<"address">> ,VcardInput),
-    Vcard = [maps:put(<<"pcode">>, null, VcardAddress)],
-    VarsSet = #{user => user_to_bin(Alice), vcard => VcardInput},
-    BodySet = #{query => QuerySet, operationName => <<"M1">>, variables => VarsSet},
-    GraphQlRequestSet = execute_auth(BodySet, Config),
-    ParsedResultSet = ok_result(<<"vcard">>, <<"setVcard">>, GraphQlRequestSet),
-    ?assertEqual(Vcard, maps:get(<<"address">>, ParsedResultSet)),
-    QueryGet = admin_get_full_vcard_as_result_query(),
-    VarsGet = #{user => user_to_bin(Alice)},
-    BodyGet = #{query => QueryGet, operationName => <<"Q1">>, variables => VarsGet},
-    GraphQlRequestGet = execute_auth(BodyGet, Config),
-    ParsedResultGet = ok_result(<<"vcard">>, <<"getVcard">>, GraphQlRequestGet),
-    ?assertEqual(Vcard, maps:get(<<"address">>, ParsedResultGet)).
+    Vcard = ?config(vcard, Config),
+    ResultSet = set_vcard(Vcard, user_to_bin(Alice), Config),
+    ParsedResultSet = get_ok_value([data, vcard, setVcard], ResultSet),
+    ?assertEqual(Vcard, skip_null_values(ParsedResultSet)),
+    ResultGet = get_vcard(user_to_bin(Alice), Config),
+    ParsedResultGet = get_ok_value([data, vcard, getVcard], ResultGet),
+    ?assertEqual(Vcard, skip_null_values(ParsedResultGet)).
 
 admin_set_vcard_no_user(Config) ->
-    Query = admin_get_full_vcard_as_result_mutation(),
-    OpName = <<"M1">>,
     Vcard = complete_vcard_input(),
-    Vars = #{user => <<"AAAAA">>, vcard => Vcard},
-    Body = #{query => Query, operationName => OpName, variables => Vars},
-    GraphQlRequest = execute_auth(Body, Config),
-    ParsedResult = error_result(<<"message">>, GraphQlRequest),
-    ?assertEqual(<<"User does not exist">>, ParsedResult).
+    Result = set_vcard(Vcard, <<"AAAAA">>, Config),
+    ?assertEqual(<<"User does not exist">>, get_err_msg(Result)).
 
 admin_get_vcard(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
@@ -216,33 +195,31 @@ admin_get_vcard(Config, Alice, _Bob) ->
         <<"pcode">> => <<"TESTPCODE">>, <<"country">> => <<"TESTCTRY">>,
         <<"tags">> => [<<"HOME">>, <<"WORK">>]}]},
     escalus_client:send_and_wait(Alice, escalus_stanza:vcard_update(Client1Fields)),
-    Vars = #{user => user_to_bin(Alice)},
-    Body = #{query => admin_get_address_query(), operationName => <<"Q1">>, variables => Vars},
-    GraphQlRequest = execute_auth(Body, Config),
-    ParsedResult = ok_result(<<"vcard">>, <<"getVcard">>, GraphQlRequest),
-    ?assertEqual(ExpectedResult, ParsedResult).
+    Result = get_vcard(user_to_bin(Alice), Config),
+    ParsedResult = get_ok_value([data, vcard, getVcard], Result),
+    ?assertEqual(ExpectedResult, skip_null_values(ParsedResult)).
 
 admin_get_vcard_no_vcard(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
                                     fun admin_get_vcard_no_vcard/2).
 
 admin_get_vcard_no_vcard(Config, Alice) ->
-    Query = admin_get_address_query(),
-    OpName = <<"Q1">>,
-    Vars = #{user => user_to_bin(Alice)},
-    Body = #{query => Query, operationName => OpName, variables => Vars},
-    GraphQlRequest = execute_auth(Body, Config),
-    ParsedResult = error_result(<<"message">>, GraphQlRequest),
-    ?assertEqual(<<"Vcard for user not found">>, ParsedResult).
+    Result = get_vcard(user_to_bin(Alice), Config),
+    ?assertEqual(<<"Vcard for user not found">>, get_err_msg(Result)).
 
 admin_get_vcard_no_user(Config) ->
-    Query = admin_get_address_query(),
-    OpName = <<"Q1">>,
-    Vars = #{user => <<"AAAAA">>},
-    Body = #{query => Query, operationName => OpName, variables => Vars},
-    GraphQlRequest = execute_auth(Body, Config),
-    ParsedResult = error_result(<<"message">>, GraphQlRequest),
-    ?assertEqual(<<"User does not exist">>, ParsedResult).
+    Result = get_vcard(<<"AAAAA">>, Config),
+    ?assertEqual(<<"User does not exist">>, get_err_msg(Result)).
+
+%% Admin commands
+
+set_vcard(VCard, User, Config) ->
+    Vars = #{vcard => VCard, user => User},
+    execute_command(<<"vcard">>, <<"setVcard">>, Vars, Config).
+
+get_vcard(User, Config) ->
+    Vars = #{user => User},
+    execute_command(<<"vcard">>, <<"getVcard">>, Vars, Config).
 
 %% Helpers
 


### PR DESCRIPTION
Support the UNION type in GraphQL CLI commands.
Unions are returned for metrics and vCards.
The `__typename` field is not added to the result, because the types currently used are not ambiguous and inform explicitly about the type.

Also:
- Add admin CLI tests for metrics and vCards - this ensures that unions are supported correctly.
- Limit type recursion to 2 levels, because vCards may contain nested vCards. If there is a third level of nesting, `__typename` is returned instead of the object fields.