### PR TITLE
Extend aggregator requests and fix stall-after-error bug

### DIFF
--- a/src/async_pools/mongoose_aggregator_worker.erl
+++ b/src/async_pools/mongoose_aggregator_worker.erl
@@ -179,7 +179,7 @@ maybe_request_next(#state{flush_elems = Acc, flush_queue = Queue} = State) ->
     end.
 
 make_async_request(Request, #state{host_type = HostType, pool_id = PoolId,
-                                 request_callback = Requestor, flush_extra = Extra} = State) ->
+                                   request_callback = Requestor, flush_extra = Extra} = State) ->
     case Requestor(Request, Extra) of
         drop ->
             State;

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -288,7 +288,7 @@ sql_transaction(HostType, F) when is_function(F) ->
     sql_call(HostType, {sql_transaction, F}).
 
 %% @doc SQL transaction based on a list of queries
--spec sql_transaction_request(server(), fun() | maybe_improper_list()) -> transaction_result().
+-spec sql_transaction_request(server(), fun() | maybe_improper_list()) -> gen_server:request_id().
 sql_transaction_request(HostType, Queries) when is_list(Queries) ->
     F = fun() -> lists:map(fun sql_query_t/1, Queries) end,
     sql_transaction_request(HostType, F);

--- a/test/batches_SUITE.erl
+++ b/test/batches_SUITE.erl
@@ -32,6 +32,7 @@ groups() ->
        sync_flushes_down_everything,
        sync_aggregates_down_everything,
        aggregating_error_is_handled,
+       aggregation_might_produce_noop_requests,
        async_request
       ]}
     ].
@@ -108,6 +109,21 @@ shared_cache_inserts_in_shared_table(_) ->
     mongoose_user_cache:start_new_cache(host_type(), ?mod(2), cache_config(?mod(1))),
     mongoose_user_cache:merge_entry(host_type(), ?mod(2), some_jid(), #{}),
     ?assert(mongoose_user_cache:is_member(host_type(), ?mod(1), some_jid())).
+
+aggregation_might_produce_noop_requests(_) ->
+    {ok, Server} = gen_server:start_link(?MODULE, [], []),
+    Requestor = fun(0, _) -> timer:sleep(1), gen_server:send_request(Server, 0);
+                   (_, _) -> drop end,
+    Aggregator = fun(T1, T2, _) -> {ok, T1 + T2} end,
+    WPoolOpts = #{pool_type => aggregate,
+                  pool_size => 10,
+                  request_callback => Requestor,
+                  aggregate_callback => Aggregator,
+                  verify_callback => fun(ok, _T, _) -> ok end},
+    {ok, _} = mongoose_async_pools:start_pool(host_type(), ?FUNCTION_NAME, WPoolOpts),
+    mongoose_async_pools:broadcast_task(host_type(), ?FUNCTION_NAME, key, 1),
+    async_helper:wait_until(
+      fun() -> gen_server:call(Server, get_acc) end, 0).
 
 broadcast_reaches_all_workers(_) ->
     {ok, Server} = gen_server:start_link(?MODULE, [], []),


### PR DESCRIPTION
Maybe one task requests to remove data a previous task added, and in the resulting task after aggregation there is no data to either remove nor request, so we might want to have the request been skipped and the next one been attempted, instead of wasting time and message passing on an empty request.