### PR TITLE
C2s/metrics

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -56,10 +56,10 @@
 {suites, "tests", mam_SUITE}.
 {suites, "tests", mam_proper_SUITE}.
 {suites, "tests", mam_send_message_SUITE}.
-% {suites, "tests", metrics_api_SUITE}.
-% {suites, "tests", metrics_c2s_SUITE}.
+{suites, "tests", metrics_api_SUITE}.
+{suites, "tests", metrics_c2s_SUITE}.
 {suites, "tests", metrics_register_SUITE}.
-% {suites, "tests", metrics_roster_SUITE}.
+{suites, "tests", metrics_roster_SUITE}.
 {suites, "tests", metrics_session_SUITE}.
 {suites, "tests", mod_blocking_SUITE}.
 {suites, "tests", mod_event_pusher_http_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -77,15 +77,15 @@
 {suites, "tests", mam_proper_SUITE}.
 {suites, "tests", mam_send_message_SUITE}.
 
-% {suites, "tests", metrics_c2s_SUITE}.
+{suites, "tests", metrics_c2s_SUITE}.
 
 {suites, "tests", metrics_register_SUITE}.
 
-% {suites, "tests", metrics_roster_SUITE}.
+{suites, "tests", metrics_roster_SUITE}.
 
-% {suites, "tests", metrics_session_SUITE}.
+{suites, "tests", metrics_session_SUITE}.
 
-% {suites, "tests", metrics_api_SUITE}.
+{suites, "tests", metrics_api_SUITE}.
 
 {suites, "tests", mod_blocking_SUITE}.
 

--- a/big_tests/tests/metrics_c2s_SUITE.erl
+++ b/big_tests/tests/metrics_c2s_SUITE.erl
@@ -255,7 +255,6 @@ error_presence(Config) ->
         Presence = escalus_stanza:presence_direct(escalus_client:short_jid(Alice),
                                                   <<"error">>, [ErrorElt]),
         escalus:send(Bob, Presence),
-        escalus:wait_for_stanza(Alice),
 
         wait_for_counter(Errors + 1, xmppErrorPresence)
 

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -7,11 +7,11 @@ MongooseIM uses [ESL's fork of this project](https://github.com/esl/exometer/tre
 All metrics are divided into the following groups:
 
 * Per host type metrics: Gathered separately for every host type supported by the cluster.
-    
+
     !!! Warning
         If a cluster supports many (thousands or more) host types, performance issues might occur.
         To avoid this, use global equivalents of the metrics with `all_metrics_are_global` config option.
-    
+
     * Hook metrics.
     They are created for every [hook](../developers-guide/Hooks-and-handlers.md) and incremented on every call to it.
 
@@ -137,7 +137,7 @@ As a result it makes more sense to maintain a list of the most relevant or usefu
 | `[HostType, xmppMessageReceived]` | spiral | A message is sent to a client. |
 | `[HostType, xmppPresenceReceived]` | spiral | A presence is sent to a client. |
 | `[HostType, xmppStanzaReceived]` | spiral | A stanza is sent to a client. |
-| `[HostType, xmppStanzaCount]` | spiral | A stanza is sent to a client. |
+| `[HostType, xmppStanzaCount]` | spiral | A stanza is sent to and by a client. |
 | `[HostType, xmppStanzaDropped]` | spiral | A stanza is dropped due to an AMP rule or a `filter_packet` processing flow. |
 
 ### Extension-specific metrics

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -217,7 +217,7 @@ activate_socket(#c2s_data{socket = Socket}) ->
 
 -spec send_text(c2s_data(), iodata()) -> ok | {error, term()}.
 send_text(#c2s_data{socket = Socket}, Text) ->
-    mongoose_metrics:update(global, [data, xmpp, sent, xml_stanza_size], size(Text)),
+    mongoose_metrics:update(global, [data, xmpp, sent, xml_stanza_size], iolist_size(Text)),
     mongoose_c2s_socket:send_text(Socket, Text).
 
 -spec filter_mechanism(c2s_data(), binary()) -> boolean().
@@ -711,10 +711,10 @@ maybe_send_xml(_StateData, _Acc, []) ->
     ok;
 maybe_send_xml(StateData = #c2s_data{host_type = HostType, lserver = LServer}, undefined, ToSend) ->
     Acc = mongoose_acc:new(#{host_type => HostType, lserver => LServer, location => ?LOCATION}),
-    [send_element(StateData, El, Acc) || El <- ToSend],
+    send_element(StateData, ToSend, Acc),
     ok;
 maybe_send_xml(StateData, Acc, ToSend) ->
-    [send_element(StateData, El, Acc) || El <- ToSend],
+    send_element(StateData, ToSend, Acc),
     ok.
 
 -spec maybe_deliver(c2s_data(), gen_hook:hook_fn_ret(mongoose_acc:t())) -> mongoose_acc:t().
@@ -833,14 +833,16 @@ sm_unset_reason(_) ->
     error.
 
 %% @doc This is the termination point - from here stanza is sent to the user
--spec send_element(c2s_data(), exml:element(), mongoose_acc:t()) -> mongoose_acc:t().
+-spec send_element(c2s_data(), [exml:element()] | exml:element(), mongoose_acc:t()) -> mongoose_acc:t().
 send_element(StateData = #c2s_data{host_type = <<>>}, El, Acc) ->
     send_xml(StateData, El),
     Acc;
-send_element(StateData = #c2s_data{host_type = HostType}, El, Acc) ->
-    Res = send_xml(StateData, El),
+send_element(StateData = #c2s_data{host_type = HostType}, Els, Acc) when is_list(Els) ->
+    Res = send_xml(StateData, Els),
     Acc1 = mongoose_acc:set(c2s, send_result, Res, Acc),
-    mongoose_hooks:xmpp_send_element(HostType, Acc1, El).
+    [mongoose_hooks:xmpp_send_element(HostType, Acc1, El) || El <- Els];
+send_element(StateData, El, Acc) ->
+    send_element(StateData, [El], Acc).
 
 -spec send_xml(c2s_data(), exml_stream:element() | [exml_stream:element()]) -> maybe_ok().
 send_xml(StateData, Xml) ->

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -448,7 +448,7 @@ terminate_session(Pid, Reason) ->
 %% Hook handlers
 %%====================================================================
 
--spec node_cleanup(Acc, Args, Extra) -> {ok, Acc} when 
+-spec node_cleanup(Acc, Args, Extra) -> {ok, Acc} when
       Acc :: any(),
       Args :: #{node := node()},
       Extra :: map().

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -83,9 +83,8 @@ create_global_metrics() ->
 -spec init_predefined_host_type_metrics(mongooseim:host_type()) -> ok.
 init_predefined_host_type_metrics(HostType) ->
     create_metrics(HostType),
-    Hooks = mongoose_metrics_hooks:get_hooks(HostType),
-    ejabberd_hooks:add(Hooks),
-    ok.
+    ejabberd_hooks:add(mongoose_metrics_hooks:hooks(HostType)),
+    gen_hook:add_handlers(mongoose_metrics_hooks:c2s_hooks(HostType)).
 
 init_subscriptions() ->
     Reporters = exometer_report:list_reporters(),

--- a/src/metrics/mongoose_metrics_hooks.erl
+++ b/src/metrics/mongoose_metrics_hooks.erl
@@ -11,7 +11,8 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 
--export([get_hooks/1]).
+-export([hooks/1]).
+-export([c2s_hooks/1]).
 
 %%-------------------
 %% Internal exports
@@ -19,8 +20,8 @@
 -export([sm_register_connection_hook/5,
          sm_remove_connection_hook/5,
          auth_failed/3,
-         user_send_packet/4,
-         user_receive_packet/5,
+         user_send_packet/3,
+         user_open_session/3,
          xmpp_bounce_message/1,
          xmpp_stanza_dropped/4,
          xmpp_send_element/2,
@@ -40,34 +41,37 @@
              privacy_list_push/5, register_user/3, remove_user/3, roster_get/2,
              roster_in_subscription/5, roster_push/4, roster_set/4,
              sm_register_connection_hook/5, sm_remove_connection_hook/5,
-             user_receive_packet/5, user_send_packet/4, xmpp_bounce_message/1,
-             xmpp_send_element/2, xmpp_stanza_dropped/4]).
+             user_send_packet/3, user_open_session/3,
+             xmpp_bounce_message/1, xmpp_send_element/2, xmpp_stanza_dropped/4]).
 
 %%-------------------
 %% Implementation
 %%-------------------
 
 %% @doc Here will be declared which hooks should be registered
--spec get_hooks(_) -> [ejabberd_hooks:hook(), ...].
-get_hooks(HostType) ->
-    [ {sm_register_connection_hook, HostType, ?MODULE, sm_register_connection_hook, 50},
-      {sm_remove_connection_hook, HostType, ?MODULE, sm_remove_connection_hook, 50},
-      {auth_failed, HostType, ?MODULE, auth_failed, 50},
-      {user_send_packet, HostType, ?MODULE, user_send_packet, 50},
-      {user_receive_packet, HostType, ?MODULE, user_receive_packet, 50},
-      {xmpp_stanza_dropped, HostType, ?MODULE, xmpp_stanza_dropped, 50},
-      {xmpp_bounce_message, HostType, ?MODULE, xmpp_bounce_message, 50},
-      {xmpp_send_element, HostType, ?MODULE, xmpp_send_element, 50},
-      {roster_get, HostType, ?MODULE, roster_get, 55},
-      {roster_set, HostType, ?MODULE, roster_set, 50},
-      {roster_push, HostType, ?MODULE, roster_push, 50},
-      {roster_in_subscription, HostType, ?MODULE, roster_in_subscription, 55},
-      {register_user, HostType, ?MODULE, register_user, 50},
-      {remove_user, HostType, ?MODULE, remove_user, 50},
-      {privacy_iq_get, HostType, ?MODULE, privacy_iq_get, 1},
-      {privacy_iq_set, HostType, ?MODULE, privacy_iq_set, 1},
-      {privacy_check_packet, HostType, ?MODULE, privacy_check_packet, 55},
-      {sm_broadcast, HostType, ?MODULE, privacy_list_push, 1}].
+-spec hooks(mongooseim:host_type()) -> [ejabberd_hooks:hook()].
+hooks(HostType) ->
+    [{sm_register_connection_hook, HostType, ?MODULE, sm_register_connection_hook, 50},
+     {sm_remove_connection_hook, HostType, ?MODULE, sm_remove_connection_hook, 50},
+     {auth_failed, HostType, ?MODULE, auth_failed, 50},
+     {xmpp_stanza_dropped, HostType, ?MODULE, xmpp_stanza_dropped, 50},
+     {xmpp_bounce_message, HostType, ?MODULE, xmpp_bounce_message, 50},
+     {xmpp_send_element, HostType, ?MODULE, xmpp_send_element, 50},
+     {roster_get, HostType, ?MODULE, roster_get, 55},
+     {roster_set, HostType, ?MODULE, roster_set, 50},
+     {roster_push, HostType, ?MODULE, roster_push, 50},
+     {roster_in_subscription, HostType, ?MODULE, roster_in_subscription, 55},
+     {register_user, HostType, ?MODULE, register_user, 50},
+     {remove_user, HostType, ?MODULE, remove_user, 50},
+     {privacy_iq_get, HostType, ?MODULE, privacy_iq_get, 1},
+     {privacy_iq_set, HostType, ?MODULE, privacy_iq_set, 1},
+     {privacy_check_packet, HostType, ?MODULE, privacy_check_packet, 55},
+     {sm_broadcast, HostType, ?MODULE, privacy_list_push, 1}].
+
+-spec c2s_hooks(mongooseim:host_type()) -> gen_hook:hook_list(mongoose_c2s_hooks:hook_fn()).
+c2s_hooks(HostType) ->
+    [{user_send_packet, HostType, fun ?MODULE:user_send_packet/3, #{}, 50},
+     {user_open_session, HostType, fun ?MODULE:user_open_session/3, #{}, 50}].
 
 -spec sm_register_connection_hook(any(), mongooseim:host_type(), tuple(), jid:jid(), term()
                                  ) -> any().
@@ -92,13 +96,14 @@ auth_failed(Acc, _, Server) ->
     mongoose_metrics:update(HostType, sessionAuthFails, 1),
     Acc.
 
--spec user_send_packet(mongoose_acc:t(), jid:jid(), tuple(), tuple()
-                      ) -> mongoose_acc:t().
-user_send_packet(Acc, _, _, Packet) ->
-    HostType = mongoose_acc:host_type(Acc),
+-spec user_send_packet(mongoose_acc:t(), mongoose_c2s:hook_params(), map()) ->
+    mongoose_c2s_hooks:hook_result().
+user_send_packet(Acc, _Params, #{host_type := HostType}) ->
     mongoose_metrics:update(HostType, xmppStanzaSent, 1),
-    user_send_packet_type(HostType, Packet),
-    Acc.
+    mongoose_metrics:update(HostType, xmppStanzaCount, 1),
+    El = mongoose_acc:element(Acc),
+    user_send_packet_type(HostType, El),
+    {ok, Acc}.
 
 -spec user_send_packet_type(HostType :: mongooseim:host_type(),
                             Packet :: exml:element()) -> ok | {error, not_found}.
@@ -108,23 +113,6 @@ user_send_packet_type(HostType, #xmlel{name = <<"iq">>}) ->
     mongoose_metrics:update(HostType, xmppIqSent, 1);
 user_send_packet_type(HostType, #xmlel{name = <<"presence">>}) ->
     mongoose_metrics:update(HostType, xmppPresenceSent, 1).
-
--spec user_receive_packet(mongoose_acc:t(), jid:jid(), tuple(), tuple(), tuple()
-                         ) -> mongoose_acc:t().
-user_receive_packet(Acc, _, _, _, Packet) ->
-    HostType = mongoose_acc:host_type(Acc),
-    mongoose_metrics:update(HostType, xmppStanzaReceived, 1),
-    user_receive_packet_type(HostType, Packet),
-    Acc.
-
--spec user_receive_packet_type(HostType :: mongooseim:host_type(),
-                               Packet :: exml:element()) -> ok | {error, not_found}.
-user_receive_packet_type(HostType, #xmlel{name = <<"message">>}) ->
-    mongoose_metrics:update(HostType, xmppMessageReceived, 1);
-user_receive_packet_type(HostType, #xmlel{name = <<"iq">>}) ->
-    mongoose_metrics:update(HostType, xmppIqReceived, 1);
-user_receive_packet_type(HostType, #xmlel{name = <<"presence">>}) ->
-    mongoose_metrics:update(HostType, xmppPresenceReceived, 1).
 
 -spec xmpp_bounce_message(Acc :: mongoose_acc:t()) -> mongoose_acc:t().
 xmpp_bounce_message(Acc) ->
@@ -139,25 +127,48 @@ xmpp_stanza_dropped(Acc, _, _, _) ->
     mongoose_metrics:update(HostType, xmppStanzaDropped, 1),
     Acc.
 
--spec xmpp_send_element(Acc :: mongoose_acc:t(), Server :: jid:server()) -> mongoose_acc:t().
-xmpp_send_element(Acc, _El) ->
+-spec xmpp_send_element(Acc :: mongoose_acc:t(), El :: exml:element()) -> mongoose_acc:t().
+xmpp_send_element(Acc, #xmlel{name = Name} = El)
+  when Name == <<"iq">>; Name == <<"message">>; Name == <<"presence">> ->
     HostType = mongoose_acc:host_type(Acc),
     mongoose_metrics:update(HostType, xmppStanzaCount, 1),
-    case mongoose_acc:stanza_type(Acc) of
+    case exml_query:attr(El, <<"type">>) of
         <<"error">> ->
             mongoose_metrics:update(HostType, xmppErrorTotal, 1),
-            case mongoose_acc:stanza_name(Acc) of
-                <<"iq">> ->
-                    mongoose_metrics:update(HostType, xmppErrorIq, 1);
-                <<"message">> ->
-                    mongoose_metrics:update(HostType, xmppErrorMessage, 1);
-                <<"presence">> ->
-                    mongoose_metrics:update(HostType, xmppErrorPresence, 1)
-            end;
-        _ -> ok
+            xmpp_send_element_error(HostType, El);
+        _ ->
+            mongoose_metrics:update(HostType, xmppStanzaReceived, 1),
+            xmpp_send_element_type(HostType, El)
     end,
+    Acc;
+xmpp_send_element(Acc, _El) ->
     Acc.
 
+-spec xmpp_send_element_error(HostType :: mongooseim:host_type(),
+                              Packet :: exml:element()) -> ok | {error, not_found}.
+xmpp_send_element_error(HostType, #xmlel{name = <<"message">>}) ->
+    mongoose_metrics:update(HostType, xmppErrorMessage, 1);
+xmpp_send_element_error(HostType, #xmlel{name = <<"iq">>}) ->
+    mongoose_metrics:update(HostType, xmppErrorIq, 1);
+xmpp_send_element_error(HostType, #xmlel{name = <<"presence">>}) ->
+    mongoose_metrics:update(HostType, xmppErrorPresence, 1).
+
+-spec xmpp_send_element_type(HostType :: mongooseim:host_type(),
+                             Packet :: exml:element()) -> ok | {error, not_found}.
+xmpp_send_element_type(HostType, #xmlel{name = <<"message">>}) ->
+    mongoose_metrics:update(HostType, xmppMessageReceived, 1);
+xmpp_send_element_type(HostType, #xmlel{name = <<"iq">>}) ->
+    mongoose_metrics:update(HostType, xmppIqReceived, 1);
+xmpp_send_element_type(HostType, #xmlel{name = <<"presence">>}) ->
+    mongoose_metrics:update(HostType, xmppPresenceReceived, 1).
+
+-spec user_open_session(mongoose_acc:t(), mongoose_c2s:hook_params(), map()) ->
+    mongoose_c2s_hooks:hook_result().
+user_open_session(Acc, _Params, #{host_type := HostType}) ->
+    mongoose_metrics:update(HostType, xmppStanzaSent, 1),
+    mongoose_metrics:update(HostType, xmppStanzaCount, 1),
+    mongoose_metrics:update(HostType, xmppIqSent, 1),
+    {ok, Acc}.
 
 %% Roster
 


### PR DESCRIPTION
Fixes metrics suites.

The following changes were introduced:

* moved counting received stanzas from `user_receive_packet` to `xmpp_send_element` as first one can be dropped by further hooks and not send at all,
* fixed the numbers in test cases (I checked the real numbers with `mongoose_c2s:send_text/2` and `mongoose_c2s:handle_socket_data/2`),
* converted hooks to c2s hooks,
* fixed the documention for `xmppStanzaCount` metric,
* `xmpp_send_element ` hook processes one element per run instead of not all.  

