### PR TITLE
Fix cache affiliations key in the accumulator

### DIFF
--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -63,6 +63,8 @@
 %% for mod_muc_light_codec_legacy
 -export([subdomain_pattern/1]).
 
+-export([get_room_affs_from_acc/2, set_room_affs_from_acc/3]).
+
 %% For tests
 -export([default_schema/0,
          force_clear_from_ct/1]).

--- a/src/muc_light/mod_muc_light_cache.erl
+++ b/src/muc_light/mod_muc_light_cache.erl
@@ -3,7 +3,6 @@
 -include("mongoose_config_spec.hrl").
 
 -behaviour(gen_mod).
--define(FRONTEND, mod_muc_light).
 
 %% gen_mod callbacks
 -export([start/2, stop/1, config_spec/0, supported_features/0]).
@@ -55,12 +54,12 @@ hooks(HostType) ->
 -spec pre_acc_room_affiliations(mongoose_acc:t(), jid:jid()) ->
     mongoose_acc:t() | {stop, mongoose_acc:t()}.
 pre_acc_room_affiliations(Acc, RoomJid) ->
-    case mongoose_acc:get(?FRONTEND, affiliations, {error, not_exists}, Acc) of
+    case mod_muc_light:get_room_affs_from_acc(Acc, RoomJid) of
         {error, _} ->
             HostType = mongoose_acc:host_type(Acc),
             case mongoose_user_cache:get_entry(HostType, ?MODULE, RoomJid) of
                 #{affs := Res} ->
-                    mongoose_acc:set(?FRONTEND, affiliations, Res, Acc);
+                    mod_muc_light:set_room_affs_from_acc(Acc, RoomJid, Res);
                 _ ->
                     Acc
             end;
@@ -70,7 +69,7 @@ pre_acc_room_affiliations(Acc, RoomJid) ->
 
 -spec post_acc_room_affiliations(mongoose_acc:t(), jid:jid()) -> mongoose_acc:t().
 post_acc_room_affiliations(Acc, RoomJid) ->
-    case mongoose_acc:get(?FRONTEND, affiliations, {error, not_exists}, Acc) of
+    case mod_muc_light:get_room_affs_from_acc(Acc, RoomJid) of
         {error, _} ->
             Acc;
         Res ->


### PR DESCRIPTION
In 884ca87045137c3d27baec5b1a2de42057443fa9, with the good intention of introducing an API to manage the accumulated affiliations, I didn't realise the old keying was used elsewhere: in the muc cache. So we've been missing using the cache recently. This is fixed now.

