### PR TITLE
Unify the admin REST API

### DIFF
--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -254,7 +254,7 @@ insert_creds(Opts = #{handlers := Handlers}, Creds) ->
     NewHandlers = [inject_creds_to_opts(Handler, Creds) || Handler <- Handlers],
     Opts#{handlers := NewHandlers}.
 
-inject_creds_to_opts(Handler = #{module := mongoose_api_admin}, Creds) ->
+inject_creds_to_opts(Handler = #{module := mongoose_admin_api}, Creds) ->
     case Creds of
         {UserName, Password} ->
             Handler#{username => UserName, password => Password};
@@ -277,7 +277,7 @@ is_roles_config(#{module := ejabberd_cowboy, handlers := Handlers}, Role) ->
     lists:any(fun(#{module := Module}) -> Module =:= RoleModule end, Handlers);
 is_roles_config(_, _) -> false.
 
-role_to_module(admin) -> mongoose_api_admin;
+role_to_module(admin) -> mongoose_admin_api;
 role_to_module(client) -> mongoose_client_api.
 
 mapfromlist(L) ->

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -56,7 +56,7 @@
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
-  [[listen.http.handlers.mongoose_api_admin]]
+  [[listen.http.handlers.mongoose_admin_api]]
     host = "localhost"
     path = "/api"
 

--- a/src/inbox/mod_inbox_api.erl
+++ b/src/inbox/mod_inbox_api.erl
@@ -12,7 +12,7 @@
         {user_does_not_exist, io_lib:format("User ~s@~s does not exist", [User, Server])}).
 
 -spec flush_user_bin(jid:jid(), Days :: integer()) ->
-    {ok, integer()} | {domain_not_found, binary()}. 
+    {ok, integer()} | {domain_not_found | user_does_not_exist, iodata()}.
 flush_user_bin(#jid{luser = LU, lserver = LS} = JID, Days) ->
     case mongoose_domain_api:get_host_type(LS) of
         {ok, HostType} ->
@@ -33,7 +33,7 @@ flush_user_bin(#jid{luser = LU, lserver = LS} = JID, Days) ->
 flush_domain_bin(Domain, Days) ->
     LDomain = jid:nodeprep(Domain),
     case mongoose_domain_api:get_host_type(LDomain) of
-        {ok, HostType} -> 
+        {ok, HostType} ->
             FromTS = days_to_timestamp(Days),
             Count = mod_inbox_backend:empty_domain_bin(HostType, Domain, FromTS),
             {ok, Count};
@@ -45,7 +45,7 @@ flush_domain_bin(Domain, Days) ->
     {ok, integer()} | {host_type_not_found, binary()}.
 flush_global_bin(HostType, Days) ->
     case validate_host_type(HostType) of
-        ok -> 
+        ok ->
             FromTS = days_to_timestamp(Days),
             Count = mod_inbox_backend:empty_global_bin(HostType, FromTS),
             {ok, Count};

--- a/src/mod_muc_api.erl
+++ b/src/mod_muc_api.erl
@@ -468,7 +468,7 @@ room_desc_to_map(Desc) ->
             #{title => Title, private => Private, users_number => Number}
     end.
 
--spec verify_room(jid:jid(), jid:jid()) -> ok | {internal | not_found, term()}.
+-spec verify_room(jid:jid(), jid:jid()) -> ok | {internal | room_not_found, term()}.
 verify_room(BareRoomJID, OwnerJID) ->
     case mod_muc_room:can_access_room(BareRoomJID, OwnerJID) of
         {ok, true} ->

--- a/src/mod_roster_api.erl
+++ b/src/mod_roster_api.erl
@@ -113,7 +113,8 @@ subscription(#jid{lserver = LServer} = CallerJID, ContactJID, Type) ->
             ?UNKNOWN_DOMAIN_RESULT
     end.
 
--spec set_mutual_subscription(jid:jid(), jid:jid(), sub_mutual_action()) -> {ok, iolist()}.
+-spec set_mutual_subscription(jid:jid(), jid:jid(), sub_mutual_action()) ->
+          {ok | contact_not_found | internal | unknown_domain | user_not_exist, iolist()}.
 set_mutual_subscription(UserA, UserB, connect) ->
     subscribe_both({UserA, <<>>, []}, {UserB, <<>>, []});
 set_mutual_subscription(UserA, UserB, disconnect) ->
@@ -127,7 +128,7 @@ set_mutual_subscription(UserA, UserB, disconnect) ->
     end.
 
 -spec subscribe_both({jid:jid(), binary(), [binary()]}, {jid:jid(), binary(), [binary()]}) ->
-    {ok, iolist()}.
+    {ok | internal | unknown_domain | user_not_exist, iolist()}.
 subscribe_both({UserA, NameA, GroupsA}, {UserB, NameB, GroupsB}) ->
     Seq = [fun() -> add_contact(UserA, UserB, NameB, GroupsB) end,
            fun() -> add_contact(UserB, UserA, NameA, GroupsA) end,

--- a/src/mongoose_admin_api/mongoose_admin_api.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api.erl
@@ -1,0 +1,142 @@
+-module(mongoose_admin_api).
+
+-behaviour(mongoose_http_handler).
+
+%% mongoose_http_handler callbacks
+-export([config_spec/0, routes/1]).
+
+%% config processing callbacks
+-export([process_config/1]).
+
+%% Utilities for the handler modules
+-export([init/2,
+         is_authorized/2,
+         parse_body/1,
+         parse_qs/1,
+         try_handle_request/3,
+         throw_error/2,
+         resource_created/4,
+         respond/3]).
+
+-include("mongoose_config_spec.hrl").
+
+-type handler_options() :: #{path := string(), username => binary(), password => binary(),
+                             atom() => any()}.
+-type req() :: cowboy_req:req().
+-type state() :: map().
+
+%% mongoose_http_handler callbacks
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{items = #{<<"username">> => #option{type = binary},
+                       <<"password">> => #option{type = binary}},
+             process = fun ?MODULE:process_config/1}.
+
+-spec process_config(handler_options()) -> handler_options().
+process_config(Opts) ->
+    case maps:is_key(username, Opts) =:= maps:is_key(password, Opts) of
+        true ->
+            Opts;
+        false ->
+            error(#{what => both_username_and_password_required, opts => Opts})
+    end.
+
+-spec routes(handler_options()) -> mongoose_http_handler:routes().
+routes(Opts = #{path := BasePath}) ->
+    [{[BasePath, Path], Module, ModuleOpts}
+     || {Path, Module, ModuleOpts} <- api_paths(Opts)].
+
+api_paths(Opts) ->
+    [{"/contacts/:user/[:contact]", mongoose_admin_api_contacts, Opts},
+     {"/contacts/:user/:contact/manage", mongoose_admin_api_contacts, Opts#{suffix => manage}},
+     {"/users/:domain/[:username]", mongoose_admin_api_users, Opts},
+     {"/sessions/:domain/[:username]/[:resource]", mongoose_admin_api_sessions, Opts},
+     {"/messages/:owner/:with", mongoose_admin_api_messages, Opts},
+     {"/messages/[:owner]", mongoose_admin_api_messages, Opts},
+     {"/stanzas", mongoose_admin_api_stanzas, Opts},
+     {"/muc-lights/:domain", mongoose_admin_api_muc_light, Opts},
+     {"/muc-lights/:domain/:id/participants", mongoose_admin_api_muc_light,
+      Opts#{suffix => participants}},
+     {"/muc-lights/:domain/:id/messages", mongoose_admin_api_muc_light,
+      Opts#{suffix => messages}},
+     {"/muc-lights/:domain/:id/management", mongoose_admin_api_muc_light,
+      Opts#{suffix => management}},
+     {"/mucs/:domain", mongoose_admin_api_muc, Opts},
+     {"/mucs/:domain/:name/:arg", mongoose_admin_api_muc, Opts},
+     {"/inbox/:host_type/:days/bin", mongoose_admin_api_inbox, Opts},
+     {"/inbox/:domain/:user/:days/bin", mongoose_admin_api_inbox, Opts}
+    ].
+
+%% Utilities for the handler modules
+
+-spec init(req(), state()) -> {cowboy_rest, req(), state()}.
+init(Req, State) ->
+    {cowboy_rest, set_cors_headers(Req), State}.
+
+set_cors_headers(Req) ->
+    Req1 = cowboy_req:set_resp_header(<<"Access-Control-Allow-Methods">>,
+                                      <<"GET, OPTIONS, PUT, POST, DELETE">>, Req),
+    Req2 = cowboy_req:set_resp_header(<<"Access-Control-Allow-Origin">>,
+                                      <<"*">>, Req1),
+    cowboy_req:set_resp_header(<<"Access-Control-Allow-Headers">>,
+                               <<"Content-Type">>, Req2).
+
+-spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
+is_authorized(Req, State) ->
+    AuthDetails = mongoose_api_common:get_auth_details(Req),
+    case authorize(State, AuthDetails) of
+        true ->
+            {true, Req, State};
+        false ->
+            mongoose_api_common:make_unauthorized_response(Req, State)
+    end.
+
+authorize(#{username := Username, password := Password}, AuthDetails) ->
+    case AuthDetails of
+        {AuthMethod, Username, Password} ->
+            mongoose_api_common:is_known_auth_method(AuthMethod);
+        _ ->
+            false
+    end;
+authorize(#{}, _) ->
+    true. % no credentials required
+
+-spec parse_body(req()) -> jiffy:json_value().
+parse_body(Req) ->
+    try
+        {Params, _} = mongoose_api_common:parse_request_body(Req),
+        maps:from_list(Params)
+    catch _:_ ->
+            throw_error(bad_request, <<"Invalid request body">>)
+    end.
+
+-spec parse_qs(req()) -> #{atom() => binary()}.
+parse_qs(Req) ->
+    maps:from_list([{binary_to_existing_atom(K), V} || {K, V} <- cowboy_req:parse_qs(Req)]).
+
+-spec try_handle_request(req(), state(), fun((req(), state()) -> Result)) -> Result.
+try_handle_request(Req, State, F) ->
+    try
+        F(Req, State)
+    catch throw:#{error_type := ErrorType, message := Msg} ->
+            mongoose_api_common:error_response(ErrorType, Msg, Req, State)
+    end.
+
+-spec throw_error(atom(), iodata()) -> no_return().
+throw_error(ErrorType, Msg) ->
+    throw(#{error_type => ErrorType, message => Msg}).
+
+-spec resource_created(req(), state(), iodata(), iodata()) -> {stop, req(), state()}.
+resource_created(Req, State, Path, Body) ->
+    Req2 = cowboy_req:set_resp_body(Body, Req),
+    Headers = #{<<"location">> => Path},
+    Req3 = cowboy_req:reply(201, Headers, Req2),
+    {stop, Req3, State}.
+
+%% @doc Send response when it can't be returned in a tuple from the handler (e.g. for DELETE)
+-spec respond(req(), state(), jiffy:json_value()) -> {stop, req(), state()}.
+respond(Req, State, Response) ->
+    Req2 = cowboy_req:set_resp_body(jiffy:encode(Response), Req),
+    Req3 = cowboy_req:reply(200, Req2),
+    {stop, Req3, State}.

--- a/src/mongoose_admin_api/mongoose_admin_api_contacts.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_contacts.erl
@@ -1,0 +1,160 @@
+-module(mongoose_admin_api_contacts).
+-behaviour(cowboy_rest).
+
+-export([init/2,
+         is_authorized/2,
+         content_types_provided/2,
+         content_types_accepted/2,
+         allowed_methods/2,
+         to_json/2,
+         from_json/2,
+         delete_resource/2]).
+
+-ignore_xref([to_json/2, from_json/2]).
+
+-import(mongoose_admin_api, [parse_body/1, try_handle_request/3, throw_error/2]).
+
+-type req() :: cowboy_req:req().
+-type state() :: map().
+
+-spec init(req(), state()) -> {cowboy_rest, req(), state()}.
+init(Req, Opts) ->
+    mongoose_admin_api:init(Req, Opts).
+
+-spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
+is_authorized(Req, State) ->
+    mongoose_admin_api:is_authorized(Req, State).
+
+-spec content_types_provided(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_provided(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, to_json}
+     ], Req, State}.
+
+-spec content_types_accepted(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_accepted(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, from_json}
+     ], Req, State}.
+
+-spec allowed_methods(req(), state()) -> {[binary()], req(), state()}.
+allowed_methods(Req, State) ->
+    {[<<"OPTIONS">>, <<"GET">>, <<"POST">>, <<"PUT">>, <<"DELETE">>], Req, State}.
+
+%% @doc Called for a method of type "GET"
+-spec to_json(req(), state()) -> {iodata() | stop, req(), state()}.
+to_json(Req, State) ->
+    try_handle_request(Req, State, fun handle_get/2).
+
+%% @doc Called for a method of type "POST" or "PUT"
+-spec from_json(req(), state()) -> {true | stop, req(), state()}.
+from_json(Req, State) ->
+    F = case cowboy_req:method(Req) of
+            <<"POST">> -> fun handle_post/2;
+            <<"PUT">> -> fun handle_put/2
+        end,
+    try_handle_request(Req, State, F).
+
+%% @doc Called for a method of type "DELETE"
+-spec delete_resource(req(), state()) -> {true | stop, req(), state()}.
+delete_resource(Req, State) ->
+    try_handle_request(Req, State, fun handle_delete/2).
+
+%% Internal functions
+
+handle_get(Req, State) ->
+    Bindings = cowboy_req:bindings(Req),
+    UserJid = get_user_jid(Bindings),
+    case mod_roster_api:list_contacts(UserJid) of
+        {ok, Rosters} ->
+            {jiffy:encode(lists:map(fun roster_info/1, Rosters)), Req, State};
+        {unknown_domain, Reason} ->
+            throw_error(not_found, Reason)
+    end.
+
+handle_post(Req, State) ->
+    Bindings = cowboy_req:bindings(Req),
+    UserJid = get_user_jid(Bindings),
+    Args = parse_body(Req),
+    ContactJid = get_jid(Args),
+    case mod_roster_api:add_contact(UserJid, ContactJid, <<>>, []) of
+        {unknown_domain, Reason} ->
+            throw_error(not_found, Reason);
+        {user_not_exist, Reason} ->
+            throw_error(not_found, Reason);
+        {ok, _} ->
+            {true, Req, State}
+    end.
+
+handle_put(Req, State) ->
+    Bindings = cowboy_req:bindings(Req),
+    UserJid = get_user_jid(Bindings),
+    ContactJid = get_contact_jid(Bindings),
+    Args = parse_body(Req),
+    Action = get_action(Args, State),
+    case perform_action(UserJid, ContactJid, Action, State) of
+        {unknown_domain, Reason} ->
+            throw_error(not_found, Reason);
+        {user_not_exist, Reason} ->
+            throw_error(not_found, Reason);
+        {contact_not_found, Reason} ->
+            throw_error(not_found, Reason);
+        {ok, _} ->
+            {true, Req, State}
+    end.
+
+handle_delete(Req, State) ->
+    Bindings = cowboy_req:bindings(Req),
+    UserJid = get_user_jid(Bindings),
+    ContactJid = get_contact_jid(Bindings),
+    case mod_roster_api:delete_contact(UserJid, ContactJid) of
+        {contact_not_found, Reason} ->
+            throw_error(not_found, Reason);
+        {ok, _} ->
+            {true, Req, State}
+    end.
+
+perform_action(UserJid, ContactJid, Action, #{suffix := manage}) ->
+    mod_roster_api:set_mutual_subscription(UserJid, ContactJid, Action);
+perform_action(UserJid, ContactJid, Action, #{}) ->
+    mod_roster_api:subscription(UserJid, ContactJid, Action).
+
+-spec roster_info(mod_roster:roster()) -> jiffy:json_object().
+roster_info(Roster) ->
+    #{jid := Jid, subscription := Sub, ask := Ask} = mod_roster:item_to_map(Roster),
+    #{jid => jid:to_binary(Jid), subscription => Sub, ask => Ask}.
+
+get_jid(#{jid := JidBin}) ->
+    case jid:from_binary(JidBin) of
+        error -> throw_error(bad_request, <<"Invalid JID">>);
+        Jid -> Jid
+    end;
+get_jid(#{}) ->
+    throw_error(bad_request, <<"Missing JID">>).
+
+get_user_jid(#{user := User}) ->
+    case jid:from_binary(User) of
+        error -> throw_error(bad_request, <<"Invalid user JID">>);
+        Jid -> Jid
+    end.
+
+get_contact_jid(#{contact := Contact}) ->
+    case jid:from_binary(Contact) of
+        error -> throw_error(bad_request, <<"Invalid contact JID">>);
+        Jid -> Jid
+    end;
+get_contact_jid(#{}) ->
+    throw_error(bad_request, <<"Missing contact JID">>).
+
+get_action(#{action := ActionBin}, State) ->
+    decode_action(ActionBin, maps:get(suffix, State, no_suffix));
+get_action(#{}, _State) ->
+    throw_error(bad_request, <<"Missing action">>).
+
+decode_action(<<"subscribe">>, no_suffix) -> subscribe;
+decode_action(<<"subscribed">>, no_suffix) -> subscribed;
+decode_action(<<"connect">>, manage) -> connect;
+decode_action(<<"disconnect">>, manage) -> disconnect;
+decode_action(_, _) -> throw_error(bad_request, <<"Invalid action">>).

--- a/src/mongoose_admin_api/mongoose_admin_api_inbox.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_inbox.erl
@@ -1,0 +1,72 @@
+-module(mongoose_admin_api_inbox).
+-behaviour(cowboy_rest).
+
+-export([init/2,
+         is_authorized/2,
+         allowed_methods/2,
+         delete_resource/2]).
+
+-import(mongoose_admin_api, [try_handle_request/3, throw_error/2, respond/3]).
+
+-type req() :: cowboy_req:req().
+-type state() :: map().
+
+-spec init(req(), state()) -> {cowboy_rest, req(), state()}.
+init(Req, Opts) ->
+    mongoose_admin_api:init(Req, Opts).
+
+-spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
+is_authorized(Req, State) ->
+    mongoose_admin_api:is_authorized(Req, State).
+
+-spec allowed_methods(req(), state()) -> {[binary()], req(), state()}.
+allowed_methods(Req, State) ->
+    {[<<"OPTIONS">>, <<"DELETE">>], Req, State}.
+
+%% @doc Called for a method of type "DELETE"
+-spec delete_resource(req(), state()) -> {stop, req(), state()}.
+delete_resource(Req, State) ->
+    try_handle_request(Req, State, fun handle_delete/2).
+
+%% Internal functions
+
+handle_delete(Req, State) ->
+    Bindings = cowboy_req:bindings(Req),
+    case Bindings of
+        #{host_type := _} ->
+            flush_global_bin(Req, State, Bindings);
+        _ ->
+            flush_user_bin(Req, State, Bindings)
+    end.
+
+flush_global_bin(Req, State, #{host_type := HostType} = Bindings) ->
+    Days = get_days(Bindings),
+    case mod_inbox_api:flush_global_bin(HostType, Days) of
+        {host_type_not_found, Msg} ->
+            throw_error(not_found, Msg);
+        {ok, Count} ->
+            respond(Req, State, Count)
+    end.
+
+flush_user_bin(Req, State, Bindings) ->
+    JID = get_jid(Bindings),
+    Days = get_days(Bindings),
+    case mod_inbox_api:flush_user_bin(JID, Days) of
+        {user_does_not_exist, Msg} ->
+            throw_error(not_found, Msg);
+        {domain_not_found, Msg} ->
+            throw_error(not_found, Msg);
+        {ok, Count} ->
+            respond(Req, State, Count)
+    end.
+
+get_days(#{days := DaysBin}) ->
+    try binary_to_integer(DaysBin)
+    catch _:_ -> throw_error(bad_request, <<"Invalid number of days">>)
+    end.
+
+get_jid(#{user := User, domain := Domain}) ->
+    case jid:make_bare(User, Domain) of
+        error -> throw_error(bad_request, <<"Invalid JID">>);
+        JID -> JID
+    end.

--- a/src/mongoose_admin_api/mongoose_admin_api_messages.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_messages.erl
@@ -1,0 +1,142 @@
+-module(mongoose_admin_api_messages).
+-behaviour(cowboy_rest).
+
+-export([init/2,
+         is_authorized/2,
+         content_types_provided/2,
+         content_types_accepted/2,
+         allowed_methods/2,
+         to_json/2,
+         from_json/2]).
+
+-ignore_xref([to_json/2, from_json/2]).
+
+-import(mongoose_admin_api, [parse_body/1, parse_qs/1, try_handle_request/3, throw_error/2]).
+
+-type req() :: cowboy_req:req().
+-type state() :: map().
+
+-spec init(req(), state()) -> {cowboy_rest, req(), state()}.
+init(Req, Opts) ->
+    mongoose_admin_api:init(Req, Opts).
+
+-spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
+is_authorized(Req, State) ->
+    mongoose_admin_api:is_authorized(Req, State).
+
+-spec content_types_provided(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_provided(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, to_json}
+     ], Req, State}.
+
+-spec content_types_accepted(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_accepted(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, from_json}
+     ], Req, State}.
+
+-spec allowed_methods(req(), state()) -> {[binary()], req(), state()}.
+allowed_methods(Req, State) ->
+    {[<<"OPTIONS">>, <<"GET">>, <<"POST">>], Req, State}.
+
+%% @doc Called for a method of type "GET"
+-spec to_json(req(), state()) -> {iodata() | stop, req(), state()}.
+to_json(Req, State) ->
+    try_handle_request(Req, State, fun handle_get/2).
+
+%% @doc Called for a method of type "POST"
+-spec from_json(req(), state()) -> {true | stop, req(), state()}.
+from_json(Req, State) ->
+    try_handle_request(Req, State, fun handle_post/2).
+
+%% Internal functions
+
+handle_get(Req, State) ->
+    Bindings = cowboy_req:bindings(Req),
+    OwnerJid = get_owner_jid(Bindings),
+    WithJid = get_with_jid(Bindings),
+    Args = parse_qs(Req),
+    Limit = get_limit(Args),
+    Before = get_before(Args),
+    Rows = mongoose_stanza_api:lookup_recent_messages(OwnerJid, WithJid, Before, Limit),
+    Messages = lists:map(fun row_to_map/1, Rows),
+    {jiffy:encode(Messages), Req, State}.
+
+handle_post(Req, State) ->
+    Args = parse_body(Req),
+    From = get_caller(Args),
+    To = get_to(Args),
+    Body = get_body(Args),
+    Packet = mongoose_stanza_helper:build_message(
+               jid:to_binary(From), jid:to_binary(To), Body),
+    case mongoose_stanza_helper:route(From, To, Packet, true) of
+        {error, #{what := unknown_domain}} ->
+            throw_error(bad_request, <<"Unknown domain">>);
+        {error, #{what := unknown_user}} ->
+            throw_error(bad_request, <<"Unknown user">>);
+        {ok, _} ->
+            {true, Req, State}
+    end.
+
+-spec row_to_map(mod_mam:message_row()) -> map().
+row_to_map(#{id := Id, jid := From, packet := Msg}) ->
+    Jbin = jid:to_binary(From),
+    {Msec, _} = mod_mam_utils:decode_compact_uuid(Id),
+    MsgId = case xml:get_tag_attr(<<"id">>, Msg) of
+                {value, MId} -> MId;
+                false -> <<"">>
+            end,
+    Body = exml_query:path(Msg, [{element, <<"body">>}, cdata]),
+    #{sender => Jbin, timestamp => round(Msec / 1000000), message_id => MsgId, body => Body}.
+
+get_limit(#{limit := LimitBin}) ->
+    try
+        Limit = binary_to_integer(LimitBin),
+        true = Limit >= 0 andalso Limit =< 500,
+        Limit
+    catch
+        _:_ -> throw_error(bad_request, <<"Invalid limit">>)
+    end;
+get_limit(#{}) -> 100.
+
+get_before(#{before := BeforeBin}) ->
+    try
+        1000000 * binary_to_integer(BeforeBin)
+    catch
+        _:_ -> throw_error(bad_request, <<"Invalid value of 'before'">>)
+    end;
+get_before(#{}) -> 0.
+
+get_owner_jid(#{owner := Owner}) ->
+    case jid:from_binary(Owner) of
+        error -> throw_error(bad_request, <<"Invalid owner JID">>);
+        OwnerJid -> OwnerJid
+    end;
+get_owner_jid(#{}) -> throw_error(not_found, <<"Missing owner JID">>).
+
+get_with_jid(#{with := With}) ->
+    case jid:from_binary(With) of
+        error -> throw_error(bad_request, <<"Invalid interlocutor JID">>);
+        WithJid -> WithJid
+    end;
+get_with_jid(#{}) -> undefined.
+
+get_caller(#{caller := Caller}) ->
+    case jid:from_binary(Caller) of
+        error -> throw_error(bad_request, <<"Invalid sender JID">>);
+        CallerJid -> CallerJid
+    end;
+get_caller(#{}) -> throw_error(bad_request, <<"Missing sender JID">>).
+
+get_to(#{to := To}) ->
+    case jid:from_binary(To) of
+        error -> throw_error(bad_request, <<"Invalid recipient JID">>);
+        ToJid -> ToJid
+    end;
+get_to(#{}) -> throw_error(bad_request, <<"Missing recipient JID">>).
+
+get_body(#{body := Body}) -> Body;
+get_body(#{}) -> throw_error(bad_request, <<"Missing message body">>).

--- a/src/mongoose_admin_api/mongoose_admin_api_muc.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_muc.erl
@@ -1,0 +1,159 @@
+-module(mongoose_admin_api_muc).
+-behaviour(cowboy_rest).
+
+-export([init/2,
+         is_authorized/2,
+         content_types_accepted/2,
+         allowed_methods/2,
+         from_json/2,
+         delete_resource/2]).
+
+-ignore_xref([to_json/2, from_json/2]).
+
+-import(mongoose_admin_api, [try_handle_request/3, throw_error/2, parse_body/1, resource_created/4]).
+
+-include("jlib.hrl").
+
+-type req() :: cowboy_req:req().
+-type state() :: map().
+
+-spec init(req(), state()) -> {cowboy_rest, req(), state()}.
+init(Req, Opts) ->
+    mongoose_admin_api:init(Req, Opts).
+
+-spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
+is_authorized(Req, State) ->
+    mongoose_admin_api:is_authorized(Req, State).
+
+-spec content_types_accepted(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_accepted(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, from_json}
+     ], Req, State}.
+
+-spec allowed_methods(req(), state()) -> {[binary()], req(), state()}.
+allowed_methods(Req, State) ->
+    {[<<"OPTIONS">>, <<"POST">>, <<"DELETE">>], Req, State}.
+
+%% @doc Called for a method of type "POST"
+-spec from_json(req(), state()) -> {true | stop, req(), state()}.
+from_json(Req, State) ->
+    try_handle_request(Req, State, fun handle_post/2).
+
+%% @doc Called for a method of type "DELETE"
+-spec delete_resource(req(), state()) -> {true | stop, req(), state()}.
+delete_resource(Req, State) ->
+    try_handle_request(Req, State, fun handle_delete/2).
+
+%% Internal functions
+
+handle_post(Req, State) ->
+    Bindings = cowboy_req:bindings(Req),
+    handle_post(Req, State, Bindings).
+
+handle_post(Req, State, #{arg := <<"participants">>} = Bindings) ->
+    RoomJid = get_room_jid(Bindings),
+    Args = parse_body(Req),
+    SenderJid = get_sender_jid(Args),
+    RecipientJid = get_recipient_jid(Args),
+    Reason = get_invite_reason(Args),
+    case mod_muc_api:invite_to_room(RoomJid, SenderJid, RecipientJid, Reason) of
+        {ok, _} ->
+            {true, Req, State};
+        {room_not_found, Msg} ->
+            throw_error(not_found, Msg)
+    end;
+handle_post(Req, State, #{arg := <<"messages">>} = Bindings) ->
+    RoomJid = get_room_jid(Bindings),
+    Args = parse_body(Req),
+    SenderJid = get_from_jid(Args),
+    Body = get_message_body(Args),
+    {ok, _} = mod_muc_api:send_message_to_room(RoomJid, SenderJid, Body),
+    {true, Req, State};
+handle_post(Req, State, #{domain := Domain}) ->
+    Args = parse_body(Req),
+    RoomName = get_room_name(Args),
+    OwnerJid = get_owner_jid(Args),
+    Nick = get_nick(Args),
+    %% TODO This check should be done in the API module to work for GraphQL as well
+    #jid{lserver = MUCDomain} = make_room_jid(RoomName, get_muc_domain(Domain)),
+    case mod_muc_api:create_instant_room(MUCDomain, RoomName, OwnerJid, Nick) of
+        {ok, #{title := R}} ->
+            Path = [cowboy_req:uri(Req), "/", R],
+            resource_created(Req, State, Path, R);
+        {user_not_found, Msg} ->
+            throw_error(not_found, Msg)
+    end.
+
+handle_delete(Req, State) ->
+    Bindings = cowboy_req:bindings(Req),
+    RoomJid = get_room_jid(Bindings),
+    #{arg := Nick} = Bindings, % 'name' was present, so 'arg' is present as well (see Cowboy paths)
+    Reason = <<"User kicked from the admin REST API">>,
+    case mod_muc_api:kick_user_from_room(RoomJid, Nick, Reason) of
+        {ok, _} ->
+            {true, Req, State};
+        {moderator_not_found, Msg} ->
+            throw_error(not_found, Msg);
+        {room_not_found, Msg} ->
+            throw_error(not_found, Msg)
+    end.
+
+get_owner_jid(#{owner := Owner}) ->
+    case jid:binary_to_bare(Owner) of
+        error -> throw_error(bad_request, <<"Invalid owner JID">>);
+        OwnerJid -> OwnerJid
+    end;
+get_owner_jid(#{}) -> throw_error(bad_request, <<"Missing owner JID">>).
+
+get_room_jid(#{domain := Domain} = Bindings) ->
+    MUCDomain = get_muc_domain(Domain),
+    RoomName = get_room_name(Bindings),
+    make_room_jid(RoomName, MUCDomain).
+
+make_room_jid(RoomName, MUCDomain) ->
+    try #jid{} = jid:make_bare(RoomName, MUCDomain)
+    catch _:_ -> throw_error(bad_request, <<"Invalid room name">>)
+    end.
+
+get_nick(#{nick := Nick}) -> Nick;
+get_nick(#{}) -> throw_error(bad_request, <<"Missing nickname">>).
+
+get_room_name(#{name := Name}) -> Name;
+get_room_name(#{}) -> throw_error(bad_request, <<"Missing room name">>).
+
+get_message_body(#{body := Body}) -> Body;
+get_message_body(#{}) -> throw_error(bad_request, <<"Missing message body">>).
+
+get_invite_reason(#{reason := Reason}) -> Reason;
+get_invite_reason(#{}) -> throw_error(bad_request, <<"Missing invite reason">>).
+
+get_from_jid(#{from := Sender}) ->
+    case jid:from_binary(Sender) of
+        error -> throw_error(bad_request, <<"Invalid sender JID">>);
+        SenderJid -> SenderJid
+    end;
+get_from_jid(#{}) -> throw_error(bad_request, <<"Missing sender JID">>).
+
+get_sender_jid(#{sender := Sender}) ->
+    case jid:from_binary(Sender) of
+        error -> throw_error(bad_request, <<"Invalid sender JID">>);
+        SenderJid -> SenderJid
+    end;
+get_sender_jid(#{}) -> throw_error(bad_request, <<"Missing sender JID">>).
+
+get_recipient_jid(#{recipient := Recipient}) ->
+    case jid:from_binary(Recipient) of
+        error -> throw_error(bad_request, <<"Invalid recipient JID">>);
+        RecipientJid -> RecipientJid
+    end;
+get_recipient_jid(#{}) -> throw_error(bad_request, <<"Missing recipient JID">>).
+
+get_muc_domain(Domain) ->
+    try
+        {ok, HostType} = mongoose_domain_api:get_domain_host_type(Domain),
+        mod_muc:server_host_to_muc_host(HostType, Domain)
+    catch _:_ ->
+            throw_error(not_found, <<"MUC domain not found">>)
+    end.

--- a/src/mongoose_admin_api/mongoose_admin_api_muc_light.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_muc_light.erl
@@ -1,0 +1,173 @@
+-module(mongoose_admin_api_muc_light).
+-behaviour(cowboy_rest).
+
+-export([init/2,
+         is_authorized/2,
+         content_types_accepted/2,
+         allowed_methods/2,
+         from_json/2,
+         delete_resource/2]).
+
+-ignore_xref([to_json/2, from_json/2]).
+
+-import(mongoose_admin_api, [try_handle_request/3, throw_error/2, parse_body/1, resource_created/4]).
+
+-type req() :: cowboy_req:req().
+-type state() :: map().
+
+-spec init(req(), state()) -> {cowboy_rest, req(), state()}.
+init(Req, Opts) ->
+    mongoose_admin_api:init(Req, Opts).
+
+-spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
+is_authorized(Req, State) ->
+    mongoose_admin_api:is_authorized(Req, State).
+
+-spec content_types_accepted(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_accepted(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, from_json}
+     ], Req, State}.
+
+-spec allowed_methods(req(), state()) -> {[binary()], req(), state()}.
+allowed_methods(Req, State) ->
+    {[<<"OPTIONS">>, <<"POST">>, <<"PUT">>, <<"DELETE">>], Req, State}.
+
+%% @doc Called for a method of type "POST" and "PUT"
+-spec from_json(req(), state()) -> {stop, req(), state()}.
+from_json(Req, State) ->
+    F = case cowboy_req:method(Req) of
+            <<"POST">> -> fun handle_post/2;
+            <<"PUT">> -> fun handle_put/2
+        end,
+    try_handle_request(Req, State, F).
+
+%% @doc Called for a method of type "DELETE"
+-spec delete_resource(req(), state()) -> {true | stop, req(), state()}.
+delete_resource(Req, State) ->
+    try_handle_request(Req, State, fun handle_delete/2).
+
+%% Internal functions
+
+handle_post(Req, #{suffix := participants} = State) ->
+    Bindings = cowboy_req:bindings(Req),
+    RoomJid = get_room_jid(Bindings),
+    Args = parse_body(Req),
+    SenderJid = get_sender_jid(Args),
+    RecipientJid = get_recipient_jid(Args),
+    case mod_muc_light_api:invite_to_room(RoomJid, SenderJid, RecipientJid) of
+        {ok, _} ->
+            {stop, Req, State};
+        {muc_server_not_found, Msg} ->
+            throw_error(not_found, Msg);
+        {not_room_member, Msg} ->
+            throw_error(denied, Msg)
+    end;
+handle_post(Req, #{suffix := messages} = State) ->
+    Bindings = cowboy_req:bindings(Req),
+    RoomJid = get_room_jid(Bindings),
+    Args = parse_body(Req),
+    SenderJid = get_from_jid(Args),
+    Body = get_message_body(Args),
+    case mod_muc_light_api:send_message(RoomJid, SenderJid, Body) of
+        {ok, _} ->
+            {stop, Req, State};
+        {muc_server_not_found, Msg} ->
+            throw_error(not_found, Msg);
+        {not_room_member, Msg} ->
+            throw_error(denied, Msg)
+    end;
+handle_post(Req, State) ->
+    #{domain := MUCDomain} = cowboy_req:bindings(Req),
+    Args = parse_body(Req),
+    OwnerJid = get_owner_jid(Args),
+    RoomName = get_room_name(Args),
+    Subject = get_room_subject(Args),
+    case mod_muc_light_api:create_room(MUCDomain, OwnerJid, RoomName, Subject) of
+        {ok, #{jid := RoomJid}} ->
+            RoomJidBin = jid:to_binary(RoomJid),
+            Path = [cowboy_req:uri(Req), "/", RoomJidBin],
+            resource_created(Req, State, Path, RoomJidBin);
+        {muc_server_not_found, Msg} ->
+            throw_error(not_found, Msg)
+    end.
+
+handle_put(Req, State) ->
+    #{domain := MUCDomain} = cowboy_req:bindings(Req),
+    Args = parse_body(Req),
+    OwnerJid = get_owner_jid(Args),
+    RoomName = get_room_name(Args),
+    RoomId = get_room_id(Args),
+    Subject = get_room_subject(Args),
+    case mod_muc_light_api:create_room(MUCDomain, RoomId, OwnerJid, RoomName, Subject) of
+        {ok, #{jid := RoomJid}} ->
+            RoomJidBin = jid:to_binary(RoomJid),
+            Path = [cowboy_req:uri(Req), "/", RoomJidBin],
+            resource_created(Req, State, Path, RoomJidBin);
+        {muc_server_not_found, Msg} ->
+            throw_error(not_found, Msg);
+        {already_exists, Msg} ->
+            throw_error(denied, Msg)
+    end.
+
+handle_delete(Req, #{suffix := management} = State) ->
+    Bindings = cowboy_req:bindings(Req),
+    RoomJid = get_room_jid(Bindings),
+    case mod_muc_light_api:delete_room(RoomJid) of
+        {ok, _} ->
+            {true, Req, State};
+        {muc_server_not_found, Msg} ->
+            throw_error(not_found, Msg);
+        {room_not_found, Msg} ->
+            throw_error(not_found, Msg)
+    end;
+handle_delete(_Req, _State) ->
+    throw_error(not_found, ""). % Cowboy returns the same for unknown paths
+
+get_owner_jid(#{owner := Owner}) ->
+    case jid:from_binary(Owner) of
+        error -> throw_error(bad_request, <<"Invalid owner JID">>);
+        OwnerJid -> OwnerJid
+    end;
+get_owner_jid(#{}) -> throw_error(bad_request, <<"Missing owner JID">>).
+
+get_room_jid(#{domain := MUCDomain} = Bindings) ->
+    RoomId = get_room_id(Bindings),
+    case jid:make_bare(RoomId, MUCDomain) of
+        error -> throw_error(bad_request, <<"Invalid room ID or domain name">>);
+        RoomJid -> RoomJid
+    end.
+
+get_room_name(#{name := Name}) -> Name;
+get_room_name(#{}) -> throw_error(bad_request, <<"Missing room name">>).
+
+get_room_id(#{id := Id}) -> Id;
+get_room_id(#{}) -> throw_error(bad_request, <<"Missing room ID">>).
+
+get_room_subject(#{subject := Subject}) -> Subject;
+get_room_subject(#{}) -> throw_error(bad_request, <<"Missing room subject">>).
+
+get_message_body(#{body := Body}) -> Body;
+get_message_body(#{}) -> throw_error(bad_request, <<"Missing message body">>).
+
+get_from_jid(#{from := Sender}) ->
+    case jid:from_binary(Sender) of
+        error -> throw_error(bad_request, <<"Invalid sender JID">>);
+        SenderJid -> SenderJid
+    end;
+get_from_jid(#{}) -> throw_error(bad_request, <<"Missing sender JID">>).
+
+get_sender_jid(#{sender := Sender}) ->
+    case jid:from_binary(Sender) of
+        error -> throw_error(bad_request, <<"Invalid sender JID">>);
+        SenderJid -> SenderJid
+    end;
+get_sender_jid(#{}) -> throw_error(bad_request, <<"Missing sender JID">>).
+
+get_recipient_jid(#{recipient := Recipient}) ->
+    case jid:from_binary(Recipient) of
+        error -> throw_error(bad_request, <<"Invalid recipient JID">>);
+        RecipientJid -> RecipientJid
+    end;
+get_recipient_jid(#{}) -> throw_error(bad_request, <<"Missing recipient JID">>).

--- a/src/mongoose_admin_api/mongoose_admin_api_sessions.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_sessions.erl
@@ -1,0 +1,69 @@
+-module(mongoose_admin_api_sessions).
+-behaviour(cowboy_rest).
+
+-export([init/2,
+         is_authorized/2,
+         content_types_provided/2,
+         allowed_methods/2,
+         to_json/2,
+         delete_resource/2]).
+
+-ignore_xref([to_json/2, from_json/2]).
+
+-import(mongoose_admin_api, [try_handle_request/3, throw_error/2]).
+
+-type req() :: cowboy_req:req().
+-type state() :: map().
+
+-spec init(req(), state()) -> {cowboy_rest, req(), state()}.
+init(Req, Opts) ->
+    mongoose_admin_api:init(Req, Opts).
+
+-spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
+is_authorized(Req, State) ->
+    mongoose_admin_api:is_authorized(Req, State).
+
+-spec content_types_provided(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_provided(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, to_json}
+     ], Req, State}.
+
+-spec allowed_methods(req(), state()) -> {[binary()], req(), state()}.
+allowed_methods(Req, State) ->
+    {[<<"OPTIONS">>, <<"GET">>, <<"DELETE">>], Req, State}.
+
+%% @doc Called for a method of type "GET"
+-spec to_json(req(), state()) -> {iodata() | stop, req(), state()}.
+to_json(Req, State) ->
+    try_handle_request(Req, State, fun handle_get/2).
+
+%% @doc Called for a method of type "DELETE"
+-spec delete_resource(req(), state()) -> {true | stop, req(), state()}.
+delete_resource(Req, State) ->
+    try_handle_request(Req, State, fun handle_delete/2).
+
+%% Internal functions
+
+handle_get(Req, State) ->
+    #{domain := Domain} = cowboy_req:bindings(Req),
+    Sessions = mongoose_session_api:list_resources(Domain),
+    {jiffy:encode(Sessions), Req, State}.
+
+handle_delete(Req, State) ->
+    #{domain := Domain} = Bindings = cowboy_req:bindings(Req),
+    UserName = get_user_name(Bindings),
+    Resource = get_resource(Bindings),
+    case mongoose_session_api:kick_session(UserName, Domain, Resource, <<"kicked">>) of
+        {ok, _} ->
+            {true, Req, State};
+        {no_session, Reason} ->
+            throw_error(not_found, Reason)
+    end.
+
+get_user_name(#{username := UserName}) -> UserName;
+get_user_name(#{}) -> throw_error(bad_request, <<"Missing user name">>).
+
+%% Resource is matched first, so it is not possible for it to be missing
+get_resource(#{resource := Resource}) -> Resource.

--- a/src/mongoose_admin_api/mongoose_admin_api_stanzas.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_stanzas.erl
@@ -1,0 +1,86 @@
+-module(mongoose_admin_api_stanzas).
+-behaviour(cowboy_rest).
+
+-export([init/2,
+         is_authorized/2,
+         content_types_accepted/2,
+         allowed_methods/2,
+         from_json/2]).
+
+-ignore_xref([to_json/2, from_json/2]).
+
+-import(mongoose_admin_api, [parse_body/1, try_handle_request/3, throw_error/2]).
+
+-type req() :: cowboy_req:req().
+-type state() :: map().
+
+-spec init(req(), state()) -> {cowboy_rest, req(), state()}.
+init(Req, Opts) ->
+    mongoose_admin_api:init(Req, Opts).
+
+-spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
+is_authorized(Req, State) ->
+    mongoose_admin_api:is_authorized(Req, State).
+
+-spec content_types_accepted(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_accepted(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, from_json}
+     ], Req, State}.
+
+-spec allowed_methods(req(), state()) -> {[binary()], req(), state()}.
+allowed_methods(Req, State) ->
+    {[<<"OPTIONS">>, <<"POST">>], Req, State}.
+
+%% @doc Called for a method of type "POST"
+-spec from_json(req(), state()) -> {true | stop, req(), state()}.
+from_json(Req, State) ->
+    try_handle_request(Req, State, fun handle_post/2).
+
+%% Internal functions
+
+handle_post(Req, State) ->
+    Args = parse_body(Req),
+    Stanza = get_stanza(Args),
+    From = get_from_jid(Stanza),
+    To = get_to_jid(Stanza),
+    case mongoose_stanza_helper:route(From, To, Stanza, true) of
+        {error, #{what := unknown_domain}} ->
+            throw_error(bad_request, <<"Unknown domain">>);
+        {error, #{what := unknown_user}} ->
+            throw_error(bad_request, <<"Unknown user">>);
+        {ok, _} ->
+            {true, Req, State}
+    end.
+
+get_stanza(#{stanza := BinStanza}) ->
+    case exml:parse(BinStanza) of
+        {ok, Stanza} ->
+            Stanza;
+        {error, _} ->
+            throw_error(bad_request, <<"Malformed stanza">>)
+    end;
+get_stanza(#{}) -> throw_error(bad_request, <<"Missing stanza">>).
+
+get_from_jid(Stanza) ->
+    case exml_query:attr(Stanza, <<"from">>) of
+        undefined ->
+            throw_error(bad_request, <<"Missing sender JID">>);
+        JidBin ->
+            case jid:from_binary(JidBin) of
+                error -> throw_error(bad_request, <<"Invalid sender JID">>);
+                Jid -> Jid
+            end
+    end.
+
+get_to_jid(Stanza) ->
+    case exml_query:attr(Stanza, <<"to">>) of
+        undefined ->
+            throw_error(bad_request, <<"Missing recipient JID">>);
+        JidBin ->
+            case jid:from_binary(JidBin) of
+                error -> throw_error(bad_request, <<"Invalid recipient JID">>);
+                Jid -> Jid
+            end
+    end.

--- a/src/mongoose_admin_api/mongoose_admin_api_users.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_users.erl
@@ -1,0 +1,123 @@
+-module(mongoose_admin_api_users).
+-behaviour(cowboy_rest).
+
+-export([init/2,
+         is_authorized/2,
+         content_types_provided/2,
+         content_types_accepted/2,
+         allowed_methods/2,
+         to_json/2,
+         from_json/2,
+         delete_resource/2]).
+
+-ignore_xref([to_json/2, from_json/2]).
+
+-import(mongoose_admin_api, [parse_body/1, try_handle_request/3, throw_error/2, resource_created/4]).
+
+-type req() :: cowboy_req:req().
+-type state() :: map().
+
+-spec init(req(), state()) -> {cowboy_rest, req(), state()}.
+init(Req, Opts) ->
+    mongoose_admin_api:init(Req, Opts).
+
+-spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
+is_authorized(Req, State) ->
+    mongoose_admin_api:is_authorized(Req, State).
+
+-spec content_types_provided(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_provided(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, to_json}
+     ], Req, State}.
+
+-spec content_types_accepted(req(), state()) ->
+          {[{{binary(), binary(), '*'}, atom()}], req(), state()}.
+content_types_accepted(Req, State) ->
+    {[
+      {{<<"application">>, <<"json">>, '*'}, from_json}
+     ], Req, State}.
+
+-spec allowed_methods(req(), state()) -> {[binary()], req(), state()}.
+allowed_methods(Req, State) ->
+    {[<<"OPTIONS">>, <<"GET">>, <<"POST">>, <<"PUT">>, <<"DELETE">>], Req, State}.
+
+%% @doc Called for a method of type "GET"
+-spec to_json(req(), state()) -> {iodata() | stop, req(), state()}.
+to_json(Req, State) ->
+    try_handle_request(Req, State, fun handle_get/2).
+
+%% @doc Called for a method of type "POST" or "PUT"
+-spec from_json(req(), state()) -> {true | stop, req(), state()}.
+from_json(Req, State) ->
+    F = case cowboy_req:method(Req) of
+            <<"POST">> -> fun handle_post/2;
+            <<"PUT">> -> fun handle_put/2
+        end,
+    try_handle_request(Req, State, F).
+
+%% @doc Called for a method of type "DELETE"
+-spec delete_resource(req(), state()) -> {true | stop, req(), state()}.
+delete_resource(Req, State) ->
+    try_handle_request(Req, State, fun handle_delete/2).
+
+%% Internal functions
+
+handle_get(Req, State) ->
+    #{domain := Domain} = cowboy_req:bindings(Req),
+    Users = mongoose_account_api:list_users(Domain),
+    {jiffy:encode(Users), Req, State}.
+
+handle_post(Req, State) ->
+    #{domain := Domain} = cowboy_req:bindings(Req),
+    Args = parse_body(Req),
+    {UserName, Password} = get_credentials(Args),
+    case mongoose_account_api:register_user(UserName, Domain, Password) of
+        {exists, Reason} ->
+            throw_error(denied, Reason);
+        {invalid_jid, Reason} ->
+            throw_error(bad_request, Reason);
+        {cannot_register, Reason} ->
+            throw_error(internal, Reason);
+        {ok, Result} ->
+            Path = [cowboy_req:uri(Req), "/", UserName],
+            resource_created(Req, State, Path, Result)
+    end.
+
+handle_put(Req, State) ->
+    #{domain := Domain} = Bindings = cowboy_req:bindings(Req),
+    UserName = get_user_name(Bindings),
+    Args = parse_body(Req),
+    Password = get_new_password(Args),
+    case mongoose_account_api:change_password(UserName, Domain, Password) of
+        {empty_password, Reason} ->
+            throw_error(bad_request, Reason);
+        {invalid_jid, Reason} ->
+            throw_error(bad_request, Reason);
+        {not_allowed, Reason} ->
+            throw_error(denied, Reason);
+        {ok, _} ->
+            {true, Req, State}
+    end.
+
+handle_delete(Req, State) ->
+    #{domain := Domain} = Bindings = cowboy_req:bindings(Req),
+    UserName = get_user_name(Bindings),
+    case mongoose_account_api:unregister_user(UserName, Domain) of
+        {invalid_jid, Reason} ->
+            throw_error(bad_request, Reason);
+        {not_allowed, Reason} ->
+            throw_error(denied, Reason);
+        {ok, _} ->
+            {true, Req, State}
+    end.
+
+get_user_name(#{username := UserName}) -> UserName;
+get_user_name(#{}) -> throw_error(bad_request, <<"Missing user name">>).
+
+get_new_password(#{newpass := Password}) -> Password;
+get_new_password(#{}) -> throw_error(bad_request, <<"Missing password">>).
+
+get_credentials(#{username := UserName, password := Password}) -> {UserName, Password};
+get_credentials(#{}) -> throw_error(bad_request, <<"Missing credentials">>).

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -85,5 +85,6 @@ configurable_handler_modules() ->
      mongoose_client_api,
      mongoose_api,
      mongoose_api_admin,
+     mongoose_admin_api,
      mongoose_domain_handler,
      mongoose_graphql_cowboy_handler].

--- a/src/mongoose_stanza_api.erl
+++ b/src/mongoose_stanza_api.erl
@@ -4,6 +4,7 @@
 -include("jlib.hrl").
 -include("mongoose_rsm.hrl").
 
+%% TODO fix error handling, do not crash for non-existing users
 %% Before is in microseconds
 -spec lookup_recent_messages(
         ArcJID :: jid:jid(),
@@ -13,10 +14,6 @@
     [mod_mam:message_row()].
 lookup_recent_messages(_, _, _, Limit) when Limit > 500 ->
     throw({error, message_limit_too_high});
-lookup_recent_messages(ArcJID, With, Before, Limit) when is_binary(ArcJID) ->
-    lookup_recent_messages(jid:from_binary(ArcJID), With, Before, Limit);
-lookup_recent_messages(ArcJID, With, Before, Limit) when is_binary(With) ->
-    lookup_recent_messages(ArcJID, jid:from_binary(With), Before, Limit);
 lookup_recent_messages(ArcJID, WithJID, Before, Limit) ->
     #jid{luser = LUser, lserver = LServer} = ArcJID,
     {ok, HostType} = mongoose_domain_api:get_domain_host_type(LServer),

--- a/src/muc_light/mod_muc_light_api.erl
+++ b/src/muc_light/mod_muc_light_api.erl
@@ -342,7 +342,7 @@ create_room_raw(InRoomJID, CreatorJID, Options) ->
         {ok, RoomJID, #create{aff_users = AffUsers, raw_config = Conf}} ->
             {ok, make_room(RoomJID, Conf, AffUsers)};
         {error, exists} ->
-            {already_exist, "Room already exists"};
+            {already_exists, "Room already exists"};
         {error, max_occupants_reached} ->
             {max_occupants_reached, "Max occupants number reached"};
         {error, {Key, Reason}} ->

--- a/src/muc_light/mod_muc_light_commands.erl
+++ b/src/muc_light/mod_muc_light_commands.erl
@@ -196,7 +196,7 @@ change_room_config(MUCServer, RoomID, RoomName, User, Subject) ->
     Result = mod_muc_light_api:change_room_config(RoomJID, UserJID, Config),
     format_result_no_msg(Result).
 
--spec send_message(jid:server(), jid:user(), jid:literal_jid(), jid:literal_jid()) ->
+-spec send_message(jid:server(), jid:user(), jid:literal_jid(), binary()) ->
     ok | {error, not_found | denied, iolist()}.
 send_message(MUCServer, RoomID, Sender, Message) ->
     SenderJID = jid:from_binary(Sender),


### PR DESCRIPTION
The main goal is to have the following structure for the Admin REST API:
- `mongoose_admin_api` implements `mongoose_http_handler`
- `mongoose_admin_api_*` implement the individual command categories.

This is the same as for the Client API, making the two unified.

The new handler modules are using exceptions for error handling, which makes it less error-prone, as it is easier to read the logic and check if all cases are covered. The previous de-facto convention of multiple nested `case` constructs was less readable.

The following future work is excluded from this PR to reduce its size:
- Update config spec tests to check `mongoose_admin_api` instead of `mongoose_api_admin`
- Remove `mongoose_api_admin`
- Remove `mongoose_commands`
- Change `mongoose_domain_handler` and `mongoose_api` (yet another admin API) to use `mongoose_admin_api`
- Update docs and the migration guide