### PR TITLE
Async rest endpoint

### DIFF
--- a/big_tests/tests/domain_rest_helper.erl
+++ b/big_tests/tests/domain_rest_helper.erl
@@ -11,6 +11,7 @@
          putt_domain_with_custom_body/2,
          rest_select_domain/2,
          rest_delete_domain/3,
+         request_delete_domain/3,
          delete_custom/4,
          patch_custom/4]).
 
@@ -79,6 +80,14 @@ rest_select_domain(Config, Domain) ->
 
 rest_delete_domain(Config, Domain, HostType) ->
     Params = #{<<"host_type">> => HostType},
+    rest_helper:make_request(#{ role => admin, method => <<"DELETE">>,
+                                port => ?TEST_PORT,
+                                path => domain_path(Domain),
+                                creds => make_creds(Config),
+                                body => Params }).
+
+request_delete_domain(Config, Domain, HostType) ->
+    Params = #{<<"host_type">> => HostType, <<"request">> => <<"true">>},
     rest_helper:make_request(#{ role => admin, method => <<"DELETE">>,
                                 port => ?TEST_PORT,
                                 path => domain_path(Domain),

--- a/doc/developers-guide/domain_management.md
+++ b/doc/developers-guide/domain_management.md
@@ -122,6 +122,22 @@ Configuration described in the [`listen` section](../configuration/listen.md#han
 REST API is documented using Swagger in [REST API for dynamic domains management](../rest-api/Dynamic-domains.md).
 Below are examples of how to use this API with the help of `curl`:
 
+### Get domain information
+
+You must provide the domain's host type inside the body:
+
+```bash
+curl -v -X GET "http://localhost:8088/api/domains/example.db" \
+    --user admin:secret \
+    -H 'content-type: application/json'
+```
+
+Result codes:
+
+* 200 - The request succeeded.
+* 404 - The domain is unknown.
+* 500 - Other errors.
+
 ### Add domain
 
 ```bash
@@ -161,6 +177,27 @@ curl -v -X DELETE "http://localhost:8088/api/domains/example.db" \
 Result codes:
 
 * 204 - The domain is removed or not found.
+* 403 - One of:
+    * the domain is static.
+    * the DB service is disabled.
+    * the host type is wrong (does not match the host type in the database).
+    * the host type is unknown.
+* 500 - Other errors.
+
+### Request to asynchronously remove a domain
+
+You must provide the domain's host type inside the body:
+
+```bash
+curl -v -X DELETE "http://localhost:8088/api/domains/example.db" \
+    --user admin:secret \
+    -H 'content-type: application/json' \
+    -d '{"host_type": "type1", "request": "true"}'
+```
+
+Result codes:
+
+* 202 - The request has been accepted.
 * 403 - One of:
     * the domain is static.
     * the DB service is disabled.

--- a/src/domain/mongoose_domain_api.erl
+++ b/src/domain/mongoose_domain_api.erl
@@ -15,6 +15,9 @@
          get_all_static/0,
          get_domains_by_host_type/1]).
 
+%% Async API
+-export([request_delete_domain/2]).
+
 %% domain admin API
 -export([check_domain_password/2,
          set_domain_password/2,
@@ -86,6 +89,10 @@ delete_domain(Domain, HostType) ->
         Other ->
             Other
     end.
+
+-spec request_delete_domain(domain(), host_type()) -> {pid(), reference()}.
+request_delete_domain(Domain, HostType) ->
+    mongoose_domain_db_cleaner:request_delete_domain(Domain, HostType).
 
 -spec disable_domain(domain()) ->
     ok | {error, not_found} | {error, static} | {error, service_disabled}

--- a/src/domain/mongoose_domain_db_cleaner.erl
+++ b/src/domain/mongoose_domain_db_cleaner.erl
@@ -4,7 +4,7 @@
 -include("mongoose_logger.hrl").
 
 -export([start/1, stop/0]).
--export([start_link/1]).
+-export([start_link/1, request_delete_domain/2]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -37,6 +37,10 @@ stop() ->
 start_link(Opts) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, Opts, []).
 
+-spec request_delete_domain(jid:lserver(), mongooseim:host_type()) -> ok.
+request_delete_domain(Domain, HostType) ->
+    gen_server:cast(?MODULE, {delete_domain, Domain, HostType}).
+
 %% ---------------------------------------------------------------------------
 %% Server callbacks
 
@@ -51,6 +55,8 @@ handle_call(Request, From, State) ->
     ?UNEXPECTED_CALL(Request, From),
     {reply, ok, State}.
 
+handle_cast({delete_domain, Domain, HostType}, State) ->
+    {noreply, handle_delete_domain(Domain, HostType, State)};
 handle_cast(Msg, State) ->
     ?UNEXPECTED_CAST(Msg),
     {noreply, State}.
@@ -89,4 +95,14 @@ schedule_removal(State = #{max_age := MaxAge}) ->
 
 handle_timeout(_TimerRef, {do_removal, LastEventId}, State) ->
     mongoose_domain_sql:delete_events_older_than(LastEventId),
+    State.
+
+handle_delete_domain(Domain, HostType, State) ->
+    try
+        mongoose_domain_api:delete_domain(Domain, HostType)
+    catch Class:Reason:Stacktrace ->
+              ?LOG_ERROR(#{what => domain_deletion_failed,
+                           domain => Domain, host_type => HostType,
+                           class => Class, reason => Reason, stacktrace => Stacktrace})
+    end,
     State.


### PR DESCRIPTION
Most often, tenant deletion can incur in many many DB operations, which can introduce very long delays and timeout any HTTP connection. And when the HTTP connection times out, the cowboy process running the tenant deletion hook will timeout, and could potentially leave the DB in an inconsistent state.

This PR introduces a parameter in the delete body, that transforms the request in asynchronous. So far, no special changes are made to the deletion itself, which if it fails it is not retried and the half-committed deletion leaves everything inconsistent. Future changes will make DB operations more incremental, and failures possible to retry, but for now only unblocking the HTTP endpoint is done.