### PR TITLE
Refactored hook handler in mod_global_distrib_disco module

### DIFF
--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1309,7 +1309,8 @@ disco_sm_identity(Acc = #{host_type := HostType}) ->
 %%% @doc `disco_local_items' hook is called to extract items associated with the server.
 -spec disco_local_items(mongoose_disco:item_acc()) -> mongoose_disco:item_acc().
 disco_local_items(Acc = #{host_type := HostType}) ->
-    run_hook_for_host_type(disco_local_items, HostType, Acc, []).
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(#{}, []),
+    run_hook_for_host_type(disco_local_items, HostType, Acc, ParamsWithLegacyArgs).
 
 %%% @doc `disco_sm_items' hook is called to get the items associated
 %%% with the client when a discovery IQ gets to session management.


### PR DESCRIPTION
This PR changes all hook handlers in `mod_global_distrib_disco` module to `gen_hook` format.