### PR TITLE
Unified REST API handlers

### DIFF
--- a/src/mongoose_admin_api/mongoose_admin_api_contacts.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_contacts.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_contacts).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+-export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          content_types_provided/2,
@@ -15,11 +18,16 @@
 -import(mongoose_admin_api, [parse_body/1, try_handle_request/3, throw_error/2]).
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
+
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/contacts/:user/[:contact]", ?MODULE, State},
+     {"/contacts/:user/:contact/manage", ?MODULE, State#{suffix => manage}}].
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_domain.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_domain.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_domain).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+-export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          content_types_provided/2,
@@ -15,11 +18,15 @@
 -import(mongoose_admin_api, [parse_body/1, try_handle_request/3, throw_error/2, resource_created/4]).
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
+
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/domains/:domain", ?MODULE, State}].
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_inbox.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_inbox.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_inbox).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+-export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          allowed_methods/2,
@@ -9,11 +12,16 @@
 -import(mongoose_admin_api, [try_handle_request/3, throw_error/2, respond/3]).
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
+
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/inbox/:host_type/:days/bin", ?MODULE, State},
+     {"/inbox/:domain/:user/:days/bin", ?MODULE, State}].
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_messages.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_messages.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_messages).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+-export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          content_types_provided/2,
@@ -14,11 +17,16 @@
 -import(mongoose_admin_api, [parse_body/1, parse_qs/1, try_handle_request/3, throw_error/2]).
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
+
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/messages/:owner/:with", ?MODULE, State},
+     {"/messages/[:owner]", ?MODULE, State}].
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_metrics.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_metrics.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_metrics).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+-export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          content_types_provided/2,
@@ -12,13 +15,20 @@
 -import(mongoose_admin_api, [parse_body/1, try_handle_request/3, throw_error/2, resource_created/4]).
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
 
 -include("mongoose.hrl").
 
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/metrics/", ?MODULE, State},
+     {"/metrics/all/[:metric]", ?MODULE, State#{suffix => all}},
+     {"/metrics/global/[:metric]", ?MODULE, State#{suffix => global}},
+     {"/metrics/host_type/:host_type/[:metric]", ?MODULE, State}].
+
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_muc.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_muc.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_muc).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+-export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          content_types_accepted/2,
@@ -15,11 +18,16 @@
 -include("jlib.hrl").
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
+
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/mucs/:domain", ?MODULE, State},
+     {"/mucs/:domain/:name/:arg", ?MODULE, State}].
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_muc_light.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_muc_light.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_muc_light).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+-export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          content_types_accepted/2,
@@ -13,11 +16,18 @@
 -import(mongoose_admin_api, [try_handle_request/3, throw_error/2, parse_body/1, resource_created/4]).
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
+
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/muc-lights/:domain", ?MODULE, State},
+     {"/muc-lights/:domain/:id/participants", ?MODULE, State#{suffix => participants}},
+     {"/muc-lights/:domain/:id/messages", ?MODULE, State#{suffix => messages}},
+     {"/muc-lights/:domain/:id/management", ?MODULE, State#{suffix => management}}].
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_sessions.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_sessions.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_sessions).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+-export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          content_types_provided/2,
@@ -13,11 +16,15 @@
 -import(mongoose_admin_api, [try_handle_request/3, throw_error/2]).
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
+
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/sessions/:domain/[:username]/[:resource]", ?MODULE, State}].
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_stanzas.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_stanzas.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_stanzas).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+-export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          content_types_accepted/2,
@@ -12,11 +15,15 @@
 -import(mongoose_admin_api, [parse_body/1, try_handle_request/3, throw_error/2]).
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
+
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/stanzas", ?MODULE, State}].
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_users.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_users.erl
@@ -1,6 +1,9 @@
 -module(mongoose_admin_api_users).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_admin_api).
+ -export([routes/1]).
+
+-behaviour(cowboy_rest).
 -export([init/2,
          is_authorized/2,
          content_types_provided/2,
@@ -15,11 +18,15 @@
 -import(mongoose_admin_api, [parse_body/1, try_handle_request/3, throw_error/2, resource_created/4]).
 
 -type req() :: cowboy_req:req().
--type state() :: map().
+-type state() :: mongoose_admin_api:state().
+
+-spec routes(state()) -> mongoose_http_handler:routes().
+routes(State) ->
+    [{"/users/:domain/[:username]", ?MODULE, State}].
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
-init(Req, Opts) ->
-    mongoose_admin_api:init(Req, Opts).
+init(Req, State) ->
+    mongoose_admin_api:init(Req, State).
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->

--- a/src/mongoose_client_api/mongoose_client_api_contacts.erl
+++ b/src/mongoose_client_api/mongoose_client_api_contacts.erl
@@ -1,6 +1,9 @@
 -module(mongoose_client_api_contacts).
--behaviour(cowboy_rest).
 
+-behaviour(mongoose_client_api).
+-export([routes/0]).
+
+-behaviour(cowboy_rest).
 -export([trails/0]).
 -export([init/2]).
 -export([content_types_provided/2]).
@@ -18,6 +21,10 @@
 
 -type req() :: cowboy_req:req().
 -type state() :: map().
+
+-spec routes() -> mongoose_http_handler:routes().
+routes() ->
+    [{"/contacts/[:jid]", ?MODULE, #{}}].
 
 trails() ->
     mongoose_client_api_contacts_doc:trails().

--- a/src/mongoose_client_api/mongoose_client_api_messages.erl
+++ b/src/mongoose_client_api/mongoose_client_api_messages.erl
@@ -1,8 +1,10 @@
 -module(mongoose_client_api_messages).
+
+-behaviour(mongoose_client_api).
+-export([routes/0]).
+
 -behaviour(cowboy_rest).
-
 -export([trails/0]).
-
 -export([init/2]).
 -export([content_types_provided/2]).
 -export([content_types_accepted/2]).
@@ -24,6 +26,10 @@
 -include("jlib.hrl").
 -include("mongoose_rsm.hrl").
 -include_lib("exml/include/exml.hrl").
+
+-spec routes() -> mongoose_http_handler:routes().
+routes() ->
+    [{"/messages/[:with]", ?MODULE, #{}}].
 
 trails() ->
     mongoose_client_api_messages_doc:trails().

--- a/src/mongoose_client_api/mongoose_client_api_rooms.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms.erl
@@ -1,8 +1,10 @@
 -module(mongoose_client_api_rooms).
+
+-behaviour(mongoose_client_api).
+-export([routes/0]).
+
 -behaviour(cowboy_rest).
-
 -export([trails/0]).
-
 -export([init/2]).
 -export([content_types_provided/2]).
 -export([content_types_accepted/2]).
@@ -20,7 +22,10 @@
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
--include_lib("exml/include/exml.hrl").
+
+-spec routes() -> mongoose_http_handler:routes().
+routes() ->
+    [{"/rooms/[:id]", ?MODULE, #{}}].
 
 trails() ->
     mongoose_client_api_rooms_doc:trails().

--- a/src/mongoose_client_api/mongoose_client_api_rooms_config.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms_config.erl
@@ -1,8 +1,10 @@
 -module(mongoose_client_api_rooms_config).
+
+-behaviour(mongoose_client_api).
+-export([routes/0]).
+
 -behaviour(cowboy_rest).
-
 -export([trails/0]).
-
 -export([init/2]).
 -export([content_types_provided/2]).
 -export([content_types_accepted/2]).
@@ -14,10 +16,9 @@
 
 -ignore_xref([from_json/2, trails/0]).
 
--include("mongoose.hrl").
--include("jlib.hrl").
--include("mongoose_rsm.hrl").
--include_lib("exml/include/exml.hrl").
+-spec routes() -> mongoose_http_handler:routes().
+routes() ->
+    [{"/rooms/[:id]/config", ?MODULE, #{}}].
 
 trails() ->
     mongoose_client_api_rooms_config_doc:trails().

--- a/src/mongoose_client_api/mongoose_client_api_rooms_messages.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms_messages.erl
@@ -1,8 +1,10 @@
 -module(mongoose_client_api_rooms_messages).
+
+-behaviour(mongoose_client_api).
+-export([routes/0]).
+
 -behaviour(cowboy_rest).
-
 -export([trails/0]).
-
 -export([init/2]).
 -export([content_types_provided/2]).
 -export([content_types_accepted/2]).
@@ -21,8 +23,11 @@
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
--include("mongoose_rsm.hrl").
 -include_lib("exml/include/exml.hrl").
+
+-spec routes() -> mongoose_http_handler:routes().
+routes() ->
+    [{"/rooms/[:id]/messages", ?MODULE, #{}}].
 
 trails() ->
     mongoose_client_api_rooms_messages_doc:trails().

--- a/src/mongoose_client_api/mongoose_client_api_rooms_users.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms_users.erl
@@ -1,8 +1,10 @@
 -module(mongoose_client_api_rooms_users).
+
+-behaviour(mongoose_client_api).
+-export([routes/0]).
+
 -behaviour(cowboy_rest).
-
 -export([trails/0]).
-
 -export([init/2]).
 -export([content_types_provided/2]).
 -export([content_types_accepted/2]).
@@ -16,9 +18,9 @@
 
 -ignore_xref([from_json/2, trails/0]).
 
--include("mongoose.hrl").
--include("jlib.hrl").
--include_lib("exml/include/exml.hrl").
+-spec routes() -> mongoose_http_handler:routes().
+routes() ->
+    [{"/rooms/:id/users/[:user]", ?MODULE, #{}}].
 
 trails() ->
     mongoose_client_api_rooms_users_doc:trails().

--- a/src/mongoose_client_api/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api/mongoose_client_api_sse.erl
@@ -1,14 +1,21 @@
 -module(mongoose_client_api_sse).
+
+-behaviour(mongoose_client_api).
+-export([routes/0]).
+
 -behaviour(lasse_handler).
-
--include("mongoose.hrl").
--include("jlib.hrl").
-
 -export([init/3]).
 -export([handle_notify/2]).
 -export([handle_info/2]).
 -export([handle_error/3]).
 -export([terminate/3]).
+
+-include("mongoose.hrl").
+-include("jlib.hrl").
+
+-spec routes() -> mongoose_http_handler:routes().
+routes() ->
+    [{"/sse", lasse_handler, #{module => mongoose_client_api_sse}}].
 
 init(_InitArgs, _LastEvtId, Req) ->
     ?LOG_DEBUG(#{what => client_api_sse_init, req => Req}),

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -10,7 +10,7 @@
                      atom() => any()}.
 
 -type path() :: iodata().
--type routes() :: [{path(), module(), options()}].
+-type routes() :: [{path(), module(), #{atom() => any()}}].
 
 -export_type([options/0, path/0, routes/0]).
 

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -1074,11 +1074,12 @@ default_config([listen, http, handlers, mod_websockets]) ->
     #{timeout => 60000,
       max_stanza_size => infinity,
       module => mod_websockets};
+default_config([listen, http, handlers, mongoose_admin_api]) ->
+    #{handlers => [contacts, users, sessions, messages, stanzas, muc_light, muc,
+                   inbox, domain, metrics],
+      module => mongoose_admin_api};
 default_config([listen, http, handlers, mongoose_client_api]) ->
-    #{handlers => [lasse_handler, mongoose_client_api_messages,
-                   mongoose_client_api_contacts, mongoose_client_api_rooms,
-                   mongoose_client_api_rooms_config, mongoose_client_api_rooms_users,
-                   mongoose_client_api_rooms_messages],
+    #{handlers => [sse, messages, contacts, rooms, rooms_config, rooms_users, rooms_messages],
       docs => true,
       module => mongoose_client_api};
 default_config([listen, http, handlers, mongoose_graphql_cowboy_handler]) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -595,14 +595,17 @@ listen_http_handlers_websockets(_Config) ->
 
 listen_http_handlers_client_api(_Config) ->
     {P, T} = test_listen_http_handler(mongoose_client_api),
-    ?cfg(P ++ [handlers], [mongoose_client_api_messages],
-         T(#{<<"handlers">> => [<<"mongoose_client_api_messages">>]})),
+    ?cfg(P ++ [handlers], [messages],
+         T(#{<<"handlers">> => [<<"messages">>]})),
     ?cfg(P ++ [docs], false, T(#{<<"docs">> => false})),
-    ?err(T(#{<<"handlers">> => [not_a_module]})),
+    ?err(T(#{<<"handlers">> => [<<"invalid">>]})),
     ?err(T(#{<<"docs">> => <<"maybe">>})).
 
 listen_http_handlers_admin_api(_Config) ->
     {P, T} = test_listen_http_handler(mongoose_admin_api),
+    ?cfg(P ++ [handlers], [muc, inbox],
+         T(#{<<"handlers">> => [<<"muc">>, <<"inbox">>]})),
+    ?err(T(#{<<"handlers">> => [<<"invalid">>]})),
     test_listen_http_handler_creds(P, T).
 
 listen_http_handlers_graphql(_Config) ->


### PR DESCRIPTION
Unify the handler configuration for Client and Admin REST API.

- Make Admin API handlers configurable
- Specify only handler suffixes instead of the long module names
- Delegate route declaration to handler modules - this way the whole logic of a handler is in one module, and there are no long lists of Cowboy routes.

Remaining work after this PR:
- Document the updated REST API, including this change.