### PR TITLE
Refactored hook handlers in mod_global_distrib_bounce module

### DIFF
--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -224,9 +224,9 @@ remove_metadata(Acc, Key) ->
 %% Hooks implementation
 %%--------------------------------------------------------------------
 
--spec maybe_reroute(drop, _, _) -> drop;
+-spec maybe_reroute(drop, _, _) -> {ok, drop};
                    (FPacket, Params, Extra) -> {ok, drop} | {ok, FPacket} when
-                FPacket :: {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()},
+                FPacket :: {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()},    
                 Params :: map(),
                 Extra :: map().
 maybe_reroute(drop, _, _) -> {ok, drop};

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1515,8 +1515,11 @@ pubsub_publish_item(Server, NodeId, Publisher, ServiceJID, ItemId, BrPayload) ->
     LocalHost :: jid:server(),
     Result :: any().
 mod_global_distrib_known_recipient(GlobalHost, From, To, LocalHost) ->
+    Params = #{from => From, to => To, target_host => LocalHost},
+    Args = [From, To, LocalHost],
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     run_hook_for_host_type(mod_global_distrib_known_recipient, GlobalHost, ok,
-                           [From, To, LocalHost]).
+                           ParamsWithLegacyArgs).
 
 %%% @doc The `mod_global_distrib_unknown_recipient' hook is called when
 %%% the recipient is unknown to `global_distrib'.
@@ -1525,7 +1528,9 @@ mod_global_distrib_known_recipient(GlobalHost, From, To, LocalHost) ->
     Info :: filter_packet_acc(),
     Result :: any().
 mod_global_distrib_unknown_recipient(GlobalHost, Info) ->
-    run_hook_for_host_type(mod_global_distrib_unknown_recipient, GlobalHost, Info, []).
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(#{}, []),
+    run_hook_for_host_type(mod_global_distrib_unknown_recipient, GlobalHost, Info,
+                           ParamsWithLegacyArgs).
 
 
 %%%----------------------------------------------------------------------


### PR DESCRIPTION
This PR changes all hook handlers in `mod_global_distrib_bounce` module to `gen_hook` format.
Note: I added `mod_global_distrib_bounce: maybe_store_message/3` to the list of handlers which use drop atom as a return value. They shall be refactored in another task.

