### PR TITLE
Update stat and domain categories

### DIFF
--- a/big_tests/tests/graphql_domain_SUITE.erl
+++ b/big_tests/tests/graphql_domain_SUITE.erl
@@ -74,7 +74,7 @@ create_domain(Config) ->
 
 create_domain(Config, DomainName) ->
     Result = add_domain(DomainName, ?HOST_TYPE, Config),
-    ParsedResult = get_ok_value([data, domains, addDomain], Result),
+    ParsedResult = get_ok_value([data, domain, addDomain], Result),
     ?assertEqual(#{<<"domain">> => DomainName,
         <<"hostType">> => ?HOST_TYPE,
         <<"enabled">> => null}, ParsedResult).
@@ -116,49 +116,49 @@ wrong_host_type_error_formatting(Config) ->
 
 disable_domain(Config) ->
     Result = disable_domain(<<"exampleDomain">>, Config),
-    ParsedResult = get_ok_value([data, domains, disableDomain], Result),
+    ParsedResult = get_ok_value([data, domain, disableDomain], Result),
     ?assertMatch(#{<<"domain">> := <<"exampleDomain">>, <<"enabled">> := false}, ParsedResult),
     {ok, Domain} = rpc(mim(), mongoose_domain_sql, select_domain, [<<"exampleDomain">>]),
     ?assertEqual(#{host_type => ?HOST_TYPE, enabled => false}, Domain).
 
 enable_domain(Config) ->
     Result = enable_domain(<<"exampleDomain">>, Config),
-    ParsedResult = get_ok_value([data, domains, enableDomain], Result),
+    ParsedResult = get_ok_value([data, domain, enableDomain], Result),
     ?assertMatch(#{<<"domain">> := <<"exampleDomain">>, <<"enabled">> := true}, ParsedResult).
 
 get_domains_by_host_type(Config) ->
     Result = get_domains_by_host_type(?HOST_TYPE, Config),
-    ParsedResult = get_ok_value([data, domains, domainsByHostType], Result),
+    ParsedResult = get_ok_value([data, domain, domainsByHostType], Result),
     ?assertEqual(lists:sort([<<"exampleDomain">>, <<"exampleDomain2">>]),
                  lists:sort(ParsedResult)).
 
 get_domain_details(Config) ->
     Result = get_domain_details(<<"exampleDomain">>, Config),
-    ParsedResult = get_ok_value([data, domains, domainDetails], Result),
+    ParsedResult = get_ok_value([data, domain, domainDetails], Result),
     ?assertEqual(#{<<"domain">> => <<"exampleDomain">>,
                    <<"hostType">> => ?HOST_TYPE,
                    <<"enabled">> => true}, ParsedResult).
 
 delete_domain(Config) ->
     Result1 = remove_domain(<<"exampleDomain">>, ?HOST_TYPE, Config),
-    ParsedResult1 = get_ok_value([data, domains, removeDomain], Result1),
+    ParsedResult1 = get_ok_value([data, domain, removeDomain], Result1),
     ?assertMatch(#{<<"msg">> := <<"Domain removed!">>,
                    <<"domain">> := #{<<"domain">> := <<"exampleDomain">>}},
                  ParsedResult1),
     Result2 = remove_domain(<<"exampleDomain2">>, ?HOST_TYPE, Config),
-    ParsedResult2 = get_ok_value([data, domains, removeDomain], Result2),
+    ParsedResult2 = get_ok_value([data, domain, removeDomain], Result2),
     ?assertMatch(#{<<"msg">> := <<"Domain removed!">>,
                    <<"domain">> := #{<<"domain">> := <<"exampleDomain2">>}},
                  ParsedResult2).
 
 get_domains_after_deletion(Config) ->
     Result = get_domains_by_host_type(?HOST_TYPE, Config),
-    ParsedResult = get_ok_value([data, domains, domainsByHostType], Result),
+    ParsedResult = get_ok_value([data, domain, domainsByHostType], Result),
     ?assertEqual([], ParsedResult).
 
 set_domain_password(Config) ->
     Result = set_domain_password(domain_helper:domain(), <<"secret">>, Config),
-    ParsedResult = get_ok_value([data, domains, setDomainPassword], Result),
+    ParsedResult = get_ok_value([data, domain, setDomainPassword], Result),
     ?assertNotEqual(nomatch, binary:match(ParsedResult, <<"successfully">>)).
 
 set_nonexistent_domain_password(Config) ->
@@ -168,42 +168,42 @@ set_nonexistent_domain_password(Config) ->
 
 delete_domain_password(Config) ->
     Result = delete_domain_password(domain_helper:domain(), Config),
-    ParsedResult = get_ok_value([data, domains, deleteDomainPassword], Result),
+    ParsedResult = get_ok_value([data, domain, deleteDomainPassword], Result),
     ?assertNotEqual(nomatch, binary:match(ParsedResult, <<"successfully">>)).
 
 %% Commands
 
 add_domain(Domain, HostType, Config) ->
     Vars = #{domain => Domain, hostType => HostType},
-    execute_command(<<"domains">>, <<"addDomain">>, Vars, Config).
+    execute_command(<<"domain">>, <<"addDomain">>, Vars, Config).
 
 enable_domain(Domain, Config) ->
     Vars = #{domain => Domain},
-    execute_command(<<"domains">>, <<"enableDomain">>, Vars, Config).
+    execute_command(<<"domain">>, <<"enableDomain">>, Vars, Config).
 
 disable_domain(Domain, Config) ->
     Vars = #{domain => Domain},
-    execute_command(<<"domains">>, <<"disableDomain">>, Vars, Config).
+    execute_command(<<"domain">>, <<"disableDomain">>, Vars, Config).
 
 get_domain_details(Domain, Config) ->
     Vars = #{domain => Domain},
-    execute_command(<<"domains">>, <<"domainDetails">>, Vars, Config).
+    execute_command(<<"domain">>, <<"domainDetails">>, Vars, Config).
 
 remove_domain(Domain, HostType, Config) ->
     Vars = #{domain => Domain, hostType => HostType},
-    execute_command(<<"domains">>, <<"removeDomain">>, Vars, Config).
+    execute_command(<<"domain">>, <<"removeDomain">>, Vars, Config).
 
 get_domains_by_host_type(HostType, Config) ->
     Vars = #{hostType => HostType},
-    execute_command(<<"domains">>, <<"domainsByHostType">>, Vars, Config).
+    execute_command(<<"domain">>, <<"domainsByHostType">>, Vars, Config).
 
 set_domain_password(Domain, Password, Config) ->
     Vars = #{domain => Domain, password => Password},
-    execute_command(<<"domains">>, <<"setDomainPassword">>, Vars, Config).
+    execute_command(<<"domain">>, <<"setDomainPassword">>, Vars, Config).
 
 delete_domain_password(Domain, Config) ->
     Vars = #{domain => Domain},
-    execute_command(<<"domains">>, <<"deleteDomainPassword">>, Vars, Config).
+    execute_command(<<"domain">>, <<"deleteDomainPassword">>, Vars, Config).
 
 %% Helpers
 

--- a/big_tests/tests/graphql_stats_SUITE.erl
+++ b/big_tests/tests/graphql_stats_SUITE.erl
@@ -2,43 +2,44 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [require_rpc_nodes/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/1]).
 -import(domain_helper, [host_type/0, domain/0]).
--import(graphql_helper, [execute_user/3, execute_auth/2, user_to_bin/1]).
--import(config_parser_helper, [mod_config/2]).
+-import(graphql_helper, [execute_command/4, get_ok_value/2]).
 -import(mongooseimctl_helper, [mongooseimctl/3, rpc_call/3]).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("exml/include/exml.hrl").
--include_lib("escalus/include/escalus.hrl").
--include("../../include/mod_roster.hrl").
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
-    [{group, admin_stats}].
+    [{group, admin_stats_http},
+     {group, admin_stats_cli}].
 
 groups() ->
-    [{admin_stats, [], admin_stats_handler()}].
+    [{admin_stats_http, [], admin_stats_tests()},
+     {admin_stats_cli, [], admin_stats_tests()}].
 
-admin_stats_handler() ->
+admin_stats_tests() ->
     [admin_stats_global_test,
      admin_stats_global_with_users_test,
      admin_stats_domain_test,
      admin_stats_domain_with_users_test].
 
 init_per_suite(Config) ->
-    escalus:init_per_suite(Config).
+    Config1 = ejabberd_node_utils:init(mim(), Config),
+    escalus:init_per_suite(Config1).
 
 end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
-init_per_group(_, Config) ->
-    graphql_helper:init_admin_handler(Config).
+init_per_group(admin_stats_http, Config) ->
+    graphql_helper:init_admin_handler(Config);
+init_per_group(admin_stats_cli, Config) ->
+    graphql_helper:init_admin_cli(Config).
 
 end_per_group(_, _Config) ->
+    graphql_helper:clean(),
     escalus_fresh:clean().
 
 init_per_testcase(CaseName, Config) ->
@@ -51,8 +52,7 @@ end_per_testcase(CaseName, Config) ->
 % Admin test cases
 
 admin_stats_global_test(Config) ->
-    GraphQlRequest = admin_get_stats(Config, #{}),
-    Result = ok_result(<<"stats">>, <<"globalStats">>, GraphQlRequest),
+    Result = get_ok_value([data, stat, globalStats], get_stats(Config)),
     #{<<"uptimeSeconds">> := UptimeSeconds, <<"registeredUsers">> := RegisteredUsers,
       <<"onlineUsersNode">> := OnlineUsersNode, <<"onlineUsers">> := OnlineUsers,
       <<"incomingS2S">> := IncomingS2S, <<"outgoingS2S">> := OutgoingS2S} = Result,
@@ -67,8 +67,7 @@ admin_stats_global_with_users_test(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_stats_global_with_users_test/2).
 
 admin_stats_global_with_users_test(Config, _Alice) ->
-    GraphQlRequest = admin_get_stats(Config, #{}),
-    Result = ok_result(<<"stats">>, <<"globalStats">>, GraphQlRequest),
+    Result = get_ok_value([data, stat, globalStats], get_stats(Config)),
     #{<<"uptimeSeconds">> := UptimeSeconds, <<"registeredUsers">> := RegisteredUsers,
       <<"onlineUsersNode">> := OnlineUsersNode, <<"onlineUsers">> := OnlineUsers,
       <<"incomingS2S">> := IncomingS2S, <<"outgoingS2S">> := OutgoingS2S} = Result,
@@ -80,9 +79,7 @@ admin_stats_global_with_users_test(Config, _Alice) ->
     ?assert(is_not_negative_integer(OutgoingS2S)).
 
 admin_stats_domain_test(Config) ->
-    Vars = #{<<"domain">> => domain()},
-    GraphQlRequest = admin_get_stats_domain(Config, Vars),
-    Result = ok_result(<<"stats">>, <<"domainStats">>, GraphQlRequest),
+    Result = get_ok_value([data, stat, domainStats], get_domain_stats(domain(), Config)),
     #{<<"registeredUsers">> := RegisteredUsers, <<"onlineUsers">> := OnlineUsers} = Result,
     ?assertEqual(0, RegisteredUsers),
     ?assertEqual(0, OnlineUsers).
@@ -91,35 +88,21 @@ admin_stats_domain_with_users_test(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_stats_domain_with_users_test/2).
 
 admin_stats_domain_with_users_test(Config, _Alice) ->
-    Vars = #{<<"domain">> => domain()},
-    GraphQlRequest = admin_get_stats_domain(Config, Vars),
-    Result = ok_result(<<"stats">>, <<"domainStats">>, GraphQlRequest),
+    Result = get_ok_value([data, stat, domainStats], get_domain_stats(domain(), Config)),
     #{<<"registeredUsers">> := RegisteredUsers, <<"onlineUsers">> := OnlineUsers} = Result,
     ?assertEqual(1, RegisteredUsers),
     ?assertEqual(1, OnlineUsers).
 
+% Commands
+
+get_stats(Config) ->
+    execute_command(<<"stat">>, <<"globalStats">>, #{}, Config).
+
+get_domain_stats(Domain, Config) ->
+    Vars = #{domain => Domain},
+    execute_command(<<"stat">>, <<"domainStats">>, Vars, Config).
+
 % Helpers
-
-admin_get_stats(Config, Vars) ->
-    Query = <<"query Q1
-                   {stats{globalStats{uptimeSeconds registeredUsers onlineUsersNode
-                                onlineUsers incomingS2S outgoingS2S}}}">>,
-    admin_send_mutation(Config, Vars, Query).
-
-admin_get_stats_domain(Config, Vars) ->
-    Query = <<"query Q1($domain: String!)
-                   {stats{domainStats(domain: $domain){registeredUsers onlineUsers}}}">>,
-    admin_send_mutation(Config, Vars, Query).
-
-admin_send_mutation(Config, Vars, Query) ->
-    Body = #{query => Query, operationName => <<"Q1">>, variables => Vars},
-    execute_auth(Body, Config).
-
-error_result(What1, What2, {{<<"200">>, <<"OK">>}, #{<<"errors">> := [Data]}}) ->
-    maps:get(What2, maps:get(What1, Data)).
-
-ok_result(What1, What2, {{<<"200">>, <<"OK">>}, #{<<"data">> := Data}}) ->
-    maps:get(What2, maps:get(What1, Data)).
 
 is_not_negative_integer(Number) when is_integer(Number), Number >= 0 ->
     true;

--- a/priv/graphql/schemas/admin/admin_schema.gql
+++ b/priv/graphql/schemas/admin/admin_schema.gql
@@ -13,7 +13,7 @@ type AdminQuery{
   "Account management"
   account: AccountAdminQuery
   "Domain management"
-  domains: DomainAdminQuery
+  domain: DomainAdminQuery
   "Last activity management"
   last: LastAdminQuery
   "MUC room management"
@@ -33,7 +33,7 @@ type AdminQuery{
   "Metrics management"
   metric: MetricAdminQuery
   "Statistics"
-  stats: StatsAdminQuery
+  stat: StatsAdminQuery
   "Personal data management according to GDPR"
   gdpr: GdprAdminQuery
 }
@@ -46,7 +46,7 @@ type AdminMutation @protected{
   "Account management"
   account: AccountAdminMutation
   "Domain management"
-  domains: DomainAdminMutation
+  domain: DomainAdminMutation
   "Inbox bin management"
   inbox: InboxAdminMutation
   "Last activity management"

--- a/src/graphql/admin/mongoose_graphql_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_mutation.erl
@@ -7,7 +7,7 @@
 
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
-execute(_Ctx, _Obj, <<"domains">>, _Args) ->
+execute(_Ctx, _Obj, <<"domain">>, _Args) ->
     {ok, admin};
 execute(_Ctx, _Obj, <<"httpUpload">>, _Args) ->
     {ok, httpUpload};

--- a/src/graphql/admin/mongoose_graphql_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_query.erl
@@ -11,7 +11,7 @@ execute(_Ctx, _Obj, <<"checkAuth">>, _Args) ->
     {ok, admin};
 execute(_Ctx, _Obj, <<"account">>, _Args) ->
     {ok, account};
-execute(_Ctx, _Obj, <<"domains">>, _Args) ->
+execute(_Ctx, _Obj, <<"domain">>, _Args) ->
     {ok, admin};
 execute(_Ctx, _Obj, <<"gdpr">>, _Args) ->
     {ok, gdpr};
@@ -27,7 +27,7 @@ execute(_Ctx, _Obj, <<"roster">>, _Args) ->
     {ok, roster};
 execute(_Ctx, _Obj, <<"session">>, _Args) ->
     {ok, session};
-execute(_Ctx, _Obj, <<"stats">>, _Args) ->
+execute(_Ctx, _Obj, <<"stat">>, _Args) ->
     {ok, stats};
 execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
     {ok, #{}};


### PR DESCRIPTION
Use singular nouns for all category names

Motivation:
  - Conflict of the new 'stats' category with the old 'stats' command in CLI.
  - Consistency - there is 'metric', 'vcard', 'stanza' etc.

Tests CLI for statistics as well.

Note: I found that there are no tests for error handling in the `stat` category. It's not urgent, so I am not fixing it here.