### PR TITLE
Reusable code for domain admin tests

### DIFF
--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -7,7 +7,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
--import(graphql_helper, [execute/3, execute_auth/2, execute_domain_auth/2, execute_user/3]).
+-import(graphql_helper, [execute/3, execute_auth/2, execute_user/3]).
 
 -define(assertAdminAuth(Domain, Type, Auth, Data),
         assert_auth(#{<<"domain">> => Domain,
@@ -133,7 +133,7 @@ domain_admin_checks_auth(Config) ->
 auth_domain_admin_checks_auth(Config) ->
     {Username, _} = ?config(domain_admin, Config),
     Domain = escalus_utils:get_server(Username),
-    Res = execute_domain_auth(admin_check_auth_body(), Config),
+    Res = execute_auth(admin_check_auth_body(), Config),
     ?assertAdminAuth(Domain, 'DOMAIN_ADMIN', 'AUTHORIZED', Res).
 
 %% Helpers

--- a/big_tests/tests/graphql_mnesia_SUITE.erl
+++ b/big_tests/tests/graphql_mnesia_SUITE.erl
@@ -8,8 +8,7 @@
 -import(domain_helper, [host_type/1]).
 -import(mongooseimctl_helper, [rpc_call/3]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, user_to_bin/1,
-                         get_ok_value/2, get_err_code/1, get_err_value/2,
-                         execute_domain_admin_command/4, get_unauthorized/1]).
+                         get_ok_value/2, get_err_code/1, get_err_value/2, get_unauthorized/1]).
 
 -record(mnesia_table_test, {key :: integer(), name :: binary()}).
 -record(vcard, {us, vcard}).
@@ -236,32 +235,31 @@ set_master_test(Config) ->
 % Domain admin tests
 
 domain_admin_dump_mnesia_table_test(Config) ->
-    get_unauthorized(domain_admin_dump_mnesia_table(<<"File">>, <<"mnesia_table_test">>, Config)).
+    get_unauthorized(dump_mnesia_table(<<"File">>, <<"mnesia_table_test">>, Config)).
 
 domain_admin_dump_mnesia_test(Config) ->
-    get_unauthorized(domain_admin_dump_mnesia(<<"File">>, Config)).
+    get_unauthorized(dump_mnesia(<<"File">>, Config)).
 
 domain_admin_backup_test(Config) ->
-    get_unauthorized(domain_admin_backup_mnesia(<<"Path">>, Config)).
+    get_unauthorized(backup_mnesia(<<"Path">>, Config)).
 
 domain_admin_restore_test(Config) ->
-    get_unauthorized(domain_admin_restore_mnesia(<<"Path">>, Config)).
+    get_unauthorized(restore_mnesia(<<"Path">>, Config)).
 
 domain_admin_load_mnesia_test(Config) ->
-    get_unauthorized(domain_admin_load_mnesia(<<"Path">>, Config)).
+    get_unauthorized(load_mnesia(<<"Path">>, Config)).
 
 domain_admin_change_nodename_test(Config) ->
-    get_unauthorized(domain_admin_change_nodename(<<"From">>, <<"To">>, <<"file1">>,
-                                                  <<"file2">>, Config)).
+    get_unauthorized(change_nodename(<<"From">>, <<"To">>, <<"file1">>, <<"file2">>, Config)).
 
 domain_admin_install_fallback_test(Config) ->
-    get_unauthorized(domain_admin_install_fallback(<<"Path">>, Config)).
+    get_unauthorized(install_fallback(<<"Path">>, Config)).
 
 domain_admin_set_master_test(Config) ->
-    get_unauthorized(domain_admin_set_master(mim(), Config)).
+    get_unauthorized(set_master(mim(), Config)).
 
 domain_admin_get_info_test(Config) ->
-    get_unauthorized(domain_admin_get_info([<<"running_db_nodes">>], Config)).
+    get_unauthorized(get_info([<<"running_db_nodes">>], Config)).
 
 %--------------------------------------------------------------------------------------------------
 %                                         Helpers
@@ -352,36 +350,6 @@ change_nodename(ChangeFrom, ChangeTo, Source, Target, Config) ->
 
 set_master(Node, Config) ->
     execute_command(<<"mnesia">>, <<"setMaster">>, Node, Config).
-
-domain_admin_get_info(Keys, Config) ->
-    execute_domain_admin_command(<<"mnesia">>, <<"systemInfo">>, #{keys => Keys}, Config).
-
-domain_admin_install_fallback(Path, Config) ->
-    execute_domain_admin_command(<<"mnesia">>, <<"installFallback">>, #{path => Path}, Config).
-
-domain_admin_dump_mnesia(Path, Config) ->
-    execute_domain_admin_command(<<"mnesia">>, <<"dump">>, #{path => Path}, Config).
-
-domain_admin_backup_mnesia(Path, Config) ->
-    execute_domain_admin_command(<<"mnesia">>, <<"backup">>, #{path => Path}, Config).
-
-domain_admin_restore_mnesia(Path, Config) ->
-    execute_domain_admin_command(<<"mnesia">>, <<"restore">>, #{path => Path}, Config).
-
-domain_admin_dump_mnesia_table(Path, Table, Config) ->
-    Vars = #{path => Path, table => Table},
-    execute_domain_admin_command(<<"mnesia">>, <<"dumpTable">>, Vars, Config).
-
-domain_admin_load_mnesia(Path, Config) ->
-    execute_domain_admin_command(<<"mnesia">>, <<"load">>, #{path => Path}, Config).
-
-domain_admin_change_nodename(ChangeFrom, ChangeTo, Source, Target, Config) ->
-    Vars = #{<<"fromString">> => ChangeFrom, <<"toString">> => ChangeTo,
-             <<"source">> => Source, <<"target">> => Target},
-    execute_domain_admin_command(<<"mnesia">>, <<"changeNodename">>, Vars, Config).
-
-domain_admin_set_master(Node, Config) ->
-    execute_domain_admin_command(<<"mnesia">>, <<"setMaster">>, Node, Config).
 
 mnesia_info_check() ->
     #{<<"access_module">> => check_binary,

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -5,8 +5,7 @@
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_value/2, get_err_msg/1,
-                         get_err_msg/2, user_to_jid/1, user_to_bin/1,
-                         execute_domain_admin_command/4, get_unauthorized/1]).
+                         get_err_msg/2, user_to_jid/1, user_to_bin/1, get_unauthorized/1]).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("../../include/mod_roster.hrl").
@@ -66,9 +65,9 @@ admin_roster_tests() ->
 
 domain_admin_tests() ->
     [domain_admin_subscribe_to_all_no_permission,
-     domain_admin_subscribe_to_all,
+     admin_subscribe_to_all,
      domain_admin_subscribe_all_to_all_no_permission,
-     domain_admin_subscribe_all_to_all].
+     admin_subscribe_all_to_all].
 
 init_per_suite(Config) ->
     Config1 = ejabberd_node_utils:init(mim(), Config),
@@ -504,39 +503,15 @@ domain_admin_subscribe_to_all_no_permission(Config) ->
                                     fun domain_admin_subscribe_to_all_no_permission/2).
 
 domain_admin_subscribe_to_all_no_permission(Config, Alice) ->
-    get_unauthorized(domain_admin_subscribe_to_all(make_contact(Alice), [], Config)).
-
-domain_admin_subscribe_to_all(Config) ->
-    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
-                                    fun domain_admin_subscribe_to_all_story/4).
-
-domain_admin_subscribe_to_all_story(Config, Alice, Bob, Kate) ->
-    Res = domain_admin_subscribe_to_all(make_contact(Alice), [Bob, Kate], Config),
-    check_if_created_succ(?SUBSCRIBE_TO_ALL_PATH, Res),
-
-    check_contacts([Bob, Kate], Alice),
-    check_contacts([Alice], Bob),
-    check_contacts([Alice], Kate).
+    get_unauthorized(admin_subscribe_to_all(Alice, [], Config)).
 
 domain_admin_subscribe_all_to_all_no_permission(Config) ->
     escalus:fresh_story_with_config(Config, [{alice_bis, 1}, {bob, 1}, {kate, 1}],
         fun domain_admin_subscribe_all_to_all_no_permission/4).
 
 domain_admin_subscribe_all_to_all_no_permission(Config, Alice, Bob, Kate) ->
-    Res = domain_admin_subscribe_all_to_all(make_contacts([Alice, Bob, Kate]), Config),
+    Res = admin_subscribe_all_to_all([Alice, Bob, Kate], Config),
     get_unauthorized(Res).
-
-domain_admin_subscribe_all_to_all(Config) ->
-    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}, {kate, 1}],
-                                    fun domain_admin_subscribe_all_to_all_story/4).
-
-domain_admin_subscribe_all_to_all_story(Config, Alice, Bob, Kate) ->
-    Res = domain_admin_subscribe_all_to_all(make_contacts([Alice, Bob, Kate]), Config),
-    check_if_created_succ(?SUBSCRIBE_ALL_TO_ALL_PATH, Res),
-
-    check_contacts([Bob, Kate], Alice),
-    check_contacts([Alice, Kate], Bob),
-    check_contacts([Alice, Bob], Kate).
 
 % Helpers
 
@@ -622,17 +597,9 @@ admin_subscribe_to_all(User, Contacts, Config) ->
     Vars = #{user => make_contact(User), contacts => make_contacts(Contacts)},
     execute_command(<<"roster">>, <<"subscribeToAll">>, Vars, Config).
 
-domain_admin_subscribe_to_all(User, Contacts, Config) ->
-    Vars = #{user => User, contacts => make_contacts(Contacts)},
-    execute_domain_admin_command(<<"roster">>, <<"subscribeToAll">>, Vars, Config).
-
 admin_subscribe_all_to_all(Users, Config) ->
     Vars = #{contacts => make_contacts(Users)},
     execute_command(<<"roster">>, <<"subscribeAllToAll">>, Vars, Config).
-
-domain_admin_subscribe_all_to_all(Users, Config) ->
-    Vars = #{contacts => Users},
-    execute_domain_admin_command(<<"roster">>, <<"subscribeAllToAll">>, Vars, Config).
 
 admin_list_contacts(User, Config) ->
     Vars = #{user => user_to_bin(User)},

--- a/big_tests/tests/graphql_stats_SUITE.erl
+++ b/big_tests/tests/graphql_stats_SUITE.erl
@@ -4,8 +4,7 @@
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1]).
 -import(domain_helper, [host_type/0, domain/0, secondary_domain/0]).
--import(graphql_helper, [execute_command/4, get_ok_value/2,
-                         execute_domain_admin_command/4, get_unauthorized/1]).
+-import(graphql_helper, [execute_command/4, get_ok_value/2, get_unauthorized/1]).
 -import(mongooseimctl_helper, [mongooseimctl/3, rpc_call/3]).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -106,33 +105,26 @@ admin_stats_domain_with_users_test(Config, _Alice) ->
 % Domain admin test cases
 
 domain_admin_stats_global_test(Config) ->
-    get_unauthorized(domain_admin_get_stats(Config)).
+    get_unauthorized(get_stats(Config)).
 
 domain_admin_stats_domain_test(Config) ->
     Result = get_ok_value([data, stat, domainStats],
-                          domain_admin_get_domain_stats(domain(), Config)),
+                          get_domain_stats(domain(), Config)),
     #{<<"registeredUsers">> := RegisteredUsers, <<"onlineUsers">> := OnlineUsers} = Result,
     ?assertEqual(0, RegisteredUsers),
     ?assertEqual(0, OnlineUsers).
 
 domain_admin_stats_domain_no_permission_test(Config) ->
-    get_unauthorized(domain_admin_get_domain_stats(secondary_domain(), Config)).
+    get_unauthorized(get_domain_stats(secondary_domain(), Config)).
 
 % Commands
 
 get_stats(Config) ->
     execute_command(<<"stat">>, <<"globalStats">>, #{}, Config).
 
-domain_admin_get_stats(Config) ->
-    execute_domain_admin_command(<<"stat">>, <<"globalStats">>, #{}, Config).
-
 get_domain_stats(Domain, Config) ->
     Vars = #{domain => Domain},
     execute_command(<<"stat">>, <<"domainStats">>, Vars, Config).
-
-domain_admin_get_domain_stats(Domain, Config) ->
-    Vars = #{domain => Domain},
-    execute_domain_admin_command(<<"stat">>, <<"domainStats">>, Vars, Config).
 
 % Helpers
 


### PR DESCRIPTION
Merged execute_auth and execute_domain_admin functions so both types of admins can use execute_command

