### PR TITLE
Fix and simplify overlays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ clean:
 	-rm -rf asngen
 	-rm configure.out
 	-rm rel/configure.vars.config
-	-rm rel/vars-toml.config
 
 # REBAR_CT_EXTRA_ARGS comes from a test runner
 ct:
@@ -27,7 +26,7 @@ ct:
 eunit:
 	@$(RUN) $(REBAR) eunit
 
-rel: certs configure.out rel/vars-toml.config
+rel: certs configure.out rel/configure.vars.config
 	. ./configure.out && $(REBAR) as prod release
 
 shell: certs etc/mongooseim.cfg
@@ -39,9 +38,6 @@ rock:
 	@if [ "$(FILE)" ]; then elvis rock $(FILE);\
 	elif [ "$(BRANCH)" ]; then tools/rock_changed.sh $(BRANCH); \
 	else tools/rock_changed.sh; fi
-
-rel/vars-toml.config: rel/vars-toml.config.in rel/configure.vars.config
-	cat $^ > $@
 
 ## Don't allow these files to go out of sync!
 configure.out rel/configure.vars.config:

--- a/rebar.config
+++ b/rebar.config
@@ -164,15 +164,15 @@
                                  {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]},
                                  {erl_opts, [{d, 'PROD_NODE'}]} ]},
              %% development nodes
-             {mim1,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/mim1.vars-toml.config"]},
+             {mim1,    [{relx, [ {overlay_vars, "rel/mim1.vars-toml.config"},
                                  {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]},
-             {mim2,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/mim2.vars-toml.config"]},
+             {mim2,    [{relx, [ {overlay_vars, "rel/mim2.vars-toml.config"},
                                  {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]},
-             {mim3,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/mim3.vars-toml.config"]},
+             {mim3,    [{relx, [ {overlay_vars, "rel/mim3.vars-toml.config"},
                                  {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]},
-             {fed1,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/fed1.vars-toml.config"]},
+             {fed1,    [{relx, [ {overlay_vars, "rel/fed1.vars-toml.config"},
                                  {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]},
-             {reg1,    [{relx, [ {overlay_vars, ["rel/vars-toml.config", "rel/reg1.vars-toml.config"]},
+             {reg1,    [{relx, [ {overlay_vars, "rel/reg1.vars-toml.config"},
                                  {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]}]},
              {test,    [{extra_src_dirs, [{"test", [{recursive, true}]}]}]}
             ]}.

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -1,3 +1,5 @@
+"./vars-toml.config".
+
 {node_name, "fed1@localhost"}.
 
 {c2s_port, 5242}.

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -1,3 +1,5 @@
+"./vars-toml.config".
+
 {c2s_tls_port, 5223}.
 {outgoing_s2s_port, 5299}.
 {service_port, 8888}.

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -1,3 +1,5 @@
+"./vars-toml.config".
+
 {node_name, "ejabberd2@localhost"}.
 
 {c2s_port, 5232}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -1,3 +1,5 @@
+"./vars-toml.config".
+
 {node_name, "mongooseim3@localhost"}.
 
 {c2s_port, 5262}.

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -1,3 +1,5 @@
+"./vars-toml.config".
+
 {node_name, "reg1@localhost"}.
 
 {c2s_port, 5252}.

--- a/rel/vars-toml.config
+++ b/rel/vars-toml.config
@@ -55,7 +55,9 @@
 {s2s_certfile, "\"priv/ssl/fake_server.pem\""}.
 {all_metrics_are_global, "false"}.
 
-%% Defined in Makefile by appending configure.vars.config
+"./configure.vars.config".
+
+%% Defined by appending configure.vars.config
 %% Uncomment for manual release generation.
 %{mongooseim_runner_user, ""}.
 %{mongooseim_script_dir, "$(cd ${0%/*} && pwd)"}.


### PR DESCRIPTION
As stated in the [rebar3 docs](https://rebar3.readme.io/docs/releases):
- There should be only one overlay file. I checked with the docs and the code, it just supports one file now.
- You can include one file from another. I checked that if a variable is declared more than once, the last value wins (https://github.com/erlware/relx/blob/main/src/rlx_overlay.erl#L149).

This is why we can just include the overlay files:
- `configure.vars.config` into `vars-toml.config`
- `vars-toml.config` into `*.vars-toml.config`

This way the overlays work correctly with the latest Rebar3, and there is no need to concatenate the files with `make`.
We have some templating utilities for tests, and they needed support for file inclusion as well.
