### PR TITLE
Set default value when null is passed to GraphQL API

### DIFF
--- a/big_tests/tests/graphql_stanza_SUITE.erl
+++ b/big_tests/tests/graphql_stanza_SUITE.erl
@@ -40,6 +40,7 @@ admin_get_last_messages_cases() ->
      admin_get_last_messages_for_unknown_user,
      admin_get_last_messages_with,
      admin_get_last_messages_limit,
+     admin_get_last_messages_limit_null,
      admin_get_last_messages_limit_enforced,
      admin_get_last_messages_before].
 
@@ -398,6 +399,19 @@ admin_get_last_messages_limit_story(Config, Alice, Bob) ->
     #{<<"stanzas">> := [M1], <<"limit">> := 1} =
         get_ok_value([data, stanza, getLastMessages], Res),
     check_stanza_map(M1, Bob).
+
+admin_get_last_messages_limit_null(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_get_last_messages_limit_null_story/3).
+
+admin_get_last_messages_limit_null_story(Config, Alice, Bob) ->
+    admin_send_message_story(Config, Alice, Bob),
+    mam_helper:wait_for_archive_size(Alice, 1),
+    Caller = escalus_client:full_jid(Alice),
+    Res = get_last_messages(Caller, null, null, null, Config),
+    #{<<"stanzas">> := [M1], <<"limit">> := 50} =
+        get_ok_value([data, stanza, getLastMessages], Res),
+    check_stanza_map(M1, Alice).
 
 admin_get_last_messages_limit_enforced(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],

--- a/priv/graphql/schemas/global/muc_light.gql
+++ b/priv/graphql/schemas/global/muc_light.gql
@@ -13,7 +13,7 @@ input BlockingInput{
   "Type of entity to block"
   entityType: BlockedEntityType!
   "Type of blocking action"
-  action: BlockingAction!
+  action: BlockingAction! = DENY
   "Entity's JID"
   entity: JID!
 }

--- a/rebar.lock
+++ b/rebar.lock
@@ -49,7 +49,7 @@
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"graphql">>,
   {git,"https://github.com/esl/graphql-erlang.git",
-       {ref,"72bf290d50b4b5e2f462e06ccfdc5645a6d6401a"}},
+       {ref,"7bca478ed484b0859f986f3c74f1013c872265bb"}},
   0},
  {<<"gun">>,{pkg,<<"gun">>,<<"1.3.3">>},0},
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.13.0">>},1},

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -74,7 +74,8 @@ execute(Ep, #{document := Doc,
         {ok, #{ast := Ast2,
                fun_env := FunEnv}} = graphql:type_check(Ep, Ast),
         ok = graphql:validate(Ast2),
-        Coerced = graphql:type_check_params(Ep, FunEnv, OpName, Vars),
+        Vars2 = remove_null_args(Vars),
+        Coerced = graphql:type_check_params(Ep, FunEnv, OpName, Vars2),
         Ctx2 = Ctx#{params => Coerced,
                     operation_name => OpName,
                     authorized => AuthStatus,
@@ -124,6 +125,9 @@ graphql_parse(Doc) ->
         {error, Err} ->
             graphql_err:abort([], parse, Err)
     end.
+
+remove_null_args(Vars) ->
+    maps:filter(fun(_Key, Value) -> Value /= null end, Vars).
 
 admin_mapping_rules() ->
     #{objects => #{


### PR DESCRIPTION
This PR changes how arguments are processed before being passed to the resolver. When an argument has an explicit null value, the GraphQL library tries to set its value to a default one if one exists.