### PR TITLE
Do return an Acc unexceptionally!

### DIFF
--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -161,7 +161,8 @@ process_packet(Acc, From, To, El, _Extra) ->
     catch
         Class:Reason:Stacktrace ->
             ?LOG_ERROR(#{what => routing_error, acc => Acc,
-                         class => Class, reason => Reason, stacktrace => Stacktrace})
+                         class => Class, reason => Reason, stacktrace => Stacktrace}),
+            Acc
     end.
 
 -spec route_iq(From :: jid:jid(),


### PR DESCRIPTION
The specs says that `process_packet` must return a `mongoose_acc:t()`, but here, if an exception is thrown, we'd return the result of the logged error, which is the `ok` atom, which will crash on a later use of the acc when it was expected to be a map. See the stacktrace below, which throws a `{badmap, ok}` error:
```erl
mongoose_local_delivery:restore_acc_fields/2:57
mongoose_router_localdomain:route/4:25
ejabberd_router:route/5:390
ejabberd_router:route/4:140
ejabberd_c2s:process_outgoing_stanza/4:896
ejabberd_c2s:process_outgoing_stanza/2:868
p1_fsm_old:handle_msg/10:587
proc_lib:wake_up/3:250
```