### PR TITLE
Graphql use annotation

### DIFF
--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -156,6 +156,10 @@ get_listener_opts(EpName) ->
     #{handlers := [Opts]} = get_listener_config(Node, EpName),
     Opts.
 
+get_not_loaded(Resp) ->
+    ?assertEqual(<<"deps_not_loaded">>, get_err_code(Resp)),
+    ?assertEqual(<<"Some of required modules or services are not loaded">>, get_err_msg(Resp)).
+
 get_err_code(Resp) ->
     get_value([extensions, code], get_error(1, Resp)).
 

--- a/big_tests/tests/graphql_http_upload_SUITE.erl
+++ b/big_tests/tests/graphql_http_upload_SUITE.erl
@@ -184,8 +184,8 @@ user_http_upload_not_configured(Config) ->
 
 user_http_upload_not_configured(Config, Alice) ->
     Result = user_get_url(<<"test">>, 123, <<"Test">>, 123, Alice, Config),
-    ?assertEqual(<<"module_not_loaded_error">>, get_err_code(Result)),
-    ?assertEqual(<<"mod_http_upload is not loaded for this host">>, get_err_msg(Result)).
+    ?assertEqual(<<"deps_not_loaded">>, get_err_code(Result)),
+    ?assertEqual(<<"Some of required modules or services are not loaded">>, get_err_msg(Result)).
 
 % Admin test cases
 
@@ -218,8 +218,8 @@ admin_get_url_no_domain(Config) ->
 
 admin_http_upload_not_configured(Config) ->
     Result = admin_get_url(domain(), <<"test">>, 123, <<"Test">>, 123, Config),
-    ?assertEqual(<<"module_not_loaded_error">>, get_err_code(Result)),
-    ?assertEqual(<<"mod_http_upload is not loaded for this host">>, get_err_msg(Result)).
+    ?assertEqual(<<"deps_not_loaded">>, get_err_code(Result)),
+    ?assertEqual(<<"Some of required modules or services are not loaded">>, get_err_msg(Result)).
 
 domain_admin_get_url_no_permission(Config) ->
     Result1 = admin_get_url(<<"AAAAA">>, <<"test">>, 123, <<"Test">>, 123, Config),

--- a/big_tests/tests/graphql_inbox_SUITE.erl
+++ b/big_tests/tests/graphql_inbox_SUITE.erl
@@ -113,8 +113,13 @@ ensure_inbox_started() ->
     ok = dynamic_modules:ensure_modules(HostType, Modules),
     ok = dynamic_modules:ensure_modules(SecHostType, Modules).
 
-end_per_group(_, _) ->
-    graphql_helper:clean().
+end_per_group(Group, _Config) when Group =:= user;
+                                   Group =:= admin_http;
+                                   Group =:= domain_admin_inbox;
+                                   Group =:= admin_cli ->
+    graphql_helper:clean();
+end_per_group(_Group, _Config) ->
+    escalus_fresh:clean().
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/big_tests/tests/graphql_inbox_SUITE.erl
+++ b/big_tests/tests/graphql_inbox_SUITE.erl
@@ -3,8 +3,10 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(domain_helper, [host_type/0, domain/0]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, user_to_bin/1,
-                         get_ok_value/2, get_err_msg/1, get_err_code/1, get_unauthorized/1]).
+                         get_ok_value/2, get_err_msg/1, get_err_code/1, get_not_loaded/1,
+                         get_unauthorized/1]).
 
 -include_lib("eunit/include/eunit.hrl").
 -include("inbox.hrl").
@@ -19,19 +21,34 @@ all() ->
     inbox_helper:skip_or_run_inbox_tests(tests()).
 
 tests() ->
-    [{group, user_inbox},
-     {group, admin_inbox_http},
-     {group, admin_inbox_cli},
+    [{group, user},
+     {group, admin_http},
+     {group, admin_cli},
      {group, domain_admin_inbox}].
 
 groups() ->
-    [{user_inbox, [], user_inbox_tests()},
-     {admin_inbox_http, [], admin_inbox_tests()},
-     {admin_inbox_cli, [], admin_inbox_tests()},
+    [{user, [], user_groups()},
+     {admin_http, [], admin_groups()},
+     {admin_cli, [], admin_groups()},
+     {user_inbox, [], user_inbox_tests()},
+     {user_inbox_not_configured, [], user_inbox_not_configured_tests()},
+     {admin_inbox, [], admin_inbox_tests()},
+     {admin_inbox_not_configured, [], admin_inbox_not_configured_tests()},
      {domain_admin_inbox, [], domain_admin_inbox_tests()}].
+
+user_groups() ->
+    [{group, user_inbox},
+     {group, user_inbox_not_configured}].
+
+admin_groups() ->
+    [{group, admin_inbox},
+     {group, domain_admin_inbox}].
 
 user_inbox_tests() ->
     [user_flush_own_bin].
+
+user_inbox_not_configured_tests() ->
+    [user_flush_own_bin_inbox_not_configured].
 
 admin_inbox_tests() ->
     [admin_flush_user_bin,
@@ -51,13 +68,15 @@ domain_admin_inbox_tests() ->
      domain_admin_try_flush_domain_bin_no_permission,
      domain_admin_flush_global_bin_no_permission].
 
+admin_inbox_not_configured_tests() ->
+    [admin_flush_user_bin_inbox_not_configured,
+     admin_flush_domain_bin_inbox_not_configured,
+     admin_flush_global_bin_inbox_not_configured].
+
 init_per_suite(Config) ->
     HostType = domain_helper:host_type(),
     SecHostType = domain_helper:secondary_host_type(),
     Config1 = dynamic_modules:save_modules([HostType, SecHostType], Config),
-    Modules = [{mod_inbox, inbox_helper:inbox_opts(async_pools)} | inbox_helper:muclight_modules()],
-    ok = dynamic_modules:ensure_modules(HostType, Modules),
-    ok = dynamic_modules:ensure_modules(SecHostType, Modules),
     Config2 = ejabberd_node_utils:init(mim(), Config1),
     escalus:init_per_suite(Config2).
 
@@ -65,14 +84,34 @@ end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-init_per_group(admin_inbox_http, Config) ->
+init_per_group(user, Config) ->
+    graphql_helper:init_user(Config);
+init_per_group(admin_http, Config) ->
     graphql_helper:init_admin_handler(Config);
-init_per_group(admin_inbox_cli, Config) ->
+init_per_group(admin_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
 init_per_group(domain_admin_inbox, Config) ->
+    ensure_inbox_started(),
     graphql_helper:init_domain_admin_handler(Config);
-init_per_group(user_inbox, Config) ->
-    graphql_helper:init_user(Config).
+init_per_group(Group, Config) when Group =:= user_inbox;
+                                   Group =:= admin_inbox ->
+    ensure_inbox_started(),
+    Config;
+init_per_group(Group, Config) when Group =:= user_inbox_not_configured;
+                                   Group =:= admin_inbox_not_configured ->
+    HostType = domain_helper:host_type(),
+    SecHostType = domain_helper:secondary_host_type(),
+    Modules = [{mod_inbox, stopped}],
+    ok = dynamic_modules:ensure_modules(HostType, Modules),
+    ok = dynamic_modules:ensure_modules(SecHostType, Modules),
+    Config.
+
+ensure_inbox_started() ->
+    HostType = domain_helper:host_type(),
+    SecHostType = domain_helper:secondary_host_type(),
+    Modules = [{mod_inbox, inbox_helper:inbox_opts(async_pools)} | inbox_helper:muclight_modules()],
+    ok = dynamic_modules:ensure_modules(HostType, Modules),
+    ok = dynamic_modules:ensure_modules(SecHostType, Modules).
 
 end_per_group(_, _) ->
     graphql_helper:clean().
@@ -159,6 +198,21 @@ admin_try_flush_nonexistent_host_type_bin(Config) ->
     ?assertErrMsg(Res, <<"not found">>),
     ?assertErrCode(Res, host_type_not_found).
 
+% Admin inbox not configured test cases
+
+admin_flush_user_bin_inbox_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_flush_user_bin_inbox_not_configured/2).
+
+admin_flush_user_bin_inbox_not_configured(Config, Alice) ->
+    get_not_loaded(flush_user_bin(Alice, Config)).
+
+admin_flush_domain_bin_inbox_not_configured(Config) ->
+    get_not_loaded(flush_domain_bin(domain(), Config)).
+
+admin_flush_global_bin_inbox_not_configured(Config) ->
+    get_not_loaded(flush_global_bin(host_type(), 10, Config)).
+
 %% Domain admin test cases
 
 domain_admin_flush_user_bin_no_permission(Config) ->
@@ -198,6 +252,15 @@ user_flush_own_bin(Config, Alice, Bob, Kate) ->
     NumOfRows = get_ok_value(p(flushBin), Res),
     ?assertEqual(1, NumOfRows),
     inbox_helper:check_inbox(Bob, [], #{box => bin}).
+
+% User inbox not configured test cases
+
+user_flush_own_bin_inbox_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun user_flush_own_bin_inbox_not_configured/2).
+
+user_flush_own_bin_inbox_not_configured(Config, Alice) ->
+    get_not_loaded(user_flush_own_bin(Alice, Config)).
 
 %% Helpers
 

--- a/big_tests/tests/graphql_last_SUITE.erl
+++ b/big_tests/tests/graphql_last_SUITE.erl
@@ -122,10 +122,9 @@ admin_last_not_configured_old_users() ->
 init_per_suite(Config) ->
     HostType = domain_helper:host_type(),
     SecHostType = domain_helper:secondary_host_type(),
-    Config1 = escalus:init_per_suite(Config),
-    Config2 = dynamic_modules:save_modules([HostType, SecHostType], Config1),
-    Config3 = ejabberd_node_utils:init(mim(), Config2),
-    escalus:init_per_suite(Config3).
+    Config1 = dynamic_modules:save_modules([HostType, SecHostType], Config),
+    Config2 = ejabberd_node_utils:init(mim(), Config1),
+    escalus:init_per_suite(Config2).
 
 end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),

--- a/big_tests/tests/graphql_last_SUITE.erl
+++ b/big_tests/tests/graphql_last_SUITE.erl
@@ -36,6 +36,8 @@ groups() ->
      {admin_old_users, [], admin_old_users_tests()},
      {domain_admin_old_users, [], domain_admin_old_users_tests()},
      {admin_last_not_configured, [], admin_last_not_configured()},
+     {admin_last_not_configured_old_users, [], admin_last_not_configured_old_users()},
+     {admin_last_not_configured_group, [], admin_last_not_configured_groups()},
      {admin_last_configured, [], admin_last_configured()},
      {user_last_not_configured, [], user_last_not_configured()}].
 
@@ -45,7 +47,7 @@ user_groups() ->
 
 admin_groups() ->
     [{group, admin_last_configured},
-     {group, admin_last_not_configured}].
+     {group, admin_last_not_configured_group}].
 
 admin_last_configured() ->
     [{group, admin_last},
@@ -54,6 +56,10 @@ admin_last_configured() ->
 domain_admin_groups() ->
     [{group, domain_admin_last},
      {group, domain_admin_old_users}].
+
+admin_last_not_configured_groups() ->
+    [{group, admin_last_not_configured},
+     {group, admin_last_not_configured_old_users}].
 
 user_tests() ->
     [user_set_last,
@@ -105,11 +111,13 @@ domain_admin_old_users_tests() ->
 admin_last_not_configured() ->
     [admin_set_last_not_configured,
      admin_get_last_not_configured,
-     admin_count_active_users_last_not_configured,
-     admin_remove_old_users_domain_last_not_configured,
-     admin_remove_old_users_global_last_not_configured,
-     admin_list_old_users_domain_last_not_configured,
-     admin_list_old_users_global_last_not_configured].
+     admin_count_active_users_last_not_configured].
+
+admin_last_not_configured_old_users() ->
+     [admin_remove_old_users_domain_last_not_configured,
+      admin_remove_old_users_global_last_not_configured,
+      admin_list_old_users_domain_last_not_configured,
+      admin_list_old_users_global_last_not_configured].
 
 init_per_suite(Config) ->
     HostType = domain_helper:host_type(),
@@ -142,20 +150,18 @@ init_per_group(admin_last, Config) ->
     Config;
 init_per_group(admin_last_configured, Config) ->
     configure_last(Config);
-init_per_group(admin_last_not_configured, Config) ->
+init_per_group(admin_last_not_configured_group, Config) ->
     stop_last(Config);
-init_per_group(admin_old_users, Config) ->
+init_per_group(Group, Config) when Group =:= admin_old_users;
+                                   Group =:= domain_admin_old_users;
+                                   Group =:= admin_last_not_configured_old_users ->
     AuthMods = mongoose_helper:auth_modules(),
     case lists:member(ejabberd_auth_ldap, AuthMods) of
         true -> {skip, not_fully_supported_with_ldap};
         false -> Config
     end;
-init_per_group(domain_admin_old_users, Config) ->
-    AuthMods = mongoose_helper:auth_modules(),
-    case lists:member(ejabberd_auth_ldap, AuthMods) of
-        true -> {skip, not_fully_supported_with_ldap};
-        false -> Config
-    end.
+init_per_group(admin_last_not_configured, Config) ->
+    Config.
 
 configure_last(Config) ->
     HostType = domain_helper:host_type(),

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -92,7 +92,7 @@ user_muc_not_configured_tests() ->
      user_moderator_set_user_role_muc_not_configured,
      user_can_enter_room_muc_not_configured,
      user_can_exit_room_muc_not_configured,
-     user_list_room_affiliation_muc_not_configured].
+     user_list_room_affiliations_muc_not_configured].
 
 admin_muc_tests() ->
     [admin_create_and_delete_room,
@@ -1610,11 +1610,11 @@ user_can_exit_room_muc_not_configured_story(Config, Alice) ->
     Res = user_exit_room(Alice, get_room_name(), <<"ali">>, Resource, Config),
     get_not_loaded(Res).
 
-user_list_room_affiliation_muc_not_configured(Config) ->
+user_list_room_affiliations_muc_not_configured(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
-        fun user_list_room_affiliation_muc_not_configured_story/2).
+        fun user_list_room_affiliations_muc_not_configured_story/2).
 
-user_list_room_affiliation_muc_not_configured_story(Config, Alice) ->
+user_list_room_affiliations_muc_not_configured_story(Config, Alice) ->
     Res = user_list_room_affiliations(Alice, get_room_name(), owner, Config),
     get_not_loaded(Res).
 

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -5,7 +5,8 @@
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_msg/1,
-                         get_coercion_err_msg/1, make_creds/1, get_unauthorized/1]).
+                         get_coercion_err_msg/1, make_creds/1, get_unauthorized/1,
+                         get_err_code/1, get_not_loaded/1]).
 
 -import(config_parser_helper, [mod_config/2]).
 
@@ -36,16 +37,28 @@ suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
-    [{group, user_muc_light},
-     {group, admin_muc_light_http},
-     {group, admin_muc_light_cli},
+    [{group, user},
+     {group, admin_http},
+     {group, admin_cli},
      {group, domain_admin_muc_light}].
 
 groups() ->
-    [{user_muc_light, [parallel], user_muc_light_tests()},
-     {admin_muc_light_http, [parallel], admin_muc_light_tests()},
-     {admin_muc_light_cli, [], admin_muc_light_tests()},
-     {domain_admin_muc_light, [], domain_admin_muc_light_tests()}].
+    [{user, [], user_groups()},
+     {admin_http, [], admin_groups()},
+     {admin_cli, [], admin_groups()},
+     {user_muc_light, [parallel], user_muc_light_tests()},
+     {user_muc_light_not_configured, [], user_muc_light_not_configured_tests()},
+     {admin_muc_light, [parallel], admin_muc_light_tests()},
+     {domain_admin_muc_light, [], domain_admin_muc_light_tests()},
+     {admin_muc_light_not_configured, [], admin_muc_light_not_configured_tests()}].
+
+user_groups() ->
+    [{group, user_muc_light},
+     {group, user_muc_light_not_configured}].
+
+admin_groups() ->
+    [{group, admin_muc_light},
+     {group, admin_muc_light_not_configured}].
 
 user_muc_light_tests() ->
     [user_create_room,
@@ -65,6 +78,19 @@ user_muc_light_tests() ->
      user_get_room_config,
      user_blocking_list
     ].
+
+user_muc_light_not_configured_tests() ->
+    [user_create_room_muc_light_not_configured,
+     user_change_room_config_muc_light_not_configured,
+     user_invite_user_muc_light_not_configured,
+     user_delete_room_muc_light_not_configured,
+     user_kick_user_muc_light_not_configured,
+     user_send_message_to_room_muc_light_not_configured,
+     user_get_room_messages_muc_light_not_configured,
+     user_list_rooms_muc_light_not_configured,
+     user_list_room_users_muc_light_not_configured,
+     user_get_room_config_muc_light_not_configured,
+     user_blocking_list_muc_light_not_configured].
 
 admin_muc_light_tests() ->
     [admin_create_room,
@@ -125,27 +151,30 @@ domain_admin_muc_light_tests() ->
      domain_admin_blocking_list_no_permission
     ].
 
+admin_muc_light_not_configured_tests() ->
+    [admin_create_room_muc_light_not_configured,
+     admin_change_room_config_muc_light_not_configured,
+     admin_invite_user_muc_light_not_configured,
+     admin_delete_room_muc_light_not_configured,
+     admin_kick_user_muc_light_not_configured,
+     admin_send_message_to_room_muc_light_not_configured,
+     admin_get_room_messages_muc_light_not_configured,
+     admin_list_user_rooms_muc_light_not_configured,
+     admin_list_room_users_muc_light_not_configured,
+     admin_get_room_config_muc_light_not_configured,
+     admin_blocking_list_muc_light_not_configured].
+
 init_per_suite(Config) ->
-    Config1 = init_modules(Config),
-    Config2 = ejabberd_node_utils:init(mim(), Config1),
-    [{muc_light_host, muc_light_helper:muc_host()},
-     {secondary_muc_light_host, <<"muclight.", (domain_helper:secondary_domain())/binary>>}
-     | escalus:init_per_suite(Config2)].
+    HostType = domain_helper:host_type(),
+    Config1 = dynamic_modules:save_modules(HostType, Config),
+    Config2 = rest_helper:maybe_enable_mam(mam_helper:backend(), HostType, Config1),
+    Config3 = ejabberd_node_utils:init(mim(), Config2),
+    escalus:init_per_suite(Config3).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
-
-init_modules(Config) ->
-    HostType = domain_helper:host_type(),
-    SecondaryHostType = domain_helper:secondary_host_type(),
-    Config1 = dynamic_modules:save_modules(HostType, Config),
-    Config2 = dynamic_modules:save_modules(SecondaryHostType, Config1),
-    Config3 = rest_helper:maybe_enable_mam(mam_helper:backend(), HostType, Config2),
-    dynamic_modules:ensure_modules(HostType, required_modules(suite)),
-    dynamic_modules:ensure_modules(SecondaryHostType, required_modules(suite)),
-    Config3.
 
 required_modules(_) ->
     MucLightOpts = mod_config(mod_muc_light, #{rooms_in_rosters => true,
@@ -160,17 +189,38 @@ custom_schema() ->
      {<<"roomname">>, <<>>, roomname, binary},
      {<<"subject">>, <<>>, subject, binary}].
 
-init_per_group(admin_muc_light_http, Config) ->
+init_per_group(admin_http, Config) ->
     graphql_helper:init_admin_handler(Config);
-init_per_group(admin_muc_light_cli, Config) ->
+init_per_group(admin_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
 init_per_group(domain_admin_muc_light, Config) ->
+    ensure_muc_light_started(Config),
     graphql_helper:init_domain_admin_handler(Config);
-init_per_group(user_muc_light, Config) ->
+init_per_group(Group, Config) when Group =:= user_muc_light;
+                                   Group =:= admin_muc_light ->
+    ensure_muc_light_started(Config);
+init_per_group(Group, Config) when Group =:= user_muc_light_not_configured;
+                                   Group =:= admin_muc_light_not_configured ->
+    ensure_muc_light_stopped(Config);
+init_per_group(user, Config) ->
     graphql_helper:init_user(Config).
 
-end_per_group(_GN, _Config) ->
-    graphql_helper:clean().
+ensure_muc_light_started(Config) ->
+    HostType = domain_helper:host_type(),
+    dynamic_modules:ensure_modules(HostType, required_modules(suite)),
+    [{muc_light_host, muc_light_helper:muc_host()} | Config].
+
+ensure_muc_light_stopped(Config) ->
+    HostType = domain_helper:host_type(),
+    dynamic_modules:ensure_modules(HostType, [{mod_muc_light, stopped}]),
+    [{muc_light_host, <<"NON_EXISTING">>} | Config].
+
+end_per_group(Group, _Config) when Group =:= user;
+                                   Group =:= admin_http;
+                                   Group =:= admin_cli ->
+    graphql_helper:clean();
+end_per_group(_Group, _Config) ->
+    escalus_fresh:clean().
 
 init_per_testcase(TC, Config) ->
     rest_helper:maybe_skip_mam_test_cases(TC, [user_get_room_messages,
@@ -1233,7 +1283,203 @@ admin_get_room_config_non_existent_domain_story(Config, Alice) ->
     Res = get_room_config(make_bare_jid(RoomID, ?UNKNOWN_DOMAIN), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
+%% User mod_muc_light not configured test cases
+user_create_room_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_create_room_muc_light_not_configured_story/2).
+
+user_create_room_muc_light_not_configured_story(Config, Alice) ->
+    MucServer = ?config(muc_light_host, Config),
+    Name = <<"first room">>,
+    Subject = <<"testing">>,
+    Res = user_create_room(Alice, MucServer, Name, Subject, null, Config),
+    ?assertEqual(<<"muc_server_not_found">>, get_err_code(Res)).
+
+user_change_room_config_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_change_room_config_muc_light_not_configured_story/2).
+
+user_change_room_config_muc_light_not_configured_story(Config, Alice) ->
+    Name = <<"changed room">>,
+    Subject = <<"not testing">>,
+    Res = user_change_room_configuration(Alice, get_room_name(), Name, Subject, Config),
+    get_not_loaded(Res).
+
+user_invite_user_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+        fun user_invite_user_muc_light_not_configured_story/3).
+
+user_invite_user_muc_light_not_configured_story(Config, Alice, Bob) ->
+    BobBin = escalus_client:short_jid(Bob),
+    Res = user_invite_user(Alice, get_room_name(), BobBin, Config),
+    get_not_loaded(Res).
+
+user_delete_room_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_delete_room_muc_light_not_configured_story/2).
+
+user_delete_room_muc_light_not_configured_story(Config, Alice) ->
+    Res = user_delete_room(Alice, get_room_name(), Config),
+    get_not_loaded(Res).
+
+user_kick_user_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_kick_user_muc_light_not_configured_story/2).
+
+user_kick_user_muc_light_not_configured_story(Config, Alice) ->
+    Res = user_kick_user(Alice, get_room_name(), null, Config),
+    get_not_loaded(Res).
+
+user_send_message_to_room_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_send_message_to_room_muc_light_not_configured_story/2).
+
+user_send_message_to_room_muc_light_not_configured_story(Config, Alice) ->
+    MsgBody = <<"Hello there!">>,
+    Res = user_send_message_to_room(Alice, get_room_name(), MsgBody, Config),
+    get_not_loaded(Res).
+
+user_get_room_messages_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_get_room_messages_muc_light_not_configured_story/2).
+
+user_get_room_messages_muc_light_not_configured_story(Config, Alice) ->
+    Before = <<"2022-02-17T04:54:13+00:00">>,
+    Res = user_get_room_messages(Alice, get_room_name(), 51, Before, Config),
+    get_not_loaded(Res).
+
+user_list_rooms_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_list_rooms_muc_light_not_configured_story/2).
+
+user_list_rooms_muc_light_not_configured_story(Config, Alice) ->
+    Res = user_list_rooms(Alice, Config),
+    get_not_loaded(Res).
+
+user_list_room_users_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_list_room_users_muc_light_not_configured_story/2).
+
+user_list_room_users_muc_light_not_configured_story(Config, Alice) ->
+    Res = user_list_room_users(Alice, get_room_name(), Config),
+    get_not_loaded(Res).
+
+user_get_room_config_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_get_room_config_muc_light_not_configured_story/2).
+
+user_get_room_config_muc_light_not_configured_story(Config, Alice) ->
+    Res = user_get_room_config(Alice, get_room_name(), Config),
+    get_not_loaded(Res).
+
+user_blocking_list_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+         fun user_blocking_list_muc_light_not_configured_story/3).
+
+user_blocking_list_muc_light_not_configured_story(Config, Alice, Bob) ->
+    BobBin = escalus_client:full_jid(Bob),
+    Res = user_get_blocking(Alice, Config),
+    get_not_loaded(Res),
+    Res2 = user_set_blocking(Alice, [{<<"USER">>, <<"DENY">>, BobBin}], Config),
+    get_not_loaded(Res2).
+
+%% Admin mod_muc_light not configured test cases
+
+admin_create_room_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun admin_create_room_muc_light_not_configured_story/2).
+
+admin_create_room_muc_light_not_configured_story(Config, Alice) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    MucServer = ?config(muc_light_host, Config),
+    Name = <<"first room">>,
+    Subject = <<"testing">>,
+    Res = create_room(MucServer, Name, AliceBin, Subject, null, Config),
+    ?assertEqual(<<"muc_server_not_found">>, get_err_code(Res)).
+
+admin_invite_user_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+        fun admin_invite_user_muc_light_not_configured_story/3).
+
+admin_invite_user_muc_light_not_configured_story(Config, Alice, Bob) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    Res = invite_user(get_room_name(), AliceBin, BobBin, Config),
+    get_not_loaded(Res).
+
+admin_change_room_config_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun admin_change_room_config_muc_light_not_configured_story/2).
+
+admin_change_room_config_muc_light_not_configured_story(Config, Alice) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    Name = <<"changed room">>,
+    Subject = <<"not testing">>,
+    Res = change_room_configuration(get_room_name(), AliceBin, Name, Subject, Config),
+    get_not_loaded(Res).
+
+admin_delete_room_muc_light_not_configured(Config) ->
+    Res = delete_room(get_room_name(), Config),
+    get_not_loaded(Res).
+
+admin_kick_user_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{bob, 1}],
+        fun admin_kick_user_muc_light_not_configured_story/2).
+
+admin_kick_user_muc_light_not_configured_story(Config, Bob) ->
+    BobBin = escalus_client:short_jid(Bob),
+    Res = kick_user(get_room_name(), BobBin, Config),
+    get_not_loaded(Res).
+
+admin_send_message_to_room_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun admin_send_message_to_room_muc_light_not_configured_story/2).
+
+admin_send_message_to_room_muc_light_not_configured_story(Config, Alice) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    MsgBody = <<"Hello there!">>,
+    Res = send_message_to_room(get_room_name(), AliceBin, MsgBody, Config),
+    get_not_loaded(Res).
+
+admin_get_room_messages_muc_light_not_configured(Config) ->
+    Limit = 40,
+    Res = get_room_messages(get_room_name(), Limit, null, Config),
+    get_not_loaded(Res).
+
+admin_list_user_rooms_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun admin_list_user_rooms_muc_light_not_configured_story/2).
+
+admin_list_user_rooms_muc_light_not_configured_story(Config, Alice) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    Res = list_user_rooms(AliceBin, Config),
+    get_not_loaded(Res).
+
+admin_list_room_users_muc_light_not_configured(Config) ->
+    Res = list_room_users(get_room_name(), Config),
+    get_not_loaded(Res).
+
+admin_get_room_config_muc_light_not_configured(Config) ->
+    Res = get_room_config(get_room_name(), Config),
+    get_not_loaded(Res).
+
 %% Helpers
+
+get_room_name() ->
+    Domain = domain_helper:domain(),
+    <<"NON_EXISTING@", Domain/binary>>.
+
+admin_blocking_list_muc_light_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+        fun admin_blocking_list_muc_light_not_configured_story/3).
+
+admin_blocking_list_muc_light_not_configured_story(Config, Alice, Bob) ->
+    AliceBin = escalus_client:full_jid(Alice),
+    BobBin = escalus_client:full_jid(Bob),
+    Res = get_user_blocking(AliceBin, Config),
+    get_not_loaded(Res),
+    Res2 = set_blocking(AliceBin, [{<<"USER">>, <<"DENY">>, BobBin}], Config),
+    get_not_loaded(Res2).
 
 make_bare_jid(User, Server) ->
     JID = jid:make_bare(User, Server),

--- a/big_tests/tests/graphql_offline_SUITE.erl
+++ b/big_tests/tests/graphql_offline_SUITE.erl
@@ -5,7 +5,7 @@
 -import(distributed_helper, [mim/0, require_rpc_nodes/1]).
 -import(domain_helper, [host_type/0, domain/0]).
 -import(graphql_helper, [execute_command/4, get_ok_value/2, get_err_code/1, user_to_bin/1,
-                         get_unauthorized/1]).
+                         get_unauthorized/1, get_not_loaded/1]).
 -import(config_parser_helper, [mod_config/2]).
 -import(mongooseimctl_helper, [mongooseimctl/3, rpc_call/3]).
 
@@ -157,11 +157,11 @@ admin_delete_old_messages_no_domain_test(Config) ->
 
 admin_delete_expired_messages_offline_not_configured_test(Config) ->
     Result = delete_expired_messages(domain(), Config),
-    ?assertEqual(<<"module_not_loaded_error">>, get_err_code(Result)).
+    get_not_loaded(Result).
 
 admin_delete_old_messages_offline_not_configured_test(Config) ->
     Result = delete_old_messages(domain(), 2, Config),
-    ?assertEqual(<<"module_not_loaded_error">>, get_err_code(Result)).
+    get_not_loaded(Result).
 
 %% Domain admin test cases
 

--- a/big_tests/tests/graphql_token_SUITE.erl
+++ b/big_tests/tests/graphql_token_SUITE.erl
@@ -67,7 +67,6 @@ init_per_suite(Config0) ->
         true ->
             HostType = domain_helper:host_type(),
             Config = dynamic_modules:save_modules(HostType, Config0),
-            dynamic_modules:ensure_modules(HostType, required_modules()),
             Config1 = escalus:init_per_suite(Config),
             ejabberd_node_utils:init(mim(), Config1);
         false ->

--- a/big_tests/tests/graphql_token_SUITE.erl
+++ b/big_tests/tests/graphql_token_SUITE.erl
@@ -4,7 +4,7 @@
 
 -import(distributed_helper, [require_rpc_nodes/1, mim/0]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, user_to_bin/1,
-                         get_ok_value/2, get_err_code/1, get_unauthorized/1]).
+                         get_ok_value/2, get_err_code/1, get_unauthorized/1, get_not_loaded/1]).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -18,15 +18,31 @@ all() ->
      {group, admin_cli}].
 
 groups() ->
-    [{user, [], user_tests()},
+    [{user, [], user_groups()},
      {domain_admin, domain_admin_tests()},
-     {admin_http, [], admin_tests()},
-     {admin_cli, [], admin_tests()}].
+     {admin_http, [], admin_groups()},
+     {admin_cli, [], admin_groups()},
+     {user_token_configured, [], user_tests()},
+     {user_token_not_configured, [], user_token_not_configured_tests()},
+     {admin_token_configured, [], admin_tests()},
+     {admin_token_not_configured, [], admin_token_not_configured_tests()}].
+
+user_groups() ->
+    [{group, user_token_configured},
+     {group, user_token_not_configured}].
+
+admin_groups() ->
+    [{group, admin_token_configured},
+     {group, admin_token_not_configured}].
 
 user_tests() ->
     [user_request_token_test,
      user_revoke_token_no_token_before_test,
      user_revoke_token_test].
+
+user_token_not_configured_tests() ->
+    [user_request_token_test_not_configured,
+     user_revoke_token_test_not_configured].
 
 domain_admin_tests() ->
     [admin_request_token_test,
@@ -41,6 +57,10 @@ admin_tests() ->
      admin_revoke_token_no_user_test,
      admin_revoke_token_no_token_test,
      admin_revoke_token_test].
+
+admin_token_not_configured_tests() ->
+    [admin_request_token_test_not_configured,
+     admin_revoke_token_test_not_configured].
 
 init_per_suite(Config0) ->
     case mongoose_helper:is_rdbms_enabled(domain_helper:host_type()) of
@@ -75,12 +95,33 @@ init_per_group(admin_http, Config) ->
 init_per_group(admin_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
 init_per_group(domain_admin, Config) ->
-    graphql_helper:init_domain_admin_handler(Config);
+    Config1 = ensure_token_started(Config),
+    graphql_helper:init_domain_admin_handler(Config1);
+init_per_group(Group, Config) when Group =:= admin_token_configured;
+                                   Group =:= user_token_configured ->
+    ensure_token_started(Config);
+init_per_group(Group, Config) when Group =:= admin_token_not_configured;
+                                   Group =:= user_token_not_configured ->
+    ensure_token_stopped(Config);
 init_per_group(user, Config) ->
     graphql_helper:init_user(Config).
 
-end_per_group(_, _Config) ->
-    graphql_helper:clean(),
+ensure_token_started(Config) ->
+    HostType = domain_helper:host_type(),
+    dynamic_modules:ensure_modules(HostType, required_modules()),
+    Config.
+
+ensure_token_stopped(Config) ->
+    HostType = domain_helper:host_type(),
+    dynamic_modules:ensure_modules(HostType, [{mod_auth_token, stopped}]),
+    Config.
+
+end_per_group(GroupName, _Config) when GroupName =:= admin_http;
+                                       GroupName =:= admin_cli;
+                                       GroupName =:= user;
+                                       GroupName =:= domain_admin ->
+    graphql_helper:clean();
+end_per_group(_GroupName, _Config) ->
     escalus_fresh:clean().
 
 init_per_testcase(CaseName, Config) ->
@@ -117,6 +158,24 @@ user_revoke_token_test(Config, Alice) ->
     ParsedRes = get_ok_value([data, token, revokeToken], Res2),
     ?assertEqual(<<"Revoked.">>, ParsedRes).
 
+% User test cases mod_token not configured
+
+user_request_token_test_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_request_token_test_not_configured/2).
+
+user_request_token_test_not_configured(Config, Alice) ->
+    Res = user_request_token(Alice, Config),
+    get_not_loaded(Res).
+
+user_revoke_token_test_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun user_revoke_token_test_not_configured/2).
+
+user_revoke_token_test_not_configured(Config, Alice) ->
+    Res = user_revoke_token(Alice, Config),
+    get_not_loaded(Res).
+
 % Domain admin tests
 
 domain_admin_request_token_no_permission_test(Config) ->
@@ -134,6 +193,7 @@ domain_admin_request_token_no_permission_test(Config, AliceBis) ->
 domain_admin_revoke_token_no_permission_test(Config) ->
     escalus:fresh_story_with_config(Config, [{alice_bis, 1}],
                                     fun domain_admin_revoke_token_no_permission_test/2).
+
 domain_admin_revoke_token_no_permission_test(Config, AliceBis) ->
     % External domain user
     Res = admin_revoke_token(user_to_bin(AliceBis), Config),
@@ -177,6 +237,26 @@ admin_revoke_token_test(Config, Alice) ->
     Res2 = admin_revoke_token(user_to_bin(Alice), Config),
     ParsedRes = get_ok_value([data, token, revokeToken], Res2),
     ?assertEqual(<<"Revoked.">>, ParsedRes).
+
+% Admin test cases token not configured
+
+admin_request_token_test_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun admin_request_token_test_not_configured/2).
+
+admin_request_token_test_not_configured(Config, Alice) ->
+    Res = admin_request_token(user_to_bin(Alice), Config),
+    get_not_loaded(Res).
+
+admin_revoke_token_test_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun admin_revoke_token_test_not_configured/2).
+
+admin_revoke_token_test_not_configured(Config, Alice) ->
+    Res = admin_request_token(user_to_bin(Alice), Config),
+    get_not_loaded(Res).
+
+% Commands
 
 user_request_token(User, Config) ->
     execute_user_command(<<"token">>, <<"requestToken">>, User, #{}, Config).

--- a/big_tests/tests/graphql_vcard_SUITE.erl
+++ b/big_tests/tests/graphql_vcard_SUITE.erl
@@ -5,7 +5,7 @@
 -import(distributed_helper, [require_rpc_nodes/1, mim/0]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5,
                          user_to_bin/1, get_ok_value/2, skip_null_fields/1, get_err_msg/1,
-                         get_unauthorized/1]).
+                         get_unauthorized/1, get_not_loaded/1, get_err_code/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -14,16 +14,28 @@ suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 all() ->
-    [{group, user_vcard},
+    [{group, user},
      {group, domain_admin_vcard},
-     {group, admin_vcard_http},
-     {group, admin_vcard_cli}].
+     {group, admin_http},
+     {group, admin_cli}].
 
 groups() ->
-    [{user_vcard, [], user_vcard_tests()},
+    [{user, [], user_groups()},
      {domain_admin_vcard, [], domain_admin_vcard_tests()},
-     {admin_vcard_http, [], admin_vcard_tests()},
-     {admin_vcard_cli, [], admin_vcard_tests()}].
+     {admin_http, [], admin_groups()},
+     {admin_cli, [], admin_groups()},
+     {user_vcard_configured, [], user_vcard_tests()},
+     {user_vcard_not_configured, [], user_vcard_not_configured_tests()},
+     {admin_vcard_configured, [], admin_vcard_tests()},
+     {admin_vcard_not_configured, [], admin_vcard_not_configured_tests()}].
+
+user_groups() ->
+    [{group, user_vcard_configured},
+     {group, user_vcard_not_configured}].
+
+admin_groups() ->
+    [{group, admin_vcard_configured},
+     {group, admin_vcard_not_configured}].
 
 user_vcard_tests() ->
     [user_set_vcard,
@@ -32,6 +44,11 @@ user_vcard_tests() ->
      user_get_others_vcard,
      user_get_others_vcard_no_user,
      user_get_others_vcard_no_vcard].
+
+user_vcard_not_configured_tests() ->
+    [user_set_vcard_not_configured,
+     user_get_their_vcard_not_configured,
+     user_get_others_vcard_not_configured].
 
 domain_admin_vcard_tests() ->
     [admin_set_vcard,
@@ -51,32 +68,61 @@ admin_vcard_tests() ->
      admin_get_vcard_no_vcard,
      admin_get_vcard_no_user].
 
+admin_vcard_not_configured_tests() ->
+    [admin_set_vcard_not_configured,
+     admin_get_vcard_not_configured].
+
 init_per_suite(Config) ->
     case vcard_helper:is_vcard_ldap() of
         true ->
             {skip, ldap_vcard_is_not_supported};
         _ ->
+            HostType = domain_helper:host_type(),
             Config1 = escalus:init_per_suite(Config),
             Config2 = ejabberd_node_utils:init(mim(), Config1),
-            dynamic_modules:save_modules(domain_helper:host_type(), Config2)
+            Config3 = dynamic_modules:save_modules(domain_helper:host_type(), Config2),
+            VCardOpts = dynamic_modules:get_saved_config(HostType, mod_vcard, Config3),
+            [{mod_vcard_opts, VCardOpts} | Config3]
     end.
 
 end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-init_per_group(admin_vcard_http, Config) ->
+init_per_group(admin_http, Config) ->
     graphql_helper:init_admin_handler(Config);
-init_per_group(admin_vcard_cli, Config) ->
+init_per_group(admin_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
 init_per_group(domain_admin_vcard, Config) ->
-    graphql_helper:init_domain_admin_handler(Config);
-init_per_group(user_vcard, Config) ->
-    graphql_helper:init_user(Config).
+    Config1 = ensure_vcard_started(Config),
+    graphql_helper:init_domain_admin_handler(Config1);
+init_per_group(user, Config) ->
+    graphql_helper:init_user(Config);
+init_per_group(Group, Config) when Group =:= admin_vcard_configured;
+                                   Group =:= user_vcard_configured ->
+    ensure_vcard_started(Config);
+init_per_group(Group, Config) when Group =:= admin_vcard_not_configured;
+                                   Group =:= user_vcard_not_configured ->
+    ensure_vcard_stopped(Config).
 
+end_per_group(GroupName, _Config) when GroupName =:= admin_http;
+                                       GroupName =:= admin_cli;
+                                       GroupName =:= user;
+                                       GroupName =:= domain_admin_vcard ->
+    graphql_helper:clean();
 end_per_group(_GroupName, _Config) ->
-    graphql_helper:clean(),
     escalus_fresh:clean().
+
+ensure_vcard_started(Config) ->
+    HostType = domain_helper:host_type(),
+    VCardConfig = ?config(mod_vcard_opts, Config),
+    dynamic_modules:restart(HostType, mod_vcard, VCardConfig),
+    Config.
+
+ensure_vcard_stopped(Config) ->
+    HostType = domain_helper:host_type(),
+    dynamic_modules:stop(HostType, mod_vcard),
+    Config.
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
@@ -155,6 +201,33 @@ user_get_others_vcard_no_user(Config) ->
 user_get_others_vcard_no_user(Config, Alice) ->
     Result = user_get_vcard(Alice, <<"AAAAA">>, Config),
     ?assertEqual(<<"User does not exist">>, get_err_msg(Result)).
+
+% User VCard not configured test cases
+
+user_set_vcard_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun user_set_vcard_not_configured/2).
+
+user_set_vcard_not_configured(Config, Alice) ->
+    Vcard = complete_vcard_input(),
+    Res = user_set_vcard(Alice, Vcard, Config),
+    get_not_loaded(Res).
+
+user_get_others_vcard_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun user_get_others_vcard_not_configured/3).
+
+user_get_others_vcard_not_configured(Config, Alice, Bob) ->
+    Res = user_get_vcard(Alice, user_to_bin(Bob), Config),
+    get_not_loaded(Res).
+
+user_get_their_vcard_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun user_get_their_vcard_not_configured/2).
+
+user_get_their_vcard_not_configured(Config, Alice) ->
+    Res = user_get_own_vcard(Alice, Config),
+    ?assertEqual(<<"vcard_not_configured_error">>, get_err_code(Res)).
 
 %% Domain admin test cases
 
@@ -238,6 +311,26 @@ admin_get_vcard_no_vcard(Config, Alice) ->
 admin_get_vcard_no_user(Config) ->
     Result = get_vcard(<<"AAAAA">>, Config),
     ?assertEqual(<<"User does not exist">>, get_err_msg(Result)).
+
+%% Admin VCard not configured test cases
+
+admin_get_vcard_not_configured(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_get_vcard_not_configured/2).
+
+admin_get_vcard_not_configured(Config, Alice) ->
+    Res = get_vcard(user_to_bin(Alice), Config),
+    get_not_loaded(Res).
+
+admin_set_vcard_not_configured(Config) ->
+    Config1 = [{vcard, complete_vcard_input()} | Config],
+    escalus:fresh_story_with_config(Config1, [{alice, 1}],
+                                    fun admin_set_vcard_not_configured/2).
+
+admin_set_vcard_not_configured(Config, Alice) ->
+    Vcard = ?config(vcard, Config),
+    Res = set_vcard(Vcard, user_to_bin(Alice), Config),
+    get_not_loaded(Res).
 
 %% Commands
 

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -73,6 +73,10 @@ unload_muc() ->
     dynamic_modules:stop(HostType, mod_muc),
     dynamic_modules:stop(HostType, mod_muc_log).
 
+unload_muc(HostType) ->
+    dynamic_modules:stop(HostType, mod_muc),
+    dynamic_modules:stop(HostType, mod_muc_log).
+
 muc_host() ->
     ct:get_config({hosts, mim, muc_service}).
 

--- a/priv/graphql/schemas/admin/http_upload.gql
+++ b/priv/graphql/schemas/admin/http_upload.gql
@@ -1,8 +1,8 @@
 """
 Allow admin to generate upload/download URL for a file on user's behalf".
 """
-type HttpUploadAdminMutation @protected{
+type HttpUploadAdminMutation @use(modules: ["mod_http_upload"]) @protected{
     "Allow admin to generate upload/download URLs for a file on user's behalf"
     getUrl(domain: String!, filename: String!, size: Int!, contentType: String!, timeout: Int!): FileUrls
-      @protected(type: DOMAIN, args: ["domain"])
+      @use(arg: "domain") @protected(type: DOMAIN, args: ["domain"])
 }

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -3,6 +3,7 @@ Allow admin to manage Multi-User Chat rooms.
 """
 type MUCAdminMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
+  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
   createInstantRoom(mucDomain: String!, name: String!, owner: JID!, nick: String!): MUCRoomDesc
     @protected(type: DOMAIN, args: ["owner"])
   "Invite a user to a MUC room"
@@ -42,6 +43,7 @@ Allow admin to get information about Multi-User Chat rooms.
 """
 type MUCAdminQuery @protected @use(modules: ["mod_muc"]){
   "Get MUC rooms under the given MUC domain"
+  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
   listRooms(mucDomain: String!, from: JID, limit: Int, index: Int): MUCRoomsPayload!
     @protected(type: DOMAIN, args: ["from"])
   "Get configuration of the MUC room"

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -1,59 +1,59 @@
 """
 Allow admin to manage Multi-User Chat rooms.
 """
-type MUCAdminMutation @protected{
+type MUCAdminMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
   createInstantRoom(mucDomain: String!, name: String!, owner: JID!, nick: String!): MUCRoomDesc
     @protected(type: DOMAIN, args: ["owner"])
   "Invite a user to a MUC room"
   inviteUser(room: JID!, sender: JID!, recipient: JID!, reason: String): String
-    @protected(type: DOMAIN, args: ["sender"])
+    @protected(type: DOMAIN, args: ["sender"]) @use(arg: "room")
   "Kick a user from a MUC room"
   kickUser(room: JID!, nick: String!, reason: String): String
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Send a message to a MUC room"
   sendMessageToRoom(room: JID!, from: FullJID!, body: String!): String
-    @protected(type: DOMAIN, args: ["from"])
+    @protected(type: DOMAIN, args: ["from"]) @use(arg: "room")
   "Send a private message to a MUC room user"
   sendPrivateMessage(room: JID!, from: FullJID!, toNick: String!, body: String!): String
-    @protected(type: DOMAIN, args: ["from"])
+    @protected(type: DOMAIN, args: ["from"]) @use(arg: "room")
   "Remove a MUC room"
   deleteRoom(room: JID!, reason: String): String
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Change configuration of a MUC room"
   changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Change a user role"
   setUserRole(room: JID!, nick: String!, role: MUCRole!): String
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Change a user affiliation"
   setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Make a user enter the room with a given nick"
   enterRoom(room: JID!, user: FullJID!, nick: String!, password: String): String
-    @protected(type: DOMAIN, args: ["user"])
+    @protected(type: DOMAIN, args: ["user"]) @use(arg: "room")
   "Make a user with the given nick exit the room"
   exitRoom(room: JID!, user: FullJID!, nick: String!): String
-    @protected(type: DOMAIN, args: ["user"])
+    @protected(type: DOMAIN, args: ["user"]) @use(arg: "room")
 }
 
 """
 Allow admin to get information about Multi-User Chat rooms.
 """
-type MUCAdminQuery @protected{
+type MUCAdminQuery @protected @use(modules: ["mod_muc"]){
   "Get MUC rooms under the given MUC domain"
   listRooms(mucDomain: String!, from: JID, limit: Int, index: Int): MUCRoomsPayload!
     @protected(type: DOMAIN, args: ["from"])
   "Get configuration of the MUC room"
   getRoomConfig(room: JID!): MUCRoomConfig
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get the user list of a given MUC room"
   listRoomUsers(room: JID!): [MUCRoomUser!]
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get the affiliation list of given MUC room"
   listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get the MUC room archived messages"
   getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
 }

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -1,47 +1,47 @@
 """
 Allow admin to manage Multi-User Chat Light rooms.
 """
-type MUCLightAdminMutation @protected{
+type MUCLightAdminMutation @protected @use(modules: ["mod_muc_light"]){
   "Create a MUC light room under the given XMPP hostname"
   createRoom(mucDomain: String!, name: String!, owner: JID!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
-    @protected(type: DOMAIN, args: ["owner"])
+    @protected(type: DOMAIN, arg: "owner")
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, owner: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Invite a user to a MUC Light room"
   inviteUser(room: JID!, sender: JID!, recipient: JID!): String
-    @protected(type: DOMAIN, args: ["sender"])
+    @protected(type: DOMAIN, args: ["sender"]) @use(arg: "room")
   "Remove a MUC Light room"
   deleteRoom(room: JID!): String
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Kick a user from a MUC Light room"
   kickUser(room: JID!, user: JID!): String
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Send a message to a MUC Light room"
   sendMessageToRoom(room: JID!, from: JID!, body: String!): String
-    @protected(type: DOMAIN, args: ["from"])
+    @protected(type: DOMAIN, args: ["from"]) @use(arg: "room")
   "Set the user's list of blocked entities"
   setBlockingList(user: JID!, items: [BlockingInput!]!): String
-    @protected(type: DOMAIN, args: ["user"])
+    @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
 }
 
 """
 Allow admin to get information about Multi-User Chat Light rooms.
 """
-type MUCLightAdminQuery @protected{
+type MUCLightAdminQuery @protected @use(modules: ["mod_muc_light"]){
   "Get the MUC Light room archived messages"
   getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get configuration of the MUC Light room"
   getRoomConfig(room: JID!): Room
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get users list of given MUC Light room"
   listRoomUsers(room: JID!): [RoomUser!]
-    @protected(type: DOMAIN, args: ["room"])
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get the list of MUC Light rooms that the user participates in"
   listUserRooms(user: JID!): [JID!]
-    @protected(type: DOMAIN, args: ["user"])
+    @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
   "Get the user's list of blocked entities"
   getBlockingList(user: JID!): [BlockingItem!]
-    @protected(type: DOMAIN, args: ["user"])
+    @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
 }

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -3,6 +3,7 @@ Allow admin to manage Multi-User Chat Light rooms.
 """
 type MUCLightAdminMutation @use(modules: ["mod_muc_light"]) @protected{
   "Create a MUC light room under the given XMPP hostname"
+  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
   createRoom(mucDomain: String!, name: String!, owner: JID!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
     @protected(type: DOMAIN, args: ["owner"])
   "Change configuration of a MUC Light room"

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -1,10 +1,10 @@
 """
 Allow admin to manage Multi-User Chat Light rooms.
 """
-type MUCLightAdminMutation @protected @use(modules: ["mod_muc_light"]){
+type MUCLightAdminMutation @use(modules: ["mod_muc_light"]) @protected{
   "Create a MUC light room under the given XMPP hostname"
   createRoom(mucDomain: String!, name: String!, owner: JID!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
-    @protected(type: DOMAIN, arg: "owner")
+    @protected(type: DOMAIN, args: ["owner"])
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, owner: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")

--- a/priv/graphql/schemas/admin/offline.gql
+++ b/priv/graphql/schemas/admin/offline.gql
@@ -1,7 +1,7 @@
 """
 Allow admin to delete offline messages from specified domain
 """
-type OjflineAdminMutation @protected @use(modules: ["mod_offline"]){
+type OfflineAdminMutation @protected @use(modules: ["mod_offline"]){
     "Delete offline messages whose date has expired"
     deleteExpiredMessages(domain: String!): String @use(arg: "domain")
       @protected(type: DOMAIN, args: ["domain"])

--- a/priv/graphql/schemas/admin/offline.gql
+++ b/priv/graphql/schemas/admin/offline.gql
@@ -1,11 +1,11 @@
 """
 Allow admin to delete offline messages from specified domain
 """
-type OfflineAdminMutation @protected{
+type OjflineAdminMutation @protected @use(modules: ["mod_offline"]){
     "Delete offline messages whose date has expired"
-    deleteExpiredMessages(domain: String!): String
+    deleteExpiredMessages(domain: String!): String @use(arg: "domain")
       @protected(type: DOMAIN, args: ["domain"])
     "Delete messages at least as old as the number of days specified in the parameter"
     deleteOldMessages(domain: String!, days: Int!): String
-      @protected(type: DOMAIN, args: ["domain"])
+      @protected(type: DOMAIN, args: ["domain"]) @use(arg: "domain")
 }

--- a/priv/graphql/schemas/admin/private.gql
+++ b/priv/graphql/schemas/admin/private.gql
@@ -1,17 +1,17 @@
 """
 Allow admin to set the user's private data
 """
-type PrivateAdminMutation @protected {
+type PrivateAdminMutation @protected @use(modules: ["mod_private"]){
     "Set the user's private data"
     setPrivate(user: JID!, elementString: String!): String
-      @protected(type: DOMAIN, args: ["user"])
+      @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
 }
 
 """
 Allow admin to get the user's private data
 """
-type PrivateAdminQuery @protected {
+type PrivateAdminQuery @protected @use(modules: ["mod_private"]){
     "Get the user's private data"
     getPrivate(user: JID!, element: String!, nameSpace: String!): String
-      @protected(type: DOMAIN, args: ["user"])
+      @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
 }

--- a/priv/graphql/schemas/admin/token.gql
+++ b/priv/graphql/schemas/admin/token.gql
@@ -1,11 +1,11 @@
 """
 Allow admin to get and revoke user's auth tokens
 """
- type TokenAdminMutation @protected {
+ type TokenAdminMutation @protected @use(modules: ["mod_auth_token"]){
     "Request auth token for a user"
     requestToken(user: JID!): Token
-      @protected(type: DOMAIN, args: ["user"])
+      @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
     "Revoke any tokens for a user"
     revokeToken(user: JID!): String
-      @protected(type: DOMAIN, args: ["user"])
+      @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
  }

--- a/priv/graphql/schemas/admin/vcard.gql
+++ b/priv/graphql/schemas/admin/vcard.gql
@@ -1,17 +1,17 @@
 """
 Allow admin to set user's vcard
 """
-type VcardAdminMutation @protected{
+type VcardAdminMutation @protected @use(modules: ["mod_vcard"]){
     "Set a new vcard for a user"
     setVcard(user: JID!, vcard: VcardInput!): Vcard
-      @protected(type: DOMAIN, args: ["user"])
+      @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
 }
 
 """
 Allow admin to get the user's vcard
 """
-type VcardAdminQuery @protected{
+type VcardAdminQuery @protected @use(modules: ["mod_vcard"]){
     "Get the user's vcard"
     getVcard(user: JID!): Vcard
-      @protected(type: DOMAIN, args: ["user"])
+      @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
 }

--- a/priv/graphql/schemas/user/http_upload.gql
+++ b/priv/graphql/schemas/user/http_upload.gql
@@ -1,7 +1,7 @@
 """
 Allow user to generate upload/download URL for a file".
 """
-type HttpUploadUserMutation @protected{
+type HttpUploadUserMutation @use(modules: ["mod_http_upload"]) @protected{
     "Allow user to generate upload/download URLs for a file"
-    getUrl(filename: String!, size: Int!, contentType: String!, timeout: Int!): FileUrls
+    getUrl(filename: String!, size: Int!, contentType: String!, timeout: Int!): FileUrls @use
 }

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -1,43 +1,43 @@
 """
 Allow user to manage Multi-User Chat rooms.
 """
-type MUCUserMutation @protected{
+type MUCUserMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
   createInstantRoom(mucDomain: String!, name: String!, nick: String!): MUCRoomDesc
   "Invite a user to a MUC room"
-  inviteUser(room: JID!, recipient: JID!, reason: String): String
+  inviteUser(room: JID!, recipient: JID!, reason: String): String @use(arg: "room")
   "Kick a user from a MUC room"
-  kickUser(room: JID!, nick: String!, reason: String): String
+  kickUser(room: JID!, nick: String!, reason: String): String @use(arg: "room")
   "Send a message to a MUC room"
-  sendMessageToRoom(room: JID!, body: String!, resource: String): String
+  sendMessageToRoom(room: JID!, body: String!, resource: String): String @use(arg: "room")
   "Send a private message to a MUC room user from the given resource"
-  sendPrivateMessage(room: JID!, toNick: String!, body: String!, resource: String): String
+  sendPrivateMessage(room: JID!, toNick: String!, body: String!, resource: String): String @use(arg: "room")
   "Remove a MUC room"
-  deleteRoom(room: JID!, reason: String): String
+  deleteRoom(room: JID!, reason: String): String @use(arg: "room")
   "Change configuration of a MUC room"
-  changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig
+  changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig @use(arg: "room")
   "Change a user role"
-  setUserRole(room: JID!, nick: String!, role: MUCRole!): String
+  setUserRole(room: JID!, nick: String!, role: MUCRole!): String @use(arg: "room")
   "Change a user affiliation"
-  setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String
+  setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String @use(arg: "room")
   "Enter the room with given resource and nick"
-  enterRoom(room: JID!, nick: String!, resource: String!, password: String): String
+  enterRoom(room: JID!, nick: String!, resource: String!, password: String): String @use(arg: "room")
   "Exit the room with given resource and nick"
-  exitRoom(room: JID!, nick: String!, resource: String!): String
+  exitRoom(room: JID!, nick: String!, resource: String!): String @use(arg: "room")
 }
 
 """
 Allow user to get information about Multi-User Chat rooms.
 """
-type MUCUserQuery @protected{
+type MUCUserQuery @protected @use(modules: ["mod_muc"]){
   "Get MUC rooms under the given MUC domain"
   listRooms(mucDomain: String!, limit: Int, index: Int): MUCRoomsPayload!
   "Get configuration of the MUC room"
-  getRoomConfig(room: JID!): MUCRoomConfig
+  getRoomConfig(room: JID!): MUCRoomConfig @use(arg: "room")
   "Get the user list of a given MUC room"
-  listRoomUsers(room: JID!): [MUCRoomUser!]
+  listRoomUsers(room: JID!): [MUCRoomUser!] @use(arg: "room")
   "Get the affiliation list of given MUC room"
-  listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
+  listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!] @use(arg: "room")
   "Get the MUC room archived messages"
-  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
+  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload @use(arg: "room")
 }

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -3,6 +3,7 @@ Allow user to manage Multi-User Chat rooms.
 """
 type MUCUserMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
+  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
   createInstantRoom(mucDomain: String!, name: String!, nick: String!): MUCRoomDesc
   "Invite a user to a MUC room"
   inviteUser(room: JID!, recipient: JID!, reason: String): String @use(arg: "room")
@@ -31,6 +32,7 @@ Allow user to get information about Multi-User Chat rooms.
 """
 type MUCUserQuery @protected @use(modules: ["mod_muc"]){
   "Get MUC rooms under the given MUC domain"
+  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
   listRooms(mucDomain: String!, limit: Int, index: Int): MUCRoomsPayload!
   "Get configuration of the MUC room"
   getRoomConfig(room: JID!): MUCRoomConfig @use(arg: "room")

--- a/priv/graphql/schemas/user/muc_light.gql
+++ b/priv/graphql/schemas/user/muc_light.gql
@@ -3,6 +3,7 @@ Allow user to manage Multi-User Chat Light rooms.
 """
 type MUCLightUserMutation @protected @use(modules: ["mod_muc_light"]){
   "Create a MUC light room under the given XMPP hostname"
+  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
   createRoom(mucDomain: String!, name: String!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room @use(arg: "room")

--- a/priv/graphql/schemas/user/muc_light.gql
+++ b/priv/graphql/schemas/user/muc_light.gql
@@ -1,35 +1,35 @@
 """
 Allow user to manage Multi-User Chat Light rooms.
 """
-type MUCLightUserMutation @protected{
+type MUCLightUserMutation @protected @use(modules: ["mod_muc_light"]){
   "Create a MUC light room under the given XMPP hostname"
   createRoom(mucDomain: String!, name: String!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
   "Change configuration of a MUC Light room"
-  changeRoomConfiguration(room: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room
+  changeRoomConfiguration(room: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room @use(arg: "room")
   "Invite a user to a MUC Light room"
-  inviteUser(room: JID!, recipient: JID!): String
+  inviteUser(room: JID!, recipient: JID!): String @use(arg: "room")
   "Remove a MUC Light room"
-  deleteRoom(room: JID!): String
+  deleteRoom(room: JID!): String @use(arg: "room")
   "Kick a user from a MUC Light room"
-  kickUser(room: JID!, user: JID): String
+  kickUser(room: JID!, user: JID): String @use(arg: "room")
   "Send a message to a MUC Light room"
-  sendMessageToRoom(room: JID!, body: String!): String
+  sendMessageToRoom(room: JID!, body: String!): String @use(arg: "room")
   "Set the user blocking list"
-  setBlockingList(items: [BlockingInput!]!): String
+  setBlockingList(items: [BlockingInput!]!): String @use
 }
 
 """
 Allow user to get information about Multi-User Chat Light rooms.
 """
-type MUCLightUserQuery @protected{
+type MUCLightUserQuery @protected @use(modules: ["mod_muc_light"]){
   "Get the MUC Light room archived messages"
-  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
+  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload @use(arg: "room")
   "Get configuration of the MUC Light room"
-  getRoomConfig(room: JID!): Room
+  getRoomConfig(room: JID!): Room @use(arg: "room")
   "Get users list of given MUC Light room"
-  listRoomUsers(room: JID!): [RoomUser!]
+  listRoomUsers(room: JID!): [RoomUser!] @use(arg: "room")
   "Get the list of MUC Light rooms that the user participates in"
-  listRooms: [JID!]
+  listRooms: [JID!] @use
   "Get the user blocking list"
-  getBlockingList: [BlockingItem!]
+  getBlockingList: [BlockingItem!] @use
 }

--- a/priv/graphql/schemas/user/private.gql
+++ b/priv/graphql/schemas/user/private.gql
@@ -1,15 +1,15 @@
 """
 Allow user to set own private
 """
-type PrivateUserMutation @protected {
+type PrivateUserMutation @protected @use(modules: ["mod_private"]){
     "Set user's own private"
-    setPrivate(elementString: String!): String
+    setPrivate(elementString: String!): String @use
 }
 
 """
 Allow user to get own private
 """
-type PrivateUserQuery @protected {
+type PrivateUserQuery @protected @use(modules: ["mod_private"]){
     "Get user's own private"
-    getPrivate(element: String!, nameSpace: String!): String
+    getPrivate(element: String!, nameSpace: String!): String @use
 }

--- a/priv/graphql/schemas/user/token.gql
+++ b/priv/graphql/schemas/user/token.gql
@@ -1,9 +1,9 @@
 """
  Allow user to get and revoke tokens.
  """
- type TokenUserMutation @protected{
+ type TokenUserMutation @protected @use(modules: ["mod_auth_token"]){
    "Get a new token"
-   requestToken: Token
+   requestToken: Token @use
    "Revoke any tokens"
-   revokeToken: String
+   revokeToken: String @use
  }

--- a/priv/graphql/schemas/user/vcard.gql
+++ b/priv/graphql/schemas/user/vcard.gql
@@ -11,5 +11,7 @@ Allow user to get user's vcard
 """
 type VcardUserQuery @protected @use(modules: ["mod_vcard"]){
     "Get user's vcard"
+    #In mod_vcard_api was left the check if the mod_vcard is loaded, because,
+    #when get_vcard is called without user variable @use directive cannot check if the module is loaded.
     getVcard(user: JID): Vcard @use(arg: "user")
 }

--- a/priv/graphql/schemas/user/vcard.gql
+++ b/priv/graphql/schemas/user/vcard.gql
@@ -1,15 +1,15 @@
 """
 Allow user to set own vcard
 """
-type VcardUserMutation @protected{
+type VcardUserMutation @protected @use(modules: ["mod_vcard"]){
     "Set user's own vcard"
-    setVcard(vcard: VcardInput!): Vcard
+    setVcard(vcard: VcardInput!): Vcard @use
 }
 
 """
 Allow user to get user's vcard
 """
-type VcardUserQuery @protected{
+type VcardUserQuery @protected @use(modules: ["mod_vcard"]){
     "Get user's vcard"
-    getVcard(user: JID): Vcard
+    getVcard(user: JID): Vcard @use(arg: "user")
 }

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_mutation.erl
@@ -10,7 +10,7 @@
 -import(mongoose_graphql_helper, [make_error/2, format_result/2]).
 -import(mongoose_graphql_muc_light_helper, [make_room/1, make_ok_user/1,
                                             prepare_blocking_items/1,
-                                            null_to_default/2, options_to_map/1]).
+                                            null_to_default/2, options_to_map/1, get_not_loaded/1]).
 
 execute(_Ctx, _Obj, <<"createRoom">>, Args) ->
     create_room(Args);

--- a/src/http_upload/mod_http_upload_api.erl
+++ b/src/http_upload/mod_http_upload_api.erl
@@ -34,18 +34,13 @@ get_urls(Domain, Filename, Size, ContentType, Timeout) ->
     end.
 
 check_module_and_get_urls(HostType, Filename, Size, ContentType, Timeout) ->
-    case gen_mod:is_loaded(HostType, mod_http_upload) of
-        true ->
-            case mod_http_upload:get_urls(HostType, Filename, Size, ContentType, Timeout) of
-                {PutURL, GetURL, Header} ->
-                    {ok, #{<<"PutUrl">> => PutURL, <<"GetUrl">> => GetURL,
-                           <<"Header">> => header_output(Header)}};
-                file_too_large_error ->
-                    {file_too_large_error,
-                     "Declared file size exceeds the host's maximum file size."}
-            end;
-        false ->
-            {module_not_loaded_error, "mod_http_upload is not loaded for this host"}
+    case mod_http_upload:get_urls(HostType, Filename, Size, ContentType, Timeout) of
+        {PutURL, GetURL, Header} ->
+            {ok, #{<<"PutUrl">> => PutURL, <<"GetUrl">> => GetURL,
+                   <<"Header">> => header_output(Header)}};
+        file_too_large_error ->
+            {file_too_large_error,
+             "Declared file size exceeds the host's maximum file size."}
     end.
 
 -spec generate_output_message(PutURL :: binary(), GetURL :: binary(),

--- a/src/http_upload/mod_http_upload_api.erl
+++ b/src/http_upload/mod_http_upload_api.erl
@@ -34,13 +34,19 @@ get_urls(Domain, Filename, Size, ContentType, Timeout) ->
     end.
 
 check_module_and_get_urls(HostType, Filename, Size, ContentType, Timeout) ->
-    case mod_http_upload:get_urls(HostType, Filename, Size, ContentType, Timeout) of
-        {PutURL, GetURL, Header} ->
-            {ok, #{<<"PutUrl">> => PutURL, <<"GetUrl">> => GetURL,
-                   <<"Header">> => header_output(Header)}};
-        file_too_large_error ->
-            {file_too_large_error,
-             "Declared file size exceeds the host's maximum file size."}
+    %The check if the module is loaded is needed by one test in mongooseimctl_SUITE
+    case gen_mod:is_loaded(HostType, mod_http_upload) of
+        true ->
+            case mod_http_upload:get_urls(HostType, Filename, Size, ContentType, Timeout) of
+                {PutURL, GetURL, Header} ->
+                    {ok, #{<<"PutUrl">> => PutURL, <<"GetUrl">> => GetURL,
+                           <<"Header">> => header_output(Header)}};
+                file_too_large_error ->
+                    {file_too_large_error,
+                     "Declared file size exceeds the host's maximum file size."}
+            end;
+        false ->
+            {module_not_loaded_error, "mod_http_upload is not loaded for this host"}
     end.
 
 -spec generate_output_message(PutURL :: binary(), GetURL :: binary(),

--- a/src/mod_private_api.erl
+++ b/src/mod_private_api.erl
@@ -19,7 +19,7 @@ private_get(JID, Element, Ns) ->
     end.
 
 -spec private_set(jid:jid(), ElementString :: binary()) -> {Res, iolist()} when
-    Res :: ok | not_found | not_loaded | parse_error.
+    Res :: ok | not_found | parse_error.
 private_set(JID, ElementString) ->
     case exml:parse(ElementString) of
         {error, Error} ->
@@ -39,27 +39,15 @@ do_private_get(JID, Element, Ns) ->
              children = [SubEl] }] = ResIq#iq.sub_el,
     exml:to_binary(SubEl).
 
-do_private_set(JID, Xml) ->
+do_private_set(#jid{lserver = Domain} = JID, Xml) ->
     case ejabberd_auth:does_user_exist(JID) of
         true ->
-            do_private_set2(JID, Xml);
-        false ->
-            {not_found, io_lib:format("User ~s does not exist", [jid:to_binary(JID)])}
-    end.
-
-do_private_set2(#jid{lserver = Domain} = JID, Xml) ->
-    {ok, HostType} = mongoose_domain_api:get_domain_host_type(Domain),
-    case is_private_module_loaded(HostType) of
-        true ->
+            {ok, HostType} = mongoose_domain_api:get_domain_host_type(Domain),
             send_iq(set, Xml, JID, HostType),
             {ok, ""};
         false ->
-            {not_loaded, io_lib:format("Module mod_private is not loaded on domain ~s", [Domain])}
+            {not_found, io_lib:format("User ~s does not exist", [jid:to_binary(JID)])}
     end.
-
--spec is_private_module_loaded(jid:server()) -> true | false.
-is_private_module_loaded(Server) ->
-    lists:member(mod_private, gen_mod:loaded_modules(Server)).
 
 send_iq(Method, Xml, From = To = _JID, HostType) ->
     IQ = {iq, <<"">>, Method, ?NS_PRIVATE, <<"">>,

--- a/src/offline/mod_offline_api.erl
+++ b/src/offline/mod_offline_api.erl
@@ -3,24 +3,19 @@
 -export([delete_expired_messages/1, delete_old_messages/2]).
 
 -spec delete_expired_messages(jid:lserver()) ->
-    {ok | domain_not_found | server_error | module_not_loaded_error, iolist()}.
+    {ok | domain_not_found | server_error, iolist()}.
 delete_expired_messages(Domain) ->
     call_for_loaded_module(Domain, fun remove_expired_messages/2, {Domain}).
 
 -spec delete_old_messages(jid:lserver(), Days :: integer()) ->
-    {ok | domain_not_found | server_error | module_not_loaded_error, iolist()}.
+    {ok | domain_not_found | server_error, iolist()}.
 delete_old_messages(Domain, Days) ->
     call_for_loaded_module(Domain, fun remove_old_messages/2, {Domain, Days}).
 
 call_for_loaded_module(Domain, Function, Args) ->
     case mongoose_domain_api:get_domain_host_type(Domain) of
         {ok, HostType} ->
-            case gen_mod:is_loaded(HostType, mod_offline) of
-                true ->
-                    Function(Args, HostType);
-                false ->
-                    {module_not_loaded_error, "mod_offline is not loaded for this host"}
-            end;
+            Function(Args, HostType);
         {error, not_found} ->
             {domain_not_found, "Unknown domain"}
     end.

--- a/src/vcard/mod_vcard_api.erl
+++ b/src/vcard/mod_vcard_api.erl
@@ -32,7 +32,13 @@ set_vcard(#jid{luser = LUser, lserver = LServer} = UserJID, Vcard) ->
 get_vcard(#jid{luser = LUser, lserver = LServer}) ->
     case mongoose_domain_api:get_domain_host_type(LServer) of
         {ok, HostType} ->
-            get_vcard_from_db(HostType, LUser, LServer);
+            % check if mod_vcard is loaded is needed in user's get_vcard command, when user variable is not passed
+            case gen_mod:is_loaded(HostType, mod_vcard) of
+                true ->
+                    get_vcard_from_db(HostType, LUser, LServer);
+                false ->
+                    {vcard_not_configured_error, "Mod_vcard is not loaded for this host"}
+            end;
         _ ->
             {not_found, "User does not exist"}
     end.


### PR DESCRIPTION
In this PR I have added "@use" directive to all schemas where it was needed. Moreover, I have deleted any unnecessary checks in API modules. The problems occurred with 3 modules:
- mod_muc
- mod_muc_light
- mod_vcard

---

In mod_muc there are 4 commands that are currently not using @use directive:
- ADMIN createInstantRoom -> it is currently impossible to get HostType from mucDomain variable
- ADMIN listRooms -> it is currently impossible to get HostType from mucDomain variable 
- USER createInstantRoom -> it is currently impossible to get HostType from mucDomain variable
- USER listRooms -> it is currently impossible to get HostType from mucDomain variable

In mod_muc_light there are 2 commands that are currently not using @use directive:
- ADMIN createInstantRoom -> it is currently impossible to get HostType from mucDomain variable
- USER createInstantRoom -> it is currently impossible to get HostType from mucDomain variable

In mod_vcard there is 1 command that currently not fully supports @use directive:
- USER getVcard -> the HostType needed for @use directive is taken from "user" variable. When it's not passed(when user takes they own VCard) its not possible to get HostType. Therefore the check if mod_vcard is loaded has been added.

---

When @use directive was added for the module or was already added, the tests were added to ensure that @use directive is working properly.