### PR TITLE
Simple MAM queries with complete result flag

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -71,6 +71,13 @@
          pagination_before10/1,
          pagination_after10/1,
          pagination_simple_before10/1,
+         pagination_simple_before3/1,
+         pagination_simple_before6/1,
+         pagination_simple_before1_pagesize0/1,
+         pagination_simple_before2_pagesize0/1,
+         pagination_simple_after5/1,
+         pagination_simple_after10/1,
+         pagination_simple_after12/1,
          pagination_last_after_id5/1,
          pagination_last_after_id5_before_id11/1,
          pagination_empty_rset/1,
@@ -178,9 +185,10 @@
          rsm_send/3,
          stanza_page_archive_request/3,
          wait_empty_rset/2,
+         wait_message_range/2,
          wait_message_range/3,
-         message_id/2,
          wait_message_range/5,
+         message_id/2,
          stanza_prefs_set_request/4,
          stanza_prefs_get_request/1,
          stanza_query_get_request/1,
@@ -498,6 +506,13 @@ rsm_cases() ->
        pagination_last_page_after_id4,
        %% Simple cases
        pagination_simple_before10,
+       pagination_simple_before3,
+       pagination_simple_before6,
+       pagination_simple_before1_pagesize0,
+       pagination_simple_before2_pagesize0,
+       pagination_simple_after5,
+       pagination_simple_after10,
+       pagination_simple_after12,
        %% item_not_found response for nonexistent message ID in before/after filters
        server_returns_item_not_found_for_before_filter_with_nonexistent_id,
        server_returns_item_not_found_for_after_filter_with_nonexistent_id,
@@ -2477,7 +2492,6 @@ pagination_offset5_max0(Config) ->
 pagination_before10(Config) ->
     P = ?config(props, Config),
     F = fun(Alice) ->
-        %% Get the last page of size 5.
         RSM = #rsm_in{max=5, direction=before, id=message_id(10, Config)},
         rsm_send(Config, Alice,
             stanza_page_archive_request(P, <<"before10">>, RSM)),
@@ -2487,17 +2501,37 @@ pagination_before10(Config) ->
     parallel_story(Config, [{alice, 1}], F).
 
 pagination_simple_before10(Config) ->
-    P = ?config(props, Config),
-    F = fun(Alice) ->
-        %% Get the last page of size 5.
-        RSM = #rsm_in{max=5, direction=before, id=message_id(10, Config), simple=true},
-        rsm_send(Config, Alice,
-            stanza_page_archive_request(P, <<"before10">>, RSM)),
-     %% wait_message_range(Client, TotalCount,    Offset, FromN, ToN),
-        wait_message_range(Alice,   undefined, undefined,     5,   9),
-        ok
-        end,
-    parallel_story(Config, [{alice, 1}], F).
+    RSM = #rsm_in{max = 5, direction = before, id = message_id(10, Config), simple = true},
+    pagination_test(before10, RSM, simple_range(5, 9, false), Config).
+
+pagination_simple_before3(Config) ->
+    RSM = #rsm_in{max = 5, direction = before, id = message_id(3, Config), simple = true},
+    pagination_test(before10, RSM, simple_range(1, 2, true), Config).
+
+pagination_simple_before6(Config) ->
+    RSM = #rsm_in{max = 5, direction = before, id = message_id(6, Config), simple = true},
+    pagination_test(before10, RSM, simple_range(1, 5, true), Config).
+
+pagination_simple_before1_pagesize0(Config) ->
+    %% No messages forwarded, but is_complete is set
+    RSM = #rsm_in{max = 0, direction = before, id = message_id(1, Config), simple = true},
+    pagination_test(before1, RSM, simple_range(undefined, undefined, true), Config).
+
+pagination_simple_before2_pagesize0(Config) ->
+    RSM = #rsm_in{max = 0, direction = before, id = message_id(2, Config), simple = true},
+    pagination_test(before2, RSM, simple_range(undefined, undefined, false), Config).
+
+pagination_simple_after5(Config) ->
+    RSM = #rsm_in{max = 3, direction = 'after', id = message_id(5, Config), simple = true},
+    pagination_test(after5, RSM, simple_range(6, 8, false), Config).
+
+pagination_simple_after10(Config) ->
+    RSM = #rsm_in{max = 5, direction = 'after', id = message_id(10, Config), simple = true},
+    pagination_test(after10, RSM, simple_range(11, 15, true), Config).
+
+pagination_simple_after12(Config) ->
+    RSM = #rsm_in{max = 5, direction = 'after', id = message_id(12, Config), simple = true},
+    pagination_test(after12, RSM, simple_range(13, 15, true), Config).
 
 pagination_after10(Config) ->
     P = ?config(props, Config),
@@ -3134,3 +3168,15 @@ retract_element(stanza_id) ->
 
 origin_id() ->
     <<"orig-id-1">>.
+
+simple_range(From, To, IsComplete) ->
+    #{total_count => undefined, offset => undefined,
+      from => From, to => To, is_complete => IsComplete}.
+
+pagination_test(Name, RSM, Range, Config) ->
+    P = ?config(props, Config),
+    F = fun(Alice) ->
+        rsm_send(Config, Alice, stanza_page_archive_request(P, atom_to_binary(Name), RSM)),
+        wait_message_range(Alice, Range)
+        end,
+    parallel_story(Config, [{alice, 1}], F).

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -2506,11 +2506,11 @@ pagination_simple_before10(Config) ->
 
 pagination_simple_before3(Config) ->
     RSM = #rsm_in{max = 5, direction = before, id = message_id(3, Config), simple = true},
-    pagination_test(before10, RSM, simple_range(1, 2, true), Config).
+    pagination_test(before3, RSM, simple_range(1, 2, true), Config).
 
 pagination_simple_before6(Config) ->
     RSM = #rsm_in{max = 5, direction = before, id = message_id(6, Config), simple = true},
-    pagination_test(before10, RSM, simple_range(1, 5, true), Config).
+    pagination_test(before6, RSM, simple_range(1, 5, true), Config).
 
 pagination_simple_before1_pagesize0(Config) ->
     %% No messages forwarded, but is_complete is set

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -43,6 +43,11 @@
                           Offset :: non_neg_integer() | undefined,
                           MessageRows :: [message_row()]}.
 
+-type lookup_result_map() :: #{total_count := TotalCount :: non_neg_integer() | undefined,
+                               offset := Offset :: non_neg_integer() | undefined,
+                               messages := MessageRows :: [message_row()],
+                               is_complete := boolean()}.
+
 %% Internal types
 -type iterator_fun() :: fun(() -> {'ok', {_, _}}).
 -type rewriter_fun() :: fun((JID :: jid:literal_jid())
@@ -73,6 +78,7 @@
               unix_timestamp/0,
               archive_id/0,
               lookup_result/0,
+              lookup_result_map/0,
               message_row/0,
               message_id/0,
               restore_option/0,

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -46,7 +46,7 @@
 -type lookup_result_map() :: #{total_count := TotalCount :: non_neg_integer() | undefined,
                                offset := Offset :: non_neg_integer() | undefined,
                                messages := MessageRows :: [message_row()],
-                               is_complete := boolean()}.
+                               is_complete => boolean()}.
 
 %% Internal types
 -type iterator_fun() :: fun(() -> {'ok', {_, _}}).

--- a/src/mam/mod_mam_muc_cassandra_arch.erl
+++ b/src/mam/mod_mam_muc_cassandra_arch.erl
@@ -757,5 +757,5 @@ db_message_format(HostType) ->
     gen_mod:get_module_opt(HostType, ?MODULE, db_message_format).
 
 -spec pool_name(HostType :: host_type()) -> mongoose_wpool:pool_name().
-pool_name(HostType) ->
+pool_name(_HostType) ->
     default.

--- a/src/mam/mod_mam_pm.erl
+++ b/src/mam/mod_mam_pm.erl
@@ -397,7 +397,7 @@ do_handle_set_message_form(Params0, From, ArcID, ArcJID,
                            HostType) ->
     QueryID = exml_query:attr(QueryEl, <<"queryid">>, <<>>),
     Params = mam_iq:lookup_params_with_archive_details(Params0, ArcID, ArcJID, From),
-    case lookup_messages2(HostType, Params) of
+    case mod_mam_utils:lookup(HostType, Params, fun lookup_messages/2) of
         {error, Reason} ->
             report_issue(Reason, mam_lookup_failed, ArcJID, IQ),
             return_error_iq(IQ, Reason);
@@ -559,20 +559,6 @@ get_prefs(HostType, ArcID, ArcJID, GlobalDefaultMode) ->
 remove_archive_hook(HostType, ArcID, ArcJID=#jid{}) ->
     mongoose_hooks:mam_remove_archive(HostType, ArcID, ArcJID),
     ok.
-
-
--spec lookup_messages2(HostType :: host_type(), Params :: mam_iq:lookup_params()) ->
-    {ok, mod_mam:lookup_result_map()} | {error, Reason :: term()}.
-lookup_messages2(HostType, Params) ->
-    case lookup_messages(HostType, Params) of
-        {ok, {TotalCount, Offset, MessageRows}} ->
-            IsComplete = mod_mam_utils:is_complete_result_page(
-                    TotalCount, Offset, MessageRows, Params),
-            {ok, #{total_count => TotalCount, offset => Offset,
-                   messages => MessageRows, is_complete => IsComplete}};
-        Other ->
-            Other
-    end.
 
 -spec lookup_messages(HostType :: host_type(), Params :: map()) ->
     {ok, mod_mam:lookup_result()}

--- a/src/mam/mod_mam_utils.erl
+++ b/src/mam/mod_mam_utils.erl
@@ -1156,18 +1156,17 @@ is_policy_violation(TotalCount, Offset, MaxResultLimit, LimitPassed) ->
       LookupResult :: mod_mam:lookup_result(),
       R :: {ok, mod_mam:lookup_result()} | {error, item_not_found}.
 check_for_item_not_found(#rsm_in{direction = before, id = ID},
-                         PageSize, {TotalCount, Offset, MessageRows}) ->
+                         _PageSize, {TotalCount, Offset, MessageRows}) ->
     case maybe_last(MessageRows) of
-        {ok, #{id := ID}} = _IntervalEndpoint ->
-            Page = lists:sublist(MessageRows, PageSize),
-            {ok, {TotalCount, Offset, Page}};
+        {ok, #{id := ID}} ->
+            {ok, {TotalCount, Offset, list_without_last(MessageRows)}};
         undefined ->
             {error, item_not_found}
     end;
 check_for_item_not_found(#rsm_in{direction = aft, id = ID},
                          _PageSize, {TotalCount, Offset, MessageRows0}) ->
     case MessageRows0 of
-        [#{id := ID} = _IntervalEndpoint | MessageRows] ->
+        [#{id := ID} | MessageRows] ->
             {ok, {TotalCount, Offset, MessageRows}};
         _ ->
             {error, item_not_found}


### PR DESCRIPTION
This PR addresses "complete flag is not always set".

Proposed changes include:
* New shared function mod_mam_utils:lookup/3
* There are two strategies to determine `complete` flag:
  * is_complete_result_page_using_offset
  * set_complete_result_page_using_extra_message for simple queries.
* set_complete_result_page_using_extra_message asks for an extra message on a page from a DB. After that it hides the message from the user, but sets complete flag properly