### PR TITLE
Generate user queries in GraphQL tests

### DIFF
--- a/big_tests/tests/graphql_metric_SUITE.erl
+++ b/big_tests/tests/graphql_metric_SUITE.erl
@@ -1,8 +1,6 @@
 -module(graphql_metric_SUITE).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("exml/include/exml.hrl").
 
 -compile([export_all, nowarn_export_all]).
 
@@ -51,7 +49,7 @@ init_per_group(metrics_cli, Config) ->
     graphql_helper:init_admin_cli(Config).
 
 end_per_group(_GroupName, _Config) ->
-    ok.
+    graphql_helper:clean().
 
 init_per_testcase(CaseName, Config) ->
      escalus:init_per_testcase(CaseName, Config).


### PR DESCRIPTION
Before the change, admin operations used auto-generated queries, while user operations used manually coded GraphQL documents.

After the change, the `build_specs` function is called with RPC per test group. It auto-generates all queries for the given endpoint. As a byproduct, the query generation code is better tested.

The specs are stored in a persistent term. There was an attempt to store them in `Config`, but the specs are huge, and test reports would grow in size and become less readable.

The scope of this PR includes the `account`, `metrics` and `vcard` categories.

Also:
- Support empty argument lists in query generation. This corner case was revealed by the `unregister` operation.
