### PR TITLE
Refactored hook handlers in mod_event_pusher_hook_translator module

### DIFF
--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -61,9 +61,10 @@ filter_local_packet({From, To, Acc0, Packet}, _, _) ->
 
 -spec user_send_packet(Acc, Args, Extra) -> {ok, Acc} when
       Acc :: mongoose_acc:t(),
-      Args :: #{from := jid:jid(), to := jid:jid(), packet := exml:element()},
+      Args :: map(),
       Extra :: map().
-user_send_packet(Acc, #{from := From, to := To, packet := Packet = #xmlel{name = <<"message">>}}, _) ->
+user_send_packet(Acc, _, _) ->
+    {From, To, Packet} = mongoose_acc:packet(Acc),
     ResultAcc = case chat_type(Acc) of
         false -> Acc;
         Type ->

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -22,14 +22,11 @@
 
 -export([add_hooks/1, delete_hooks/1]).
 
--export([user_send_packet/4,
-         filter_local_packet/1,
-         user_present/2,
-         user_not_present/5,
-         unacknowledged_message/2]).
-
--ignore_xref([filter_local_packet/1, unacknowledged_message/2, user_not_present/5,
-              user_present/2, user_send_packet/4]).
+-export([user_send_packet/3,
+         filter_local_packet/3,
+         user_present/3,
+         user_not_present/3,
+         unacknowledged_message/3]).
 
 %%--------------------------------------------------------------------
 %% gen_mod API
@@ -37,21 +34,21 @@
 
 -spec add_hooks(mongooseim:host_type()) -> ok.
 add_hooks(HostType) ->
-    ejabberd_hooks:add(hooks(HostType)).
+    gen_hook:add_handlers(hooks(HostType)).
 
 -spec delete_hooks(mongooseim:host_type()) -> ok.
 delete_hooks(HostType) ->
-    ejabberd_hooks:delete(hooks(HostType)).
+    gen_hook:delete_handlers(hooks(HostType)).
 
 %%--------------------------------------------------------------------
 %% Hook callbacks
 %%--------------------------------------------------------------------
 -type routing_data() :: {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()}.
--spec filter_local_packet(drop) -> drop;
-                         (routing_data()) -> routing_data().
-filter_local_packet(drop) ->
-    drop;
-filter_local_packet({From, To, Acc0, Packet}) ->
+-spec filter_local_packet(drop, _, _) -> {ok, drop};
+                         (routing_data(), _, _) -> {ok, routing_data()}.
+filter_local_packet(drop, _, _) ->
+    {ok, drop};
+filter_local_packet({From, To, Acc0, Packet}, _, _) ->
     Acc = case chat_type(Acc0) of
               false -> Acc0;
               Type ->
@@ -60,40 +57,51 @@ filter_local_packet({From, To, Acc0, Packet}) ->
                   NewAcc = mod_event_pusher:push_event(Acc0, Event),
                   merge_acc(Acc0, NewAcc)
           end,
-    {From, To, Acc, Packet}.
+    {ok, {From, To, Acc, Packet}}.
 
--spec user_send_packet(mongoose_acc:t(), From :: jid:jid(), To :: jid:jid(),
-                       Packet :: exml:element()) -> mongoose_acc:t().
-user_send_packet(Acc, From, To, Packet = #xmlel{name = <<"message">>}) ->
-    case chat_type(Acc) of
+-spec user_send_packet(Acc, Args, Extra) -> {ok, Acc} when
+      Acc :: mongoose_acc:t(),
+      Args :: #{from := jid:jid(), to := jid:jid(), packet := exml:element()},
+      Extra :: map().
+user_send_packet(Acc, #{from := From, to := To, packet := Packet = #xmlel{name = <<"message">>}}, _) ->
+    ResultAcc = case chat_type(Acc) of
         false -> Acc;
         Type ->
             Event = #chat_event{type = Type, direction = in,
                                 from = From, to = To, packet = Packet},
             NewAcc = mod_event_pusher:push_event(Acc, Event),
             merge_acc(Acc, NewAcc)
-    end;
-user_send_packet(Acc, _From, _To, _Packet) ->
-    Acc.
+    end,
+    {ok, ResultAcc};
+user_send_packet(Acc, _, _) ->
+    {ok, Acc}.
 
--spec user_present(mongoose_acc:t(), UserJID :: jid:jid()) -> mongoose_acc:t().
-user_present(Acc, #jid{} = UserJID) ->
+-spec user_present(Acc, Args, Extra) -> {ok, Acc} when
+      Acc :: mongoose_acc:t(),
+      Args :: #{jid := jid:jid()},
+      Extra :: map().
+user_present(Acc, #{jid := UserJID = #jid{}}, _) ->
     Event = #user_status_event{jid = UserJID, status = online},
     NewAcc = mod_event_pusher:push_event(Acc, Event),
-    merge_acc(Acc, NewAcc).
+    {ok, merge_acc(Acc, NewAcc)}.
 
--spec user_not_present(mongoose_acc:t(), User :: jid:luser(), Server :: jid:lserver(),
-                       Resource :: jid:lresource(), Status :: any()) -> mongoose_acc:t().
-user_not_present(Acc, LUser, LServer, LResource, _Status) ->
-    UserJID = jid:make_noprep(LUser, LServer, LResource),
+-spec user_not_present(Acc, Args, Extra) -> {ok, Acc} when
+      Acc :: mongoose_acc:t(),
+      Args :: #{jid := jid:jid()},
+      Extra :: map().
+user_not_present(Acc, #{jid := UserJID}, _) ->
     Event = #user_status_event{jid = UserJID, status = offline},
     NewAcc = mod_event_pusher:push_event(Acc, Event),
-    merge_acc(Acc, NewAcc).
+    {ok, merge_acc(Acc, NewAcc)}.
 
-unacknowledged_message(Acc, Jid) ->
+-spec unacknowledged_message(Acc, Args, Extra) -> {ok, Acc} when
+      Acc :: mongoose_acc:t(),
+      Args :: #{jid := jid:jid()},
+      Extra :: map().
+unacknowledged_message(Acc, #{jid := Jid}, _) ->
     Event = #unack_msg_event{to = Jid},
     NewAcc = mod_event_pusher:push_event(Acc, Event),
-    merge_acc(Acc, NewAcc).
+    {ok, merge_acc(Acc, NewAcc)}.
 
 %%--------------------------------------------------------------------
 %% Helpers
@@ -115,13 +123,13 @@ merge_acc(Acc, EventPusherAcc) ->
     NS = mongoose_acc:get(event_pusher, EventPusherAcc),
     mongoose_acc:set_permanent(event_pusher, NS, Acc).
 
--spec hooks(mongooseim:host_type()) -> [ejabberd_hooks:hook()].
+-spec hooks(mongooseim:host_type()) -> [gen_hook:hook_tuple()].
 hooks(HostType) ->
     [
-        {filter_local_packet, HostType, ?MODULE, filter_local_packet, 80},
-        {unset_presence_hook, HostType, ?MODULE, user_not_present, 90},
-        {user_available_hook, HostType, ?MODULE, user_present, 90},
-        {user_send_packet, HostType, ?MODULE, user_send_packet, 90},
-        {rest_user_send_packet, HostType, ?MODULE, user_send_packet, 90},
-        {unacknowledged_message, HostType, ?MODULE, unacknowledged_message, 90}
+        {filter_local_packet, HostType, fun ?MODULE:filter_local_packet/3, #{}, 80},
+        {unset_presence_hook, HostType, fun ?MODULE:user_not_present/3, #{}, 90},
+        {user_available_hook, HostType, fun ?MODULE:user_present/3, #{}, 90},
+        {user_send_packet, HostType, fun ?MODULE:user_send_packet/3, #{}, 90},
+        {rest_user_send_packet, HostType, fun ?MODULE:user_send_packet/3, #{}, 90},
+        {unacknowledged_message, HostType, fun ?MODULE:unacknowledged_message/3, #{}, 90}
     ].

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -267,7 +267,8 @@ failed_to_store_message(Acc) ->
     Result :: drop | filter_packet_acc().
 filter_local_packet(FilterAcc = {_From, _To, Acc, _Packet}) ->
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(filter_local_packet, HostType, FilterAcc, #{args => []}).
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(#{}, []),
+    run_hook_for_host_type(filter_local_packet, HostType, FilterAcc, ParamsWithLegacyArgs).
 
 %%% @doc The `filter_packet' hook is called to filter out
 %%% stanzas routed with `mongoose_router_global'.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -267,7 +267,7 @@ failed_to_store_message(Acc) ->
     Result :: drop | filter_packet_acc().
 filter_local_packet(FilterAcc = {_From, _To, Acc, _Packet}) ->
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(filter_local_packet, HostType, FilterAcc, []).
+    run_hook_for_host_type(filter_local_packet, HostType, FilterAcc, #{args => []}).
 
 %%% @doc The `filter_packet' hook is called to filter out
 %%% stanzas routed with `mongoose_router_global'.
@@ -392,8 +392,11 @@ resend_offline_messages_hook(Acc, JID) ->
     Packet :: exml:element(),
     Result :: mongoose_acc:t().
 rest_user_send_packet(Acc, From, To, Packet) ->
+    Params = #{from => From, to => To, packet => Packet},
+    Args = [From, To, Packet],
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(rest_user_send_packet, HostType, Acc, [From, To, Packet]).
+    run_hook_for_host_type(rest_user_send_packet, HostType, Acc, ParamsWithLegacyArgs).
 
 %%% @doc The `session_cleanup' hook is called when sm backend cleans up a user's session.
 -spec session_cleanup(Server, Acc, User, Resource, SID) -> Result when
@@ -458,8 +461,11 @@ unregister_subhost(LDomain) ->
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
 user_available_hook(Acc, JID) ->
+    Params = #{jid => JID},
+    Args = [JID],
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(user_available_hook, HostType, Acc, [JID]).
+    run_hook_for_host_type(user_available_hook, HostType, Acc, ParamsWithLegacyArgs).
 
 %%% @doc The `user_ping_response' hook is called when a user responds to a ping.
 -spec user_ping_response(HostType, Acc, JID, Response, TDelta) -> Result when
@@ -513,8 +519,11 @@ user_sent_keep_alive(HostType, JID) ->
     Packet :: exml:element(),
     Result :: mongoose_acc:t().
 user_send_packet(Acc, From, To, Packet) ->
+    Params = #{from => From, to => To, packet => Packet},
+    Args = [From, To, Packet],
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(user_send_packet, HostType, Acc, [From, To, Packet]).
+    run_hook_for_host_type(user_send_packet, HostType, Acc, ParamsWithLegacyArgs).
 
 %%% @doc The `vcard_set' hook is called to inform that the vcard
 %%% has been set in mod_vcard backend.
@@ -775,9 +784,11 @@ sm_remove_connection_hook(Acc, SID, JID, Info, Reason) ->
     Result :: mongoose_acc:t().
 unset_presence_hook(Acc, JID, Status) ->
     #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
+    Params = #{jid => JID},
+    Args = [LUser, LServer, LResource, Status],
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(unset_presence_hook, HostType, Acc,
-                           [LUser, LServer, LResource, Status]).
+    run_hook_for_host_type(unset_presence_hook, HostType, Acc, ParamsWithLegacyArgs).
 
 -spec xmpp_bounce_message(Acc) -> Result when
     Acc :: mongoose_acc:t(),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -392,7 +392,7 @@ resend_offline_messages_hook(Acc, JID) ->
     Packet :: exml:element(),
     Result :: mongoose_acc:t().
 rest_user_send_packet(Acc, From, To, Packet) ->
-    Params = #{from => From, to => To, packet => Packet},
+    Params = #{},
     Args = [From, To, Packet],
     ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     HostType = mongoose_acc:host_type(Acc),
@@ -519,7 +519,7 @@ user_sent_keep_alive(HostType, JID) ->
     Packet :: exml:element(),
     Result :: mongoose_acc:t().
 user_send_packet(Acc, From, To, Packet) ->
-    Params = #{from => From, to => To, packet => Packet},
+    Params = #{},
     Args = [From, To, Packet],
     ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     HostType = mongoose_acc:host_type(Acc),


### PR DESCRIPTION
This PR changes all hook handlers in `mod_event_pusher_hook_translator` module to `gen_hook` format.