### PR TITLE
Remove imports, use library function [refactor]

### DIFF
--- a/src/graphql/user/mongoose_graphql_stanza_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_stanza_user_mutation.erl
@@ -35,22 +35,19 @@ send_message_headline2(Args = #{<<"from">> := From, <<"to">> := To}) ->
 send_stanza(#{user := User}, #{<<"stanza">> := Packet}) ->
     From = jid:from_binary(exml_query:attr(Packet, <<"from">>)),
     To = jid:from_binary(exml_query:attr(Packet, <<"to">>)),
-    case compare_bare_jids(User, From) of
+    case jid:are_bare_equal(User, From) of
         true ->
             mongoose_stanza_helper:route(From, To, Packet, false);
         false ->
             {error, #{what => bad_from_jid}}
     end.
 
-compare_bare_jids(#jid{luser = U, lserver = S}, #jid{luser = U, lserver = S}) -> true;
-compare_bare_jids(_, _) -> false.
-
 with_from(_Ctx = #{user := User}, Args, Next) ->
     case maps:get(<<"from">>, Args, null) of
         null ->
             Next(Args#{<<"from">> => User});
         From ->
-            case compare_bare_jids(User, From) of
+            case jid:are_bare_equal(User, From) of
                 true ->
                     %% We still can allow a custom resource
                     Next(Args#{<<"from">> => From});

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -60,37 +60,6 @@
               delete_archive/2, disco_muc_features/1, filter_room_packet/3,
               forget_room/4, get_personal_data/3, start/2, stop/1, supported_features/0]).
 
-%% ----------------------------------------------------------------------
-%% Imports
-
-%% UID
--import(mod_mam_utils,
-        [generate_message_id/1,
-         decode_compact_uuid/1]).
-
-%% XML
--import(mod_mam_utils,
-        [maybe_add_arcid_elems/4,
-         replace_x_user_element/4,
-         delete_x_user_element/1,
-         packet_to_x_user_jid/1,
-         wrap_message/6,
-         result_set/4,
-         result_query/2,
-         result_prefs/4,
-         make_fin_element/7,
-         parse_prefs/1,
-         borders_decode/1,
-         features/2]).
-
-%% Forms
--import(mod_mam_utils,
-        [message_form/3]).
-
-%% Other
--import(mod_mam_utils,
-        [mess_id_to_external_binary/1]).
-
 -include_lib("mongoose.hrl").
 -include_lib("jlib.hrl").
 -include_lib("exml/include/exml.hrl").
@@ -170,7 +139,7 @@ supported_features() ->
 
 -spec disco_muc_features(mongoose_disco:feature_acc()) -> mongoose_disco:feature_acc().
 disco_muc_features(Acc = #{host_type := HostType, node := <<>>}) ->
-    mongoose_disco:add_features(features(?MODULE, HostType), Acc);
+    mongoose_disco:add_features(mod_mam_utils:features(?MODULE, HostType), Acc);
 disco_muc_features(Acc) ->
     Acc.
 
@@ -209,8 +178,8 @@ archive_room_packet(HostType, Packet, FromNick, FromJID = #jid{},
         end,
     case IsInteresting of
         true ->
-            MessID = generate_message_id(TS),
-            Packet1 = replace_x_user_element(FromJID, Role, Affiliation, Packet),
+            MessID = mod_mam_utils:generate_message_id(TS),
+            Packet1 = mod_mam_utils:replace_x_user_element(FromJID, Role, Affiliation, Packet),
             OriginID = mod_mam_utils:get_origin_id(Packet),
             Params = #{message_id => MessID,
                        archive_id => ArcID,
@@ -225,9 +194,9 @@ archive_room_packet(HostType, Packet, FromNick, FromJID = #jid{},
             Result = archive_message(HostType, Params),
             case Result of
                 ok ->
-                    ExtID = mess_id_to_external_binary(MessID),
+                    ExtID = mod_mam_utils:mess_id_to_external_binary(MessID),
                     ShouldAdd = mod_mam_params:add_stanzaid_element(?MODULE, HostType),
-                    maybe_add_arcid_elems(RoomJID, ExtID, Packet, ShouldAdd);
+                    mod_mam_utils:maybe_add_arcid_elems(RoomJID, ExtID, Packet, ShouldAdd);
                 {error, _} -> Packet
             end;
         false -> Packet
@@ -346,7 +315,7 @@ handle_mam_iq(HostType, Action, From, To, IQ) ->
                               jlib:iq() | {error, any(), jlib:iq()}.
 handle_set_prefs(HostType, ArcJID = #jid{},
                  IQ = #iq{sub_el = PrefsEl}) ->
-    {DefaultMode, AlwaysJIDs, NeverJIDs} = parse_prefs(PrefsEl),
+    {DefaultMode, AlwaysJIDs, NeverJIDs} = mod_mam_utils:parse_prefs(PrefsEl),
     ?LOG_DEBUG(#{what => mam_muc_set_prefs, archive_jid => ArcJID,
                  default_mode => DefaultMode,
                  always_jids => AlwaysJIDs, never_jids => NeverJIDs, iq => IQ}),
@@ -355,7 +324,7 @@ handle_set_prefs(HostType, ArcJID = #jid{},
     handle_set_prefs_result(Res, DefaultMode, AlwaysJIDs, NeverJIDs, IQ).
 
 handle_set_prefs_result(ok, DefaultMode, AlwaysJIDs, NeverJIDs, IQ) ->
-    ResultPrefsEl = result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, IQ#iq.xmlns),
+    ResultPrefsEl = mod_mam_utils:result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, IQ#iq.xmlns),
     IQ#iq{type = result, sub_el = [ResultPrefsEl]};
 handle_set_prefs_result({error, Reason},
                         _DefaultMode, _AlwaysJIDs, _NeverJIDs, IQ) ->
@@ -372,7 +341,7 @@ handle_get_prefs_result(ArcJID, {DefaultMode, AlwaysJIDs, NeverJIDs}, IQ) ->
     ?LOG_DEBUG(#{what => mam_muc_get_prefs_result, archive_jid => ArcJID,
                  default_mode => DefaultMode,
                  always_jids => AlwaysJIDs, never_jids => NeverJIDs, iq => IQ}),
-    ResultPrefsEl = result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, IQ#iq.xmlns),
+    ResultPrefsEl = mod_mam_utils:result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, IQ#iq.xmlns),
     IQ#iq{type = result, sub_el = [ResultPrefsEl]};
 handle_get_prefs_result(_ArcJID, {error, Reason}, IQ) ->
     return_error_iq(IQ, Reason).
@@ -431,9 +400,11 @@ send_messages_and_iq_result(#{total_count := TotalCount, offset := Offset,
                                                  QueryID, MessageRows, true),
     %% Make fin iq
     IsStable = true,
-    ResultSetEl = result_set(FirstMessID, LastMessID, Offset, TotalCount),
+    ResultSetEl = mod_mam_utils:result_set(FirstMessID, LastMessID, Offset, TotalCount),
     ExtFinMod = mod_mam_params:extra_fin_element_module(?MODULE, HostType),
-    FinElem = make_fin_element(HostType, Params, IQ#iq.xmlns, IsComplete, IsStable, ResultSetEl, ExtFinMod),
+    FinElem = mod_mam_utils:make_fin_element(HostType, Params, IQ#iq.xmlns,
+                                             IsComplete, IsStable,
+                                             ResultSetEl, ExtFinMod),
     IQ#iq{type = result, sub_el = [FinElem]}.
 
 forward_messages(HostType, From, ArcJID, MamNs, QueryID, MessageRows, SetClientNs) ->
@@ -541,19 +512,19 @@ archive_message(HostType, Params) ->
                                 exml:element().
 message_row_to_xml(MamNs, ReceiverJID, HideUser, SetClientNs,
                    #{id := MessID, jid := SrcJID, packet := Packet}, QueryID) ->
-    {Microseconds, _NodeMessID} = decode_compact_uuid(MessID),
+    {Microseconds, _NodeMessID} = mod_mam_utils:decode_compact_uuid(MessID),
     TS = calendar:system_time_to_rfc3339(Microseconds, [{offset, "Z"}, {unit, microsecond}]),
-    BExtMessID = mess_id_to_external_binary(MessID),
+    BExtMessID = mod_mam_utils:mess_id_to_external_binary(MessID),
     Packet1 = maybe_delete_x_user_element(HideUser, ReceiverJID, Packet),
     Packet2 = mod_mam_utils:maybe_set_client_xmlns(SetClientNs, Packet1),
     Packet3 = replace_from_to_attributes(SrcJID, Packet2),
-    wrap_message(MamNs, Packet3, QueryID, BExtMessID, TS, SrcJID).
+    mod_mam_utils:wrap_message(MamNs, Packet3, QueryID, BExtMessID, TS, SrcJID).
 
 maybe_delete_x_user_element(true, ReceiverJID, Packet) ->
-    PacketJID = packet_to_x_user_jid(Packet),
+    PacketJID = mod_mam_utils:packet_to_x_user_jid(Packet),
     case jid:are_bare_equal(ReceiverJID, PacketJID) of
         false ->
-            delete_x_user_element(Packet);
+            mod_mam_utils:delete_x_user_element(Packet);
         true -> %% expose identity for user's own messages
             Packet
     end;
@@ -571,7 +542,7 @@ replace_from_to_attributes(SrcJID, Packet = #xmlel{attrs = Attrs}) ->
 
 -spec message_row_to_ext_id(row()) -> binary().
 message_row_to_ext_id(#{id := MessID}) ->
-    mess_id_to_external_binary(MessID).
+    mod_mam_utils:mess_id_to_external_binary(MessID).
 
 -spec handle_error_iq(mongoose_acc:t(), host_type(), jid:jid(), atom(),
     {error, term(), jlib:iq()} | jlib:iq() | ignore) -> {mongoose_acc:t(), jlib:iq() | ignore}.
@@ -614,7 +585,8 @@ return_max_delay_reached_error_iq(IQ) ->
     IQ#iq{type = error, sub_el = [ErrorEl]}.
 
 return_message_form_iq(HostType, IQ) ->
-    IQ#iq{type = result, sub_el = [message_form(?MODULE, HostType, IQ#iq.xmlns)]}.
+    Form = mod_mam_utils:message_form(?MODULE, HostType, IQ#iq.xmlns),
+    IQ#iq{type = result, sub_el = [Form]}.
 
 % the stacktrace is a big lie
 report_issue({Reason, {stacktrace, Stacktrace}}, Issue, ArcJID, IQ) ->

--- a/src/mam/mod_mam_pm.erl
+++ b/src/mam/mod_mam_pm.erl
@@ -343,12 +343,7 @@ is_action_allowed(HostType, Action, From, To) ->
 -spec is_action_allowed_by_default(Action :: mam_iq:action(), From :: jid:jid(),
                                    To :: jid:jid()) -> boolean().
 is_action_allowed_by_default(_Action, From, To) ->
-    compare_bare_jids(From, To).
-
--spec compare_bare_jids(jid:simple_jid() | jid:jid(),
-                        jid:simple_jid() | jid:jid()) -> boolean().
-compare_bare_jids(JID1, JID2) ->
-    jid:to_bare(JID1) =:= jid:to_bare(JID2).
+    jid:are_bare_equal(From, To).
 
 -spec handle_mam_iq(mam_iq:action(), From :: jid:jid(), To :: jid:jid(),
                     IQ :: jlib:iq(), Acc :: mongoose_acc:t()) ->

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -137,7 +137,7 @@ process_iq(Acc,
            IQ = #iq{type = Type, sub_el = SubElem = #xmlel{children = Elems}},
            _Extra) ->
     HostType = mongoose_acc:host_type(Acc),
-    IsEqual = compare_bare_jids(From, To),
+    IsEqual = jid:are_bare_equal(From, To),
     Strategy = choose_strategy(IsEqual, Type),
     Res = case Strategy of
         get ->
@@ -175,10 +175,6 @@ process_iq(Acc, _From, _To, IQ, _Extra) ->
 choose_strategy(true, get) -> get;
 choose_strategy(true, set) -> set;
 choose_strategy(_,    _  ) -> forbidden.
-
-compare_bare_jids(#jid{luser = LUser, lserver = LServer},
-                  #jid{luser = LUser, lserver = LServer}) -> true;
-compare_bare_jids(_, _) -> false.
 
 element_to_namespace(#xmlel{attrs = Attrs}) ->
     xml:get_attr_s(<<"xmlns">>, Attrs);


### PR DESCRIPTION
This PR addresses "just found some code which is a bit weird".

Proposed changes include:
* use jid:are_bare_equal instead of writing the same function in the modules.
* don't use imports in mam to make code a bit cleaner - we usually use the imported function only once.