### PR TITLE
GraphQL CLI args as "--name value" with new help

### DIFF
--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -22,7 +22,7 @@ execute(EpName, Body, Creds) ->
     rest_helper:make_request(Request).
 
 execute_user_command(Category, Command, User, Args, Config) ->
-    #{Category := #{Command := #{doc := Doc}}} = get_specs(),
+    #{Category := #{commands := #{Command := #{doc := Doc}}}} = get_specs(),
     execute_user(#{query => Doc, variables => Args}, User, Config).
 
 execute_command(Category, Command, Args, Config) ->
@@ -31,12 +31,28 @@ execute_command(Category, Command, Args, Config) ->
 
 %% Admin commands can be executed as GraphQL over HTTP or with CLI (mongooseimctl)
 execute_command(Category, Command, Args, Config, http) ->
-    #{Category := #{Command := #{doc := Doc}}} = get_specs(),
+    #{Category := #{commands := #{Command := #{doc := Doc}}}} = get_specs(),
     execute_auth(#{query => Doc, variables => Args}, Config);
 execute_command(Category, Command, Args, Config, cli) ->
-    VarsJSON = iolist_to_binary(jiffy:encode(Args)),
-    {Result, Code} = mongooseimctl_helper:mongooseimctl(Category, [Command, VarsJSON], Config),
+    CLIArgs = encode_cli_args(Args),
+    {Result, Code} = mongooseimctl_helper:mongooseimctl(Category, [Command | CLIArgs], Config),
     {{exit_status, Code}, rest_helper:decode(Result, #{return_maps => true})}.
+
+encode_cli_args(Args) ->
+    lists:flatmap(fun({Name, Value}) -> encode_cli_arg(Name, Value) end, maps:to_list(Args)).
+
+encode_cli_arg(_Name, null) ->
+    [];
+encode_cli_arg(Name, Value) ->
+    [<<"--", (arg_name_to_binary(Name))/binary>>, arg_value_to_binary(Value)].
+
+arg_name_to_binary(Name) when is_atom(Name) -> atom_to_binary(Name);
+arg_name_to_binary(Name) when is_binary(Name) -> Name.
+
+arg_value_to_binary(Value) when is_integer(Value) -> integer_to_binary(Value);
+arg_value_to_binary(Value) when is_binary(Value) -> Value;
+arg_value_to_binary(Value) when is_list(Value);
+                                is_map(Value) -> iolist_to_binary(jiffy:encode(Value)).
 
 execute_auth(Body, Config) ->
     Ep = ?config(schema_endpoint, Config),

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -46,8 +46,8 @@ if [ -z "$NODENAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1
 fi
-FORCE_FLAG1='"--force"'
-FORCE_FLAG2='"-f"'
+FORCE_FLAG1='--force'
+FORCE_FLAG2='-f'
 
 NAME_TYPE="${NODENAME_ARG% *}"
 NODENAME="${NODENAME_ARG#* }"
@@ -79,19 +79,21 @@ remove_from_cluster()
 
 manage_cluster()
 {
-        case $QUOTED_ARGS in
-            *$FORCE_FLAG1*|*$FORCE_FLAG2*)
-                QUOTED_ARGS=$(echo $QUOTED_ARGS|sed "s/$FORCE_FLAG1//")
-                QUOTED_ARGS=$(echo $QUOTED_ARGS|sed "s/$FORCE_FLAG2//")
-                ctl $QUOTED_ARGS;;
-             *)
+        case "$ARGS" in
+            *$FORCE_FLAG1*)
+                ARGS_ARRAY=( ${ARGS_ARRAY[@]/$FORCE_FLAG1} )
+                ctl;;
+            *$FORCE_FLAG2*)
+                ARGS_ARRAY=( ${ARGS_ARRAY[@]/$FORCE_FLAG2} )
+                ctl;;
+            *)
                 GUARD="unknown"
                 until [ "$GUARD" = "yes" ] || [ "$GUARD" = "no" ] ; do
                     echo $1
                     read GUARD
                     if [ "$GUARD" =  "yes" ]; then
                         echo $2
-                        ctl $QUOTED_ARGS
+                        ctl
                     elif [ "$GUARD" = "no" ]; then
                         echo "Operation discarded by user"
                         exit 1
@@ -188,8 +190,6 @@ help ()
 # common control function
 ctl ()
 {
-    COMMAND=$@
-
     # Control number of connections identifiers
     # using flock if available. Expects a linux-style
     # flock that can lock a file descriptor.
@@ -202,13 +202,13 @@ ctl ()
 	if [ ! -x "$JOT" ] ; then
 	    # no flock or jot, simply invoke ctlexec()
 	    CTL_CONN="ctl-${NODENAME}"
-	    ctlexec $CTL_CONN $COMMAND
+	    ctlexec $CTL_CONN
 	    result=$?
 	else
 	    # no flock, but at least there is jot
 	    RAND=`jot -r 1 0 $MAXCONNID`
 	    CTL_CONN="ctl-${RAND}-${NODENAME}"
-	    ctlexec $CTL_CONN $COMMAND
+	    ctlexec $CTL_CONN
 	    result=$?
 	fi
     else
@@ -223,7 +223,7 @@ ctl ()
 	    (
 		exec 8>"$CTL_LOCKFILE"
 		if flock --nb 8; then
-		    ctlexec $CTL_CONN $COMMAND
+		    ctlexec $CTL_CONN
                     ssresult=$?
                     # segregate from possible flock exit(1)
 		    ssresult=$(expr $ssresult \* 10)
@@ -266,7 +266,6 @@ ctlexec ()
 {
     export BINDIR=$ERTS_PATH
     CONN_NAME=$1; shift
-    COMMAND=$@
     $ERTS_PATH/erlexec \
       -boot "$MIM_DIR/releases/$APP_VSN/start_clean" \
       $NAME_TYPE ${CONN_NAME} \
@@ -275,7 +274,7 @@ ctlexec ()
       $COOKIE_ARG \
       -args_file "$RUNNER_ETC_DIR"/vm.dist.args \
       -pa "$MIM_DIR"/lib/mongooseim-*/ebin/ \
-      -s ejabberd_ctl -extra $NODENAME $COMMAND
+      -s ejabberd_ctl -extra $NODENAME "${ARGS_ARRAY[@]}"
 }
 
 # display ctl usage
@@ -376,18 +375,9 @@ function is_started_status_file
     [ "$status" = "started" ]
 }
 
-# parse command line parameters
-ARGS=""; QUOTED_ARGS=""
-for PARAM in "$@"
-do
-    case $PARAM in
-        --)
-	    break ;;
-         *)
-	    ARGS="$ARGS$PARAM"; ARGS="$ARGS ";
-	    QUOTED_ARGS=$QUOTED_ARGS'"'$PARAM'"'; QUOTED_ARGS=$QUOTED_ARGS" " ;;
-    esac
-done
+# parse command line arguments
+ARGS="$@"
+ARGS_ARRAY=( "$@" )
 
 case $1 in
     'bootstrap') bootstrap;;
@@ -404,5 +394,5 @@ case $1 in
     'stopped') is_started_status_file && wait_for_status_file stopped 30 1 || true; wait_for_status 3 15 2; stop_epmd;; # wait 15x2s before timeout
     'print_install_dir') print_install_dir;;
     'escript') run_escript $@;;
-    *) ctl $QUOTED_ARGS;;
+    *) ctl;;
 esac

--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -75,8 +75,7 @@
 -spec start() -> none().
 start() ->
     case init:get_plain_arguments() of
-        [SNode | Args0] ->
-        Args = args_join_xml(args_join_strings(Args0)),
+        [SNode | Args] ->
             SNode1 = case string:tokens(SNode, "@") of
                          [_Node, _Server] ->
                              SNode;
@@ -374,60 +373,6 @@ call_command([CmdString | Args], Auth, AccessCommands) ->
 %%-----------------------------
 %% Format arguments
 %%-----------------------------
-
-%% @private
--spec args_join_xml([string()]) -> [string()].
-args_join_xml([]) ->
-    [];
-args_join_xml([ [ $< | _ ] = Arg | RArgs ]) ->
-    case bal(Arg, $<, $>) of
-        true ->
-            [Arg | args_join_xml(RArgs)];
-        false ->
-            [NextArg | RArgs1] = RArgs,
-            args_join_xml([Arg ++ " " ++ NextArg | RArgs1])
-    end;
-args_join_xml([ Arg | RArgs ]) ->
-    [ Arg | args_join_xml(RArgs) ].
-
-
-%% @private
--spec args_join_strings([string()]) -> [string()].
-args_join_strings([]) ->
-    [];
-args_join_strings([ "\"", NextArg | RArgs ]) ->
-    args_join_strings([ "\"" ++ NextArg | RArgs ]);
-args_join_strings([ [ $" | _ ] = Arg | RArgs ]) ->
-    case lists:nthtail(length(Arg)-2, Arg) of
-        [C1, $"] when C1 /= ?ASCII_SPACE_CHARACTER ->
-            [ string:substr(Arg, 2, length(Arg)-2) | args_join_strings(RArgs) ];
-        _ ->
-            [NextArg | RArgs1] = RArgs,
-            args_join_strings([Arg ++ " " ++ NextArg | RArgs1])
-    end;
-args_join_strings([ Arg | RArgs ]) ->
-    [ Arg | args_join_strings(RArgs) ].
-
-
-%% @private
--spec bal(string(), char(), char()) -> boolean().
-bal(String, Left, Right) ->
-    bal(String, Left, Right, 0).
-
-
-%% @private
--spec bal(string(), L :: char(), R :: char(), Bal :: integer()) -> boolean().
-bal([], _Left, _Right, Bal) ->
-    Bal == 0;
-bal([?ASCII_SPACE_CHARACTER, _NextChar | T], Left, Right, Bal) ->
-    bal(T, Left, Right, Bal);
-bal([Left | T], Left, Right, Bal) ->
-    bal(T, Left, Right, Bal-1);
-bal([Right | T], Left, Right, Bal) ->
-    bal(T, Left, Right, Bal+1);
-bal([_C | T], Left, Right, Bal) ->
-    bal(T, Left, Right, Bal).
-
 
 %% @private
 -spec format_args(Args :: [any()],


### PR DESCRIPTION
There are two main goals of this PR:

### 1. Change the argument format
The previous argument format for the GraphQL-based CLI was always JSON, which a bit difficult to use. For example, this is how you would ask for the number of users in a domain:

```
mongooseimctl account listUsers '{"domain": "localhost"}'
```

This is how you do it after the change:

```
mongooseimctl account listUsers --domain localhost
```

Strings and integers are automatically processed, so they don't need quoting (unless the string has special characters or spaces).
Arguments with complex types (lists, input objects) need to be passed as JSON.

### 2. Provide help for the new commands

The new commands are to replace the old ones, which used `admin_extra`.
- `mongooseimctl` on its own displays a list of categories, basic commands (not categorized) and general help.
- `mongooseimctl help` displays the old-style help with all deprecated commands, which are still supported.
- `mongooseimctl categoryName` displays a list of commands with descriptions.
- `mongooseimctl categoryName commandName --help` displays a list of arguments with descriptions. `--help` is required for argument-less commands, because otherwise they would be executed. For other commands you can omit `--help`.
- Errors in the command line should result in user-friendly help.

There is more information displayed, please try it for yourself. Some examples are shown below, but the formatting is better in the shell.

<details><summary><code>mongooseimctl</code></summary>
<pre>Usage: <b>mongooseimctl</b> [<u style="text-decoration-style:single">category</u>] <u style="text-decoration-style:single">command</u> [<u style="text-decoration-style:single">arguments</u>]

Most MongooseIM commands are grouped into the following categories:
  <b>account</b>     Account management 
  <b>domain</b>      Domain management 
  <b>gdpr</b>        Personal data management according to GDPR 
  <b>httpUpload</b>  Http upload 
  <b>inbox</b>       Inbox bin management 
  <b>last</b>        Last activity management 
  <b>metric</b>      Metrics management 
  <b>muc</b>         MUC room management 
  <b>muc_light</b>   MUC Light room management 
  <b>offline</b>     Offline deleting old messages 
  <b>private</b>     Private storage management 
  <b>roster</b>      Roster/Contacts management 
  <b>session</b>     Session management 
  <b>stanza</b>      Stanza management 
  <b>stat</b>        Statistics 
  <b>token</b>       OAUTH token management 
  <b>vcard</b>       Vcard management 

To list the commands in a particular category:
  mongooseimctl <u style="text-decoration-style:single">category</u>

The following basic system management commands do not have a category:
  <b>graphql</b> <u style="text-decoration-style:single">query</u>                Execute graphql query or mutation 
  <b>help</b> <u style="text-decoration-style:single">[--tags [tag] | com?*]</u>  Show help for the deprecated commands 
  <b>mnesia</b> <u style="text-decoration-style:single">[info]</u>                show information of Mnesia system 
  <b>restart</b>                      Restart MongooseIM 
  <b>status</b>                       Get MongooseIM status 
  <b>stop</b>                         Stop MongooseIM 

Commands to start a MongooseIM node:
  start           Start a MongooseIM node as daemon (detached from terminal)
  debug           Attach an interactive Erlang shell to a running MongooseIM node
  live            Start MongooseIM node in live (interactive) mode
  foreground      Start MongooseIM node in foreground (non-interactive) mode
MongooseIM cluster management commands:
  join_cluster other_node_name                Add current node to cluster
  leave_cluster                               Make the current node leave the cluster
  remove_from_cluster other_node_name         Remove dead node from the cluster
Extra Commands:
  bootstrap           Executes MongooseIM init scripts (used for initial configuration)
  print_install_dir   Prints path to MongooseIM release directory
  escript             Runs escript command using embedded Erlang Runtime System
</pre></details>

<details><summary><code>mongooseimctl account</code></summary>
<pre>The following commands are available in the category &apos;account&apos;:
  <b>banUser</b>             Ban an account: kick sessions and set a random password 
  <b>changeUserPassword</b>  Change the password of a user 
  <b>checkPassword</b>       Check if a password is correct 
  <b>checkPasswordHash</b>   Check if a password hash is correct (allowed methods: md5, sha). Works only for a plain passwords 
  <b>checkUser</b>           Check if a user exists 
  <b>countUsers</b>          Get number of users per domain 
  <b>listUsers</b>           List users per domain 
  <b>registerUser</b>        Register a user. Username will be generated when skipped 
  <b>removeUser</b>          Remove a user 

To list the arguments for a particular command:
  mongooseimctl account <u style="text-decoration-style:single">command</u> --help
</pre></details>

<details><summary><code>mongooseimctl account listUsers</code></summary>
<pre>Missing mandatory arguments for command &apos;listUsers&apos;: &apos;domain&apos;

Usage: <b>mongooseimctl</b> account listUsers <u style="text-decoration-style:single">arguments</u>

Each argument has the format: --<u style="text-decoration-style:single">name</u> <u style="text-decoration-style:single">value</u>
Available arguments are listed below with the corresponding GraphQL types:
  <b>domain</b>  String! 

Scalar values do not need quoting unless they contain special characters or spaces.
Complex input types are passed as JSON maps or lists, depending on the type.
When a type is followed by &apos;!&apos;, the corresponding argument is required.
</pre></details>