### PR TITLE
Document the new GraphQL-based CLI

### DIFF
--- a/doc/configuration/Services.md
+++ b/doc/configuration/Services.md
@@ -18,14 +18,20 @@ Typical services are already specified in the example configuration file.
 
 ## service_admin_extra
 
+This service provides additional commands to the mongooseimctl script.
+
+!!! Warning
+    This service is deprecated.
+    The commands are still supported, but they **will be removed** soon.
+    You should use the new GraphQL-based command line interface instead.
+
 ### `services.service_admin_extra.submods`
 * **Syntax:** Array of strings representing function groups added by `service_admin_extra`.
 * **Default:** All submodules: `["node", "account", "sessions", "vcard", "gdpr",
  "upload", "roster", "last", "private", "stanza", "stats", "domain"]`
 * **Example:** `submods = ["stats", "gdpr"]`
 
-This service provides additional commands to the mongooseimctl script.
-They are bundled in the following groups:
+The commands are bundled in the following groups:
 
 * `accounts`: Adds `change_password`, `check_password_hash`, `delete_old_users`,
  `delete_old_users_vhost`, `ban_account`, `num_active_users`, `check_account`,

--- a/doc/configuration/general.md
+++ b/doc/configuration/general.md
@@ -90,6 +90,11 @@ When using MSSQL or PostgreSQL databases, this option allows MongooseIM to optim
 User access rules are configured mainly in the [`acl`](acl.md) and [`access`](access.md) sections. Here you can find some additional options.
 
 ### `general.mongooseimctl_access_commands`
+
+!!! Warning
+    This option is deprecated. The commands are still supported, but they **will be removed** soon.
+    You should use the new GraphQL-based command line interface instead.
+
 * **Syntax:** TOML table, whose **keys** are the names of the access rules defined in the [`access`](access.md) config section and **values** specify allowed administration commands. Each value is a table with the following nested options:
     * `commands`: optional, a list of strings representing the allowed commands. When not specified, all commands are allowed.
     * `argument_restrictions`: optional, a table whose keys are the argument names, and the values are strings representing the allowed values. When not specified, there are no restrictions.

--- a/doc/developers-guide/domain_management.md
+++ b/doc/developers-guide/domain_management.md
@@ -100,7 +100,7 @@ We use `id` field to sort records when paginating.
 
 ### Domain removal
 
-You cannot delete domains with unknown host-type. 
+You cannot delete domains with unknown host-type.
 Configure host-type first to delete such domains.
 
 Modules which store data in RDBMS and support dynamic domains will remove **all** persistent data associated with a domain when its removal is requested.
@@ -189,36 +189,28 @@ Result codes:
 
 ## Command Line Interface
 
-Implemented by `service_admin_extra_domain` module.
+Domain management commands are grouped into the `domain` category.
 
-### Configuration example:
-
-```toml
-[services.service_admin_extra]
-  submods = ["node", "accounts", "sessions", "vcard", "gdpr", "upload",
-             "roster", "last", "private", "stanza", "stats", "domain"]
-```
- 
 ### Add domain:
 
 ```
-./mongooseimctl insert_domain domain host_type
+./mongooseimctl domain addDomain --domain example.com --hostType type1
 ```
 
 ### Delete domain:
 
 ```
-./mongooseimctl delete_domain domain host_type
+./mongooseimctl domain removeDomain --domain example.com --hostType type1
 ```
 
 ### Disable domain:
 
 ```
-./mongooseimctl disable_domain domain
+./mongooseimctl domain disableDomain --domain example.com
 ```
 
 ### Enable domain:
 
 ```
-./mongooseimctl enable_domain domain
+./mongooseimctl domain enableDomain --domain example.com
 ```

--- a/doc/getting-started/Quick-setup.md
+++ b/doc/getting-started/Quick-setup.md
@@ -123,7 +123,7 @@ mongooseimctl account listUsers --domain localhost
 }
 ```
 
-If you want to delete users in your host:
+If you want to delete a user from your host:
 ```bash
 mongooseimctl account removeUser --user dan@localhost
 {

--- a/doc/modules/mod_commands.md
+++ b/doc/modules/mod_commands.md
@@ -6,7 +6,6 @@ This is a basic set of administration and client commands.
 Our goal is to provide a consistent, easy to use API for MongooseIM.
 Both backend and client commands provide enough information to allow auto-generating access methods.
 We currently use it in our admin and client REST API interface.
-In the future it may replace the current `mongooseimctl` implementation.
 
 ## Configuration
 

--- a/doc/modules/mod_http_upload.md
+++ b/doc/modules/mod_http_upload.md
@@ -121,15 +121,13 @@ The [AWS region][aws-region] to use for requests.
 
 Since there is no direct connection between MongooseIM and an [S3][s3] bucket,
 it is not possible to verify the provided [S3][s3] credentials during startup.
-However, the testing can be done manually. MongooseIM provides a dedicated
-`mongooseimctl http_upload` command for the manual URLs generation, it accepts
-the following parameters:
+However, the testing can be done manually. MongooseIM provides a dedicated `mongooseimctl httpUpload getUrl` command for the manual URLs generation. It requires the following arguments:
 
-* **Host** - XMPP host name.
-* **FileName** - The name of the file.
-* **FileSize** - The size of the file (positive integer).
-* **ContentType** - [Content-Type][Content-Type], optional parameter. If not provided, must be an empty string `""`.
-* **ExpirationTime** - Duration (in seconds, positive integer) after which the generated `PUT` URL will become invalid. This parameter shadows the **expiration_time** configuration.
+* **domain** - XMPP host name.
+* **filename** - Name of the file.
+* **size** - Size of the file in bytes (positive integer).
+* **contentType** - [Content-Type][Content-Type].
+* **timeout** - Duration (in seconds, positive integer) after which the generated `PUT` URL will become invalid. This argument shadows the **expiration_time** configuration.
 
 The generated URLs can be used to upload/download a file using the `curl` utility:
 
@@ -144,7 +142,7 @@ filesize="$(wc -c tmp.txt | awk '{print $1}')"
 content_type="text/plain"
 
 # Generate upload/download URLs
-urls="$(./mongooseimctl http_upload localhost test.txt "$filesize" "$content_type" 600)"
+urls="$(./mongooseimctl httpUpload getUrl --domain localhost --filename test.txt --size "$filesize" --contentType "$content_type" --timeout 600)"
 put_url="$(echo "$urls" | awk '/PutURL:/ {print $2}')"
 get_url="$(echo "$urls" | awk '/GetURL:/ {print $2}')"
 

--- a/doc/operation-and-maintenance/gdpr-considerations.md
+++ b/doc/operation-and-maintenance/gdpr-considerations.md
@@ -18,11 +18,9 @@ This page describes what GDPR implies in terms of server management.
 
 All CLI commands are accessible via the `mongooseimctl` command, located in the `bin/` directory inside the MIM release.
 
-Personal data retrieval requires `service_admin_extra` with `gdpr` group enabled.
-
 ### Creating a GDPR-safe user account
 
-`mongooseimctl register <domain> <password>`
+`mongooseimctl account registerUser --domain <domain> --password <password>`
 
 This command will create an anonymised JID with a random username part.
 It ensures that no personal information will be leaked via logs or database entries, which include the user's JID.
@@ -30,13 +28,22 @@ It ensures that no personal information will be leaked via logs or database entr
 #### Example
 
 ```bash
-$ mongooseimctl register localhost abc123
-User 1567-420657-155810-C1CEC31F5C993258@localhost successfully registered
+$ mongooseimctl account registerUser --domain localhost --password secret
+{
+  "data" : {
+    "account" : {
+      "registerUser" : {
+        "message" : "User 1661-175924-881845-449bca06515e060a@localhost successfully registered",
+        "jid" : "1661-175924-881845-449bca06515e060a@localhost"
+      }
+    }
+  }
+}
 ```
 
 ### Retrieval of Personal Data
 
-`mongooseimctl retrieve_personal_data <username> <domain> <filepath for the output as a zip>`
+`mongooseimctl gdpr retrievePersonalData --username <username> --domain <domain> --resultFilepath <filepath for the output as a zip>`
 
 It retrieves personal data accessible to the server (see "Technical limitations" section below).
 The directory where the zip file will be created must already exist.
@@ -46,19 +53,29 @@ After the execution is complete, a zip file will appear in the specified folder 
 #### Example
 
 ```bash
-mongooseimctl retrieve_personal_data 1567-420657-155810-C1CEC31F5C993258 localhost /home/mongooseim/gdpr/1567-420657-155810-C1CEC31F5C993258.zip
+$ mongooseimctl gdpr retrievePersonalData --username 1661-175924-881845-449bca06515e060a --domain localhost --resultFilepath /home/mongooseim/gdpr/1661-175924-881845-449bca06515e060a.zip
 ```
 
 ### Removal of Personal Data
 
-`mongooseimctl unregister <username> <domain>`
+`mongooseimctl account removeUser --user <jid>`
 
 It removes the user's account along with all associated personal data accessible to the server (see "Technical limitations" section below).
 
 #### Example
 
 ```bash
-mongooseimctl unregister 1567-420657-155810-C1CEC31F5C993258 localhost
+$ mongooseimctl account removeUser --user 1661-175924-881845-449bca06515e060a@localhost
+{
+  "data" : {
+    "account" : {
+      "removeUser" : {
+        "message" : "User 1661-175924-881845-449bca06515e060a@localhost successfully unregistered",
+        "jid" : "1661-175924-881845-449bca06515e060a@localhost"
+      }
+    }
+  }
+}
 ```
 
 ## Technical limitations of GDPR retrieval and removal

--- a/doc/tutorials/ICE_tutorial.md
+++ b/doc/tutorials/ICE_tutorial.md
@@ -60,7 +60,7 @@ In order to enable signalling we need an instance of [MongooseIM] running with t
 ### Configuration
 
 You can find MongooseIM installation instructions on [this page](../getting-started/Quick-setup.md).
-Once you have cloned the repository and compiled the project, you need to modify the `mongooseim.toml` config file (you can find this file at `$REPO/_build/prod/rel/mongooseim/etc/mongooseim.toml`, where `$REPO` is a top-level directory of the cloned repo).
+Once you have it installed, you need to modify the [`mongooseim.toml`](../../configuration/configuration-files/#mongooseimtoml) config file:
 ```toml
 [general]
   hosts = ["localhost", "myxmpp.com"]
@@ -68,7 +68,7 @@ Once you have cloned the repository and compiled the project, you need to modify
 This sets the virtual hostname of the XMPP server, so that you can register users in this domain.
 After that, you can start MongooseIM with
 ```bash
-$REPO/_build/prod/rel/mongooseim/bin/mongooseimctl start
+mongooseimctl start
 ```
 
 ### Users
@@ -78,8 +78,8 @@ For this demo we need two users: *movie@myxmpp.com* and *phone@myxmpp.com*, for 
 In order to do that, type:
 
 ```bash
-$REPO/_build/prod/rel/mongooseim/bin/mongooseimctl register_identified phone myxmpp.com xmpp_password
-$REPO/_build/prod/rel/mongooseim/bin/mongooseimctl register_identified movie myxmpp.com xmpp_password
+mongooseimctl account registerUser --username movie --domain myxmpp.com --password xmpp_password
+mongooseimctl account registerUser --username phone --domain myxmpp.com --password xmpp_password
 ```
 
 on the machine that has [MongooseIM] installed.

--- a/doc/tutorials/Jingle-SIP-setup.md
+++ b/doc/tutorials/Jingle-SIP-setup.md
@@ -115,18 +115,17 @@ and in [Modules configuration](../configuration/Modules.md)
 
 Now we are registering both users in MongooseIM by calling the following commands:
 
-    bin/mongooseimctl register_identified xmpp.user xmpp.example test_pass
-    bin/mongooseimctl register_identified sip.user sip.example test_pass
+    mongooseimctl account registerUser --username xmpp.user --domain xmpp.example --password test_pass
+    mongooseimctl account registerUser --username sip.user --domain sip.example --password test_pass
 
 Yes, we need to have the `sip.user@sip.example` registered in MongooseIM.
 This is needed because a Jingle call can be initiated by a regular XMPP client only when the app knows the other user's full JID.
 The easiest way to achieve that is to exchange presence information between these 2 users.
 This can happen automatically if 2 xmpp users have each other in the roster.
 
-The roster can be set by us with the following commands:
+The roster can be set up with the following command:
 
-    bin/mongooseimctl add_rosteritem sip.user sip.example xmpp.user xmpp.example xmpp.user none both
-    bin/mongooseimctl add_rosteritem xmpp.user xmpp.example sip.user sip.example sip.user none both
+    mongooseimctl roster setMutualSubscription --userA xmpp.user@xmpp.example --userB sip.user@sip.example --action CONNECT
 
 ## Adding users to Jitsi
 


### PR DESCRIPTION
- Introduce the CLI in "Quick Setup"
- Replace examples of old commands with the new ones.

The GraphQL API itself needs more docs as well - there are examples with REST API that can be converted to GraphQL.