### PR TITLE
Test GraphQL CLI for all categories

### DIFF
--- a/big_tests/tests/graphql_domain_SUITE.erl
+++ b/big_tests/tests/graphql_domain_SUITE.erl
@@ -1,13 +1,11 @@
 -module(graphql_domain_SUITE).
 
- -include_lib("common_test/include/ct.hrl").
  -include_lib("eunit/include/eunit.hrl").
- -include_lib("exml/include/exml.hrl").
 
  -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
--import(graphql_helper, [execute_auth/2, init_admin_handler/1]).
+-import(graphql_helper, [execute_command/4, get_ok_value/2, get_err_msg/1, skip_null_fields/1]).
 
 -define(HOST_TYPE, <<"dummy auth">>).
 -define(SECOND_HOST_TYPE, <<"test type">>).
@@ -16,12 +14,14 @@ suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
-     [{group, domain_handler}].
+     [{group, domain_http},
+      {group, domain_cli}].
 
 groups() ->
-     [{domain_handler, [sequence], domain_handler()}].
+     [{domain_http, [sequence], domain_tests()},
+      {domain_cli, [sequence], domain_tests()}].
 
-domain_handler() ->
+domain_tests() ->
     [create_domain,
      unknown_host_type_error_formatting,
      static_domain_error_formatting,
@@ -43,29 +43,38 @@ domain_handler() ->
 
 init_per_suite(Config) ->
     case mongoose_helper:is_rdbms_enabled(?HOST_TYPE) of
-        true -> escalus:init_per_suite(init_admin_handler(Config));
-        false -> {skip, require_rdbms}
+        true ->
+            Config1 = ejabberd_node_utils:init(mim(), Config),
+            escalus:init_per_suite(Config1);
+        false ->
+            {skip, require_rdbms}
     end.
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     escalus:end_per_suite(Config).
 
+init_per_group(domain_http, Config) ->
+    graphql_helper:init_admin_handler(Config);
+init_per_group(domain_cli, Config) ->
+    graphql_helper:init_admin_cli(Config).
+
+end_per_group(_GroupName, _Config) ->
+    graphql_helper:clean().
+
 init_per_testcase(CaseName, Config) ->
-     escalus:init_per_testcase(CaseName, Config).
+    escalus:init_per_testcase(CaseName, Config).
 
 end_per_testcase(CaseName, Config) ->
-     escalus:end_per_testcase(CaseName, Config).
+    escalus:end_per_testcase(CaseName, Config).
 
 create_domain(Config) ->
     create_domain(Config, <<"exampleDomain">>),
     create_domain(Config, <<"exampleDomain2">>).
 
 create_domain(Config, DomainName) ->
-    Vars = #{domain => DomainName, hostType => ?HOST_TYPE},
-    Result = execute_auth(#{query => create_domain_call(), variables => Vars,
-        operationName => <<"M1">>}, Config),
-    ParsedResult = ok_result(<<"domains">>, <<"addDomain">>, Result),
+    Result = add_domain(DomainName, ?HOST_TYPE, Config),
+    ParsedResult = get_ok_value([data, domains, addDomain], Result),
     ?assertEqual(#{<<"domain">> => DomainName,
         <<"hostType">> => ?HOST_TYPE,
         <<"enabled">> => null}, ParsedResult).
@@ -73,241 +82,130 @@ create_domain(Config, DomainName) ->
 unknown_host_type_error_formatting(Config) ->
     DomainName = <<"exampleDomain">>,
     HostType = <<"NonExistingHostType">>,
-    Vars = #{domain => DomainName, hostType => HostType},
-    Result = execute_auth(#{query => create_domain_call(), variables => Vars,
-                   operationName => <<"M1">>}, Config),
-    ParsedResult = error_result(1, Result),
-    ?assertEqual(#{<<"extensions">> =>
-                     #{<<"code">> => <<"unknown_host_type">>,
-                       <<"hostType">> => HostType},
-                   <<"message">> => <<"Unknown host type">>,
-                   <<"path">> => [<<"domains">>, <<"addDomain">>]}, ParsedResult).
+    Result = add_domain(DomainName, HostType, Config),
+    ?assertEqual(<<"Unknown host type">>, get_err_msg(Result)).
 
 static_domain_error_formatting(Config) ->
     DomainName = <<"localhost">>,
-    Vars = #{domain => DomainName, hostType => ?HOST_TYPE},
-    Result = execute_auth(#{query => create_domain_call(), variables => Vars,
-                   operationName => <<"M1">>}, Config),
-    ParsedResult = error_result(1, Result),
-    ?assertEqual(#{<<"extensions">> =>
-                     #{<<"code">> => <<"domain_static">>,
-                       <<"domain">> => DomainName},
-                   <<"message">> => <<"Domain static">>,
-                   <<"path">> => [<<"domains">>, <<"addDomain">>]}, ParsedResult).
+    Result = add_domain(DomainName, ?HOST_TYPE, Config),
+    ?assertEqual(<<"Domain static">>, get_err_msg(Result)).
 
 domain_duplicate_error_formatting(Config) ->
     DomainName = <<"exampleDomain">>,
-    Vars = #{domain => DomainName, hostType => ?SECOND_HOST_TYPE},
-    Result = execute_auth(#{query => create_domain_call(), variables => Vars,
-                   operationName => <<"M1">>}, Config),
-    ParsedResult = error_result(1, Result),
-    ?assertEqual(#{<<"extensions">> =>
-                     #{<<"code">> => <<"domain_duplicate">>,
-                       <<"domain">> => DomainName},
-                   <<"message">> => <<"Domain already exists">>,
-                   <<"path">> => [<<"domains">>, <<"addDomain">>]}, ParsedResult).
+    Result = add_domain(DomainName, ?SECOND_HOST_TYPE, Config),
+    ?assertEqual(<<"Domain already exists">>, get_err_msg(Result)).
 
 domain_not_found_error_formatting_after_mutation_enable_domain(Config) ->
     DomainName = <<"NonExistingDomain">>,
-    Vars = #{domain => DomainName},
-    Result = execute_auth(#{query => enable_domain_call(), variables => Vars,
-                   operationName => <<"M1">>}, Config),
-    domain_not_found_error_formatting(Result, DomainName, <<"enableDomain">>).
+    Result = enable_domain(DomainName, Config),
+    domain_not_found_error_formatting(Result).
 
 domain_not_found_error_formatting_after_mutation_disable_domain(Config) ->
     DomainName = <<"NonExistingDomain">>,
-    Vars = #{domain => DomainName},
-    Result = execute_auth(#{query => disable_domain_call(), variables => Vars,
-                   operationName => <<"M1">>}, Config),
-    domain_not_found_error_formatting(Result, DomainName, <<"disableDomain">>).
+    Result = disable_domain(DomainName, Config),
+    domain_not_found_error_formatting(Result).
 
 domain_not_found_error_formatting_after_query(Config) ->
     DomainName = <<"NonExistingDomain">>,
-    Vars = #{domain => DomainName},
-    Result = execute_auth(#{query => get_domain_details_call(), variables => Vars,
-                   operationName => <<"Q1">>}, Config),
-    domain_not_found_error_formatting(Result, DomainName, <<"domainDetails">>).
-
-domain_not_found_error_formatting(Result, DomainName, GraphqlCall) ->
-    ParsedResult = error_result(1, Result),
-    ?assertEqual(#{<<"extensions">> =>
-                     #{<<"code">> => <<"domain_not_found">>,
-                       <<"domain">> => DomainName},
-                   <<"message">> => <<"Given domain does not exist">>,
-                   <<"path">> => [<<"domains">>, GraphqlCall]}, ParsedResult).
+    Result = get_domain_details(DomainName, Config),
+    domain_not_found_error_formatting(Result).
 
 wrong_host_type_error_formatting(Config) ->
-    DomainName = <<"exampleDomain">>,
-    Vars = #{domain => DomainName, hostType => ?SECOND_HOST_TYPE},
-    Result = execute_auth(#{query => delete_domain_call(), variables => Vars,
-                   operationName => <<"M1">>}, Config),
-    ParsedResult = error_result(1, Result),
-    ?assertEqual(#{<<"extensions">> =>
-                     #{<<"code">> => <<"wrong_host_type">>,
-                       <<"hostType">> => ?SECOND_HOST_TYPE},
-                   <<"message">> => <<"Wrong host type">>,
-                   <<"path">> => [<<"domains">>, <<"removeDomain">>]}, ParsedResult).
+    Result = remove_domain(<<"exampleDomain">>, ?SECOND_HOST_TYPE, Config),
+    ?assertEqual(<<"Wrong host type">>, get_err_msg(Result)).
 
 disable_domain(Config) ->
-    Vars = #{domain => <<"exampleDomain">>},
-    Result = execute_auth(#{query => disable_domain_call(), variables => Vars,
-                   operationName => <<"M1">>}, Config),
-    ParsedResult = ok_result(<<"domains">>, <<"disableDomain">>, Result),
-    ?assertEqual(#{<<"domain">> => <<"exampleDomain">>, <<"enabled">> => false}, ParsedResult),
+    Result = disable_domain(<<"exampleDomain">>, Config),
+    ParsedResult = get_ok_value([data, domains, disableDomain], Result),
+    ?assertMatch(#{<<"domain">> := <<"exampleDomain">>, <<"enabled">> := false}, ParsedResult),
     {ok, Domain} = rpc(mim(), mongoose_domain_sql, select_domain, [<<"exampleDomain">>]),
-    ?assertEqual(#{host_type => ?HOST_TYPE,
-                   enabled => false}, Domain).
-
+    ?assertEqual(#{host_type => ?HOST_TYPE, enabled => false}, Domain).
 
 enable_domain(Config) ->
-    Vars = #{domain => <<"exampleDomain">>},
-    Result = execute_auth(#{query => enable_domain_call(), variables => Vars,
-                   operationName => <<"M1">>}, Config),
-    ParsedResult = ok_result(<<"domains">>, <<"enableDomain">>, Result),
-    ?assertEqual(#{<<"domain">> => <<"exampleDomain">>, <<"enabled">> => true}, ParsedResult).
+    Result = enable_domain(<<"exampleDomain">>, Config),
+    ParsedResult = get_ok_value([data, domains, enableDomain], Result),
+    ?assertMatch(#{<<"domain">> := <<"exampleDomain">>, <<"enabled">> := true}, ParsedResult).
 
 get_domains_by_host_type(Config) ->
-    Vars = #{hostType => ?HOST_TYPE},
-    Result = execute_auth(#{query => get_domains_by_host_type_call(),
-                   variables => Vars,
-                   operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"domains">>, <<"domainsByHostType">>, Result),
+    Result = get_domains_by_host_type(?HOST_TYPE, Config),
+    ParsedResult = get_ok_value([data, domains, domainsByHostType], Result),
     ?assertEqual(lists:sort([<<"exampleDomain">>, <<"exampleDomain2">>]),
                  lists:sort(ParsedResult)).
 
 get_domain_details(Config) ->
-    Vars = #{domain => <<"exampleDomain">>},
-    Result = execute_auth(#{query => get_domain_details_call(),
-                   variables => Vars,
-                   operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"domains">>, <<"domainDetails">>, Result),
+    Result = get_domain_details(<<"exampleDomain">>, Config),
+    ParsedResult = get_ok_value([data, domains, domainDetails], Result),
     ?assertEqual(#{<<"domain">> => <<"exampleDomain">>,
                    <<"hostType">> => ?HOST_TYPE,
                    <<"enabled">> => true}, ParsedResult).
 
 delete_domain(Config) ->
-    Vars = #{domain => <<"exampleDomain">>, hostType => ?HOST_TYPE},
-    Result1 = execute_auth(#{query => delete_domain_call(), variables => Vars,
-                   operationName => <<"M1">>}, Config),
-    ParsedResult1 = ok_result(<<"domains">>, <<"removeDomain">>, Result1),
-    ?assertEqual(#{<<"msg">> => <<"Domain removed!">>,
-                   <<"domain">> => #{<<"domain">> => <<"exampleDomain">>}},
-                   ParsedResult1),
-
-    Vars2 = #{domain => <<"exampleDomain2">>, hostType => ?HOST_TYPE},
-    Result2 = execute_auth(#{query => delete_domain_call(), variables => Vars2,
-                   operationName => <<"M1">>}, Config),
-    ParsedResult2 = ok_result(<<"domains">>, <<"removeDomain">>, Result2),
-    ?assertEqual(#{<<"msg">> => <<"Domain removed!">>,
-                   <<"domain">> => #{<<"domain">> => <<"exampleDomain2">>}},
-                   ParsedResult2).
+    Result1 = remove_domain(<<"exampleDomain">>, ?HOST_TYPE, Config),
+    ParsedResult1 = get_ok_value([data, domains, removeDomain], Result1),
+    ?assertMatch(#{<<"msg">> := <<"Domain removed!">>,
+                   <<"domain">> := #{<<"domain">> := <<"exampleDomain">>}},
+                 ParsedResult1),
+    Result2 = remove_domain(<<"exampleDomain2">>, ?HOST_TYPE, Config),
+    ParsedResult2 = get_ok_value([data, domains, removeDomain], Result2),
+    ?assertMatch(#{<<"msg">> := <<"Domain removed!">>,
+                   <<"domain">> := #{<<"domain">> := <<"exampleDomain2">>}},
+                 ParsedResult2).
 
 get_domains_after_deletion(Config) ->
-    Vars = #{hostType => ?HOST_TYPE},
-    Result = execute_auth(#{query => get_domains_by_host_type_call(),
-                   variables => Vars,
-                   operationName => <<"Q1">>}, Config),
-    ParsedResult = ok_result(<<"domains">>, <<"domainsByHostType">>, Result),
+    Result = get_domains_by_host_type(?HOST_TYPE, Config),
+    ParsedResult = get_ok_value([data, domains, domainsByHostType], Result),
     ?assertEqual([], ParsedResult).
 
 set_domain_password(Config) ->
-    Result = execute_auth(#{query => set_domain_password_call(),
-                   variables => #{domain => domain_helper:domain(),
-                                  password => <<"secret">>},
-                   operationName => <<"M1">>}, Config),
-    ParsedResult = ok_result(<<"domains">>, <<"setDomainPassword">>, Result),
+    Result = set_domain_password(domain_helper:domain(), <<"secret">>, Config),
+    ParsedResult = get_ok_value([data, domains, setDomainPassword], Result),
     ?assertNotEqual(nomatch, binary:match(ParsedResult, <<"successfully">>)).
 
 set_nonexistent_domain_password(Config) ->
     Domain = <<"unknown-domain.com">>,
-    Result = execute_auth(#{query => set_domain_password_call(),
-                   variables => #{domain => Domain,
-                                  password => <<"secret">>},
-                   operationName => <<"M1">>}, Config),
-    domain_not_found_error_formatting(Result, Domain, <<"setDomainPassword">>).
+    Result = set_domain_password(Domain, <<"secret">>, Config),
+    domain_not_found_error_formatting(Result).
 
 delete_domain_password(Config) ->
-    Result = execute_auth(#{query => delete_domain_password_call(),
-                   variables => #{domain => domain_helper:domain()},
-                   operationName => <<"M1">>}, Config),
-    ParsedResult = ok_result(<<"domains">>, <<"deleteDomainPassword">>, Result),
+    Result = delete_domain_password(domain_helper:domain(), Config),
+    ParsedResult = get_ok_value([data, domains, deleteDomainPassword], Result),
     ?assertNotEqual(nomatch, binary:match(ParsedResult, <<"successfully">>)).
 
-create_domain_call() ->
-    <<"mutation M1($domain: String!, $hostType: String!)
-           {domains
-               {addDomain(domain: $domain, hostType: $hostType)
-                   {
-                       domain
-                       hostType
-                       enabled
-                   }
-               }
-           }">>.
+%% Commands
 
-enable_domain_call() ->
-    <<"mutation M1($domain: String!)
-           {domains
-               {enableDomain(domain: $domain)
-                   {
-                       enabled
-                       domain
-                   }
-               }
-           }">>.
+add_domain(Domain, HostType, Config) ->
+    Vars = #{domain => Domain, hostType => HostType},
+    execute_command(<<"domains">>, <<"addDomain">>, Vars, Config).
 
-disable_domain_call() ->
-    <<"mutation M1($domain: String!)
-           {domains
-               {disableDomain(domain: $domain)
-                   {
-                       enabled
-                       domain
-                   }
-               }
-           }">>.
+enable_domain(Domain, Config) ->
+    Vars = #{domain => Domain},
+    execute_command(<<"domains">>, <<"enableDomain">>, Vars, Config).
 
-get_domains_by_host_type_call() ->
-    <<"query Q1($hostType: String!)
-           {domains
-               {domainsByHostType(hostType: $hostType)}
-           }">>.
+disable_domain(Domain, Config) ->
+    Vars = #{domain => Domain},
+    execute_command(<<"domains">>, <<"disableDomain">>, Vars, Config).
 
-get_domain_details_call() ->
-    <<"query Q1($domain: String!)
-           {domains
-               {domainDetails(domain: $domain)
-                   {
-                       domain
-                       hostType
-                       enabled
-                   }
-               }
-           }">>.
+get_domain_details(Domain, Config) ->
+    Vars = #{domain => Domain},
+    execute_command(<<"domains">>, <<"domainDetails">>, Vars, Config).
 
-delete_domain_call() ->
-    <<"mutation M1($domain: String!, $hostType: String!)
-           {domains
-               {removeDomain(domain: $domain, hostType: $hostType)
-                   {
-                       msg
-                       domain
-                           {domain}
-                   }
-               }
-           }">>.
+remove_domain(Domain, HostType, Config) ->
+    Vars = #{domain => Domain, hostType => HostType},
+    execute_command(<<"domains">>, <<"removeDomain">>, Vars, Config).
 
-set_domain_password_call() ->
-    <<"mutation M1($domain: String!, $password: String!)"
-      "{ domains { setDomainPassword(domain: $domain, password: $password)} }">>.
+get_domains_by_host_type(HostType, Config) ->
+    Vars = #{hostType => HostType},
+    execute_command(<<"domains">>, <<"domainsByHostType">>, Vars, Config).
 
-delete_domain_password_call() ->
-    <<"mutation M1($domain: String!)"
-      "{ domains { deleteDomainPassword(domain: $domain)} }">>.
+set_domain_password(Domain, Password, Config) ->
+    Vars = #{domain => Domain, password => Password},
+    execute_command(<<"domains">>, <<"setDomainPassword">>, Vars, Config).
+
+delete_domain_password(Domain, Config) ->
+    Vars = #{domain => Domain},
+    execute_command(<<"domains">>, <<"deleteDomainPassword">>, Vars, Config).
 
 %% Helpers
-ok_result(What1, What2, {{<<"200">>, <<"OK">>}, #{<<"data">> := Data}}) ->
-    maps:get(What2, maps:get(What1, Data)).
 
-error_result(ErrorNumber, {{<<"200">>, <<"OK">>}, #{<<"errors">> := Errors}}) ->
-    lists:nth(ErrorNumber, Errors).
+domain_not_found_error_formatting(Result) ->
+    ?assertEqual(<<"Given domain does not exist">>, get_err_msg(Result)).

--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -5,6 +5,7 @@
 -import(distributed_helper, [mim/0, rpc/4]).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
 -include_lib("escalus/include/escalus.hrl").
 
 -spec execute(atom(), binary(), {binary(), binary()} | undefined) ->
@@ -115,6 +116,11 @@ get_err_code(Resp) ->
 get_err_msg(Resp) ->
     get_err_msg(1, Resp).
 
+get_coercion_err_msg({Code, #{<<"errors">> := [Error]}}) ->
+    assert_response_code(bad_request, Code),
+    ?assertEqual(<<"input_coercion">>, get_value([extensions, code], Error)),
+    get_value([message], Error).
+
 get_err_msg(N, Resp) ->
     get_value([message], get_error(N, Resp)).
 
@@ -131,7 +137,10 @@ get_ok_value(Path, {Code, Data}) ->
     assert_response_code(ok, Code),
     get_value(Path, Data).
 
-assert_response_code(_, {<<"200">>, <<"OK">>}) -> ok;
+assert_response_code(bad_request, {<<"400">>, <<"Bad Request">>}) -> ok;
+assert_response_code(error, {<<"200">>, <<"OK">>}) -> ok;
+assert_response_code(ok, {<<"200">>, <<"OK">>}) -> ok;
+assert_response_code(bad_request, {exit_status, 1}) -> ok;
 assert_response_code(error, {exit_status, 1}) -> ok;
 assert_response_code(ok, {exit_status, 0}) -> ok;
 assert_response_code(Type, Code) ->

--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -122,6 +122,11 @@ get_error(N, {Code, #{<<"errors">> := Errors}}) ->
     assert_response_code(error, Code),
     lists:nth(N, Errors).
 
+%% Expect both errors and successful responses
+get_err_value(Path, {Code, Data}) ->
+    assert_response_code(error, Code),
+    get_value(Path, Data).
+
 get_ok_value(Path, {Code, Data}) ->
     assert_response_code(ok, Code),
     get_value(Path, Data).

--- a/big_tests/tests/graphql_http_upload_SUITE.erl
+++ b/big_tests/tests/graphql_http_upload_SUITE.erl
@@ -2,15 +2,12 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [require_rpc_nodes/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/1]).
 -import(domain_helper, [host_type/0, domain/0]).
--import(graphql_helper, [execute_user/3, execute_auth/2, user_to_bin/1]).
+-import(graphql_helper, [execute_user_command/5, execute_command/4, get_ok_value/2,
+                         get_err_msg/1, get_err_code/1]).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("exml/include/exml.hrl").
--include_lib("escalus/include/escalus.hrl").
--include("../../include/mod_roster.hrl").
 
 -define(S3_HOSTNAME, <<"http://bucket.s3-eu-east-25.example.com">>).
 
@@ -18,59 +15,80 @@ suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
-    [{group, user_http_upload},
-     {group, user_http_upload_not_configured},
-     {group, admin_http_upload},
-     {group, admin_http_upload_not_configured}].
+    [{group, user},
+     {group, admin_http},
+     {group, admin_cli}].
 
 groups() ->
-    [{user_http_upload, [], user_http_upload_handler()},
-     {user_http_upload_not_configured, [], user_http_upload_not_configured_handler()},
-     {admin_http_upload, [], admin_http_upload_handler()},
-     {admin_http_upload_not_configured, [], admin_http_upload_not_configured_handler()}].
+    [{user, [], user_groups()},
+     {admin_http, [], admin_groups()},
+     {admin_cli, [], admin_groups()},
+     {user_http_upload, [], user_http_upload_tests()},
+     {user_http_upload_not_configured, [], user_http_upload_not_configured_tests()},
+     {admin_http_upload, [], admin_http_upload_tests()},
+     {admin_http_upload_not_configured, [], admin_http_upload_not_configured_tests()}].
 
-user_http_upload_handler() ->
+user_groups() ->
+    [{group, user_http_upload},
+     {group, user_http_upload_not_configured}].
+
+admin_groups() ->
+    [{group, admin_http_upload},
+     {group, admin_http_upload_not_configured}].
+
+user_http_upload_tests() ->
     [user_get_url_test,
      user_get_url_zero_size,
      user_get_url_too_large_size,
      user_get_url_zero_timeout].
 
-user_http_upload_not_configured_handler() ->
+user_http_upload_not_configured_tests() ->
     [user_http_upload_not_configured].
 
-admin_http_upload_handler() ->
+admin_http_upload_tests() ->
     [admin_get_url_test,
      admin_get_url_zero_size,
      admin_get_url_too_large_size,
      admin_get_url_zero_timeout,
      admin_get_url_no_domain].
 
-admin_http_upload_not_configured_handler() ->
+admin_http_upload_not_configured_tests() ->
     [admin_http_upload_not_configured].
 
 init_per_suite(Config) ->
     Config1 = dynamic_modules:save_modules(host_type(), Config),
-    escalus:init_per_suite(Config1).
+    Config2 = ejabberd_node_utils:init(mim(), Config1),
+    escalus:init_per_suite(Config2).
 
 end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
+init_per_group(user, Config) ->
+    graphql_helper:init_user(Config);
+init_per_group(admin_http, Config) ->
+    graphql_helper:init_admin_handler(Config);
+init_per_group(admin_cli, Config) ->
+    graphql_helper:init_admin_cli(Config);
 init_per_group(user_http_upload, Config) ->
     dynamic_modules:ensure_modules(host_type(),
         [{mod_http_upload, create_opts(?S3_HOSTNAME, true)}]),
-    [{schema_endpoint, user} | Config];
+    Config;
 init_per_group(user_http_upload_not_configured, Config) ->
     dynamic_modules:ensure_modules(host_type(), [{mod_http_upload, stopped}]),
-    [{schema_endpoint, user} | Config];
+    Config;
 init_per_group(admin_http_upload, Config) ->
     dynamic_modules:ensure_modules(host_type(),
         [{mod_http_upload, create_opts(?S3_HOSTNAME, true)}]),
-    graphql_helper:init_admin_handler(Config);
+    Config;
 init_per_group(admin_http_upload_not_configured, Config) ->
     dynamic_modules:ensure_modules(host_type(), [{mod_http_upload, stopped}]),
-    graphql_helper:init_admin_handler(Config).
+    Config.
 
+end_per_group(GroupName, _Config) when GroupName =:= user;
+                                       GroupName =:= admin_http;
+                                       GroupName =:= admin_cli ->
+    graphql_helper:clean();
 end_per_group(_, _Config) ->
     escalus_fresh:clean().
 
@@ -100,10 +118,8 @@ user_get_url_test(Config) ->
                                     fun user_get_url_test/2).
 
 user_get_url_test(Config, Alice) ->
-    Vars = #{<<"filename">> => <<"test">>, <<"size">> => 123,
-             <<"contentType">> => <<"Test">>, <<"timeout">> => 123},
-    GraphQlRequest = user_send_request(Config, Vars, Alice),
-    ParsedResult = ok_result(<<"httpUpload">>, <<"getUrl">>, GraphQlRequest),
+    Result = user_get_url(<<"test">>, 123, <<"Test">>, 123, Alice, Config),
+    ParsedResult = get_ok_value([data, httpUpload, getUrl], Result),
     #{<<"PutUrl">> := PutURL, <<"GetUrl">> := GetURL, <<"Header">> := _Headers} = ParsedResult,
     ?assertMatch({_, _}, binary:match(PutURL, [?S3_HOSTNAME])),
     ?assertMatch({_, _}, binary:match(GetURL, [?S3_HOSTNAME])).
@@ -113,124 +129,79 @@ user_get_url_zero_size(Config) ->
                                     fun user_get_url_zero_size/2).
 
 user_get_url_zero_size(Config, Alice) ->
-    Vars = #{<<"filename">> => <<"test">>, <<"size">> => 0,
-             <<"contentType">> => <<"Test">>, <<"timeout">> => 123},
-    GraphQlRequest = user_send_request(Config, Vars, Alice),
-    ParsedResult = error_result(<<"extensions">>, <<"code">>, GraphQlRequest),
-    ?assertEqual(<<"size_error">>, ParsedResult).
+    Result = user_get_url(<<"test">>, 0, <<"Test">>, 123, Alice, Config),
+    ?assertEqual(<<"size_error">>, get_err_code(Result)),
+    ?assertEqual(<<"size must be positive integer">>, get_err_msg(Result)).
 
 user_get_url_too_large_size(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
                                     fun user_get_url_too_large_size/2).
 
 user_get_url_too_large_size(Config, Alice) ->
-    Vars = #{<<"filename">> => <<"test">>, <<"size">> => 100000,
-             <<"contentType">> => <<"Test">>, <<"timeout">> => 123},
-    GraphQlRequest = user_send_request(Config, Vars, Alice),
-    ParsedResult = error_result(<<"extensions">>, <<"code">>, GraphQlRequest),
-    ?assertEqual(<<"file_too_large_error">>, ParsedResult).
+    Result = user_get_url(<<"test">>, 100000, <<"Test">>, 123, Alice, Config),
+    ?assertEqual(<<"file_too_large_error">>, get_err_code(Result)),
+    ?assertMatch(<<"Declared file size exceeds", _/bits>>, get_err_msg(Result)).
 
 user_get_url_zero_timeout(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
                                     fun user_get_url_zero_timeout/2).
 
 user_get_url_zero_timeout(Config, Alice) ->
-    Vars = #{<<"filename">> => <<"test">>, <<"size">> => 123,
-             <<"contentType">> => <<"Test">>, <<"timeout">> => 0},
-    GraphQlRequest = user_send_request(Config, Vars, Alice),
-    ParsedResult = error_result(<<"extensions">>, <<"code">>, GraphQlRequest),
-    ?assertEqual(<<"timeout_error">>, ParsedResult).
+    Result = user_get_url(<<"test">>, 123, <<"Test">>, 0, Alice, Config),
+    ?assertEqual(<<"timeout_error">>, get_err_code(Result)),
+    ?assertEqual(<<"timeout must be positive integer">>, get_err_msg(Result)).
 
 user_http_upload_not_configured(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
                                     fun user_http_upload_not_configured/2).
 
 user_http_upload_not_configured(Config, Alice) ->
-    Vars = #{<<"filename">> => <<"test">>, <<"size">> => 123,
-             <<"contentType">> => <<"Test">>, <<"timeout">> => 123},
-    GraphQlRequest = user_send_request(Config, Vars, Alice),
-    ParsedResult = error_result(<<"extensions">>, <<"code">>, GraphQlRequest),
-    ?assertEqual(<<"module_not_loaded_error">>, ParsedResult).
+    Result = user_get_url(<<"test">>, 123, <<"Test">>, 123, Alice, Config),
+    ?assertEqual(<<"module_not_loaded_error">>, get_err_code(Result)),
+    ?assertEqual(<<"mod_http_upload is not loaded for this host">>, get_err_msg(Result)).
 
 % Admin test cases
 
 admin_get_url_test(Config) ->
-    Vars = #{<<"domain">> => domain(), <<"filename">> => <<"test">>,
-             <<"size">> => 123, <<"contentType">> => <<"Test">>, <<"timeout">> => 123},
-    GraphQlRequest = admin_send_request(Config, Vars),
-    ParsedResult = ok_result(<<"httpUpload">>, <<"getUrl">>, GraphQlRequest),
+    Result = admin_get_url(domain(), <<"test">>, 123, <<"Test">>, 123, Config),
+    ParsedResult = get_ok_value([data, httpUpload, getUrl], Result),
     #{<<"PutUrl">> := PutURL, <<"GetUrl">> := GetURL, <<"Header">> := _Headers} = ParsedResult,
     ?assertMatch({_, _}, binary:match(PutURL, [?S3_HOSTNAME])),
     ?assertMatch({_, _}, binary:match(GetURL, [?S3_HOSTNAME])).
 
 admin_get_url_zero_size(Config) ->
-    Vars = #{<<"domain">> => domain(), <<"filename">> => <<"test">>,
-             <<"size">> => 0, <<"contentType">> => <<"Test">>, <<"timeout">> => 123},
-    GraphQlRequest = admin_send_request(Config, Vars),
-    ParsedResult = error_result(<<"extensions">>, <<"code">>, GraphQlRequest),
-    ?assertEqual(<<"size_error">>, ParsedResult).
+    Result = admin_get_url(domain(), <<"test">>, 0, <<"Test">>, 123, Config),
+    ?assertEqual(<<"size_error">>, get_err_code(Result)),
+    ?assertEqual(<<"size must be positive integer">>, get_err_msg(Result)).
 
 admin_get_url_too_large_size(Config) ->
-    Vars = #{<<"domain">> => domain(), <<"filename">> => <<"test">>,
-             <<"size">> => 1000000, <<"contentType">> => <<"Test">>, <<"timeout">> => 123},
-    GraphQlRequest = admin_send_request(Config, Vars),
-    ParsedResult = error_result(<<"extensions">>, <<"code">>, GraphQlRequest),
-    ?assertEqual(<<"file_too_large_error">>, ParsedResult).
+    Result = admin_get_url(domain(), <<"test">>, 100000, <<"Test">>, 123, Config),
+    ?assertEqual(<<"file_too_large_error">>, get_err_code(Result)),
+    ?assertMatch(<<"Declared file size exceeds", _/bits>>, get_err_msg(Result)).
 
 admin_get_url_zero_timeout(Config) ->
-    Vars = #{<<"domain">> => domain(), <<"filename">> => <<"test">>,
-             <<"size">> => 123, <<"contentType">> => <<"Test">>, <<"timeout">> => 0},
-    GraphQlRequest = admin_send_request(Config, Vars),
-    ParsedResult = error_result(<<"extensions">>, <<"code">>, GraphQlRequest),
-    ?assertEqual(<<"timeout_error">>, ParsedResult).
+    Result = admin_get_url(domain(), <<"test">>, 123, <<"Test">>, 0, Config),
+    ?assertEqual(<<"timeout_error">>, get_err_code(Result)),
+    ?assertEqual(<<"timeout must be positive integer">>, get_err_msg(Result)).
 
 admin_get_url_no_domain(Config) ->
-    Vars = #{<<"domain">> => <<"AAAAA">>, <<"filename">> => <<"test">>,
-             <<"size">> => 123, <<"contentType">> => <<"Test">>, <<"timeout">> => 123},
-    GraphQlRequest = admin_send_request(Config, Vars),
-    ParsedResult = error_result(<<"extensions">>, <<"code">>, GraphQlRequest),
-    ?assertEqual(<<"domain_not_found">>, ParsedResult).
+    Result = admin_get_url(<<"AAAAA">>, <<"test">>, 123, <<"Test">>, 123, Config),
+    ?assertEqual(<<"domain_not_found">>, get_err_code(Result)),
+    ?assertEqual(<<"domain does not exist">>, get_err_msg(Result)).
 
 admin_http_upload_not_configured(Config) ->
-    Vars = #{<<"domain">> => domain(), <<"filename">> => <<"test">>,
-             <<"size">> => 123, <<"contentType">> => <<"Test">>, <<"timeout">> => 123},
-    GraphQlRequest = admin_send_request(Config, Vars),
-    ParsedResult = error_result(<<"extensions">>, <<"code">>, GraphQlRequest),
-    ?assertEqual(<<"module_not_loaded_error">>, ParsedResult).
+    Result = admin_get_url(domain(), <<"test">>, 123, <<"Test">>, 123, Config),
+    ?assertEqual(<<"module_not_loaded_error">>, get_err_code(Result)),
+    ?assertEqual(<<"mod_http_upload is not loaded for this host">>, get_err_msg(Result)).
 
 % Helpers
 
-user_get_url() ->
-    <<"mutation M1($filename: String!, $size: Int!,
-                   $contentType: String!, $timeout: Int!)",
-          "{httpUpload{getUrl(filename: $filename, size: $size,
-                              contentType: $contentType, timeout: $timeout)
-                {PutUrl, GetUrl, Header}}}">>.
+user_get_url(FileName, Size, ContentType, Timeout, User, Config) ->
+    Vars = #{<<"filename">> => FileName, <<"size">> => Size,
+             <<"contentType">> => ContentType, <<"timeout">> => Timeout},
+    execute_user_command(<<"httpUpload">>, <<"getUrl">>, User, Vars, Config).
 
-admin_get_url() ->
-    <<"mutation M1($domain: String!, $filename: String!, $size: Int!,
-                   $contentType: String!, $timeout: Int!)",
-          "{httpUpload{getUrl(domain: $domain, filename: $filename,
-                       size: $size, contentType: $contentType, timeout: $timeout)
-                {PutUrl, GetUrl, Header}}}">>.
-
-user_send_request(Config, Vars, User) ->
-    Body = #{query => user_get_url(), operationName => <<"M1">>, variables => Vars},
-    execute_user(Body, User, Config).
-
-admin_send_request(Config, Vars) ->
-    Body = #{query => admin_get_url(), operationName => <<"M1">>, variables => Vars},
-    execute_auth(Body, Config).
-
-error_result(What1, What2, {{<<"200">>, <<"OK">>}, #{<<"errors">> := [Data]}}) ->
-    maps:get(What2, maps:get(What1, Data)).
-
-ok_result(What1, What2, {{<<"200">>, <<"OK">>}, #{<<"data">> := Data}}) ->
-    maps:get(What2, maps:get(What1, Data)).
-
-url_contains(UrlType, Filename, Result) ->
-    Url = extract_url(Result, UrlType),
-    binary:match(Url, Filename) =/= nomatch.
-
-extract_url(Result, UrlType) ->
-    exml_query:path(Result, [{element, <<"slot">>}, {element, UrlType}, {attr, <<"url">>}]).
+admin_get_url(Domain, FileName, Size, ContentType, Timeout, Config) ->
+    Vars = #{<<"domain">> => Domain, <<"filename">> => FileName, <<"size">> => Size,
+             <<"contentType">> => ContentType, <<"timeout">> => Timeout},
+    execute_command(<<"httpUpload">>, <<"getUrl">>, Vars, Config).

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -913,7 +913,7 @@ get_coertion_err_msg(Response) ->
                         <<"extensions">> := #{<<"code">> := <<"input_coercion">>}}]}} = Response,
     Msg.
 
-%% Request bodies
+%% Commands
 
 admin_create_room_body(MUCDomain, Name, Owner, Subject, Id) ->
     Query = <<"mutation M1($mucDomain: String!, $name: String!, $owner: JID!, $subject: String!, $id: NonEmptyString)

--- a/big_tests/tests/graphql_private_SUITE.erl
+++ b/big_tests/tests/graphql_private_SUITE.erl
@@ -2,31 +2,30 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [require_rpc_nodes/1]).
--import(graphql_helper, [execute_user/3, execute_auth/2, user_to_bin/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/1]).
+-import(graphql_helper, [execute_user_command/5, execute_command/4, get_ok_value/2, get_err_code/1,
+                         user_to_bin/1]).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("exml/include/exml.hrl").
--include_lib("escalus/include/escalus.hrl").
--include("../../include/mod_roster.hrl").
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
-    [{group, user_private}, {group, admin_private}].
+    [{group, user_private}, {group, admin_private_http}, {group, admin_private_cli}].
 
 groups() ->
-    [{user_private, [], user_private_handler()},
-     {admin_private, [], admin_private_handler()}].
+    [{user_private, [], user_private_tests()},
+     {admin_private_http, [], admin_private_tests()},
+     {admin_private_cli, [], admin_private_tests()}].
 
-user_private_handler() ->
+user_private_tests() ->
     [user_set_private,
      user_get_private,
      parse_xml_error].
 
-admin_private_handler() ->
+admin_private_tests() ->
     [admin_set_private,
      admin_get_private,
      no_user_error_set,
@@ -35,10 +34,11 @@ admin_private_handler() ->
 init_per_suite(Config0) ->
     HostType = domain_helper:host_type(),
     Config1 = dynamic_modules:save_modules(HostType, Config0),
+    Config2 = ejabberd_node_utils:init(mim(), Config1),
     Backend = mongoose_helper:get_backend_mnesia_rdbms_riak(HostType),
     ModConfig = create_config(Backend),
     dynamic_modules:ensure_modules(HostType, ModConfig),
-    escalus:init_per_suite([{backend, Backend} | Config1]).
+    escalus:init_per_suite([{backend, Backend} | Config2]).
 
 create_config(riak) ->
     [{mod_private, #{backend => riak,
@@ -51,15 +51,16 @@ end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-init_per_group(admin_private, Config) ->
+init_per_group(admin_private_http, Config) ->
     graphql_helper:init_admin_handler(Config);
+init_per_group(admin_private_cli, Config) ->
+    graphql_helper:init_admin_cli(Config);
 init_per_group(user_private, Config) ->
-    [{schema_endpoint, user} | Config].
+    graphql_helper:init_user(Config).
 
-end_per_group(admin_private, _Config) ->
-    escalus_fresh:clean();
-end_per_group(user_private, _Config) ->
-    escalus_fresh:clean().
+end_per_group(_GroupName, _Config) ->
+    escalus_fresh:clean(),
+    graphql_helper:clean().
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
@@ -73,46 +74,32 @@ user_set_private(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_set_private/2).
 
 user_set_private(Config, Alice) ->
-    QuerySet = user_private_mutation(),
-    Expected = exml:to_binary(private_input()),
-    BodySet = #{query => QuerySet, operationName => <<"M1">>,
-                variables => #{elementString => Expected}},
-    GraphQlRequestSet = execute_user(BodySet, Alice, Config),
-    ParsedResultSet = ok_result(<<"private">>, <<"setPrivate">>, GraphQlRequestSet),
+    ElemStr = exml:to_binary(private_input()),
+    ResultSet = user_set_private(Alice, ElemStr, Config),
+    ParsedResultSet = get_ok_value([data, private, setPrivate], ResultSet),
     ?assertEqual(<<"[]">>, ParsedResultSet),
-    Vars = #{element => <<"my_element">>, nameSpace => <<"alice:private:ns">>},
-    QueryGet = user_private_query(),
-    BodyGet = #{query => QueryGet, operationName => <<"Q1">>, variables => Vars},
-    GraphQlRequestGet = execute_user(BodyGet, Alice, Config),
-    ParsedResultGet = ok_result(<<"private">>, <<"getPrivate">>, GraphQlRequestGet),
-    ?assertEqual(Expected, ParsedResultGet).
+    ResultGet = user_get_private(Alice, <<"my_element">>, <<"alice:private:ns">>, Config),
+    ParsedResultGet = get_ok_value([data, private, getPrivate], ResultGet),
+    ?assertEqual(ElemStr, ParsedResultGet).
 
 user_get_private(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_get_private/2).
 
 user_get_private(Config, Alice) ->
-    Expected = exml:to_binary(private_input()),
+    ElemStr = exml:to_binary(private_input()),
     IQ = escalus_stanza:to(escalus_stanza:private_set(private_input()),
                            escalus_users:get_jid(Config, alice)),
     escalus_client:send_and_wait(Alice, IQ),
-    Vars = #{element => <<"my_element">>, nameSpace => <<"alice:private:ns">>},
-    QueryGet = user_private_query(),
-    BodyGet = #{query => QueryGet, operationName => <<"Q1">>, variables => Vars},
-    GraphQlRequestGet = execute_user(BodyGet, Alice, Config),
-    ParsedResultGet = ok_result(<<"private">>, <<"getPrivate">>, GraphQlRequestGet),
-    ?assertEqual(Expected, ParsedResultGet).
+    ResultGet = user_get_private(Alice, <<"my_element">>, <<"alice:private:ns">>, Config),
+    ParsedResultGet = get_ok_value([data, private, getPrivate], ResultGet),
+    ?assertEqual(ElemStr, ParsedResultGet).
 
 parse_xml_error(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun parse_xml_error/2).
 
 parse_xml_error(Config, Alice) ->
-    QuerySet = user_private_mutation(),
-    Input = <<"AAAABBBB">>,
-    BodySet = #{query => QuerySet, operationName => <<"M1">>,
-                variables => #{elementString => Input}},
-    GraphQlRequestSet = execute_user(BodySet, Alice, Config),
-    ParsedResultSet = error_result2(<<"extensions">>, <<"code">>, GraphQlRequestSet),
-    ?assertEqual(<<"parse_error">>, ParsedResultSet).
+    ResultSet = user_set_private(Alice, <<"AAAABBBB">>, Config),
+    ?assertEqual(<<"parse_error">>, get_err_code(ResultSet)).
 
 % Admin tests
 
@@ -120,101 +107,56 @@ admin_set_private(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_set_private/2).
 
 admin_set_private(Config, Alice) ->
-    QuerySet = admin_private_mutation(),
-    Expected = exml:to_binary(private_input()),
-    BodySet = #{query => QuerySet, operationName => <<"M1">>,
-                variables => #{elementString => Expected, user => user_to_bin(Alice)}},
-    GraphQlRequestSet = execute_auth(BodySet, Config),
-    ParsedResultSet = ok_result(<<"private">>, <<"setPrivate">>, GraphQlRequestSet),
+    AliceBin = user_to_bin(Alice),
+    ElemStr = exml:to_binary(private_input()),
+    ResultSet = admin_set_private(AliceBin, ElemStr, Config),
+    ParsedResultSet = get_ok_value([data, private, setPrivate], ResultSet),
     ?assertEqual(<<"[]">>, ParsedResultSet),
-    Vars = #{element => <<"my_element">>, nameSpace => <<"alice:private:ns">>,
-             user => user_to_bin(Alice)},
-    QueryGet = admin_private_query(),
-    BodyGet = #{query => QueryGet, operationName => <<"Q1">>, variables => Vars},
-    GraphQlRequestGet = execute_auth(BodyGet, Config),
-    ParsedResultGet = ok_result(<<"private">>, <<"getPrivate">>, GraphQlRequestGet),
-    ?assertEqual(Expected, ParsedResultGet).
+    ResultGet = admin_get_private(AliceBin, <<"my_element">>, <<"alice:private:ns">>, Config),
+    ParsedResultGet = get_ok_value([data, private, getPrivate], ResultGet),
+    ?assertEqual(ElemStr, ParsedResultGet).
 
 admin_get_private(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_get_private/2).
 
 admin_get_private(Config, Alice) ->
-    Expected = exml:to_binary(private_input()),
+    AliceBin = user_to_bin(Alice),
+    ElemStr = exml:to_binary(private_input()),
     IQ = escalus_stanza:to(escalus_stanza:private_set(private_input()),
                            escalus_users:get_jid(Config, alice)),
     escalus_client:send_and_wait(Alice, IQ),
-    Vars = #{element => <<"my_element">>, nameSpace => <<"alice:private:ns">>,
-             user => user_to_bin(Alice)},
-    QueryGet = admin_private_query(),
-    BodyGet = #{query => QueryGet, operationName => <<"Q1">>, variables => Vars},
-    GraphQlRequestGet = execute_auth(BodyGet, Config),
-    ParsedResultGet = ok_result(<<"private">>, <<"getPrivate">>, GraphQlRequestGet),
-    ?assertEqual(Expected, ParsedResultGet).
-
-no_user_error_get(Config) ->
-    Vars = #{element => <<"my_element">>, nameSpace => <<"alice:private:ns">>,
-             user => <<"AAAAA">>},
-    QueryGet = admin_private_query(),
-    BodyGet = #{query => QueryGet, operationName => <<"Q1">>, variables => Vars},
-    GraphQlRequestGet = execute_auth(BodyGet, Config),
-    ParsedResultGet = error_result2(<<"extensions">>, <<"code">>, GraphQlRequestGet),
-    ?assertEqual(<<"not_found">>, ParsedResultGet).
+    ResultGet = admin_get_private(AliceBin, <<"my_element">>, <<"alice:private:ns">>, Config),
+    ParsedResultGet = get_ok_value([data, private, getPrivate], ResultGet),
+    ?assertEqual(ElemStr, ParsedResultGet).
 
 no_user_error_set(Config) ->
-    QuerySet = admin_private_mutation(),
-    Expected = exml:to_binary(private_input()),
-    BodySet = #{query => QuerySet, operationName => <<"M1">>,
-             variables => #{elementString => Expected, user => <<"AAAAA">>}},
-    GraphQlRequestSet = execute_auth(BodySet, Config),
-    ParsedResultSet = error_result2(<<"extensions">>, <<"code">>, GraphQlRequestSet),
-    ?assertEqual(<<"not_found">>, ParsedResultSet).
+    ElemStr = exml:to_binary(private_input()),
+    Result = admin_set_private(<<"AAAAA">>, ElemStr, Config),
+    ?assertEqual(<<"not_found">>, get_err_code(Result)).
+
+no_user_error_get(Config) ->
+    Result = admin_get_private(<<"AAAAA">>, <<"my_element">>, <<"alice:private:ns">>, Config),
+    ?assertEqual(<<"not_found">>, get_err_code(Result)).
 
 private_input() ->
     #xmlel{name = <<"my_element">>,
            attrs = [{<<"xmlns">>, "alice:private:ns"}],
            children = [{xmlcdata, <<"DATA">>}]}.
 
-ok_result(What1, What2, {{<<"200">>, <<"OK">>}, #{<<"data">> := Data}}) ->
-    maps:get(What2, maps:get(What1, Data)).
+%% Commands
 
-error_result(What, {{<<"200">>, <<"OK">>}, #{<<"errors">> := [Data]}}) ->
-    maps:get(What, Data).
+user_set_private(User, ElementString, Config) ->
+    Vars = #{elementString => ElementString},
+    execute_user_command(<<"private">>, <<"setPrivate">>, User, Vars, Config).
 
-error_result2(What1, What2, {{<<"200">>, <<"OK">>}, #{<<"errors">> := [Data]}}) ->
-    maps:get(What2, maps:get(What1, Data)).
+user_get_private(User, Element, NameSpace, Config) ->
+    Vars = #{element => Element, nameSpace => NameSpace},
+    execute_user_command(<<"private">>, <<"getPrivate">>, User, Vars, Config).
 
-user_private_mutation() ->
-    <<"mutation M1($elementString: String!)
-       {
-        private
-           {
-               setPrivate(elementString: $elementString)
-           }
-       }">>.
+admin_set_private(User, ElementString, Config) ->
+    Vars = #{user => User, elementString => ElementString},
+    execute_command(<<"private">>, <<"setPrivate">>, Vars, Config).
 
-user_private_query() ->
-    <<"query Q1($element: String! $nameSpace: String!)
-       {
-        private
-           {
-               getPrivate(element: $element, nameSpace: $nameSpace)
-           }
-       }">>.
-
-admin_private_mutation() ->
-    <<"mutation M1($elementString: String!, $user: JID!)
-       {
-        private
-           {
-               setPrivate(user: $user, elementString: $elementString)
-           }
-       }">>.
-
-admin_private_query() ->
-    <<"query Q1($user: JID!, $element: String! $nameSpace: String!)
-       {
-        private
-           {
-               getPrivate(user: $user, element: $element, nameSpace: $nameSpace)
-           }
-       }">>.
+admin_get_private(User, Element, NameSpace, Config) ->
+    Vars = #{user => User, element => Element, nameSpace => NameSpace},
+    execute_command(<<"private">>, <<"getPrivate">>, Vars, Config).

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -3,14 +3,11 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
--import(graphql_helper, [execute_user/3, execute_auth/2, get_listener_port/1,
-                         get_listener_config/1, get_ok_value/2, get_err_msg/1,
-                         get_err_msg/2, make_creds/1, user_to_jid/1, user_to_bin/1]).
+-import(graphql_helper, [execute_user_command/5, execute_command/4, get_listener_port/1,
+                         get_listener_config/1, get_ok_value/2, get_err_value/2, get_err_msg/1,
+                         get_err_msg/2, user_to_jid/1, user_to_bin/1]).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("exml/include/exml.hrl").
--include_lib("escalus/include/escalus.hrl").
 -include_lib("../../include/mod_roster.hrl").
 
 suite() ->
@@ -18,13 +15,15 @@ suite() ->
 
 all() ->
     [{group, user_roster},
-     {group, admin_roster}].
+     {group, admin_roster_http},
+     {group, admin_roster_cli}].
 
 groups() ->
-    [{user_roster, [], user_roster_handler()},
-     {admin_roster, [], admin_roster_handler()}].
+    [{user_roster, [], user_roster_tests()},
+     {admin_roster_http, [], admin_roster_tests()},
+     {admin_roster_cli, [], admin_roster_tests()}].
 
-user_roster_handler() ->
+user_roster_tests() ->
     [user_add_and_delete_contact,
      user_try_add_nonexistent_contact,
      user_add_contacts,
@@ -37,7 +36,7 @@ user_roster_handler() ->
      user_get_nonexistent_contact
     ].
 
-admin_roster_handler() ->
+admin_roster_tests() ->
     [admin_add_and_delete_contact,
      admin_try_add_nonexistent_contact,
      admin_try_add_contact_to_nonexistent_user,
@@ -63,21 +62,23 @@ admin_roster_handler() ->
     ].
 
 init_per_suite(Config) ->
-    Config2 = escalus:init_per_suite(Config),
+    Config1 = ejabberd_node_utils:init(mim(), Config),
+    Config2 = escalus:init_per_suite(Config1),
     dynamic_modules:save_modules(domain_helper:host_type(), Config2).
 
 end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-init_per_group(admin_roster, Config) ->
+init_per_group(admin_roster_http, Config) ->
     graphql_helper:init_admin_handler(Config);
+init_per_group(admin_roster_cli, Config) ->
+    graphql_helper:init_admin_cli(Config);
 init_per_group(user_roster, Config) ->
-    [{schema_endpoint, user} | Config].
+    graphql_helper:init_user(Config).
 
-end_per_group(admin_roster, _Config) ->
-    escalus_fresh:clean();
-end_per_group(user_roster, _Config) ->
+end_per_group(_GroupName, _Config) ->
+    graphql_helper:clean(),
     escalus_fresh:clean().
 
 init_per_testcase(CaseName, Config) ->
@@ -113,7 +114,7 @@ admin_add_and_delete_contact_story(Config, Alice, Bob) ->
                                           <<"successfully">>)),
     check_contacts([Bob], Alice),
 
-    Res2 = execute_auth(admin_delete_contact_body(Alice, Bob), Config),
+    Res2 = admin_delete_contact(Alice, Bob, Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(?DELETE_CONTACT_PATH, Res2),
                                           <<"successfully">>)),
     check_contacts([], Alice).
@@ -145,12 +146,12 @@ admin_try_delete_nonexistent_contact(Config) ->
                                     fun admin_try_delete_nonexistent_contact_story/3).
 
 admin_try_delete_nonexistent_contact_story(Config, Alice, Bob) ->
-    Res = execute_auth(admin_delete_contact_body(Alice, Bob), Config),
+    Res = admin_delete_contact(Alice, Bob, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not exist">>)).
 
 admin_try_delete_contact_with_unknown_domain(Config) ->
     User = ?NONEXISTENT_DOMAIN_USER,
-    Res = execute_auth(admin_delete_contact_body(User, User), Config),
+    Res = admin_delete_contact(User, User, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 admin_add_contacts(Config) ->
@@ -158,8 +159,8 @@ admin_add_contacts(Config) ->
                                     fun admin_add_contacts_story/3).
 
 admin_add_contacts_story(Config, Alice, Bob) ->
-    Res = execute_auth(admin_add_contacts_body(Alice, [Bob, ?NONEXISTENT_DOMAIN_USER]), Config),
-    [R1, null] = get_ok_value(?ADD_CONTACTS_PATH, Res),
+    Res = admin_add_contacts(Alice, [Bob, ?NONEXISTENT_DOMAIN_USER], Config),
+    [R1, null] = get_err_value(?ADD_CONTACTS_PATH, Res),
     ?assertNotEqual(nomatch, binary:match(R1, <<"successfully">>)),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)).
 
@@ -168,9 +169,9 @@ admin_delete_contacts(Config) ->
                                     fun admin_delete_contacts_story/3).
 
 admin_delete_contacts_story(Config, Alice, Bob) ->
-    execute_auth(admin_add_contacts_body(Alice, [Bob]), Config),
-    Res = execute_auth(admin_delete_contacts_body(Alice, [Bob, ?NONEXISTENT_DOMAIN_USER]), Config),
-    [R1, null] = get_ok_value(?DELETE_CONTACTS_PATH, Res),
+    admin_add_contacts(Alice, [Bob], Config),
+    Res = admin_delete_contacts(Alice, [Bob, ?NONEXISTENT_DOMAIN_USER], Config),
+    [R1, null] = get_err_value(?DELETE_CONTACTS_PATH, Res),
     ?assertNotEqual(nomatch, binary:match(R1, <<"successfully">>)),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)).
 
@@ -184,20 +185,20 @@ admin_invite_accept_and_cancel_subscription_story(Config, Alice, Bob) ->
     admin_add_contact(Bob, Alice, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob, 1)),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice, 1)),
-    % Send invitation to subscribe 
-    execute_auth(admin_subscription_body(Alice, Bob, <<"INVITE">>), Config),
+    % Send invitation to subscribe
+    admin_subscription(Alice, Bob, <<"INVITE">>, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice)),
     escalus:assert(is_presence_with_type, [<<"subscribe">>], escalus:wait_for_stanza(Bob)),
     ?assertMatch(#roster{ask = out, subscription = none}, get_roster(Alice, Bob)),
-    % Accept invitation 
-    execute_auth(admin_subscription_body(Bob, Alice, <<"ACCEPT">>), Config),
+    % Accept invitation
+    admin_subscription(Bob, Alice, <<"ACCEPT">>, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob)),
     IsSub = fun(S) -> escalus_pred:is_presence_with_type(<<"subscribed">>, S) end,
     escalus:assert_many([is_roster_set, IsSub, is_presence],
                         escalus:wait_for_stanzas(Alice, 3)),
     ?assertMatch(#roster{ask = none, subscription = from}, get_roster(Bob, Alice)),
     % Cancel subscription
-    execute_auth(admin_subscription_body(Alice, Bob, <<"CANCEL">>), Config),
+    admin_subscription(Alice, Bob, <<"CANCEL">>, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice)),
     ?assertMatch(#roster{ask = none, subscription = none}, get_roster(Alice, Bob)).
 
@@ -207,23 +208,23 @@ admin_decline_subscription_ask(Config) ->
 
 admin_decline_subscription_ask_story(Config, Alice, Bob) ->
     % Add contacts
-    execute_auth(admin_add_contact_body(Alice, Bob, null, null), Config),
-    execute_auth(admin_add_contact_body(Bob, Alice, null, null), Config),
+    admin_add_contact(Alice, Bob, null, null, Config),
+    admin_add_contact(Bob, Alice, null, null, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob, 1)),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice, 1)),
-    % Send invitation to subscribe 
-    execute_auth(admin_subscription_body(Bob, Alice, <<"INVITE">>), Config),
+    % Send invitation to subscribe
+    admin_subscription(Bob, Alice, <<"INVITE">>, Config),
     ?assertMatch(#roster{ask = in, subscription = none}, get_roster(Alice, Bob)),
     ?assertMatch(#roster{ask = out, subscription = none}, get_roster(Bob, Alice)),
-    % Decline the invitation 
-    execute_auth(admin_subscription_body(Alice, Bob, <<"DECLINE">>), Config),
+    % Decline the invitation
+    admin_subscription(Alice, Bob, <<"DECLINE">>, Config),
     ?assertMatch(does_not_exist, get_roster(Alice, Bob)),
     ?assertMatch(#roster{ask = none, subscription = none}, get_roster(Bob, Alice)).
 
 admin_try_subscribe_with_unknown_domain(Config) ->
     Bob = ?NONEXISTENT_DOMAIN_USER,
     Alice = ?NONEXISTENT_USER,
-    Res = execute_auth(admin_subscription_body(Bob, Alice, <<"INVITE">>), Config),
+    Res = admin_subscription(Bob, Alice, <<"INVITE">>, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 admin_set_mutual_subscription(Config) ->
@@ -231,13 +232,13 @@ admin_set_mutual_subscription(Config) ->
                                     fun admin_set_mutual_subscription_story/3).
 
 admin_set_mutual_subscription_story(Config, Alice, Bob) ->
-    Res = execute_auth(admin_mutual_subscription_body(Alice, Bob, <<"CONNECT">>), Config),
+    Res = admin_mutual_subscription(Alice, Bob, <<"CONNECT">>, Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(?MUTUAL_SUBSCRIPTION_PATH, Res),
                                           <<"successfully">>)),
     ?assertMatch(#roster{ask = none, subscription = both}, get_roster(Alice, Bob)),
     ?assertMatch(#roster{ask = none, subscription = both}, get_roster(Bob, Alice)),
 
-    Res2 = execute_auth(admin_mutual_subscription_body(Alice, Bob, <<"DISCONNECT">>), Config),
+    Res2 = admin_mutual_subscription(Alice, Bob, <<"DISCONNECT">>, Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(?MUTUAL_SUBSCRIPTION_PATH, Res2),
                                           <<"successfully">>)),
     ?assertMatch(does_not_exist, get_roster(Alice, Bob)),
@@ -246,13 +247,13 @@ admin_set_mutual_subscription_story(Config, Alice, Bob) ->
 admin_set_mutual_subscription_try_connect_nonexistent_users(Config) ->
     Alice = ?NONEXISTENT_DOMAIN_USER,
     Bob = ?NONEXISTENT_USER,
-    Res = execute_auth(admin_mutual_subscription_body(Alice, Bob, <<"CONNECT">>), Config),
+    Res = admin_mutual_subscription(Alice, Bob, <<"CONNECT">>, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 admin_set_mutual_subscription_try_disconnect_nonexistent_users(Config) ->
     Alice = ?NONEXISTENT_DOMAIN_USER,
     Bob = ?NONEXISTENT_USER,
-    Res = execute_auth(admin_mutual_subscription_body(Alice, Bob, <<"DISCONNECT">>), Config),
+    Res = admin_mutual_subscription(Alice, Bob, <<"DISCONNECT">>, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 admin_subscribe_to_all(Config) ->
@@ -260,7 +261,7 @@ admin_subscribe_to_all(Config) ->
                                     fun admin_subscribe_to_all_story/4).
 
 admin_subscribe_to_all_story(Config, Alice, Bob, Kate) ->
-    Res = execute_auth(admin_subscribe_to_all_body(Alice, [Bob, Kate]), Config),
+    Res = admin_subscribe_to_all(Alice, [Bob, Kate], Config),
     check_if_created_succ(?SUBSCRIBE_TO_ALL_PATH, Res),
 
     check_contacts([Bob, Kate], Alice),
@@ -273,7 +274,7 @@ admin_subscribe_to_all_with_wrong_user(Config) ->
 
 admin_subscribe_to_all_with_wrong_user_story(Config, Alice, Bob) ->
     Kate = ?NONEXISTENT_DOMAIN_USER,
-    Res = execute_auth(admin_subscribe_to_all_body(Alice, [Bob, Kate]), Config),
+    Res = admin_subscribe_to_all(Alice, [Bob, Kate], Config),
     check_if_created_succ(?SUBSCRIBE_TO_ALL_PATH, Res, [true, false]),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)),
 
@@ -285,7 +286,7 @@ admin_subscribe_all_to_all(Config) ->
                                     fun admin_subscribe_all_to_all_story/4).
 
 admin_subscribe_all_to_all_story(Config, Alice, Bob, Kate) ->
-    Res = execute_auth(admin_subscribe_all_to_all_body([Alice, Bob, Kate]), Config),
+    Res = admin_subscribe_all_to_all([Alice, Bob, Kate], Config),
     check_if_created_succ(?SUBSCRIBE_ALL_TO_ALL_PATH, Res),
 
     check_contacts([Bob, Kate], Alice),
@@ -298,7 +299,7 @@ admin_subscribe_all_to_all_with_wrong_user(Config) ->
 
 admin_subscribe_all_to_all_with_wrong_user_story(Config, Alice, Bob) ->
     Kate = ?NONEXISTENT_DOMAIN_USER,
-    Res = execute_auth(admin_subscribe_all_to_all_body([Alice, Bob, Kate]), Config),
+    Res = admin_subscribe_all_to_all([Alice, Bob, Kate], Config),
     check_if_created_succ(?SUBSCRIBE_ALL_TO_ALL_PATH, Res, [true, false, false]),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(1, Res), <<"does not exist">>)),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(2, Res), <<"does not exist">>)),
@@ -314,17 +315,17 @@ admin_list_contacts_story(Config, Alice, Bob) ->
     BobBin = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
     BobName = escalus_client:username(Bob),
     admin_add_contact(Alice, Bob, Config),
-    Res = execute_auth(admin_list_contacts_body(Alice), Config),
+    Res = admin_list_contacts(Alice, Config),
     [#{<<"subscription">> := <<"NONE">>, <<"ask">> := <<"NONE">>, <<"jid">> := BobBin,
        <<"name">> := BobName, <<"groups">> := ?DEFAULT_GROUPS}] =
         get_ok_value([data, roster, listContacts], Res).
 
 admin_list_contacts_wrong_user(Config) ->
     % User with a non-existent domain
-    Res = execute_auth(admin_list_contacts_body(?NONEXISTENT_DOMAIN_USER), Config),
+    Res = admin_list_contacts(?NONEXISTENT_DOMAIN_USER, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)),
     % Non-existent user with existent domain
-    Res2 = execute_auth(admin_list_contacts_body(?NONEXISTENT_USER), Config),
+    Res2 = admin_list_contacts(?NONEXISTENT_USER, Config),
     ?assertEqual([], get_ok_value(?LIST_CONTACTS_PATH, Res2)).
 
 admin_get_contact(Config) ->
@@ -335,17 +336,17 @@ admin_get_contact_story(Config, Alice, Bob) ->
     BobBin = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
     BobName = escalus_client:username(Bob),
     admin_add_contact(Alice, Bob, Config),
-    Res = execute_auth(admin_get_contact_body(Alice, Bob), Config),
+    Res = admin_get_contact(Alice, Bob, Config),
     #{<<"subscription">> := <<"NONE">>, <<"ask">> := <<"NONE">>, <<"jid">> := BobBin,
       <<"name">> := BobName, <<"groups">> := ?DEFAULT_GROUPS} =
         get_ok_value([data, roster, getContact], Res).
 
 admin_get_contact_wrong_user(Config) ->
     % User with a non-existent domain
-    Res = execute_auth(admin_get_contact_body(?NONEXISTENT_DOMAIN_USER, ?NONEXISTENT_USER), Config),
+    Res = admin_get_contact(?NONEXISTENT_DOMAIN_USER, ?NONEXISTENT_USER, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)),
     % Non-existent user with existent domain
-    Res2 = execute_auth(admin_get_contact_body(?NONEXISTENT_USER, ?NONEXISTENT_USER), Config),
+    Res2 = admin_get_contact(?NONEXISTENT_USER, ?NONEXISTENT_USER, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"does not exist">>)).
 
 %% User test cases
@@ -361,7 +362,7 @@ user_add_and_delete_contact_story(Config, Alice, Bob) ->
                                           <<"successfully">>)),
     check_contacts([Bob], Alice),
     % Delete a contact
-    Res2 = execute_user(user_delete_contact_body(Bob), Alice, Config),
+    Res2 = user_delete_contact(Alice, Bob, Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(?DELETE_CONTACT_PATH, Res2),
                                           <<"successfully">>)),
     check_contacts([], Alice).
@@ -380,7 +381,7 @@ user_add_contacts(Config) ->
                                     fun user_add_contacts_story/3).
 
 user_add_contacts_story(Config, Alice, Bob) ->
-    Res = execute_user(user_add_contacts_body([Bob, ?NONEXISTENT_DOMAIN_USER]), Alice, Config),
+    Res = user_add_contacts(Alice, [Bob, ?NONEXISTENT_DOMAIN_USER], Config),
     [R1, null] = get_ok_value(?ADD_CONTACTS_PATH, Res),
     ?assertNotEqual(nomatch, binary:match(R1, <<"successfully">>)),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)).
@@ -390,7 +391,7 @@ user_try_delete_nonexistent_contact(Config) ->
                                     fun user_try_delete_nonexistent_contact_story/3).
 
 user_try_delete_nonexistent_contact_story(Config, Alice, Bob) ->
-    Res = execute_user(user_delete_contact_body(Bob), Alice, Config),
+    Res = user_delete_contact(Alice, Bob, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not exist">>)).
 
 user_delete_contacts(Config) ->
@@ -400,7 +401,7 @@ user_delete_contacts(Config) ->
 user_delete_contacts_story(Config, Alice, Bob) ->
     user_add_contact(Alice, Bob, Config),
 
-    Res = execute_user(user_delete_contacts_body([Bob, ?NONEXISTENT_DOMAIN_USER]), Alice, Config),
+    Res = user_delete_contacts(Alice, [Bob, ?NONEXISTENT_DOMAIN_USER], Config),
     [R1, null] = get_ok_value(?DELETE_CONTACTS_PATH, Res),
     ?assertNotEqual(nomatch, binary:match(R1, <<"successfully">>)),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)).
@@ -415,20 +416,20 @@ user_invite_accept_and_cancel_subscription_story(Config, Alice, Bob) ->
     user_add_contact(Bob, Alice, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob, 1)),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice, 1)),
-    % Send invitation to subscribe 
-    execute_user(user_subscription_body(Bob, <<"INVITE">>), Alice, Config),
+    % Send invitation to subscribe
+    user_subscription(Alice, Bob, <<"INVITE">>, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice)),
     escalus:assert(is_presence_with_type, [<<"subscribe">>], escalus:wait_for_stanza(Bob)),
     ?assertMatch(#roster{ask = out, subscription = none}, get_roster(Alice, Bob)),
-    % Accept invitation 
-    execute_user(user_subscription_body(Alice, <<"ACCEPT">>), Bob, Config),
+    % Accept invitation
+    user_subscription(Bob, Alice, <<"ACCEPT">>, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob)),
     IsSub = fun(S) -> escalus_pred:is_presence_with_type(<<"subscribed">>, S) end,
     escalus:assert_many([is_roster_set, IsSub, is_presence],
                         escalus:wait_for_stanzas(Alice, 3)),
     ?assertMatch(#roster{ask = none, subscription = from}, get_roster(Bob, Alice)),
     % Cancel subscription
-    execute_user(user_subscription_body(Bob, <<"CANCEL">>), Alice, Config),
+    user_subscription(Alice, Bob, <<"CANCEL">>, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice)),
     ?assertMatch(#roster{ask = none, subscription = none}, get_roster(Alice, Bob)).
 
@@ -442,12 +443,12 @@ user_decline_subscription_ask_story(Config, Alice, Bob) ->
     user_add_contact(Bob, Alice, Config),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Bob, 1)),
     escalus:assert(is_roster_set, escalus:wait_for_stanza(Alice, 1)),
-    % Send invitation to subscribe 
-    execute_user(user_subscription_body(Alice, <<"INVITE">>), Bob, Config),
+    % Send invitation to subscribe
+    user_subscription(Bob, Alice, <<"INVITE">>, Config),
     ?assertMatch(#roster{ask = in, subscription = none}, get_roster(Alice, Bob)),
     ?assertMatch(#roster{ask = out, subscription = none}, get_roster(Bob, Alice)),
-    % Decline the invitation 
-    execute_user(user_subscription_body(Bob, <<"DECLINE">>), Alice, Config),
+    % Decline the invitation
+    user_subscription(Alice, Bob, <<"DECLINE">>, Config),
     ?assertMatch(does_not_exist, get_roster(Alice, Bob)),
     ?assertMatch(#roster{ask = none, subscription = none}, get_roster(Bob, Alice)).
 
@@ -458,8 +459,8 @@ user_list_contacts(Config) ->
 user_list_contacts_story(Config, Alice, Bob) ->
     BobBin = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
     Name = <<"Bobek">>,
-    execute_user(user_add_contact_body(Bob, Name, ?DEFAULT_GROUPS), Alice, Config),
-    Res = execute_user(user_list_contacts_body(), Alice, Config),
+    user_add_contact(Alice, Bob, Name, ?DEFAULT_GROUPS, Config),
+    Res = user_list_contacts(Alice, Config),
     [#{<<"subscription">> := <<"NONE">>, <<"ask">> := <<"NONE">>, <<"jid">> := BobBin,
        <<"name">> := Name, <<"groups">> := ?DEFAULT_GROUPS}] =
         get_ok_value(?LIST_CONTACTS_PATH, Res).
@@ -471,8 +472,8 @@ user_get_contact(Config) ->
 user_get_contact_story(Config, Alice, Bob) ->
     BobBin = escalus_utils:jid_to_lower(escalus_client:short_jid(Bob)),
     Name = <<"Bobek">>,
-    execute_user(user_add_contact_body(Bob, Name, ?DEFAULT_GROUPS), Alice, Config),
-    Res = execute_user(user_get_contact_body(Bob), Alice, Config),
+    user_add_contact(Alice, Bob, Name, ?DEFAULT_GROUPS, Config),
+    Res = user_get_contact(Alice, Bob, Config),
     #{<<"subscription">> := <<"NONE">>, <<"ask">> := <<"NONE">>, <<"jid">> := BobBin,
       <<"name">> := Name, <<"groups">> := ?DEFAULT_GROUPS} =
         get_ok_value(?GET_CONTACT_PATH, Res).
@@ -482,18 +483,18 @@ user_get_nonexistent_contact(Config) ->
                                     fun user_get_nonexistent_contact_story/2).
 
 user_get_nonexistent_contact_story(Config, Alice) ->
-    Res = execute_user(user_get_contact_body(?NONEXISTENT_DOMAIN_USER), Alice, Config),
+    Res = user_get_contact(Alice, ?NONEXISTENT_DOMAIN_USER, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)).
 
 % Helpers
 
 admin_add_contact(User, Contact, Config) ->
     Name = escalus_utils:get_username(Contact),
-    execute_auth(admin_add_contact_body(User, Contact, Name, ?DEFAULT_GROUPS), Config).
+    admin_add_contact(User, Contact, Name, ?DEFAULT_GROUPS, Config).
 
 user_add_contact(User, Contact, Config) ->
     Name = escalus_utils:get_username(Contact),
-    execute_user(user_add_contact_body(Contact, Name, ?DEFAULT_GROUPS), User, Config).
+    user_add_contact(User, Contact, Name, ?DEFAULT_GROUPS, Config).
 
 check_contacts(ContactClients, User) ->
     Expected = [escalus_utils:jid_to_lower(escalus_client:short_jid(Client))
@@ -507,19 +508,19 @@ check_contacts(ContactClients, User) ->
     [?assertEqual(?DEFAULT_GROUPS, Groups) || #roster{groups = Groups} <- ActualContacts].
 
 check_if_created_succ(Path, Res) ->
-    check_if_created_succ(Path, Res, null).
+    OkList = get_ok_value(Path, Res),
+    lists:foreach(fun check_created_msg/1, OkList).
 
 check_if_created_succ(Path, Res, ExpectedOkValue) ->
-    OkList = get_ok_value(Path, Res),
+    OkList = case lists:member(false, ExpectedOkValue) of
+                 true -> get_err_value(Path, Res);
+                 false -> get_ok_value(Path, Res)
+             end,
+    OkList2 = lists:zip(OkList, ExpectedOkValue),
+    [check_created_msg(Msg) || {Msg, true} <- OkList2].
 
-    OkList2 = case ExpectedOkValue of
-                  null ->
-                      [{Msg, true} || Msg <- OkList];
-                  _ when is_list(ExpectedOkValue) ->
-                      lists:zip(OkList, ExpectedOkValue)
-              end,
-    [?assertNotEqual(nomatch, binary:match(Msg, <<"created successfully">>))
-     || {Msg, ShouldHaveValue} <- OkList2, ShouldHaveValue].
+check_created_msg(Msg) ->
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"created successfully">>)).
 
 get_roster(User) ->
     {ok, Roster} = rpc(mim(), mod_roster_api, list_contacts, [user_to_jid(User)]),
@@ -532,130 +533,78 @@ get_roster(User, Contact) ->
          jid:to_lower(user_to_jid(Contact)),
          full]).
 
-make_contact(Users) when is_list(Users) ->
-    [make_contact(U) || U <- Users];
+make_contacts(Users) ->
+    [make_contact(U) || U <- Users].
+
 make_contact(U) ->
     #{jid => user_to_bin(U), name => escalus_utils:get_username(U), groups => ?DEFAULT_GROUPS}.
 
-%% Request bodies
+%% Commands
 
-admin_add_contact_body(User, Contact, Name, Groups) ->
-    Query = <<"mutation M1($user: JID!, $contact: JID!, $name: String, $groups: [String!])
-              { roster { addContact(user: $user, contact: $contact, name: $name, groups: $groups) } }">>,
-    OpName = <<"M1">>,
+admin_add_contact(User, Contact, Name, Groups, Config) ->
     Vars = #{user => user_to_bin(User), contact => user_to_bin(Contact),
              name => Name, groups => Groups},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"roster">>, <<"addContact">>, Vars, Config).
 
-admin_add_contacts_body(User, Contacts) ->
-    Query = <<"mutation M1($user: JID!, $contacts: [ContactInput!]!)
-              { roster { addContacts(user: $user, contacts: $contacts) } }">>,
-    OpName = <<"M1">>,
-    Vars = #{user => user_to_bin(User), contacts => make_contact(Contacts)},
-    #{query => Query, operationName => OpName, variables => Vars}.
+admin_add_contacts(User, Contacts, Config) ->
+    Vars = #{user => user_to_bin(User), contacts => make_contacts(Contacts)},
+    execute_command(<<"roster">>, <<"addContacts">>, Vars, Config).
 
-admin_delete_contact_body(User, Contact) ->
-    Query = <<"mutation M1($user: JID!, $contact: JID!)
-              { roster { deleteContact(user: $user, contact: $contact) } }">>,
-    OpName = <<"M1">>,
+admin_delete_contact(User, Contact, Config) ->
     Vars = #{user => user_to_bin(User), contact => user_to_bin(Contact)},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"roster">>, <<"deleteContact">>, Vars, Config).
 
-admin_delete_contacts_body(User, Contacts) ->
-    Query = <<"mutation M1($user: JID!, $contacts: [JID!]!)
-              { roster { deleteContacts(user: $user, contacts: $contacts) } }">>,
-    OpName = <<"M1">>,
+admin_delete_contacts(User, Contacts, Config) ->
     Vars = #{user => user_to_bin(User), contacts => [user_to_bin(C) || C <- Contacts]},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"roster">>, <<"deleteContacts">>, Vars, Config).
 
-admin_subscription_body(User, Contact, Action) ->
-    Query = <<"mutation M1($user: JID!, $contact: JID!, $action: SubAction!)
-              { roster { subscription(user: $user, contact: $contact, action: $action) } }">>,
-    OpName = <<"M1">>,
+admin_subscription(User, Contact, Action, Config) ->
     Vars = #{user => user_to_bin(User), contact => user_to_bin(Contact), action => Action},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"roster">>, <<"subscription">>, Vars, Config).
 
-admin_mutual_subscription_body(User, Contact, Action) ->
-    Query = <<"mutation M1($userA: JID!, $userB: JID!, $action: MutualSubAction!)
-              { roster { setMutualSubscription(userA: $userA, userB: $userB, action: $action) } }">>,
-    OpName = <<"M1">>,
+admin_mutual_subscription(User, Contact, Action, Config) ->
     Vars = #{userA => user_to_bin(User), userB => user_to_bin(Contact), action => Action},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"roster">>, <<"setMutualSubscription">>, Vars, Config).
 
-admin_subscribe_to_all_body(User, Contacts) ->
-    Query = <<"mutation M1($user: ContactInput!, $contacts: [ContactInput!]!)
-              { roster { subscribeToAll(user: $user, contacts: $contacts) } }">>,
-    OpName = <<"M1">>,
-    Vars = #{user => make_contact(User), contacts => make_contact(Contacts)},
-    #{query => Query, operationName => OpName, variables => Vars}.
+admin_subscribe_to_all(User, Contacts, Config) ->
+    Vars = #{user => make_contact(User), contacts => make_contacts(Contacts)},
+    execute_command(<<"roster">>, <<"subscribeToAll">>, Vars, Config).
 
-admin_subscribe_all_to_all_body(Users) ->
-    Query = <<"mutation M1($contacts: [ContactInput!]!)
-              { roster { subscribeAllToAll(contacts: $contacts) } }">>,
-    OpName = <<"M1">>,
-    Vars = #{contacts => make_contact(Users)},
-    #{query => Query, operationName => OpName, variables => Vars}.
+admin_subscribe_all_to_all(Users, Config) ->
+    Vars = #{contacts => make_contacts(Users)},
+    execute_command(<<"roster">>, <<"subscribeAllToAll">>, Vars, Config).
 
-admin_list_contacts_body(User) ->
-    Query = <<"query Q1($user: JID!)
-              { roster { listContacts(user: $user)
-              { jid subscription ask name groups} } }">>,
-    OpName = <<"Q1">>,
+admin_list_contacts(User, Config) ->
     Vars = #{user => user_to_bin(User)},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"roster">>, <<"listContacts">>, Vars, Config).
 
-admin_get_contact_body(User, Contact) ->
-    Query = <<"query Q1($user: JID!, $contact: JID!)
-              { roster { getContact(user: $user, contact: $contact)
-              { jid subscription ask name groups} } }">>,
-    OpName = <<"Q1">>,
+admin_get_contact(User, Contact, Config) ->
     Vars = #{user => user_to_bin(User), contact => user_to_bin(Contact)},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_command(<<"roster">>, <<"getContact">>, Vars, Config).
 
-user_add_contact_body(Contact, Name, Groups) ->
-    Query = <<"mutation M1($contact: JID!, $name: String, $groups: [String!])
-              { roster { addContact(contact: $contact, name: $name, groups: $groups) } }">>,
-    OpName = <<"M1">>,
+user_add_contact(User, Contact, Name, Groups, Config) ->
     Vars = #{contact => user_to_bin(Contact), name => Name, groups => Groups},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_user_command(<<"roster">>, <<"addContact">>, User, Vars, Config).
 
-user_add_contacts_body(Contacts) ->
-    Query = <<"mutation M1($contacts: [ContactInput!]!)
-              { roster { addContacts(contacts: $contacts) } }">>,
-    OpName = <<"M1">>,
-    Vars = #{contacts => make_contact(Contacts)},
-    #{query => Query, operationName => OpName, variables => Vars}.
+user_add_contacts(User, Contacts, Config) ->
+    Vars = #{contacts => make_contacts(Contacts)},
+    execute_user_command(<<"roster">>, <<"addContacts">>, User, Vars, Config).
 
-user_delete_contact_body(Contact) ->
-    Query = <<"mutation M1($contact: JID!)
-              { roster { deleteContact(contact: $contact) } }">>,
-    OpName = <<"M1">>,
+user_delete_contact(User, Contact, Config) ->
     Vars = #{contact => user_to_bin(Contact)},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_user_command(<<"roster">>, <<"deleteContact">>, User, Vars, Config).
 
-user_delete_contacts_body(Contacts) ->
-    Query = <<"mutation M1($contacts: [JID!]!)
-              { roster { deleteContacts(contacts: $contacts) } }">>,
-    OpName = <<"M1">>,
+user_delete_contacts(User, Contacts, Config) ->
     Vars = #{contacts => [user_to_bin(C) || C <- Contacts]},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_user_command(<<"roster">>, <<"deleteContacts">>, User, Vars, Config).
 
-user_subscription_body(Contact, Action) ->
-    Query = <<"mutation M1($contact: JID!, $action: SubAction!)
-              { roster { subscription(contact: $contact, action: $action) } }">>,
-    OpName = <<"M1">>,
+user_subscription(User, Contact, Action, Config) ->
     Vars = #{contact => user_to_bin(Contact), action => Action},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_user_command(<<"roster">>, <<"subscription">>, User, Vars, Config).
 
-user_list_contacts_body() ->
-    Query = <<"query Q1 { roster { listContacts
-              { jid subscription ask name groups} } }">>,
-    #{query => Query, operationName => <<"Q1">>, variables => #{}}.
+user_list_contacts(User, Config) ->
+    execute_user_command(<<"roster">>, <<"listContacts">>, User, #{}, Config).
 
-user_get_contact_body(Contact) ->
-    Query = <<"query Q1($contact: JID!)
-              { roster { getContact(contact: $contact)
-              { jid subscription ask name groups} } }">>,
-    OpName = <<"Q1">>,
+user_get_contact(User, Contact, Config) ->
     Vars = #{contact => user_to_bin(Contact)},
-    #{query => Query, operationName => OpName, variables => Vars}.
+    execute_user_command(<<"roster">>, <<"getContact">>, User, Vars, Config).

--- a/big_tests/tests/graphql_session_SUITE.erl
+++ b/big_tests/tests/graphql_session_SUITE.erl
@@ -1,13 +1,11 @@
 -module(graphql_session_SUITE).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("exml/include/exml.hrl").
 
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
--import(graphql_helper, [execute/3, execute_auth/2, get_listener_port/1,
+-import(graphql_helper, [execute_user_command/5, execute_command/4,  get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_msg/1]).
 
 suite() ->
@@ -18,15 +16,17 @@ all() ->
      {group, admin_session}].
 
 groups() ->
-    [{user_session, [parallel], user_session_handler()},
-     {admin_session, [], admin_session_handler()}].
+    [{user_session, [parallel], user_session_tests()},
+     {admin_session, [], [{group, admin_session_http}, {group, admin_session_cli}]},
+     {admin_session_http, [], admin_session_tests()},
+     {admin_session_cli, [], admin_session_tests()}].
 
-user_session_handler() ->
+user_session_tests() ->
     [user_list_resources,
      user_count_resources,
      user_sessions_info].
 
-admin_session_handler() ->
+admin_session_tests() ->
     [admin_list_sessions,
      admin_count_sessions,
      admin_list_user_sessions,
@@ -40,7 +40,8 @@ admin_session_handler() ->
      admin_set_presence_unavailable].
 
 init_per_suite(Config) ->
-    Config2 = escalus:init_per_suite(Config),
+    Config1 = ejabberd_node_utils:init(mim(), Config),
+    Config2 = escalus:init_per_suite(Config1),
     dynamic_modules:save_modules(domain_helper:host_type(), Config2).
 
 end_per_suite(Config) ->
@@ -48,16 +49,19 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(admin_session, Config) ->
-    Config1 = escalus:create_users(Config, escalus:get_users([alice, alice_bis, bob])),
-    graphql_helper:init_admin_handler(Config1);
+    escalus:create_users(Config, escalus:get_users([alice, alice_bis, bob]));
+init_per_group(admin_session_cli, Config) ->
+    graphql_helper:init_admin_handler(Config);
+init_per_group(admin_session_http, Config) ->
+    graphql_helper:init_admin_cli(Config);
 init_per_group(user_session, Config) ->
-    [{schema_endpoint, user} | Config].
+    graphql_helper:init_user(Config).
 
 end_per_group(admin_session, Config) ->
-    escalus_fresh:clean(),
     escalus:delete_users(Config, escalus:get_users([alice, alice_bis, bob]));
-end_per_group(user_session, _Config) ->
-    escalus_fresh:clean().
+end_per_group(_GroupName, _Config) ->
+    escalus_fresh:clean(),
+    graphql_helper:clean().
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
@@ -71,12 +75,7 @@ user_list_resources(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 2}], fun user_list_resources_story/3).
 
 user_list_resources_story(Config, Alice, Alice2) ->
-    Ep = ?config(schema_endpoint, Config),
-    Creds = graphql_helper:make_creds(Alice),
-
-    Query = <<"query{ session { listResources } }">>,
-    Result = execute(Ep, #{query => Query}, Creds),
-
+    Result = user_list_resources(Alice, Config),
     Path = [data, session, listResources],
     ExpectedRes = [escalus_client:resource(Alice), escalus_client:resource(Alice2)],
     ?assertMatch(ExpectedRes, lists:sort(get_ok_value(Path, Result))).
@@ -85,12 +84,7 @@ user_count_resources(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 3}], fun user_count_resources_story/4).
 
 user_count_resources_story(Config, Alice, _Alice2, _Alice3) ->
-    Ep = ?config(schema_endpoint, Config),
-    Creds = graphql_helper:make_creds(Alice),
-
-    Query = <<"query{ session { countResources } }">>,
-    Result = execute(Ep, #{query => Query}, Creds),
-
+    Result = user_count_resources(Alice, Config),
     Path = [data, session, countResources],
     ?assertEqual(3, get_ok_value(Path, Result)).
 
@@ -98,13 +92,8 @@ user_sessions_info(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_sessions_info_story/2).
 
 user_sessions_info_story(Config, Alice) ->
-    Ep = ?config(schema_endpoint, Config),
-    Creds = graphql_helper:make_creds(Alice),
-
-    Query = <<"query{ session { listSessions { user } } }">>,
-    Result = execute(Ep, #{query => Query}, Creds),
+    Result = user_list_sessions(Alice, Config),
     ExpectedUser = escalus_utils:jid_to_lower(escalus_client:full_jid(Alice)),
-
     Path = [data, session, listSessions],
     ?assertMatch([#{<<"user">> := ExpectedUser}], get_ok_value(Path, Result)).
 
@@ -116,11 +105,11 @@ admin_list_sessions_story(Config, _Alice, AliceB, _Bob) ->
     BisDomain = escalus_client:server(AliceB),
     Path = [data, session, listSessions],
     % List all sessions
-    Res = execute_auth(list_sessions_body(null), Config),
+    Res = list_sessions(null, Config),
     Sessions = get_ok_value(Path, Res),
     ?assertEqual(3, length(Sessions)),
     % List sessions for a domain
-    Res2 = execute_auth(list_sessions_body(BisDomain), Config),
+    Res2 = list_sessions(BisDomain, Config),
     Sessions2 = get_ok_value(Path, Res2),
     ?assertEqual(1, length(Sessions2)).
 
@@ -132,11 +121,11 @@ admin_count_sessions_story(Config, _Alice, AliceB, _Bob) ->
     BisDomain = escalus_client:server(AliceB),
     Path = [data, session, countSessions],
     % Count all sessions
-    Res = execute_auth(count_sessions_body(null), Config),
+    Res = count_sessions(null, Config),
     Number = get_ok_value(Path, Res),
     ?assertEqual(3, Number),
     % Count sessions for a domain
-    Res2 = execute_auth(count_sessions_body(BisDomain), Config),
+    Res2 = count_sessions(BisDomain, Config),
     Number2 = get_ok_value(Path, Res2),
     ?assertEqual(1, Number2).
 
@@ -148,11 +137,11 @@ admin_list_user_sessions_story(Config, Alice, Alice2, _Bob) ->
     S1JID = escalus_client:full_jid(Alice),
     S2JID = escalus_client:full_jid(Alice2),
     Path = [data, session, listUserSessions],
-    Res = execute_auth(list_user_sessions_body(S1JID), Config),
+    Res = list_user_sessions(S1JID, Config),
     ExpectedRes = lists:map(fun escalus_utils:jid_to_lower/1, [S1JID, S2JID]),
     Sessions = get_ok_value(Path, Res),
     ?assertEqual(2, length(Sessions)),
-    ?assert(users_match(ExpectedRes, Sessions)).
+    check_users(ExpectedRes, Sessions).
 
 admin_count_user_resources(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 3}], fun admin_count_user_resources_story/4).
@@ -160,7 +149,7 @@ admin_count_user_resources(Config) ->
 admin_count_user_resources_story(Config, Alice, _Alice2, _Alice3) ->
     Path = [data, session, countUserResources],
     JID = escalus_client:full_jid(Alice),
-    Res = execute_auth(count_user_resources_body(JID), Config),
+    Res = count_user_resources(JID, Config),
     ?assertEqual(3, get_ok_value(Path, Res)).
 
 admin_get_user_resource(Config) ->
@@ -170,10 +159,10 @@ admin_get_user_resource_story(Config, Alice, Alice2, _Alice3) ->
     Path = [data, session, getUserResource],
     JID = escalus_client:short_jid(Alice),
     % Provide a correct resource number
-    Res = execute_auth(get_user_resource_body(JID, 2), Config),
+    Res = get_user_resource(JID, 2, Config),
     ?assertEqual(escalus_client:resource(Alice2), get_ok_value(Path, Res)),
     % Provide a wrong resource number
-    Res2 = execute_auth(get_user_resource_body(JID, 4), Config),
+    Res2 = get_user_resource(JID, 4, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"Wrong resource number">>)).
 
 admin_count_users_with_status(Config) ->
@@ -189,14 +178,14 @@ admin_count_users_with_status_story(Config, Alice, AliceB) ->
     % Count users with away status globally
     escalus_client:send(Alice, AwayPresence),
     escalus_client:send(AliceB, AwayPresence),
-    Res = execute_auth(count_users_with_status_body(null, AwayStatus), Config),
+    Res = count_users_with_status(null, AwayStatus, Config),
     ?assertEqual(2, get_ok_value(Path, Res)),
     % Count users with away status for a domain
-    Res2 = execute_auth(count_users_with_status_body(domain_helper:domain(), AwayStatus), Config),
+    Res2 = count_users_with_status(domain_helper:domain(), AwayStatus, Config),
     ?assertEqual(1, get_ok_value(Path, Res2)),
     % Count users with dnd status globally
     escalus_client:send(AliceB, DndPresence),
-    Res3 = execute_auth(count_users_with_status_body(null, DndStatus), Config),
+    Res3 = count_users_with_status(null, DndStatus, Config),
     ?assertEqual(1, get_ok_value(Path, Res3)).
 
 admin_list_users_with_status(Config) ->
@@ -214,21 +203,21 @@ admin_list_users_with_status_story(Config, Alice, AliceB) ->
     % List users with away status globally
     escalus_client:send(Alice, AwayPresence),
     escalus_client:send(AliceB, AwayPresence),
-    Res = execute_auth(list_users_with_status_body(null, AwayStatus), Config),
+    Res = list_users_with_status(null, AwayStatus, Config),
     StatusUsers = get_ok_value(Path, Res),
     ?assertEqual(2, length(StatusUsers)),
-    ?assert(users_match([AliceJID, AliceBJID], StatusUsers)),
+    check_users([AliceJID, AliceBJID], StatusUsers),
     % List users with away status for a domain
-    Res2 = execute_auth(list_users_with_status_body(domain_helper:domain(), AwayStatus), Config),
+    Res2 = list_users_with_status(domain_helper:domain(), AwayStatus, Config),
     StatusUsers2 = get_ok_value(Path, Res2),
     ?assertEqual(1, length(StatusUsers2)),
-    ?assert(users_match([AliceJID], StatusUsers2)),
+    check_users([AliceJID], StatusUsers2),
     % List users with dnd status globally
     escalus_client:send(AliceB, DndPresence),
-    Res3 = execute_auth(list_users_with_status_body(null, DndStatus), Config),
+    Res3 = list_users_with_status(null, DndStatus, Config),
     StatusUsers3 = get_ok_value(Path, Res3),
     ?assertEqual(1, length(StatusUsers3)),
-    ?assert(users_match([AliceBJID], StatusUsers3)).
+    check_users([AliceBJID], StatusUsers3).
 
 admin_kick_session(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 2}], fun admin_kick_session_story/3).
@@ -238,18 +227,18 @@ admin_kick_session_story(Config, Alice1, Alice2) ->
     JIDA2 = escalus_client:full_jid(Alice2),
     Reason = <<"Test kick">>,
     Path = [data, session, kickUser, message],
-    Res = execute_auth(kick_session_body(JIDA1, Reason), Config),
+    Res = kick_user(JIDA1, Reason, Config),
     % Kick an active session
     ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Res), <<"kicked">>)),
     ?assertEqual(JIDA1, get_ok_value([data, session, kickUser, jid], Res)),
     % Try to kick an offline session
-    Res2 = execute_auth(kick_session_body(JIDA1, Reason), Config),
+    Res2 = kick_user(JIDA1, Reason, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res2), <<"No active session">>)),
     % Try to kick a session with JID without a resource
-    Res3 = execute_auth(kick_session_body(escalus_client:short_jid(Alice2), Reason), Config),
+    Res3 = kick_user(escalus_client:short_jid(Alice2), Reason, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"No active session">>)),
     % Kick another active session
-    Res4 = execute_auth(kick_session_body(JIDA2, Reason), Config),
+    Res4 = kick_user(JIDA2, Reason, Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Res4), <<"kicked">>)).
 
 admin_set_presence(Config) ->
@@ -263,11 +252,11 @@ admin_set_presence_story(Config, Alice) ->
     Status = <<"Be right back">>,
     Priority = 1,
     % Send short JID
-    Res = execute_auth(set_presence_body(ShortJID, Type, Show, Status, Priority), Config),
+    Res = set_presence(ShortJID, Type, Show, Status, Priority, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"resource is empty">>)),
     % Send full JID
     Path = [data, session, setPresence, message],
-    Res2 = execute_auth(set_presence_body(JID, Type, Show, Status, Priority), Config),
+    Res2 = set_presence(JID, Type, Show, Status, Priority, Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Res2), <<"set successfully">>)),
     Presence = escalus:wait_for_stanza(Alice),
     ?assertNot(escalus_pred:is_presence_with_show(<<"online">>, Presence)),
@@ -283,7 +272,7 @@ admin_set_presence_away_story(Config, Alice) ->
     Type = <<"AVAILABLE">>,
     Show = <<"AWAY">>,
     Path = [data, session, setPresence, message],
-    Res2 = execute_auth(set_presence_body(JID, Type, Show, null, null), Config),
+    Res2 = set_presence(JID, Type, Show, null, null, Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Res2), <<"set successfully">>)),
     Presence = escalus:wait_for_stanza(Alice),
     escalus:assert(is_presence_with_type, [<<"available">>], Presence),
@@ -297,80 +286,64 @@ admin_set_presence_unavailable_story(Config, Alice, Alice2) ->
     Type = <<"UNAVAILABLE">>,
     Status = <<"I'm sleeping">>,
     Path = [data, session, setPresence, message],
-    Res2 = execute_auth(set_presence_body(JID, Type, null, Status, null), Config),
+    Res2 = set_presence(JID, Type, null, Status, null, Config),
     ?assertNotEqual(nomatch, binary:match(get_ok_value(Path, Res2), <<"set successfully">>)),
     Presence = escalus:wait_for_stanza(Alice2),
     escalus:assert(is_presence_with_type, [<<"unavailable">>], Presence),
     escalus:assert(is_presence_with_status, [Status], Presence).
 
+
+%% Commands
+
+user_list_resources(User, Config) ->
+    execute_user_command(<<"session">>, <<"listResources">>, User, #{}, Config).
+
+user_count_resources(User, Config) ->
+    execute_user_command(<<"session">>, <<"countResources">>, User, #{}, Config).
+
+user_list_sessions(User, Config) ->
+    execute_user_command(<<"session">>, <<"listSessions">>, User, #{}, Config).
+
+list_sessions(Domain, Config) ->
+    Vars = #{<<"domain">> => Domain},
+    execute_command(<<"session">>, <<"listSessions">>, Vars, Config).
+
+count_sessions(Domain, Config) ->
+    Vars = #{<<"domain">> => Domain},
+    execute_command(<<"session">>, <<"countSessions">>, Vars, Config).
+
+list_user_sessions(User, Config) ->
+    Vars = #{<<"user">> => User},
+    execute_command(<<"session">>, <<"listUserSessions">>, Vars, Config).
+
+count_user_resources(User, Config) ->
+    Vars = #{<<"user">> => User},
+    execute_command(<<"session">>, <<"countUserResources">>, Vars, Config).
+
+get_user_resource(User, Number, Config) ->
+    Vars = #{<<"user">> => User, <<"number">> => Number},
+    execute_command(<<"session">>, <<"getUserResource">>, Vars, Config).
+
+list_users_with_status(Domain, Status, Config) ->
+    Vars = #{<<"domain">> => Domain, <<"status">> => Status},
+    execute_command(<<"session">>, <<"listUsersWithStatus">>, Vars, Config).
+
+count_users_with_status(Domain, Status, Config) ->
+    Vars = #{<<"domain">> => Domain, <<"status">> => Status},
+    execute_command(<<"session">>, <<"countUsersWithStatus">>, Vars, Config).
+
+kick_user(JID, Reason, Config) ->
+    Vars = #{<<"user">> => JID, <<"reason">> => Reason},
+    execute_command(<<"session">>, <<"kickUser">>, Vars, Config).
+
+set_presence(JID, Type, Show, Status, Priority, Config) ->
+    Vars = #{<<"user">> => JID, <<"type">> => Type, <<"show">> => Show,
+             <<"status">> => Status, <<"priority">> => Priority},
+    execute_command(<<"session">>, <<"setPresence">>, Vars, Config).
+
 %% Helpers
 
--spec users_match([jid:literal_jid()], [#{user := jid:literal_jid()}]) -> boolean().
-users_match(Expected, Actual) ->
-    lists:all(fun(#{<<"user">> := JID}) -> lists:member(JID, Expected) end, Actual).
-
-%% Request bodies
-
-list_sessions_body(Domain) ->
-    Query = <<"query Q1($domain: String)
-              { session { listSessions(domain: $domain) { user } } }">>,
-    OpName = <<"Q1">>,
-    Vars = #{<<"domain">> => Domain},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
-count_sessions_body(Domain) ->
-    Query = <<"query Q1($domain: String)
-              { session { countSessions(domain: $domain) } }">>,
-    OpName = <<"Q1">>,
-    Vars = #{<<"domain">> => Domain},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
-list_user_sessions_body(JID) ->
-    Query = <<"query Q1($user: JID!)
-              { session { listUserSessions(user: $user) { user } } }">>,
-    OpName = <<"Q1">>,
-    Vars = #{<<"user">> => JID},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
-count_user_resources_body(JID) ->
-    Query = <<"query Q1($user: JID!)
-              { session { countUserResources(user: $user) } }">>,
-    OpName = <<"Q1">>,
-    Vars = #{<<"user">> => JID},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
-get_user_resource_body(JID, Number) ->
-    Query = <<"query Q1($user: JID!, $number: Int!)
-              { session { getUserResource(user: $user, number: $number) } }">>,
-    OpName = <<"Q1">>,
-    Vars = #{<<"user">> => JID, <<"number">> => Number},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
-list_users_with_status_body(Domain, Status) ->
-    Query = <<"query Q1($domain: String, $status: String!)
-              { session { listUsersWithStatus(domain: $domain, status: $status) { user } } }">>,
-    OpName = <<"Q1">>,
-    Vars = #{<<"domain">> => Domain, <<"status">> => Status},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
-count_users_with_status_body(Domain, Status) ->
-    Query = <<"query Q1($domain: String, $status: String!)
-              { session { countUsersWithStatus(domain: $domain, status: $status) } }">>,
-    OpName = <<"Q1">>,
-    Vars = #{<<"domain">> => Domain, <<"status">> => Status},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
-kick_session_body(JID, Reason) ->
-    Query = <<"mutation M1($user: JID!, $reason: String!)
-              { session { kickUser(user: $user, reason: $reason) { jid message }} }">>,
-    OpName = <<"M1">>,
-    Vars = #{<<"user">> => JID, <<"reason">> => Reason},
-    #{query => Query, operationName => OpName, variables => Vars}.
-
-set_presence_body(JID, Type, Show, Status, Priority) ->
-    Query = <<"mutation M1($user: JID!, $type: PresenceType!, $show: PresenceShow, $status: String, $priority: Int)
-              { session { setPresence(user: $user, type: $type, show: $show, status: $status, priority: $priority)
-              { message jid } } }">>,
-    OpName = <<"M1">>,
-    Vars = #{<<"user">> => JID, <<"type">> => Type, <<"show">> => Show, <<"status">> => Status, <<"priority">> => Priority},
-    #{query => Query, operationName => OpName, variables => Vars}.
+-spec check_users([jid:literal_jid()], [#{user := jid:literal_jid()}]) -> boolean().
+check_users(Expected, ActualUsers) ->
+    ActualJIDs = [JID || #{<<"user">> := JID} <- ActualUsers],
+    ?assertEqual(lists:sort(Expected), lists:sort(ActualJIDs)).

--- a/big_tests/tests/graphql_stanza_SUITE.erl
+++ b/big_tests/tests/graphql_stanza_SUITE.erl
@@ -1,26 +1,28 @@
 -module(graphql_stanza_SUITE).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("exml/include/exml.hrl").
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [require_rpc_nodes/1]).
--import(graphql_helper, [execute_auth/2]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/1]).
+-import(graphql_helper, [execute_user_command/5, execute_command/4,
+                         get_ok_value/2, get_err_code/1, get_err_msg/1, get_coercion_err_msg/1]).
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
-    [{group, admin_stanza_category},
-     {group, user_stanza_caregory}].
+    [{group, admin_stanza_http},
+     {group, admin_stanza_cli},
+     {group, user_stanza}].
 
 groups() ->
-    [{admin_stanza_category, [parallel], admin_stanza_category()},
-     {user_stanza_caregory, [parallel], user_stanza_caregory()}].
+    [{admin_stanza_http, [parallel], admin_stanza_cases()},
+     {admin_stanza_cli, [], admin_stanza_cases()},
+     {user_stanza, [parallel], user_stanza_cases()}].
 
-admin_stanza_category() ->
+admin_stanza_cases() ->
     [admin_send_message,
      admin_send_message_to_unparsable_jid,
      admin_send_message_headline,
@@ -38,7 +40,7 @@ admin_get_last_messages_cases() ->
      admin_get_last_messages_limit_enforced,
      admin_get_last_messages_before].
 
-user_stanza_caregory() ->
+user_stanza_cases() ->
     [user_send_message,
      user_send_message_without_from,
      user_send_message_with_spoofed_from,
@@ -52,22 +54,25 @@ user_get_last_messages_cases() ->
     [user_get_last_messages].
 
 init_per_suite(Config) ->
-    Config1 = escalus:init_per_suite(Config),
-    dynamic_modules:save_modules(domain_helper:host_type(), Config1).
+    Config1 = ejabberd_node_utils:init(mim(), Config),
+    Config2 = escalus:init_per_suite(Config1),
+    dynamic_modules:save_modules(domain_helper:host_type(), Config2),
+    init_mam(Config2).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-init_per_group(admin_stanza_category, Config) ->
-    Config2 = graphql_helper:init_admin_handler(Config),
-    init_mam(Config2);
-init_per_group(user_stanza_caregory, Config) ->
-    init_mam(Config).
+init_per_group(admin_stanza_http, Config) ->
+    graphql_helper:init_admin_handler(Config);
+init_per_group(admin_stanza_cli, Config) ->
+    graphql_helper:init_admin_cli(Config);
+init_per_group(user_stanza, Config) ->
+    graphql_helper:init_user(Config).
 
 end_per_group(_, _Config) ->
-    ok.
+    graphql_helper:clean().
 
 init_per_testcase(CaseName, Config) ->
     HasMam = proplists:get_value(has_mam, Config, false),
@@ -103,27 +108,22 @@ admin_send_message(Config) ->
                                     fun admin_send_message_story/3).
 
 admin_send_message_story(Config, Alice, Bob) ->
-    Body = <<"Hi!">>,
-    Vars = #{from => escalus_client:full_jid(Alice),
-             to => escalus_client:short_jid(Bob),
-             body => Body},
-    Res = ok_result(<<"stanza">>, <<"sendMessage">>,
-                    execute_send_message(Vars, Config)),
-    #{<<"id">> := MamID} = Res,
-    assert_not_empty(MamID, Config).
+    From = escalus_client:full_jid(Alice),
+    To = escalus_client:short_jid(Bob),
+    Res = send_message(From, To, <<"Hi!">>, Config),
+    #{<<"id">> := MamID} = get_ok_value([data, stanza, sendMessage], Res),
+    assert_not_empty(MamID, Config),
+    escalus:assert(is_message, escalus:wait_for_stanza(Bob)).
 
 user_send_message(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
                                     fun user_send_message_story/3).
 
 user_send_message_story(Config, Alice, Bob) ->
-    Body = <<"Hi!">>,
-    Vars = #{from => escalus_client:full_jid(Alice),
-             to => escalus_client:short_jid(Bob),
-             body => Body},
-    Res = ok_result(<<"stanza">>, <<"sendMessage">>,
-                    execute_user_send_message(Alice, Vars, Config)),
-    #{<<"id">> := MamID} = Res,
+    From = escalus_client:full_jid(Alice),
+    To = escalus_client:short_jid(Bob),
+    Res = user_send_message(Alice, From, To, <<"Hi!">>, Config),
+    #{<<"id">> := MamID} = get_ok_value([data, stanza, sendMessage], Res),
     assert_not_empty(MamID, Config),
     escalus:assert(is_message, escalus:wait_for_stanza(Bob)).
 
@@ -132,12 +132,9 @@ user_send_message_without_from(Config) ->
                                     fun user_send_message_without_from_story/3).
 
 user_send_message_without_from_story(Config, Alice, Bob) ->
-    Body = <<"Hi!">>,
-    Vars = #{to => escalus_client:short_jid(Bob),
-             body => Body},
-    Res = ok_result(<<"stanza">>, <<"sendMessage">>,
-                    execute_user_send_message(Alice, Vars, Config)),
-    #{<<"id">> := MamID} = Res,
+    To = escalus_client:short_jid(Bob),
+    Res = user_send_message(Alice, null, To, <<"Hi!">>, Config),
+    #{<<"id">> := MamID} = get_ok_value([data, stanza, sendMessage], Res),
     assert_not_empty(MamID, Config),
     escalus:assert(is_message, escalus:wait_for_stanza(Bob)).
 
@@ -146,61 +143,45 @@ user_send_message_with_spoofed_from(Config) ->
                                     fun user_send_message_with_spoofed_from_story/3).
 
 user_send_message_with_spoofed_from_story(Config, Alice, Bob) ->
-    Body = <<"Hi!">>,
-    Vars = #{from => escalus_client:short_jid(Bob),
-             to => escalus_client:short_jid(Bob),
-             body => Body},
-    Res = execute_user_send_message(Alice, Vars, Config),
-    spoofed_error(<<"sendMessage">>, Res).
+    To = From = escalus_client:short_jid(Bob),
+    Res = user_send_message(Alice, From, To, <<"Hi!">>, Config),
+    spoofed_error(sendMessage, Res).
 
 admin_send_message_to_unparsable_jid(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
                                     fun admin_send_message_to_unparsable_jid_story/2).
 
 admin_send_message_to_unparsable_jid_story(Config, Alice) ->
-    Body = <<"Hi!">>,
-    Vars = #{from => escalus_client:full_jid(Alice),
-             to => <<"test@">>,
-             body => Body},
-    Res = execute_send_message(Vars, Config),
-    {{<<"400">>, <<"Bad Request">>}, #{<<"errors">> := Errors}} = Res,
-    [#{<<"extensions">> := #{<<"code">> := <<"input_coercion">>},
-       <<"message">> := ErrMsg, <<"path">> := ErrPath}] = Errors,
-    ?assertEqual([<<"M1">>, <<"to">>], ErrPath),
+    From = escalus_client:full_jid(Alice),
+    To = <<"test@">>,
+    Res = send_message(From, To, <<"Hi!">>, Config),
     ?assertEqual(<<"Input coercion failed for type JID with value "
                    "<<\"test@\">>. The reason it failed is: failed_to_parse_jid">>,
-                 ErrMsg).
+                 get_coercion_err_msg(Res)).
 
 admin_send_message_headline(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
                                     fun admin_send_message_headline_story/3).
 
 admin_send_message_headline_story(Config, Alice, Bob) ->
-    Subject = <<"Welcome">>,
-    Body = <<"Hi!">>,
-    Vars = #{from => escalus_client:full_jid(Alice),
-             to => escalus_client:short_jid(Bob),
-             subject => Subject, body => Body},
-    Res = ok_result(<<"stanza">>, <<"sendMessageHeadLine">>,
-                    execute_send_message_headline(Vars, Config)),
-    #{<<"id">> := MamID} = Res,
-    %% Headlines are not stored in MAM
-    <<>> = MamID.
+    From = escalus_client:full_jid(Alice),
+    To = escalus_client:short_jid(Bob),
+    Res = send_message_headline(From, To, <<"Welcome">>, <<"Hi!">>, Config),
+    #{<<"id">> := MamID} = get_ok_value([data, stanza, sendMessageHeadLine], Res),
+    % Headlines are not stored in MAM
+    <<>> = MamID,
+    escalus:assert(is_message, escalus:wait_for_stanza(Bob)).
 
 user_send_message_headline(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
                                     fun user_send_message_headline_story/3).
 
 user_send_message_headline_story(Config, Alice, Bob) ->
-    Subject = <<"Welcome">>,
-    Body = <<"Hi!">>,
-    Vars = #{from => escalus_client:full_jid(Alice),
-             to => escalus_client:short_jid(Bob),
-             subject => Subject, body => Body},
-    Res = ok_result(<<"stanza">>, <<"sendMessageHeadLine">>,
-                    execute_user_send_message_headline(Alice, Vars, Config)),
-    #{<<"id">> := MamID} = Res,
-    %% Headlines are not stored in MAM
+    From = escalus_client:full_jid(Alice),
+    To = escalus_client:short_jid(Bob),
+    Res = user_send_message_headline(Alice, From, To, <<"Welcome">>, <<"Hi!">>, Config),
+    #{<<"id">> := MamID} = get_ok_value([data, stanza, sendMessageHeadLine], Res),
+    % Headlines are not stored in MAM
     <<>> = MamID,
     escalus:assert(is_message, escalus:wait_for_stanza(Bob)).
 
@@ -209,13 +190,9 @@ user_send_message_headline_with_spoofed_from(Config) ->
                                     fun user_send_message_headline_with_spoofed_from_story/3).
 
 user_send_message_headline_with_spoofed_from_story(Config, Alice, Bob) ->
-    Subject = <<"Welcome">>,
-    Body = <<"Hi!">>,
-    Vars = #{from => escalus_client:short_jid(Bob),
-             to => escalus_client:short_jid(Bob),
-             subject => Subject, body => Body},
-    Res = execute_user_send_message_headline(Alice, Vars, Config),
-    spoofed_error(<<"sendMessageHeadLine">>, Res).
+    To = From = escalus_client:short_jid(Bob),
+    Res = user_send_message_headline(Alice, From, To, <<"Welcome">>, <<"Hi!">>, Config),
+    spoofed_error(sendMessageHeadLine, Res).
 
 admin_send_stanza(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
@@ -224,10 +201,10 @@ admin_send_stanza(Config) ->
 admin_send_stanza_story(Config, Alice, Bob) ->
     Body = <<"Hi!">>,
     Stanza = escalus_stanza:from(escalus_stanza:chat_to_short_jid(Bob, Body), Alice),
-    Vars = #{stanza => exml:to_binary(Stanza)},
-    Res = ok_result(<<"stanza">>, <<"sendStanza">>, execute_send_stanza(Vars, Config)),
-    #{<<"id">> := MamID} = Res,
-    assert_not_empty(MamID, Config).
+    Res = send_stanza(exml:to_binary(Stanza), Config),
+    #{<<"id">> := MamID} = get_ok_value([data, stanza, sendStanza], Res),
+    assert_not_empty(MamID, Config),
+    escalus:assert(is_message, escalus:wait_for_stanza(Bob)).
 
 user_send_stanza(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
@@ -236,11 +213,10 @@ user_send_stanza(Config) ->
 user_send_stanza_story(Config, Alice, Bob) ->
     Body = <<"Hi!">>,
     Stanza = escalus_stanza:from(escalus_stanza:chat_to_short_jid(Bob, Body), Alice),
-    Vars = #{stanza => exml:to_binary(Stanza)},
-    Res = ok_result(<<"stanza">>, <<"sendStanza">>,
-                    execute_user_send_stanza(Alice, Vars, Config)),
-    #{<<"id">> := MamID} = Res,
-    assert_not_empty(MamID, Config).
+    Res = user_send_stanza(Alice, exml:to_binary(Stanza), Config),
+    #{<<"id">> := MamID} = get_ok_value([data, stanza, sendStanza], Res),
+    assert_not_empty(MamID, Config),
+    escalus:assert(is_message, escalus:wait_for_stanza(Bob)).
 
 user_send_stanza_with_spoofed_from(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
@@ -249,19 +225,14 @@ user_send_stanza_with_spoofed_from(Config) ->
 user_send_stanza_with_spoofed_from_story(Config, Alice, Bob) ->
     Body = <<"Hi!">>,
     Stanza = escalus_stanza:from(escalus_stanza:chat_to_short_jid(Bob, Body), Bob),
-    Vars = #{stanza => exml:to_binary(Stanza)},
-    Res = execute_user_send_stanza(Alice, Vars, Config),
-    spoofed_error(<<"sendStanza">>, Res).
+    Res = user_send_stanza(Alice, exml:to_binary(Stanza), Config),
+    spoofed_error(sendStanza, Res).
 
 admin_send_unparsable_stanza(Config) ->
-    Vars = #{stanza => <<"<test">>},
-    Res = execute_send_stanza(Vars, Config),
-    {{<<"400">>, <<"Bad Request">>}, #{<<"errors">> := Errors}} = Res,
-    [#{<<"extensions">> := #{<<"code">> := <<"input_coercion">>},
-       <<"message">> := ErrMsg, <<"path">> := ErrPath}] = Errors,
+    Res = send_stanza(<<"<test">>, Config),
     ?assertEqual(<<"Input coercion failed for type Stanza with value <<\"<test\">>. "
-                   "The reason it failed is: \"expected >\"">>, ErrMsg),
-    ?assertEqual([<<"M1">>, <<"stanza">>], ErrPath).
+                   "The reason it failed is: \"expected >\"">>,
+                 get_coercion_err_msg(Res)).
 
 admin_send_stanza_from_unknown_user(Config) ->
     escalus:fresh_story_with_config(Config, [{bob, 1}],
@@ -271,18 +242,10 @@ admin_send_stanza_from_unknown_user_story(Config, Bob) ->
     Body = <<"Hi!">>,
     Server = escalus_client:server(Bob),
     From = <<"YeeeAH@", Server/binary>>,
-    LFrom = jid:str_tolower(From),
     Stanza = escalus_stanza:from(escalus_stanza:chat_to_short_jid(Bob, Body), From),
-    Vars = #{stanza => exml:to_binary(Stanza)},
-    Res = execute_send_stanza(Vars, Config),
-    {{<<"200">>,<<"OK">>},
-         #{<<"data">> := #{<<"stanza">> := #{<<"sendStanza">> := null}},
-           <<"errors">> := Errors}} = Res,
-    [#{<<"extensions">> := #{<<"code">> := <<"unknown_user">>,
-                             <<"jid">> := LFrom},
-       <<"message">> := ErrMsg, <<"path">> := ErrPath}] = Errors,
-    ?assertEqual(<<"Given user does not exist">>, ErrMsg),
-    ?assertEqual([<<"stanza">>, <<"sendStanza">>], ErrPath).
+    Res = send_stanza(exml:to_binary(Stanza), Config),
+    ?assertEqual(<<"unknown_user">>, get_err_code(Res)),
+    ?assertEqual(<<"Given user does not exist">>, get_err_msg(Res)).
 
 admin_send_stanza_from_unknown_domain(Config) ->
     escalus:fresh_story_with_config(Config, [{bob, 1}],
@@ -292,16 +255,9 @@ admin_send_stanza_from_unknown_domain_story(Config, Bob) ->
     Body = <<"Hi!">>,
     From = <<"YeeeAH@oopsie">>,
     Stanza = escalus_stanza:from(escalus_stanza:chat_to_short_jid(Bob, Body), From),
-    Vars = #{stanza => exml:to_binary(Stanza)},
-    Res = execute_send_stanza(Vars, Config),
-    {{<<"200">>, <<"OK">>},
-     #{<<"data">> := #{<<"stanza">> := #{<<"sendStanza">> := null}},
-       <<"errors">> := Errors}} = Res,
-    [#{<<"extensions">> := #{<<"code">> := <<"unknown_domain">>,
-                             <<"domain">> := <<"oopsie">>},
-       <<"message">> := ErrMsg, <<"path">> := ErrPath}] = Errors,
-    ?assertEqual([<<"stanza">>, <<"sendStanza">>], ErrPath),
-    ?assertEqual(<<"Given domain does not exist">>, ErrMsg).
+    Res = send_stanza(exml:to_binary(Stanza), Config),
+    ?assertEqual(<<"unknown_domain">>, get_err_code(Res)),
+    ?assertEqual(<<"Given domain does not exist">>, get_err_msg(Res)).
 
 admin_get_last_messages(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
@@ -311,15 +267,13 @@ admin_get_last_messages_story(Config, Alice, Bob) ->
     admin_send_message_story(Config, Alice, Bob),
     mam_helper:wait_for_archive_size(Alice, 1),
     mam_helper:wait_for_archive_size(Bob, 1),
-    Vars1 = #{caller => escalus_client:full_jid(Alice)},
-    Vars2 = #{caller => escalus_client:full_jid(Bob)},
-    Res1 = ok_result(<<"stanza">>, <<"getLastMessages">>,
-                     execute_get_last_messages(Vars1, Config)),
-    #{<<"stanzas">> := [M1], <<"limit">> := 50} = Res1,
+    Res1 = get_last_messages(escalus_client:full_jid(Alice), null, null, Config),
+    #{<<"stanzas">> := [M1], <<"limit">> := 50} =
+        get_ok_value([data, stanza, getLastMessages], Res1),
     check_stanza_map(M1, Alice),
-    Res2 = ok_result(<<"stanza">>, <<"getLastMessages">>,
-                     execute_get_last_messages(Vars2, Config)),
-    #{<<"stanzas">> := [M2], <<"limit">> := 50} = Res2,
+    Res2 = get_last_messages(escalus_client:full_jid(Bob), null, null, Config),
+    #{<<"stanzas">> := [M2], <<"limit">> := 50} =
+        get_ok_value([data, stanza, getLastMessages], Res2),
     check_stanza_map(M2, Alice).
 
 user_get_last_messages(Config) ->
@@ -330,30 +284,21 @@ user_get_last_messages_story(Config, Alice, Bob) ->
     user_send_message_story(Config, Alice, Bob),
     mam_helper:wait_for_archive_size(Alice, 1),
     mam_helper:wait_for_archive_size(Bob, 1),
-    Vars1 = #{caller => escalus_client:full_jid(Alice)},
-    Vars2 = #{caller => escalus_client:full_jid(Bob)},
-    Res1 = ok_result(<<"stanza">>, <<"getLastMessages">>,
-                     execute_user_get_last_messages(Alice, Vars1, Config)),
-    #{<<"stanzas">> := [M1], <<"limit">> := 50} = Res1,
+    Res1 = user_get_last_messages(Alice, null, null, Config),
+    #{<<"stanzas">> := [M1], <<"limit">> := 50} =
+        get_ok_value([data, stanza, getLastMessages], Res1),
     check_stanza_map(M1, Alice),
-    Res2 = ok_result(<<"stanza">>, <<"getLastMessages">>,
-                     execute_user_get_last_messages(Alice, Vars2, Config)),
-    #{<<"stanzas">> := [M2], <<"limit">> := 50} = Res2,
+    Res2 = user_get_last_messages(Bob, null, null, Config),
+    #{<<"stanzas">> := [M2], <<"limit">> := 50} =
+        get_ok_value([data, stanza, getLastMessages], Res2),
     check_stanza_map(M2, Alice).
 
 admin_get_last_messages_for_unknown_user(Config) ->
     Domain = domain_helper:domain(),
     Jid = <<"maybemaybebutnot@", Domain/binary>>,
-    Vars = #{caller => Jid},
-    Res = execute_get_last_messages(Vars, Config),
-    {{<<"200">>, <<"OK">>},
-     #{<<"data">> := #{<<"stanza">> := #{<<"getLastMessages">> := null}},
-       <<"errors">> := Errors}} = Res,
-    [#{<<"extensions">> := #{<<"code">> := <<"unknown_user">>,
-                             <<"jid">> := Jid},
-       <<"message">> := ErrMsg, <<"path">> := ErrPath}] = Errors,
-    ?assertEqual([<<"stanza">>, <<"getLastMessages">>], ErrPath),
-    ?assertEqual(<<"Given user does not exist">>, ErrMsg).
+    Res = get_last_messages(Jid, null, null, Config),
+    ?assertEqual(<<"unknown_user">>, get_err_code(Res)),
+    ?assertEqual(<<"Given user does not exist">>, get_err_msg(Res)).
 
 admin_get_last_messages_with(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
@@ -364,11 +309,11 @@ admin_get_last_messages_with_story(Config, Alice, Bob, Kate) ->
     mam_helper:wait_for_archive_size(Alice, 1),
     admin_send_message_story(Config, Kate, Alice),
     mam_helper:wait_for_archive_size(Alice, 2),
-    Vars = #{caller => escalus_client:full_jid(Alice),
-             with => escalus_client:short_jid(Bob)},
-    Res = ok_result(<<"stanza">>, <<"getLastMessages">>,
-                    execute_get_last_messages(Vars, Config)),
-    #{<<"stanzas">> := [M1], <<"limit">> := 50} = Res,
+    Caller = escalus_client:full_jid(Alice),
+    With = escalus_client:short_jid(Bob),
+    Res = get_last_messages(Caller, With, null, Config),
+    #{<<"stanzas">> := [M1], <<"limit">> := 50} =
+        get_ok_value([data, stanza, getLastMessages], Res),
     check_stanza_map(M1, Alice).
 
 admin_get_last_messages_limit(Config) ->
@@ -380,10 +325,10 @@ admin_get_last_messages_limit_story(Config, Alice, Bob) ->
     mam_helper:wait_for_archive_size(Alice, 1),
     admin_send_message_story(Config, Bob, Alice),
     mam_helper:wait_for_archive_size(Alice, 2),
-    Vars = #{caller => escalus_client:full_jid(Alice), limit => 1},
-    Res = ok_result(<<"stanza">>, <<"getLastMessages">>,
-                    execute_get_last_messages(Vars, Config)),
-    #{<<"stanzas">> := [M1], <<"limit">> := 1} = Res,
+    Caller = escalus_client:full_jid(Alice),
+    Res = get_last_messages(Caller, null, 1, null, Config),
+    #{<<"stanzas">> := [M1], <<"limit">> := 1} =
+        get_ok_value([data, stanza, getLastMessages], Res),
     check_stanza_map(M1, Bob).
 
 admin_get_last_messages_limit_enforced(Config) ->
@@ -393,11 +338,11 @@ admin_get_last_messages_limit_enforced(Config) ->
 admin_get_last_messages_limit_enforced_story(Config, Alice, Bob) ->
     admin_send_message_story(Config, Alice, Bob),
     mam_helper:wait_for_archive_size(Alice, 1),
-    Vars = #{caller => escalus_client:full_jid(Alice), limit => 1000},
-    Res = ok_result(<<"stanza">>, <<"getLastMessages">>,
-                    execute_get_last_messages(Vars, Config)),
+    Caller = escalus_client:full_jid(Alice),
+    Res = get_last_messages(Caller, null, 1000, null, Config),
     %% The actual limit is returned
-    #{<<"stanzas">> := [M1], <<"limit">> := 500} = Res,
+    #{<<"stanzas">> := [M1], <<"limit">> := 500} =
+        get_ok_value([data, stanza, getLastMessages], Res),
     check_stanza_map(M1, Alice).
 
 admin_get_last_messages_before(Config) ->
@@ -411,74 +356,54 @@ admin_get_last_messages_before_story(Config, Alice, Bob) ->
     mam_helper:wait_for_archive_size(Alice, 2),
     admin_send_message_story(Config, Bob, Alice),
     mam_helper:wait_for_archive_size(Alice, 3),
-    Vars1 = #{caller => escalus_client:full_jid(Alice)},
-    Res1 = ok_result(<<"stanza">>, <<"getLastMessages">>,
-                     execute_get_last_messages(Vars1, Config)),
-    #{<<"stanzas">> := [M1, M2, _M3], <<"limit">> := 50} = Res1,
-    Vars2 = #{caller => escalus_client:full_jid(Alice),
-              before => maps:get(<<"timestamp">>, M2)},
-    Res2 = ok_result(<<"stanza">>, <<"getLastMessages">>,
-                     execute_get_last_messages(Vars2, Config)),
-    #{<<"stanzas">> := [M1, M2], <<"limit">> := 50} = Res2.
+    Caller = escalus_client:full_jid(Alice),
+    Res1 = get_last_messages(Caller, null, null, Config),
+    #{<<"stanzas">> := [M1, M2, _M3], <<"limit">> := 50} =
+        get_ok_value([data, stanza, getLastMessages], Res1),
+    Before = maps:get(<<"timestamp">>, M2),
+    Res2 = get_last_messages(Caller, null, Before, Config),
+    #{<<"stanzas">> := [M1, M2], <<"limit">> := 50} =
+        get_ok_value([data, stanza, getLastMessages], Res2).
+
+%% Commands
+
+send_message(From, To, Body, Config) ->
+    Vars = #{from => From, to => To, body => Body},
+    execute_command(<<"stanza">>, <<"sendMessage">>, Vars, Config).
+
+user_send_message(User, From, To, Body, Config) ->
+    Vars = #{from => From, to => To, body => Body},
+    execute_user_command(<<"stanza">>, <<"sendMessage">>, User, Vars, Config).
+
+send_message_headline(From, To, Subject, Body, Config) ->
+    Vars = #{from => From, to => To, subject => Subject, body => Body},
+    execute_command(<<"stanza">>, <<"sendMessageHeadLine">>, Vars, Config).
+
+user_send_message_headline(User, From, To, Subject, Body, Config) ->
+    Vars = #{from => From, to => To, subject => Subject, body => Body},
+    execute_user_command(<<"stanza">>, <<"sendMessageHeadLine">>, User, Vars, Config).
+
+send_stanza(Stanza, Config) ->
+    Vars = #{stanza => Stanza},
+    execute_command(<<"stanza">>, <<"sendStanza">>, Vars, Config).
+
+user_send_stanza(User, Stanza, Config) ->
+    Vars = #{stanza => Stanza},
+    execute_user_command(<<"stanza">>, <<"sendStanza">>, User, Vars, Config).
+
+get_last_messages(Caller, With, Before, Config) ->
+    Vars = #{caller => Caller, with => With, before => Before},
+    execute_command(<<"stanza">>, <<"getLastMessages">>, Vars, Config).
+
+get_last_messages(Caller, With, Limit, Before, Config) ->
+    Vars = #{caller => Caller, with => With, limit => Limit, before => Before},
+    execute_command(<<"stanza">>, <<"getLastMessages">>, Vars, Config).
+
+user_get_last_messages(User, With, Before, Config) ->
+    Vars = #{with => With, before => Before},
+    execute_user_command(<<"stanza">>, <<"getLastMessages">>, User, Vars, Config).
 
 %% Helpers
-
-execute_send_message(Vars, Config) ->
-    Q = <<"mutation M1($from: JID!, $to: JID!, $body: String!) "
-          "{ stanza { sendMessage(from: $from, to: $to, body: $body) { id } } }">>,
-    execute_auth(#{query => Q, variables => Vars,
-                   operationName => <<"M1">>}, Config).
-
-execute_user_send_message(User, Vars, _Config) ->
-    Creds = graphql_helper:make_creds(User),
-    Q = <<"mutation M1($from: JID, $to: JID!, $body: String!) "
-          "{ stanza { sendMessage(from: $from, to: $to, body: $body) { id } } }">>,
-    QQ = #{query => Q, variables => Vars, operationName => <<"M1">>},
-    graphql_helper:execute(user, QQ, Creds).
-
-execute_send_message_headline(Vars, Config) ->
-    Q = <<"mutation M1($from: JID!, $to: JID!, $subject: String, $body: String) "
-          "{ stanza { sendMessageHeadLine("
-            "from: $from, to: $to, subject: $subject, body: $body) { id } } }">>,
-    execute_auth(#{query => Q, variables => Vars,
-                   operationName => <<"M1">>}, Config).
-
-execute_user_send_message_headline(User, Vars, _Config) ->
-    Creds = graphql_helper:make_creds(User),
-    Q = <<"mutation M1($from: JID, $to: JID!, $subject: String, $body: String) "
-          "{ stanza { sendMessageHeadLine("
-            "from: $from, to: $to, subject: $subject, body: $body) { id } } }">>,
-    QQ = #{query => Q, variables => Vars, operationName => <<"M1">>},
-    graphql_helper:execute(user, QQ, Creds).
-
-execute_send_stanza(Vars, Config) ->
-    Q = <<"mutation M1($stanza: Stanza!) "
-          "{ stanza { sendStanza(stanza: $stanza) { id } } }">>,
-    execute_auth(#{query => Q, variables => Vars,
-                   operationName => <<"M1">>}, Config).
-
-execute_user_send_stanza(User, Vars, _Config) ->
-    Creds = graphql_helper:make_creds(User),
-    Q = <<"mutation M1($stanza: Stanza!) "
-          "{ stanza { sendStanza(stanza: $stanza) { id } } }">>,
-    QQ = #{query => Q, variables => Vars, operationName => <<"M1">>},
-    graphql_helper:execute(user, QQ, Creds).
-
-execute_get_last_messages(Vars, Config) ->
-    Q = <<"query Q1($caller: JID!, $with: JID, $limit: Int, $before: DateTime) "
-          "{ stanza { getLastMessages(caller: $caller, with: $with, "
-                 " limit: $limit, before: $before) "
-                     "{ stanzas { stanza_id stanza sender timestamp } limit } } }">>,
-    execute_auth(#{query => Q, variables => Vars,
-                   operationName => <<"Q1">>}, Config).
-
-execute_user_get_last_messages(User, Vars, _Config) ->
-    Creds = graphql_helper:make_creds(User),
-    Q = <<"query Q1($with: JID, $limit: Int, $before: DateTime) "
-          "{ stanza { getLastMessages(with: $with, limit: $limit, before: $before) "
-                     "{ stanzas { stanza_id stanza sender timestamp } limit } } }">>,
-    QQ = #{query => Q, variables => Vars, operationName => <<"Q1">>},
-    graphql_helper:execute(user, QQ, Creds).
 
 assert_not_empty(Bin, Config) ->
     case proplists:get_value(has_mam, Config) of
@@ -503,11 +428,7 @@ check_stanza_map(#{<<"sender">> := SenderJID,
      true = is_integer(calendar:rfc3339_to_system_time(binary_to_list(TS))),
      {ok, #xmlel{name = <<"message">>}} = exml:parse(XML).
 
-spoofed_error(Call, Res) ->
-    {{<<"200">>, <<"OK">>},
-     #{<<"data">> := #{<<"stanza">> := #{Call := null}},
-       <<"errors">> := Errors}} = Res,
-    [#{<<"extensions">> := #{<<"code">> := <<"bad_from_jid">>},
-       <<"message">> := ErrMsg, <<"path">> := ErrPath}] = Errors,
-    ?assertEqual([<<"stanza">>, Call], ErrPath),
-    ?assertEqual(<<"Sending from this JID is not allowed">>, ErrMsg).
+spoofed_error(Call, Response) ->
+    null = graphql_helper:get_err_value([data, stanza, Call], Response),
+    ?assertEqual(<<"Sending from this JID is not allowed">>, get_err_msg(Response)),
+    ?assertEqual(<<"bad_from_jid">>, get_err_code(Response)).

--- a/big_tests/tests/offline_SUITE.erl
+++ b/big_tests/tests/offline_SUITE.erl
@@ -142,6 +142,7 @@ offline_message_is_stored_and_delivered_at_login(Config) ->
         fun(FreshConfig, Alice, Bob) ->
                 logout(FreshConfig, Bob),
                 escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"msgtxt">>)),
+                wait_for_n_offline_messages(Bob, 1),
                 NewBob = login_send_presence(FreshConfig, bob),
                 Stanzas = escalus:wait_for_stanzas(NewBob, 2),
                 escalus_new_assert:mix_match


### PR DESCRIPTION
Finish testing GraphQL with CLI in a unified way, making use of generated queries.

Categories included in this PR:
- [x] domain
- [x] http_upload
- [x] inbox
- [x] last
- [x] muc
- [x] muc_light
- [x] offline
- [x] private
- [x] roster
- [x] session
- [x] stanza

Also: fix a race condition in `offline_SUITE`, that for some reason started presenting itself in this PR.