### PR TITLE
Don't override included overlay vars

### DIFF
--- a/big_tests/dynamic_domains.config
+++ b/big_tests/dynamic_domains.config
@@ -27,7 +27,7 @@
                  {hidden_service_port, 8189},
                  {gd_endpoint_port, 5555},
                  {http_notifications_port, 8000}]},
-         {mim2, [{node, ejabberd2@localhost},
+         {mim2, [{node, mongooseim2@localhost},
                  {domain, <<"domain.example.com">>},
                  {host_type, <<"test type">>},
                  {dynamic_domains, [{<<"test type">>, [<<"domain.example.com">>]}]},

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -7,7 +7,7 @@
 %%       See s2s_SUITE for example on using `hosts` to RPC into nodes (uses CT "require").
 %% the Erlang node name of tested ejabberd/MongooseIM
 {ejabberd_node, 'mongooseim@localhost'}.
-{ejabberd2_node, 'ejabberd2@localhost'}.
+{ejabberd2_node, 'mongooseim2@localhost'}.
 {ejabberd_cookie, ejabberd}.
 {ejabberd_string_format, bin}.
 
@@ -40,7 +40,7 @@
                  {hidden_service_port, 8189},
                  {gd_endpoint_port, 5555},
                  {http_notifications_port, 8000}]},
-         {mim2, [{node, ejabberd2@localhost},
+         {mim2, [{node, mongooseim2@localhost},
                  {domain, <<"localhost">>},
                  {host_type, <<"localhost">>},
                  {vars, "mim2"},

--- a/rebar.config
+++ b/rebar.config
@@ -160,7 +160,7 @@
  ]}.
 
 {profiles, [ {prod,    [{relx, [ {dev_mode, false},
-                                 {overlay_vars, "rel/vars-toml.config"},
+                                 {overlay_vars, "rel/prod.vars-toml.config"},
                                  {overlay, [{template, "rel/files/mongooseim.toml", "etc/mongooseim.toml"}]} ]},
                                  {erl_opts, [{d, 'PROD_NODE'}]} ]},
              %% development nodes

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -1,16 +1,17 @@
-"./vars-toml.config".
-
+%% vm.args
 {node_name, "fed1@localhost"}.
 
+%% mongooseim.toml
 {c2s_port, 5242}.
+{outgoing_s2s_port, 5269}.
 {incoming_s2s_port, 5299}.
 {http_port, 5282}.
 {https_port, 5287}.
-{http_api_endpoint_port, 5294}.
-{http_api_client_endpoint_port, 8095}.
 {http_graphql_api_admin_endpoint_port, 5556}.
 {http_graphql_api_domain_admin_endpoint_port, 5546}.
 {http_graphql_api_user_endpoint_port, 5566}.
+{http_api_endpoint_port, 5294}.
+{http_api_client_endpoint_port, 8095}.
 
 %% This node is for s2s testing.
 %% "localhost" host should NOT be defined.
@@ -38,30 +39,16 @@
     host = \"domain.example.com\"
     ip_address = \"127.0.0.1\"
 "}.
-{s2s_default_policy, "\"allow\""}.
-{highload_vm_args, ""}.
-{listen_service, false}.
 
 {tls_config, "tls.verify_mode = \"none\"
   tls.certfile = \"priv/ssl/fake_server.pem\"
   tls.mode = \"starttls\"
   tls.ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
 
-{http_api_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{ http_api_endpoint_port }}"}.
-{http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
-{http_graphql_api_admin_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{http_graphql_api_admin_endpoint_port}}"}.
-{http_graphql_api_domain_admin_endpoint, "ip_address = \"0.0.0.0\"
-  port = {{http_graphql_api_domain_admin_endpoint_port}}"}.
-{http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
-  port = {{http_graphql_api_user_endpoint_port}}"}.
-
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 
-{mod_last, false}.
-{mod_private, false}.
-{mod_privacy, false}.
-{mod_blocking, false}.
-{mod_offline, false}.
+{mod_cache_users, ""}.
+
+%% Include common vars shared by all profiles
+"./vars-toml.config".

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -5,8 +5,12 @@
   default_server_domain = {{{default_server_domain}}}
   registration_timeout = "infinity"
   language = "en"
+  {{#all_metrics_are_global}}
   all_metrics_are_global = {{{all_metrics_are_global}}}
+  {{/all_metrics_are_global}}
+  {{#sm_backend}}
   sm_backend = {{{sm_backend}}}
+  {{/sm_backend}}
   max_fsm_queue = 1000
   {{#http_server_name}}
   http_server_name = {{{http_server_name}}}
@@ -351,7 +355,9 @@
   {{#s2s_certfile}}
   certfile = {{{s2s_certfile}}}
   {{/s2s_certfile}}
+  {{#s2s_default_policy}}
   default_policy = {{{s2s_default_policy}}}
+  {{/s2s_default_policy}}
   outgoing.port = {{{outgoing_s2s_port}}}
   {{#s2s_addr}}
 

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -1,10 +1,21 @@
-"./vars-toml.config".
+%% vm.args
+{node_name, "mongooseim@localhost"}.
 
+%% mongooseim.toml
+{c2s_port, 5222}.
 {c2s_tls_port, 5223}.
 {outgoing_s2s_port, 5299}.
+{incoming_s2s_port, 5269}.
+{http_port, 5280}.
+{https_port, 5285}.
 {service_port, 8888}.
 {kicking_service_port, 8666}.
 {hidden_service_port, 8189}.
+{http_graphql_api_admin_endpoint_port, 5551}.
+{http_graphql_api_domain_admin_endpoint_port, 5541}.
+{http_graphql_api_user_endpoint_port, 5561}.
+{http_api_endpoint_port, 8088}.
+{http_api_client_endpoint_port, 8089}.
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
 {host_types, "\"test type\", \"dummy auth\", \"anonymous\""}.
@@ -41,10 +52,9 @@
 {s2s_addr, "[[s2s.address]]
     host = \"fed1\"
     ip_address = \"127.0.0.1\""}.
-{s2s_default_policy, "\"allow\""}.
 
-% Disable highload args to save memory for dev builds
-{highload_vm_args, ""}.
+{tls_config, "tls.verify_mode = \"none\"
+  tls.certfile = \"priv/ssl/fake_server.pem\""}.
 
 {secondary_c2s,
   "[[listen.c2s]]
@@ -79,11 +89,10 @@
 
 {mod_cache_users, "  time_to_live = 2
   number_of_segments = 5\n"}.
-{mod_last, false}.
-{mod_private, false}.
-{mod_privacy, false}.
-{mod_blocking, false}.
-{mod_offline, false}.
 {zlib, "10_000"}.
+
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
+
+%% Include common vars shared by all profiles
+"./vars-toml.config".

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -1,9 +1,10 @@
-"./vars-toml.config".
+%% vm.args
+{node_name, "mongooseim2@localhost"}.
 
-{node_name, "ejabberd2@localhost"}.
-
+%% mongooseim.toml
 {c2s_port, 5232}.
 {c2s_tls_port, 5233}.
+{outgoing_s2s_port, 5269}.
 {incoming_s2s_port, 5279}.
 {http_port, 5281}.
 {https_port, 5286}.
@@ -20,18 +21,6 @@
 {s2s_addr, "[[s2s.address]]
     host = \"localhost2\"
     ip_address = \"127.0.0.1\""}.
-{s2s_default_policy, "\"allow\""}.
-{highload_vm_args, ""}.
-
-{http_graphql_api_admin_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{http_graphql_api_admin_endpoint_port}}"}.
-{http_graphql_api_domain_admin_endpoint, "ip_address = \"0.0.0.0\"
-  port = {{http_graphql_api_domain_admin_endpoint_port}}"}.
-{http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
-  port = {{http_graphql_api_user_endpoint_port}}"}.
-{http_api_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{ http_api_endpoint_port }}"}.
-{http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
 
 {tls_config, "tls.verify_mode = \"none\"
   tls.certfile = \"priv/ssl/fake_server.pem\"
@@ -68,9 +57,5 @@
   modules = { }
   auth.dummy = { }"}.
 
-{mod_cache_users, false}.
-{mod_last, false}.
-{mod_private, false}.
-{mod_privacy, false}.
-{mod_blocking, false}.
-{mod_offline, false}.
+%% Include common vars shared by all profiles
+"./vars-toml.config".

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -1,18 +1,22 @@
-"./vars-toml.config".
-
+%% vm.args
 {node_name, "mongooseim3@localhost"}.
 
+%% mongooseim.toml
 {c2s_port, 5262}.
 {c2s_tls_port, 5263}.
 {outgoing_s2s_port, 5295}.
 {incoming_s2s_port, 5291}.
 {http_port, 5283}.
 {https_port, 5290}.
-{http_api_endpoint_port, 8092}.
-{http_api_client_endpoint_port, 8193}.
 {http_graphql_api_admin_endpoint_port, 5553}.
 {http_graphql_api_domain_admin_endpoint_port, 5543}.
 {http_graphql_api_user_endpoint_port, 5563}.
+{http_api_endpoint_port, 8092}.
+{http_api_client_endpoint_port, 8193}.
+
+"./vars-toml.config".
+
+{node_name, "mongooseim3@localhost"}.
 
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
 {default_server_domain, "\"localhost\""}.
@@ -20,8 +24,6 @@
 {s2s_addr, "[[s2s.address]]
     host = \"localhost2\"
     ip_address = \"127.0.0.1\""}.
-{s2s_default_policy, "\"allow\""}.
-{highload_vm_args, ""}.
 {listen_service, ""}.
 
 {tls_config, "tls.verify_mode = \"none\"
@@ -41,22 +43,8 @@
   tls.module = \"just_tls\"
   tls.ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
 
-{http_graphql_api_admin_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{http_graphql_api_admin_endpoint_port}}"}.
-{http_graphql_api_domain_admin_endpoint, "ip_address = \"0.0.0.0\"
-  port = {{http_graphql_api_domain_admin_endpoint_port}}"}.
-{http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
-  port = {{http_graphql_api_user_endpoint_port}}"}.
-{http_api_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{ http_api_endpoint_port }}"}.
-{http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
-
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 
-{mod_cache_users, false}.
-{mod_last, false}.
-{mod_private, false}.
-{mod_privacy, false}.
-{mod_blocking, false}.
-{mod_offline, false}.
+%% Include common vars shared by all profiles
+"./vars-toml.config".

--- a/rel/prod.vars-toml.config
+++ b/rel/prod.vars-toml.config
@@ -1,0 +1,38 @@
+%% vm.args
+{node_name, "mongooseim@localhost"}.
+{highload_vm_args, "+P 10000000 -env ERL_MAX_PORTS 250000"}.
+
+%% mongooseim.toml
+{c2s_port, 5222}.
+{outgoing_s2s_port, 5269}.
+{incoming_s2s_port, 5269}.
+{http_port, 5280}.
+{https_port, 5285}.
+{http_graphql_api_admin_endpoint_port, 5551}.
+{http_graphql_api_domain_admin_endpoint_port, 5541}.
+{http_graphql_api_user_endpoint_port, 5561}.
+{http_api_endpoint_port, 8088}.
+{http_api_client_endpoint_port, 8089}.
+
+{hosts, "\"localhost\""}.
+{default_server_domain, "\"localhost\""}.
+{s2s_default_policy, "\"deny\""}.
+{listen_service, "[[listen.service]]
+  port = 8888
+  access = \"all\"
+  shaper_rule = \"fast\"
+  ip_address = \"127.0.0.1\"
+  password = \"secret\""}.
+
+%% "" means that the module is enabled without any options
+{mod_cache_users, ""}.
+{mod_last, ""}.
+{mod_offline, ""}.
+{mod_privacy, ""}.
+{mod_blocking, ""}.
+{mod_private, ""}.
+{tls_config, "tls.verify_mode = \"none\"
+  tls.certfile = \"priv/ssl/fake_server.pem\""}.
+
+%% Include common vars shared by all profiles
+"./vars-toml.config".

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -1,17 +1,18 @@
-"./vars-toml.config".
-
+%% vm.args
 {node_name, "reg1@localhost"}.
 
+%% mongooseim.toml
 {c2s_port, 5252}.
+{outgoing_s2s_port, 5269}.
 {incoming_s2s_port, 5298}.
 {http_port, 5272}.
 {https_port, 5277}.
 {service_port, 9990}.
-{http_api_endpoint_port, 8074}.
-{http_api_client_endpoint_port, 8075}.
-{http_qraphql_api_admin_endpoint_port, 5554}.
+{http_graphql_api_admin_endpoint_port, 5554}.
 {http_graphql_api_domain_admin_endpoint_port, 5544}.
 {http_graphql_api_user_endpoint_port, 5564}.
+{http_api_endpoint_port, 8074}.
+{http_api_client_endpoint_port, 8075}.
 
 %% This node is for global distribution testing.
 %% reg is short for region.
@@ -27,7 +28,6 @@
   [[s2s.address]]
     host = \"localhost.bis\"
     ip_address = \"127.0.0.1\""}.
-{s2s_default_policy, "\"allow\""}.
 {listen_service, "[[listen.service]]
   port = {{ service_port }}
   access = \"all\"
@@ -39,23 +39,11 @@
   tls.certfile = \"priv/ssl/fake_server.pem\"
   tls.mode = \"starttls\"
   tls.ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
-{secondary_c2s, ""}.
-
-{http_graphql_api_admin_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{http_qraphql_api_admin_endpoint_port}}"}.
-{http_graphql_api_domain_admin_endpoint, "ip_address = \"0.0.0.0\"
-  port = {{http_graphql_api_domain_admin_endpoint_port}}"}.
-{http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
-  port = {{http_graphql_api_user_endpoint_port}}"}.
-{http_api_endpoint, "ip_address = \"127.0.0.1\"
-  port = {{ http_api_endpoint_port }}"}.
-{http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
 
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 
-{mod_last, false}.
-{mod_private, false}.
-{mod_privacy, false}.
-{mod_blocking, false}.
-{mod_offline, false}.
+{mod_cache_users, ""}.
+
+%% Include common vars shared by all profiles
+"./vars-toml.config".

--- a/rel/vars-toml.config
+++ b/rel/vars-toml.config
@@ -1,41 +1,7 @@
-{node_name, "mongooseim@localhost"}.
-
-{c2s_port, 5222}.
-{outgoing_s2s_port, 5269}.
-{incoming_s2s_port, 5269}.
-{http_port, 5280}.
-{https_port, 5285}.
-{http_graphql_api_admin_endpoint_port, 5551}.
-{http_graphql_api_domain_admin_endpoint_port, 5541}.
-{http_graphql_api_user_endpoint_port, 5561}.
-
-% vm.args
-{highload_vm_args, "+P 10000000 -env ERL_MAX_PORTS 250000"}.
-
-% TOML config
-{hosts, "\"localhost\""}.
-{default_server_domain, "\"localhost\""}.
-{s2s_default_policy, "\"deny\""}.
-{listen_service, "[[listen.service]]
-  port = 8888
-  access = \"all\"
-  shaper_rule = \"fast\"
-  ip_address = \"127.0.0.1\"
-  password = \"secret\""}.
-
 %% "" means that the module is enabled without any options
-{mod_cache_users, ""}.
-{mod_last, ""}.
-{mod_offline, ""}.
-{mod_privacy, ""}.
-{mod_blocking, ""}.
-{mod_private, ""}.
 {mod_roster, ""}.
 {mod_vcard, "  host = \"vjud.@HOST@\"\n"}.
-{sm_backend, "\"mnesia\""}.
 {auth_method, "internal"}.
-{tls_config, "tls.verify_mode = \"none\"
-  tls.certfile = \"priv/ssl/fake_server.pem\""}.
 {https_config, "tls.verify_mode = \"none\"
   tls.certfile = \"priv/ssl/fake_cert.pem\"
   tls.keyfile = \"priv/ssl/fake_key.pem\"
@@ -47,11 +13,10 @@
 {http_graphql_api_user_endpoint, "ip_address = \"0.0.0.0\"
   port = {{http_graphql_api_user_endpoint_port}}"}.
 {http_api_endpoint, "ip_address = \"127.0.0.1\"
-  port = 8088"}.
-{http_api_client_endpoint, "port = 8089"}.
+  port = {{http_api_endpoint_port}}"}.
+{http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
 {s2s_use_starttls, "\"optional\""}.
 {s2s_certfile, "\"priv/ssl/fake_server.pem\""}.
-{all_metrics_are_global, "false"}.
 
 "./configure.vars.config".
 


### PR DESCRIPTION
There is an issue with the overriding logic in `relx`: included vars override previously defined ones, but there is no simple
way of overriding the included vars other than including another file. This way making the `dev` releases resulted in incorrect vars.
Big tests succeeded because they had their own overriding logic.

This change ensures that no vars are overridden. The included file is always at the bottom, and in this case both `relx` and our templating scripts work the same (included vars override the previous ones).

Another changes:
- Avoid specifying defaults explicitly - they are documented, and the user could define them with different values if necessary.
- Rename `mim2` node for consistency.

Possible further improvements:
- Improve `relx` with a more intuitive and useful overriding logic.
- Adjust our templating scripts to work like relx - I am reluctant to do so, because our scripts are more intuitive, and the logic extends nicely to merging multiple files, what we do for big tests.