### PR TITLE
Domain admin tests

### DIFF
--- a/big_tests/tests/domain_helper.erl
+++ b/big_tests/tests/domain_helper.erl
@@ -13,6 +13,7 @@
          host_type/1,
          domain_to_host_type/2,
          domain/0,
+         secondary_domain/0,
          domain/1,
          secondary_host_type/0,
          secondary_host_type/1]).
@@ -30,6 +31,9 @@ host_type() ->
 
 domain() ->
     domain(mim).
+
+secondary_domain() ->
+    get_or_fail({hosts, mim, secondary_domain}).
 
 host_type(NodeKey) ->
     get_or_fail({hosts, NodeKey, host_type}).

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -71,7 +71,6 @@ domain_admin_tests() ->
      domain_admin_subscribe_all_to_all_one_user_not_from_admin_domain,
      domain_admin_subscribe_all_to_all].
 
-
 init_per_suite(Config) ->
     Config1 = ejabberd_node_utils:init(mim(), Config),
     Config2 = escalus:init_per_suite(Config1),

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -5,7 +5,8 @@
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_value/2, get_err_msg/1,
-                         get_err_msg/2, user_to_jid/1, user_to_bin/1]).
+                         get_err_msg/2, user_to_jid/1, user_to_bin/1,
+                         execute_domain_admin_command/4, get_unauthorized/1]).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("../../include/mod_roster.hrl").
@@ -16,12 +17,14 @@ suite() ->
 all() ->
     [{group, user_roster},
      {group, admin_roster_http},
-     {group, admin_roster_cli}].
+     {group, admin_roster_cli},
+     {group, domain_admin_roster}].
 
 groups() ->
     [{user_roster, [], user_roster_tests()},
      {admin_roster_http, [], admin_roster_tests()},
-     {admin_roster_cli, [], admin_roster_tests()}].
+     {admin_roster_cli, [], admin_roster_tests()},
+     {domain_admin_roster, [], domain_admin_tests()}].
 
 user_roster_tests() ->
     [user_add_and_delete_contact,
@@ -61,6 +64,14 @@ admin_roster_tests() ->
      admin_get_contact_wrong_user
     ].
 
+domain_admin_tests() ->
+    [domain_admin_subscribe_to_all_no_permission,
+     domain_admin_subscribe_to_all,
+     domain_admin_subscribe_all_to_all_no_permission,
+     domain_admin_subscribe_all_to_all_one_user_not_from_admin_domain,
+     domain_admin_subscribe_all_to_all].
+
+
 init_per_suite(Config) ->
     Config1 = ejabberd_node_utils:init(mim(), Config),
     Config2 = escalus:init_per_suite(Config1),
@@ -74,6 +85,8 @@ init_per_group(admin_roster_http, Config) ->
     graphql_helper:init_admin_handler(Config);
 init_per_group(admin_roster_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
+init_per_group(domain_admin_roster, Config) ->
+    graphql_helper:init_domain_admin_handler(Config);
 init_per_group(user_roster, Config) ->
     graphql_helper:init_user(Config).
 
@@ -486,6 +499,51 @@ user_get_nonexistent_contact_story(Config, Alice) ->
     Res = user_get_contact(Alice, ?NONEXISTENT_DOMAIN_USER, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"does not exist">>)).
 
+% Domain admin test cases
+
+domain_admin_subscribe_to_all_no_permission(Config) ->
+    Contact = #{jid => <<"NONEXISTING@AAA">>, name => <<"NAME">>, groups => ?DEFAULT_GROUPS},
+    get_unauthorized(domain_admin_subscribe_to_all(Contact, [], Config)).
+
+domain_admin_subscribe_to_all(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
+                                    fun domain_admin_subscribe_to_all_story/4).
+
+domain_admin_subscribe_to_all_story(Config, Alice, Bob, Kate) ->
+    Res = domain_admin_subscribe_to_all(make_contact(Alice), [Bob, Kate], Config),
+    check_if_created_succ(?SUBSCRIBE_TO_ALL_PATH, Res),
+
+    check_contacts([Bob, Kate], Alice),
+    check_contacts([Alice], Bob),
+    check_contacts([Alice], Kate).
+
+domain_admin_subscribe_all_to_all_no_permission(Config) ->
+    Contacts = [#{jid => <<"NONEXISTING@AAA">>, name => <<"NAME">>, groups => ?DEFAULT_GROUPS},
+                #{jid => <<"NONEXISTING1@AAA">>, name => <<"NAME">>, groups => ?DEFAULT_GROUPS}],
+    get_unauthorized(domain_admin_subscribe_all_to_all(Contacts, Config)).
+
+domain_admin_subscribe_all_to_all_one_user_not_from_admin_domain(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
+        fun domain_admin_subscribe_all_to_all_one_user_not_from_admin_domain_story/4).
+
+domain_admin_subscribe_all_to_all_one_user_not_from_admin_domain_story(Config, Alice, Bob, Kate) ->
+    Contact = #{jid => <<"NONEXISTING@AAA">>, name => <<"NAME">>, groups => ?DEFAULT_GROUPS},
+    Res = domain_admin_subscribe_all_to_all(make_contacts([Alice, Bob, Kate]) ++ [Contact], Config),
+    get_unauthorized(Res).
+
+domain_admin_subscribe_all_to_all(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
+                                    fun domain_admin_subscribe_all_to_all_story/4).
+
+domain_admin_subscribe_all_to_all_story(Config, Alice, Bob, Kate) ->
+    Res = domain_admin_subscribe_all_to_all(make_contacts([Alice, Bob, Kate]), Config),
+    check_if_created_succ(?SUBSCRIBE_ALL_TO_ALL_PATH, Res),
+
+    check_contacts([Bob, Kate], Alice),
+    check_contacts([Alice, Kate], Bob),
+    check_contacts([Alice, Bob], Kate).
+
+
 % Helpers
 
 admin_add_contact(User, Contact, Config) ->
@@ -570,9 +628,17 @@ admin_subscribe_to_all(User, Contacts, Config) ->
     Vars = #{user => make_contact(User), contacts => make_contacts(Contacts)},
     execute_command(<<"roster">>, <<"subscribeToAll">>, Vars, Config).
 
+domain_admin_subscribe_to_all(User, Contacts, Config) ->
+    Vars = #{user => User, contacts => make_contacts(Contacts)},
+    execute_domain_admin_command(<<"roster">>, <<"subscribeToAll">>, Vars, Config).
+
 admin_subscribe_all_to_all(Users, Config) ->
     Vars = #{contacts => make_contacts(Users)},
     execute_command(<<"roster">>, <<"subscribeAllToAll">>, Vars, Config).
+
+domain_admin_subscribe_all_to_all(Users, Config) ->
+    Vars = #{contacts => Users},
+    execute_domain_admin_command(<<"roster">>, <<"subscribeAllToAll">>, Vars, Config).
 
 admin_list_contacts(User, Config) ->
     Vars = #{user => user_to_bin(User)},

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -68,7 +68,6 @@ domain_admin_tests() ->
     [domain_admin_subscribe_to_all_no_permission,
      domain_admin_subscribe_to_all,
      domain_admin_subscribe_all_to_all_no_permission,
-     domain_admin_subscribe_all_to_all_one_user_not_from_admin_domain,
      domain_admin_subscribe_all_to_all].
 
 init_per_suite(Config) ->
@@ -501,8 +500,11 @@ user_get_nonexistent_contact_story(Config, Alice) ->
 % Domain admin test cases
 
 domain_admin_subscribe_to_all_no_permission(Config) ->
-    Contact = #{jid => <<"NONEXISTING@AAA">>, name => <<"NAME">>, groups => ?DEFAULT_GROUPS},
-    get_unauthorized(domain_admin_subscribe_to_all(Contact, [], Config)).
+    escalus:fresh_story_with_config(Config, [{alice_bis, 1}],
+                                    fun domain_admin_subscribe_to_all_no_permission/2).
+
+domain_admin_subscribe_to_all_no_permission(Config, Alice) ->
+    get_unauthorized(domain_admin_subscribe_to_all(make_contact(Alice), [], Config)).
 
 domain_admin_subscribe_to_all(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
@@ -517,17 +519,11 @@ domain_admin_subscribe_to_all_story(Config, Alice, Bob, Kate) ->
     check_contacts([Alice], Kate).
 
 domain_admin_subscribe_all_to_all_no_permission(Config) ->
-    Contacts = [#{jid => <<"NONEXISTING@AAA">>, name => <<"NAME">>, groups => ?DEFAULT_GROUPS},
-                #{jid => <<"NONEXISTING1@AAA">>, name => <<"NAME">>, groups => ?DEFAULT_GROUPS}],
-    get_unauthorized(domain_admin_subscribe_all_to_all(Contacts, Config)).
+    escalus:fresh_story_with_config(Config, [{alice_bis, 1}, {bob, 1}, {kate, 1}],
+        fun domain_admin_subscribe_all_to_all_no_permission/4).
 
-domain_admin_subscribe_all_to_all_one_user_not_from_admin_domain(Config) ->
-    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
-        fun domain_admin_subscribe_all_to_all_one_user_not_from_admin_domain_story/4).
-
-domain_admin_subscribe_all_to_all_one_user_not_from_admin_domain_story(Config, Alice, Bob, Kate) ->
-    Contact = #{jid => <<"NONEXISTING@AAA">>, name => <<"NAME">>, groups => ?DEFAULT_GROUPS},
-    Res = domain_admin_subscribe_all_to_all(make_contacts([Alice, Bob, Kate]) ++ [Contact], Config),
+domain_admin_subscribe_all_to_all_no_permission(Config, Alice, Bob, Kate) ->
+    Res = domain_admin_subscribe_all_to_all(make_contacts([Alice, Bob, Kate]), Config),
     get_unauthorized(Res).
 
 domain_admin_subscribe_all_to_all(Config) ->
@@ -541,7 +537,6 @@ domain_admin_subscribe_all_to_all_story(Config, Alice, Bob, Kate) ->
     check_contacts([Bob, Kate], Alice),
     check_contacts([Alice, Kate], Bob),
     check_contacts([Alice, Bob], Kate).
-
 
 % Helpers
 

--- a/big_tests/tests/graphql_stats_SUITE.erl
+++ b/big_tests/tests/graphql_stats_SUITE.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1]).
--import(domain_helper, [host_type/0, domain/0]).
+-import(domain_helper, [host_type/0, domain/0, secondary_domain/0]).
 -import(graphql_helper, [execute_command/4, get_ok_value/2,
                          execute_domain_admin_command/4, get_unauthorized/1]).
 -import(mongooseimctl_helper, [mongooseimctl/3, rpc_call/3]).
@@ -116,7 +116,7 @@ domain_admin_stats_domain_test(Config) ->
     ?assertEqual(0, OnlineUsers).
 
 domain_admin_stats_domain_no_permission_test(Config) ->
-    get_unauthorized(domain_admin_get_domain_stats(<<"AA">>, Config)).
+    get_unauthorized(domain_admin_get_domain_stats(secondary_domain(), Config)).
 
 % Commands
 

--- a/big_tests/tests/graphql_stats_SUITE.erl
+++ b/big_tests/tests/graphql_stats_SUITE.erl
@@ -4,7 +4,8 @@
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1]).
 -import(domain_helper, [host_type/0, domain/0]).
--import(graphql_helper, [execute_command/4, get_ok_value/2]).
+-import(graphql_helper, [execute_command/4, get_ok_value/2,
+                         execute_domain_admin_command/4, get_unauthorized/1]).
 -import(mongooseimctl_helper, [mongooseimctl/3, rpc_call/3]).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -14,17 +15,24 @@ suite() ->
 
 all() ->
     [{group, admin_stats_http},
-     {group, admin_stats_cli}].
+     {group, admin_stats_cli},
+     {group, domain_admin_stats}].
 
 groups() ->
     [{admin_stats_http, [], admin_stats_tests()},
-     {admin_stats_cli, [], admin_stats_tests()}].
+     {admin_stats_cli, [], admin_stats_tests()},
+     {domain_admin_stats, [], domain_admin_tests()}].
 
 admin_stats_tests() ->
     [admin_stats_global_test,
      admin_stats_global_with_users_test,
      admin_stats_domain_test,
      admin_stats_domain_with_users_test].
+
+domain_admin_tests() ->
+    [domain_admin_stats_global_test,
+     domain_admin_stats_domain_test,
+     domain_admin_stats_domain_no_permission_test].
 
 init_per_suite(Config) ->
     Config1 = ejabberd_node_utils:init(mim(), Config),
@@ -36,7 +44,9 @@ end_per_suite(Config) ->
 init_per_group(admin_stats_http, Config) ->
     graphql_helper:init_admin_handler(Config);
 init_per_group(admin_stats_cli, Config) ->
-    graphql_helper:init_admin_cli(Config).
+    graphql_helper:init_admin_cli(Config);
+init_per_group(domain_admin_stats, Config) ->
+    graphql_helper:init_domain_admin_handler(Config).
 
 end_per_group(_, _Config) ->
     graphql_helper:clean(),
@@ -93,14 +103,36 @@ admin_stats_domain_with_users_test(Config, _Alice) ->
     ?assertEqual(1, RegisteredUsers),
     ?assertEqual(1, OnlineUsers).
 
+% Domain admin test cases
+
+domain_admin_stats_global_test(Config) ->
+    get_unauthorized(domain_admin_get_stats(Config)).
+
+domain_admin_stats_domain_test(Config) ->
+    Result = get_ok_value([data, stat, domainStats],
+                          domain_admin_get_domain_stats(domain(), Config)),
+    #{<<"registeredUsers">> := RegisteredUsers, <<"onlineUsers">> := OnlineUsers} = Result,
+    ?assertEqual(0, RegisteredUsers),
+    ?assertEqual(0, OnlineUsers).
+
+domain_admin_stats_domain_no_permission_test(Config) ->
+    get_unauthorized(domain_admin_get_domain_stats(<<"AA">>, Config)).
+
 % Commands
 
 get_stats(Config) ->
     execute_command(<<"stat">>, <<"globalStats">>, #{}, Config).
 
+domain_admin_get_stats(Config) ->
+    execute_domain_admin_command(<<"stat">>, <<"globalStats">>, #{}, Config).
+
 get_domain_stats(Domain, Config) ->
     Vars = #{domain => Domain},
     execute_command(<<"stat">>, <<"domainStats">>, Vars, Config).
+
+domain_admin_get_domain_stats(Domain, Config) ->
+    Vars = #{domain => Domain},
+    execute_domain_admin_command(<<"stat">>, <<"domainStats">>, Vars, Config).
 
 % Helpers
 

--- a/priv/graphql/schemas/admin/roster.gql
+++ b/priv/graphql/schemas/admin/roster.gql
@@ -22,7 +22,7 @@ type RosterAdminMutation @protected{
     @protected(type: DOMAIN, args: ["userA", "userB"])
   "Set mutual subscriptions between the user and each of the given contacts"
   subscribeToAll(user: ContactInput!, contacts: [ContactInput!]!): [String]!
-    @protected(type: DOMAIN, args: ["user"])
+    @protected(type: DOMAIN, args: ["user.jid"])
   "Set mutual subscriptions between all of the given contacts"
   subscribeAllToAll(contacts: [ContactInput!]): [String]!
     @protected(type: DOMAIN, args: ["contacts.jid"])
@@ -33,7 +33,7 @@ Allow admin to get information about user roster/contacts.
 """
 type RosterAdminQuery @protected{
   "Get the user's roster/contacts"
-  listContacts(user: JID!): [Contact!] 
+  listContacts(user: JID!): [Contact!]
     @protected(type: DOMAIN, args: ["user"])
   "Get the user's contact"
   getContact(user: JID!, contact: JID!): Contact


### PR DESCRIPTION
Adding example tests to graphql_stats_SUITE and tests to graphql_roster_SUITE. This PR shows how to add tests when the domain is taken from the domain variable and user variable.