### PR TITLE
C2s/pubsub

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -73,9 +73,9 @@
 {suites, "tests", mongoose_elasticsearch_SUITE}.
 % {suites, "tests", mongooseimctl_SUITE}.
 % {suites, "tests", muc_SUITE}.
-% {suites, "tests", muc_http_api_SUITE}.
-% {suites, "tests", muc_light_SUITE}.
-% {suites, "tests", muc_light_http_api_SUITE}.
+{suites, "tests", muc_http_api_SUITE}.
+{suites, "tests", muc_light_SUITE}.
+{suites, "tests", muc_light_http_api_SUITE}.
 % {suites, "tests", muc_light_legacy_SUITE}.
 {suites, "tests", oauth_SUITE}.
 {suites, "tests", offline_SUITE}.
@@ -85,8 +85,8 @@
 {suites, "tests", presence_SUITE}.
 {suites, "tests", privacy_SUITE}.
 {suites, "tests", private_SUITE}.
-% {suites, "tests", pubsub_SUITE}.
-% {suites, "tests", pubsub_s2s_SUITE}.
+{suites, "tests", pubsub_SUITE}.
+{suites, "tests", pubsub_s2s_SUITE}.
 % {suites, "tests", push_SUITE}.
 {suites, "tests", push_http_SUITE}.
 % {suites, "tests", push_integration_SUITE}.

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -569,8 +569,15 @@ maybe_retry_state({wait_for_sasl_response, SaslState, Retries}) ->
 verify_from(El, StateJid) ->
     case exml_query:attr(El, <<"from">>) of
         undefined -> true;
-        SJid ->
-            jid:are_equal(jid:from_binary(SJid), StateJid)
+        GJid ->
+            case jid:from_binary(GJid) of
+                error ->
+                    false;
+                #jid{lresource = <<>>} = GivenJid ->
+                    jid:are_bare_equal(GivenJid, StateJid);
+                #jid{} = GivenJid ->
+                    jid:are_equal(GivenJid, StateJid)
+            end
     end.
 
 -spec handle_foreign_packet(c2s_data(), c2s_state(), exml:element()) -> fsm_res().


### PR DESCRIPTION
Really what needed fixing was the `from` verification in the core c2s code, that enabled not only pubsub but also another bunch of suites.