### PR TITLE
Make RDBMS query timeout configurable

### DIFF
--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -87,6 +87,13 @@ Selects the driver for RDBMS connection. The choice of a driver impacts the set 
 
 When enabled, MongooseIM will send `SELECT 1 `query through every DB connection at given interval to keep them open. This option should be used to ensure that database connections are restarted after they became broken (e.g. due to a database restart or a load balancer dropping connections). Currently, not every network-related error returned from a database driver to a regular query will imply a connection restart.
 
+#### `outgoing_pools.rdbms.*.connection.query_timeout`
+* **Syntax:** positive integer, in milliseconds
+* **Default:** 5000
+* **Example:** `query_timeout = 5000`
+
+How long MongooseIM will wait for the database to answer for a query.
+
 #### `outgoing_pools.rdbms.*.connection.max_start_interval`
 * **Syntax:** positive integer
 * **Default:** 30

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -555,6 +555,8 @@ outgoing_pool_connection(<<"rdbms">>) ->
                                          validate = {enum, [odbc, pgsql, mysql]}},
                  <<"keepalive_interval">> => #option{type = integer,
                                                      validate = positive},
+                 <<"query_timeout">> => #option{type = integer,
+                                                validate = non_negative},
                  <<"max_start_interval">> => #option{type = integer,
                                                      validate = positive},
 
@@ -575,7 +577,8 @@ outgoing_pool_connection(<<"rdbms">>) ->
                  <<"tls">> => sql_tls()
                 },
        required = [<<"driver">>],
-       defaults = #{<<"max_start_interval">> => 30},
+       defaults = #{<<"query_timeout">> => 5000,
+                    <<"max_start_interval">> => 30},
        process = fun mongoose_rdbms:process_options/1
       };
 outgoing_pool_connection(<<"redis">>) ->

--- a/src/wpool/mongoose_wpool_rdbms.erl
+++ b/src/wpool/mongoose_wpool_rdbms.erl
@@ -36,7 +36,7 @@ stop(_, _) ->
 
 %% --------------------------------------------------------------
 %% Helper functions
-do_start(HostType, Tag, WpoolOpts0, RdbmsOpts) when is_list(WpoolOpts0) and is_map(RdbmsOpts) ->
+do_start(HostType, Tag, WpoolOpts0, RdbmsOpts) when is_list(WpoolOpts0), is_map(RdbmsOpts) ->
     #{driver := BackendName} = RdbmsOpts,
     mongoose_backend:init(global, mongoose_rdbms, [query, execute], #{backend => BackendName}),
     mongoose_metrics:ensure_db_pool_metric({rdbms, HostType, Tag}),

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -343,7 +343,7 @@ options("outgoing_pools") ->
                           max_worker_queue_len => 100}},
          #{type => rdbms,
            opts => #{workers => 5},
-           conn_opts => #{keepalive_interval => 30,
+           conn_opts => #{query_timeout => 5000, keepalive_interval => 30,
                           driver => pgsql, host => "localhost", port => 5432, database => "ejabberd",
                           username => "ejabberd", password => "mongooseim_secret",
                           tls => #{required => true,
@@ -836,7 +836,7 @@ default_pool_conn_opts(redis) ->
       database => 0,
       password => ""};
 default_pool_conn_opts(rdbms) ->
-    #{max_start_interval => 30};
+    #{query_timeout => 5000, max_start_interval => 30};
 default_pool_conn_opts(_Type) ->
     #{}.
 

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -948,8 +948,10 @@ test_pool_rdbms_connection_sql_opts(P, T, Required, Expected) ->
     ?err(T(Required#{<<"password">> => <<>>})).
 
 test_pool_rdbms_connection_common_opts(P, T, Required) ->
+    ?cfg(P ++ [query_timeout], 100, T(Required#{<<"query_timeout">> => 100})),
     ?cfg(P ++ [keepalive_interval], 100, T(Required#{<<"keepalive_interval">> => 100})),
     ?cfg(P ++ [max_start_interval], 200, T(Required#{<<"max_start_interval">> => 200})),
+    ?err(T(Required#{<<"query_timeout">> => -1})),
     ?err(T(Required#{<<"keepalive_interval">> => 0})),
     ?err(T(Required#{<<"max_start_interval">> => 0})),
     [?err(T(maps:remove(K, Required))) || K <- maps:keys(Required)].

--- a/test/mongoose_rdbms_SUITE.erl
+++ b/test/mongoose_rdbms_SUITE.erl
@@ -60,13 +60,13 @@ init_per_testcase(does_backoff_increase_to_a_point, Config) ->
     meck_connection_error(DbType),
     meck_rand(),
     ServerOpts = server_opts(DbType),
-    [{db_opts, ServerOpts#{keepalive_interval => 2, max_start_interval => 10}} | Config];
+    [{db_opts, ServerOpts#{query_timeout => 5000, keepalive_interval => 2, max_start_interval => 10}} | Config];
 init_per_testcase(_, Config) ->
     DbType = ?config(db_type, Config),
     set_opts(),
     meck_db(DbType),
     ServerOpts = server_opts(DbType),
-    [{db_opts, ServerOpts#{keepalive_interval => ?KEEPALIVE_INTERVAL,
+    [{db_opts, ServerOpts#{query_timeout => 5000, keepalive_interval => ?KEEPALIVE_INTERVAL,
                            max_start_interval => ?MAX_INTERVAL}} | Config].
 
 end_per_testcase(does_backoff_increase_to_a_point, Config) ->


### PR DESCRIPTION
A strict hardcoded macro is too inflexible and this is a parameter I want to iterate on the configuration easily.