### PR TITLE
Return error messages from the Admin REST API in JSON

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -27,6 +27,7 @@
 
 -define(ROOM3, <<"testroom3">>).
 -define(ROOM4, <<"testroom4">>).
+-define(MSG(Text), {[{<<"message">>, Text}]}).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -1331,13 +1332,13 @@ rest_api_bin_flush_user_errors(Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}]),
     User = escalus_users:get_username(Config1, alice),
     Domain = escalus_users:get_server(Config1, alice),
-    {{<<"400">>, <<"Bad Request">>}, <<"Invalid number of days">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"Invalid number of days">>)} =
         rest_helper:delete(admin, <<"/inbox/", Domain/binary, "/", User/binary, "/x/bin">>),
-    {{<<"400">>, <<"Bad Request">>}, <<"Invalid JID">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"Invalid JID">>)} =
         rest_helper:delete(admin, <<"/inbox/", Domain/binary, "/@/0/bin">>),
-    {{<<"404">>, <<"Not Found">>}, <<"Domain not found">>} =
+    {{<<"404">>, <<"Not Found">>}, ?MSG(<<"Domain not found">>)} =
         rest_helper:delete(admin, <<"/inbox/baddomain/", User/binary, "/0/bin">>),
-    {{<<"404">>, <<"Not Found">>}, <<"User baduser@", _/binary>>} =
+    {{<<"404">>, <<"Not Found">>}, ?MSG(<<"User baduser@", _/binary>>)} =
         rest_helper:delete(admin, <<"/inbox/", Domain/binary, "/baduser/0/bin">>).
 
 rest_api_bin_flush_all(Config) ->
@@ -1354,9 +1355,9 @@ rest_api_bin_flush_all(Config) ->
 
 rest_api_bin_flush_all_errors(_Config) ->
     HostTypePath = uri_string:normalize(#{path => domain_helper:host_type()}),
-    {{<<"400">>, <<"Bad Request">>}, <<"Invalid number of days">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"Invalid number of days">>)} =
         rest_helper:delete(admin, <<"/inbox/", HostTypePath/binary, "/x/bin">>),
-    {{<<"404">>, <<"Not Found">>}, <<"Host type not found">>} =
+    {{<<"404">>, <<"Not Found">>}, ?MSG(<<"Host type not found">>)} =
         rest_helper:delete(admin, <<"/inbox/bad_host_type/0/bin">>).
 
 timeout_cleaner_flush_all(Config) ->

--- a/big_tests/tests/muc_light_http_api_SUITE.erl
+++ b/big_tests/tests/muc_light_http_api_SUITE.erl
@@ -20,9 +20,7 @@
 -module(muc_light_http_api_SUITE).
 -compile([export_all, nowarn_export_all]).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("escalus/include/escalus.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
 -include_lib("exml/include/exml.hrl").
 
@@ -31,6 +29,8 @@
 -import(domain_helper, [host_type/0, domain/0]).
 -import(config_parser_helper, [mod_config/2]).
 -import(rest_helper, [putt/3, post/3, delete/2]).
+
+-define(MSG(Text), {[{<<"message">>, Text}]}).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -200,15 +200,15 @@ create_room_errors(Config) ->
     AliceJid = escalus_users:get_jid(Config1, alice),
     Path = path([muc_light_domain()]),
     Body = #{name => <<"Name">>, owner => AliceJid, subject => <<"Lewis Carol">>},
-    {{<<"400">>, _}, <<"Missing room name">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing room name">>)} =
         post(admin, Path, maps:remove(name, Body)),
-    {{<<"400">>, _}, <<"Missing owner JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing owner JID">>)} =
         post(admin, Path, maps:remove(owner, Body)),
-    {{<<"400">>, _}, <<"Missing room subject">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing room subject">>)} =
         post(admin, Path, maps:remove(subject, Body)),
-    {{<<"400">>, _}, <<"Invalid owner JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Invalid owner JID">>)} =
         post(admin, Path, Body#{owner := <<"@invalid">>}),
-    {{<<"404">>, _}, <<"MUC Light server not found">>} =
+    {{<<"404">>, _}, ?MSG(<<"MUC Light server not found">>)} =
         post(admin, path([domain_helper:domain()]), Body).
 
 create_identifiable_room_errors(Config) ->
@@ -218,19 +218,19 @@ create_identifiable_room_errors(Config) ->
     Body = #{id => <<"ID">>, name => <<"NameA">>, owner => AliceJid, subject => <<"Lewis Carol">>},
     {{<<"201">>, _}, _RoomJID} = putt(admin, Path, Body#{id => <<"ID1">>}),
     % Fails to create a room with the same ID
-    {{<<"400">>, _}, <<"Missing room ID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing room ID">>)} =
         putt(admin, Path, maps:remove(id, Body)),
-    {{<<"400">>, _}, <<"Missing room name">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing room name">>)} =
         putt(admin, Path, maps:remove(name, Body)),
-    {{<<"400">>, _}, <<"Missing owner JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing owner JID">>)} =
         putt(admin, Path, maps:remove(owner, Body)),
-    {{<<"400">>, _}, <<"Missing room subject">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing room subject">>)} =
         putt(admin, Path, maps:remove(subject, Body)),
-    {{<<"400">>, _}, <<"Invalid owner JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Invalid owner JID">>)} =
         putt(admin, Path, Body#{owner := <<"@invalid">>}),
-    {{<<"403">>, _}, <<"Room already exists">>} =
+    {{<<"403">>, _}, ?MSG(<<"Room already exists">>)} =
         putt(admin, Path, Body#{id := <<"ID1">>, name := <<"NameB">>}),
-    {{<<"404">>, _}, <<"MUC Light server not found">>} =
+    {{<<"404">>, _}, ?MSG(<<"MUC Light server not found">>)} =
         putt(admin, path([domain_helper:domain()]), Body).
 
 invite_to_room_errors(Config) ->
@@ -241,17 +241,17 @@ invite_to_room_errors(Config) ->
     muc_light_helper:create_room(Name, muc_light_domain(), alice, [], Config1, <<"v1">>),
     Path = path([muc_light_domain(), Name, "participants"]),
     Body = #{sender => AliceJid, recipient => BobJid},
-    {{<<"400">>, _}, <<"Missing recipient JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing recipient JID">>)} =
         rest_helper:post(admin, Path, maps:remove(recipient, Body)),
-    {{<<"400">>, _}, <<"Missing sender JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing sender JID">>)} =
         rest_helper:post(admin, Path, maps:remove(sender, Body)),
-    {{<<"400">>, _}, <<"Invalid recipient JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Invalid recipient JID">>)} =
         rest_helper:post(admin, Path, Body#{recipient := <<"@invalid">>}),
-    {{<<"400">>, _}, <<"Invalid sender JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Invalid sender JID">>)} =
         rest_helper:post(admin, Path, Body#{sender := <<"@invalid">>}),
-    {{<<"403">>, _}, <<"Given user does not occupy this room">>} =
+    {{<<"403">>, _}, ?MSG(<<"Given user does not occupy this room">>)} =
         rest_helper:post(admin, Path, Body#{sender := BobJid, recipient := AliceJid}),
-    {{<<"404">>, _}, <<"MUC Light server not found">>} =
+    {{<<"404">>, _}, ?MSG(<<"MUC Light server not found">>)} =
         rest_helper:post(admin, path([domain(), Name, "participants"]), Body).
 
 send_message_errors(Config) ->
@@ -264,31 +264,31 @@ send_message_errors(Config) ->
     Body = #{from => AliceJid, body => <<"hello">>},
     {{<<"204">>, _}, <<>>} =
         rest_helper:post(admin, Path, Body),
-    {{<<"400">>, _}, <<"Missing message body">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing message body">>)} =
         rest_helper:post(admin, Path, maps:remove(body, Body)),
-    {{<<"400">>, _}, <<"Missing sender JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Missing sender JID">>)} =
         rest_helper:post(admin, Path, maps:remove(from, Body)),
-    {{<<"400">>, _}, <<"Invalid sender JID">>} =
+    {{<<"400">>, _}, ?MSG(<<"Invalid sender JID">>)} =
         rest_helper:post(admin, Path, Body#{from := <<"@invalid">>}),
-    {{<<"403">>, _}, <<"Given user does not occupy this room">>} =
+    {{<<"403">>, _}, ?MSG(<<"Given user does not occupy this room">>)} =
         rest_helper:post(admin, Path, Body#{from := BobJid}),
-    {{<<"403">>, _}, <<"Given user does not occupy this room">>} =
+    {{<<"403">>, _}, ?MSG(<<"Given user does not occupy this room">>)} =
         rest_helper:post(admin, path([muc_light_domain(), "badroom", "messages"]), Body),
-    {{<<"404">>, _}, <<"MUC Light server not found">>} =
+    {{<<"404">>, _}, ?MSG(<<"MUC Light server not found">>)} =
         rest_helper:post(admin, path([domain(), Name, "messages"]), Body).
 
 delete_room_errors(_Config) ->
-    {{<<"400">>, _}, <<"Invalid room ID or domain name">>} =
+    {{<<"400">>, _}, ?MSG(<<"Invalid room ID or domain name">>)} =
         delete(admin, path([muc_light_domain(), "@badroom", "management"])),
     {{<<"404">>, _}, _} =
         delete(admin, path([muc_light_domain()])),
     {{<<"404">>, _}, _} =
         delete(admin, path([muc_light_domain(), "badroom"])),
-    {{<<"404">>, _}, <<"Cannot remove not existing room">>} =
+    {{<<"404">>, _}, ?MSG(<<"Cannot remove not existing room">>)} =
         delete(admin, path([muc_light_domain(), "badroom", "management"])),
-    {{<<"404">>, _}, <<"MUC Light server not found">>} =
+    {{<<"404">>, _}, ?MSG(<<"MUC Light server not found">>)} =
         delete(admin, path([domain(), "badroom", "management"])),
-    {{<<"404">>, _}, <<"MUC Light server not found">>} =
+    {{<<"404">>, _}, ?MSG(<<"MUC Light server not found">>)} =
         delete(admin, path(["baddomain", "badroom", "management"])).
 
 %%--------------------------------------------------------------------

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -23,6 +23,8 @@
 -import(domain_helper, [domain/0]).
 -import(config_parser_helper, [config/2]).
 
+-define(MSG(Text), {[{<<"message">>, Text}]}).
+
 suite() ->
     require_rpc_nodes([mim, mim2, mim3]).
 
@@ -829,7 +831,7 @@ rest_can_delete_domain(Config) ->
 
 rest_cannot_delete_domain_without_correct_type(Config) ->
     rest_put_domain(Config, <<"example.db">>, <<"type1">>),
-    {{<<"403">>, <<"Forbidden">>}, <<"Wrong host type">>} =
+    {{<<"403">>, <<"Forbidden">>}, ?MSG(<<"Wrong host type">>)} =
         rest_delete_domain(Config, <<"example.db">>, <<"type2">>),
     {ok, _} = select_domain(mim(), <<"example.db">>).
 
@@ -838,20 +840,20 @@ rest_delete_missing_domain(Config) ->
         rest_delete_domain(Config, <<"example.db">>, <<"type1">>).
 
 rest_cannot_enable_missing_domain(Config) ->
-    {{<<"404">>, <<"Not Found">>}, <<"Domain not found">>} =
+    {{<<"404">>, <<"Not Found">>}, ?MSG(<<"Domain not found">>)} =
         rest_patch_enabled(Config, <<"example.db">>, true).
 
 rest_cannot_insert_domain_twice_with_another_host_type(Config) ->
     rest_put_domain(Config, <<"example.db">>, <<"type1">>),
-    {{<<"409">>, <<"Conflict">>}, <<"Duplicate domain">>} =
+    {{<<"409">>, <<"Conflict">>}, ?MSG(<<"Duplicate domain">>)} =
         rest_put_domain(Config, <<"example.db">>, <<"type2">>).
 
 rest_cannot_insert_domain_with_unknown_host_type(Config) ->
-    {{<<"403">>,<<"Forbidden">>}, <<"Unknown host type">>} =
+    {{<<"403">>,<<"Forbidden">>}, ?MSG(<<"Unknown host type">>)} =
         rest_put_domain(Config, <<"example.db">>, <<"type6">>).
 
 rest_cannot_delete_domain_with_unknown_host_type(Config) ->
-    {{<<"403">>,<<"Forbidden">>}, <<"Unknown host type">>} =
+    {{<<"403">>,<<"Forbidden">>}, ?MSG(<<"Unknown host type">>)} =
         rest_delete_domain(Config, <<"example.db">>, <<"type6">>).
 
 %% auth provided, but not configured:
@@ -919,7 +921,7 @@ rest_cannot_select_domain_without_auth(Config) ->
 
 
 rest_cannot_disable_missing_domain(Config) ->
-    {{<<"404">>, <<"Not Found">>}, <<"Domain not found">>} =
+    {{<<"404">>, <<"Not Found">>}, ?MSG(<<"Domain not found">>)} =
         rest_patch_enabled(Config, <<"example.db">>, false).
 
 rest_can_enable_domain(Config) ->
@@ -936,89 +938,89 @@ rest_can_select_domain(Config) ->
         rest_select_domain(Config, <<"example.db">>).
 
 rest_cannot_select_domain_if_domain_not_found(Config) ->
-    {{<<"404">>, <<"Not Found">>}, <<"Domain not found">>} =
+    {{<<"404">>, <<"Not Found">>}, ?MSG(<<"Domain not found">>)} =
         rest_select_domain(Config, <<"example.db">>).
 
 rest_cannot_put_domain_without_host_type(Config) ->
-    {{<<"400">>, <<"Bad Request">>}, <<"'host_type' field is missing">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"'host_type' field is missing">>)} =
         putt_domain_with_custom_body(Config, #{}).
 
 rest_cannot_put_domain_without_body(Config) ->
-    {{<<"400">>, <<"Bad Request">>}, <<"Invalid request body">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"Invalid request body">>)} =
         putt_domain_with_custom_body(Config, <<>>).
 
 rest_cannot_put_domain_with_invalid_json(Config) ->
-    {{<<"400">>, <<"Bad Request">>}, <<"Invalid request body">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"Invalid request body">>)} =
         putt_domain_with_custom_body(Config, <<"{kek">>).
 
 rest_cannot_put_domain_with_invalid_name(Config) ->
-    {{<<"400">>, <<"Bad Request">>}, <<"Invalid domain name">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"Invalid domain name">>)} =
         rest_put_domain(Config, <<"%f3">>, <<"type1">>). % nameprep fails for ASCII code 243
 
 rest_cannot_put_domain_when_it_is_static(Config) ->
-    {{<<"403">>, <<"Forbidden">>}, <<"Domain is static">>} =
+    {{<<"403">>, <<"Forbidden">>}, ?MSG(<<"Domain is static">>)} =
         rest_put_domain(Config, <<"example.cfg">>, <<"type1">>).
 
 rest_cannot_delete_domain_without_host_type(Config) ->
-    {{<<"400">>, <<"Bad Request">>}, <<"'host_type' field is missing">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"'host_type' field is missing">>)} =
         delete_custom(Config, admin, <<"/domains/example.db">>, #{}).
 
 rest_cannot_delete_domain_without_body(Config) ->
-    {{<<"400">>, <<"Bad Request">>}, <<"Invalid request body">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"Invalid request body">>)} =
         delete_custom(Config, admin, <<"/domains/example.db">>, <<>>).
 
 rest_cannot_delete_domain_with_invalid_json(Config) ->
-    {{<<"400">>, <<"Bad Request">>}, <<"Invalid request body">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"Invalid request body">>)} =
         delete_custom(Config, admin, <<"/domains/example.db">>, <<"{kek">>).
 
 rest_cannot_delete_domain_when_it_is_static(Config) ->
-    {{<<"403">>, <<"Forbidden">>}, <<"Domain is static">>} =
+    {{<<"403">>, <<"Forbidden">>}, ?MSG(<<"Domain is static">>)} =
         rest_delete_domain(Config, <<"example.cfg">>, <<"type1">>).
 
 rest_cannot_patch_domain_without_enabled_field(Config) ->
-    {{<<"400">>, <<"Bad Request">>}, <<"'enabled' field is missing">>} =
+    {{<<"400">>, <<"Bad Request">>}, ?MSG(<<"'enabled' field is missing">>)} =
         patch_custom(Config, admin, <<"/domains/example.db">>, #{}).
 
 rest_cannot_patch_domain_without_body(Config) ->
-    {{<<"400">>,<<"Bad Request">>}, <<"Invalid request body">>} =
+    {{<<"400">>,<<"Bad Request">>}, ?MSG(<<"Invalid request body">>)} =
         patch_custom(Config, admin, <<"/domains/example.db">>, <<>>).
 
 rest_cannot_patch_domain_with_invalid_json(Config) ->
-    {{<<"400">>,<<"Bad Request">>}, <<"Invalid request body">>} =
+    {{<<"400">>,<<"Bad Request">>}, ?MSG(<<"Invalid request body">>)} =
         patch_custom(Config, admin, <<"/domains/example.db">>, <<"{kek">>).
 
 %% SQL query is mocked to fail
 rest_insert_domain_fails_if_db_fails(Config) ->
-    {{<<"500">>, <<"Internal Server Error">>}, <<"Database error">>} =
+    {{<<"500">>, <<"Internal Server Error">>}, ?MSG(<<"Database error">>)} =
         rest_put_domain(Config, <<"example.db">>, <<"type1">>).
 
 rest_insert_domain_fails_if_service_disabled(Config) ->
     service_disabled(mim()),
-    {{<<"403">>, <<"Forbidden">>}, <<"Service disabled">>} =
+    {{<<"403">>, <<"Forbidden">>}, ?MSG(<<"Service disabled">>)} =
         rest_put_domain(Config, <<"example.db">>, <<"type1">>).
 
 %% SQL query is mocked to fail
 rest_delete_domain_fails_if_db_fails(Config) ->
-    {{<<"500">>, <<"Internal Server Error">>}, <<"Database error">>} =
+    {{<<"500">>, <<"Internal Server Error">>}, ?MSG(<<"Database error">>)} =
         rest_delete_domain(Config, <<"example.db">>, <<"type1">>).
 
 rest_delete_domain_fails_if_service_disabled(Config) ->
     service_disabled(mim()),
-    {{<<"403">>, <<"Forbidden">>}, <<"Service disabled">>} =
+    {{<<"403">>, <<"Forbidden">>}, ?MSG(<<"Service disabled">>)} =
         rest_delete_domain(Config, <<"example.db">>, <<"type1">>).
 
 %% SQL query is mocked to fail
 rest_enable_domain_fails_if_db_fails(Config) ->
-    {{<<"500">>, <<"Internal Server Error">>}, <<"Database error">>} =
+    {{<<"500">>, <<"Internal Server Error">>}, ?MSG(<<"Database error">>)} =
         rest_patch_enabled(Config, <<"example.db">>, true).
 
 rest_enable_domain_fails_if_service_disabled(Config) ->
     service_disabled(mim()),
-    {{<<"403">>, <<"Forbidden">>}, <<"Service disabled">>} =
+    {{<<"403">>, <<"Forbidden">>}, ?MSG(<<"Service disabled">>)} =
         rest_patch_enabled(Config, <<"example.db">>, true).
 
 rest_cannot_enable_domain_when_it_is_static(Config) ->
-    {{<<"403">>, <<"Forbidden">>}, <<"Domain is static">>} =
+    {{<<"403">>, <<"Forbidden">>}, ?MSG(<<"Domain is static">>)} =
         rest_patch_enabled(Config, <<"example.cfg">>, true).
 
 rest_delete_domain_cleans_data_from_mam(Config) ->

--- a/src/mongoose_admin_api/mongoose_admin_api.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api.erl
@@ -158,7 +158,8 @@ error_response(ErrorType, Message, Req, State) ->
                                  error_type => ErrorType,
                                  message => BinMessage,
                                  req => Req}),
-    Req1 = cowboy_req:reply(error_code(ErrorType), #{}, BinMessage, Req),
+    Response = jiffy:encode(#{message => BinMessage}),
+    Req1 = cowboy_req:reply(error_code(ErrorType), #{}, Response, Req),
     {stop, Req1, State}.
 
 -spec error_code(error_type()) -> non_neg_integer().


### PR DESCRIPTION
The `Content-Type` is specified as `application/json`, and this type should be returned.
Also: Swagger UI does not show the response at all when the returned type is invalid.