### PR TITLE
Remove MAM unused functions and exports

### DIFF
--- a/src/mam/mam_iq.erl
+++ b/src/mam/mam_iq.erl
@@ -2,25 +2,8 @@
 
 -export([action/1]).
 -export([action_type/1]).
-
--export([fix_rsm/1]).
--export([elem_to_start_microseconds/1]).
--export([elem_to_end_microseconds/1]).
--export([elem_to_with_jid/1]).
--export([elem_to_limit/1]).
--export([query_to_lookup_params/4]).
-
--export([form_to_start_microseconds/1]).
--export([form_to_end_microseconds/1]).
--export([form_to_with_jid/1]).
 -export([form_to_lookup_params/4]).
-
 -export([lookup_params_with_archive_details/4]).
-
--ignore_xref([behaviour_info/1, elem_to_end_microseconds/1, elem_to_limit/1,
-              elem_to_start_microseconds/1, elem_to_with_jid/1, fix_rsm/1,
-              form_to_end_microseconds/1, form_to_start_microseconds/1,
-              form_to_with_jid/1, query_to_lookup_params/4]).
 
 -import(mod_mam_utils,
         [maybe_microseconds/1,
@@ -70,8 +53,7 @@
         atom() => _
       }.
 
--export_type([action/0]).
--export_type([lookup_params/0]).
+-export_type([action/0, lookup_params/0]).
 
 -callback extra_lookup_params(jlib:iq(), lookup_params()) -> lookup_params().
 
@@ -112,21 +94,6 @@ fix_rsm(RSM=#rsm_in{id = BExtMessID}) when is_binary(BExtMessID) ->
     MessID = mod_mam_utils:external_binary_to_mess_id(BExtMessID),
     RSM#rsm_in{id = MessID}.
 
-
--spec elem_to_start_microseconds(exml:element()) -> 'undefined' | non_neg_integer().
-elem_to_start_microseconds(El) ->
-    maybe_microseconds(exml_query:path(El, [{element, <<"start">>}, cdata], <<>>)).
-
-
--spec elem_to_end_microseconds(exml:element()) -> 'undefined' | non_neg_integer().
-elem_to_end_microseconds(El) ->
-    maybe_microseconds(exml_query:path(El, [{element, <<"end">>}, cdata], <<>>)).
-
-
--spec elem_to_with_jid(exml:element()) -> 'error' | 'undefined' | jid:jid().
-elem_to_with_jid(El) ->
-    maybe_jid(exml_query:path(El, [{element, <<"with">>}, cdata], <<>>)).
-
 %% @doc This element's name is "limit". But it must be "max" according XEP-0313.
 -spec elem_to_limit(any()) -> any().
 elem_to_limit(QueryEl) ->
@@ -140,40 +107,19 @@ elem_to_limit(QueryEl) ->
 form_to_start_microseconds(El) ->
     maybe_microseconds(form_field_value_s(El, <<"start">>)).
 
-
 -spec form_to_end_microseconds(_) -> 'undefined' | non_neg_integer().
 form_to_end_microseconds(El) ->
     maybe_microseconds(form_field_value_s(El, <<"end">>)).
 
-
 -spec form_to_with_jid(exml:element()) -> 'error' | 'undefined' | jid:jid().
 form_to_with_jid(El) ->
     maybe_jid(form_field_value_s(El, <<"with">>)).
-
 
 -spec maybe_jid(binary()) -> 'error' | 'undefined' | jid:jid().
 maybe_jid(<<>>) ->
     undefined;
 maybe_jid(JID) when is_binary(JID) ->
     jid:from_binary(JID).
-
--spec query_to_lookup_params(jlib:iq(), integer(), integer(), undefined | module()) ->
-    lookup_params().
-query_to_lookup_params(#iq{sub_el = QueryEl} = IQ, MaxResultLimit, DefaultResultLimit, Module) ->
-    Params0 = common_lookup_params(QueryEl, MaxResultLimit, DefaultResultLimit),
-    Params = Params0#{
-               %% Filtering by date.
-               %% Start :: integer() | undefined
-               start_ts => elem_to_start_microseconds(QueryEl),
-               end_ts => elem_to_end_microseconds(QueryEl),
-               %% Filtering by contact.
-               search_text => undefined,
-               with_jid => elem_to_with_jid(QueryEl),
-               borders => mod_mam_utils:borders_decode(QueryEl),
-               is_simple => mod_mam_utils:decode_optimizations(QueryEl)},
-
-    maybe_add_extra_lookup_params(Module, Params, IQ).
-
 
 -spec form_to_lookup_params(jlib:iq(), integer(), integer(), undefined | module()) ->
     lookup_params().

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -42,8 +42,6 @@
          result_prefs/4,
          make_fin_element/7,
          parse_prefs/1,
-         borders_decode/1,
-         decode_optimizations/1,
          form_borders_decode/1,
          form_decode_optimizations/1,
          is_mam_result_message/1,
@@ -630,14 +628,6 @@ binary_jid_to_lower(BinJid) when is_binary(BinJid) ->
 skip_bad_jids(MaybeJids) ->
     [Jid || Jid <- MaybeJids, is_binary(Jid)].
 
--spec borders_decode(exml:element()) -> 'undefined' | mod_mam:borders().
-borders_decode(QueryEl) ->
-    AfterID  = tag_id(QueryEl, <<"after_id">>),
-    BeforeID = tag_id(QueryEl, <<"before_id">>),
-    FromID   = tag_id(QueryEl, <<"from_id">>),
-    ToID     = tag_id(QueryEl, <<"to_id">>),
-    borders(AfterID, BeforeID, FromID, ToID).
-
 -spec form_borders_decode(exml:element()) -> 'undefined' | mod_mam:borders().
 form_borders_decode(QueryEl) ->
     AfterID  = form_field_mess_id(QueryEl, <<"after_id">>),
@@ -662,20 +652,10 @@ borders(AfterID, BeforeID, FromID, ToID) ->
         to_id     = ToID
     }.
 
-
--spec tag_id(exml:element(), binary()) -> 'undefined' | integer().
-tag_id(QueryEl, Name) ->
-    BExtMessID = exml_query:attr(QueryEl, Name, <<>>),
-    maybe_external_binary_to_mess_id(BExtMessID).
-
 -spec form_field_mess_id(exml:element(), binary()) -> 'undefined' | integer().
 form_field_mess_id(QueryEl, Name) ->
     BExtMessID = form_field_value_s(QueryEl, Name),
     maybe_external_binary_to_mess_id(BExtMessID).
-
--spec decode_optimizations(exml:element()) -> boolean().
-decode_optimizations(QueryEl) ->
-    exml_query:path(QueryEl, [{element, <<"simple">>}, cdata]) =:= <<"true">>.
 
 -spec form_decode_optimizations(exml:element()) -> boolean().
 form_decode_optimizations(QueryEl) ->


### PR DESCRIPTION
Some functions here are not used, some are used but only locally so we can skip exporting them.
