### PR TITLE
Fix 'mongooseimctl started'

### DIFF
--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -103,7 +103,8 @@ all() ->
      {group, basic},
      {group, upload},
      {group, graphql},
-     {group, help}
+     {group, help},
+     {group, server}
     ].
 
 groups() ->
@@ -121,7 +122,8 @@ groups() ->
      {upload_with_acl, [], upload_enabled()},
      {upload_without_acl, [], upload_enabled()},
      {graphql, [], graphql()},
-     {help, [], help()}].
+     {help, [], help()},
+     {server, [], server()}].
 
 basic() ->
     [simple_register,
@@ -194,6 +196,10 @@ graphql() ->
 help() ->
     [default_help,
      old_help].
+
+server() ->
+    [server_status,
+     server_is_started].
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
@@ -1243,6 +1249,20 @@ old_help(Config) ->
     ?assertMatch({match, _}, re:run(Res, "Usage")),
     ?assertMatch(nomatch, re:run(Res, "account\s+Account management")),
     ?assertMatch({match, _}, re:run(Res, "add_rosteritem")).
+
+%%-----------------------------------------------------------------
+%% Server management tests
+%%-----------------------------------------------------------------
+
+server_status(Config) ->
+    {Res, 0} = mongooseimctl("status", [], Config),
+    ?assertMatch({match, _}, re:run(Res, "Erlang VM status: started")).
+
+server_is_started(Config) ->
+    %% Wait for the server to start, but it is already running
+    {Res, 0} = mongooseimctl("started", [], Config),
+    %% Expect only whitespace
+    ?assertMatch(nomatch, re:run(Res, "\S")).
 
 %%-----------------------------------------------------------------
 %% Improve coverage

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -82,10 +82,10 @@ manage_cluster()
         case "$ARGS" in
             *$FORCE_FLAG1*)
                 ARGS_ARRAY=( ${ARGS_ARRAY[@]/$FORCE_FLAG1} )
-                ctl;;
+                ctl "${ARGS_ARRAY[@]}";;
             *$FORCE_FLAG2*)
                 ARGS_ARRAY=( ${ARGS_ARRAY[@]/$FORCE_FLAG2} )
-                ctl;;
+                ctl "${ARGS_ARRAY[@]}";;
             *)
                 GUARD="unknown"
                 until [ "$GUARD" = "yes" ] || [ "$GUARD" = "no" ] ; do
@@ -93,7 +93,7 @@ manage_cluster()
                     read GUARD
                     if [ "$GUARD" =  "yes" ]; then
                         echo $2
-                        ctl
+                        ctl "${ARGS_ARRAY[@]}"
                     elif [ "$GUARD" = "no" ]; then
                         echo "Operation discarded by user"
                         exit 1
@@ -202,13 +202,13 @@ ctl ()
 	if [ ! -x "$JOT" ] ; then
 	    # no flock or jot, simply invoke ctlexec()
 	    CTL_CONN="ctl-${NODENAME}"
-	    ctlexec $CTL_CONN
+	    ctlexec $CTL_CONN "$@"
 	    result=$?
 	else
 	    # no flock, but at least there is jot
 	    RAND=`jot -r 1 0 $MAXCONNID`
 	    CTL_CONN="ctl-${RAND}-${NODENAME}"
-	    ctlexec $CTL_CONN
+	    ctlexec $CTL_CONN "$@"
 	    result=$?
 	fi
     else
@@ -223,7 +223,7 @@ ctl ()
 	    (
 		exec 8>"$CTL_LOCKFILE"
 		if flock --nb 8; then
-		    ctlexec $CTL_CONN
+		    ctlexec $CTL_CONN "$@"
                     ssresult=$?
                     # segregate from possible flock exit(1)
 		    ssresult=$(expr $ssresult \* 10)
@@ -274,7 +274,7 @@ ctlexec ()
       $COOKIE_ARG \
       -args_file "$RUNNER_ETC_DIR"/vm.dist.args \
       -pa "$MIM_DIR"/lib/mongooseim-*/ebin/ \
-      -s ejabberd_ctl -extra $NODENAME "${ARGS_ARRAY[@]}"
+      -s ejabberd_ctl -extra $NODENAME "$@"
 }
 
 # display ctl usage
@@ -393,6 +393,6 @@ case $1 in
     'started') wait_for_status_file started 60 1 || true; wait_for_status 0 30 2;; # wait 30x2s before timeout
     'stopped') is_started_status_file && wait_for_status_file stopped 30 1 || true; wait_for_status 3 15 2; stop_epmd;; # wait 15x2s before timeout
     'print_install_dir') print_install_dir;;
-    'escript') run_escript $@;;
-    *) ctl;;
+    'escript') run_escript "$@";;
+    *) ctl "$@";;
 esac


### PR DESCRIPTION
- Pass arguments to `ctl` and `ctlexec` to allow calling `ctl status`, which is needed by `mongooseimctl started` and `mongooseimctl stopped`.
- Add tests for `started` and `status`.
- Check `started`, `status` and `stopped` manually.