### PR TITLE
Remove domain/async

### DIFF
--- a/big_tests/tests/domain_rest_helper.erl
+++ b/big_tests/tests/domain_rest_helper.erl
@@ -11,6 +11,7 @@
          putt_domain_with_custom_body/2,
          rest_select_domain/2,
          rest_delete_domain/3,
+         request_delete_domain/3,
          delete_custom/4,
          patch_custom/4]).
 
@@ -68,6 +69,13 @@ rest_select_domain(Config, Domain) ->
 
 rest_delete_domain(Config, Domain, HostType) ->
     Params = #{<<"host_type">> => HostType},
+    rest_helper:make_request(#{ role => admin, method => <<"DELETE">>,
+                                path => domain_path(Domain),
+                                creds => make_creds(Config),
+                                body => Params }).
+
+request_delete_domain(Config, Domain, HostType) ->
+    Params = #{<<"host_type">> => HostType, <<"request">> => true},
     rest_helper:make_request(#{ role => admin, method => <<"DELETE">>,
                                 path => domain_path(Domain),
                                 creds => make_creds(Config),

--- a/doc/rest-api/Administration-backend_swagger.yml
+++ b/doc/rest-api/Administration-backend_swagger.yml
@@ -767,7 +767,20 @@ paths:
               host_type:
                 example: "type1"
                 type: string
+        - in: body
+          name: request
+          description: Flag to indicate if the request should be async.
+          required: false
+          schema:
+            title: request
+            type: object
+            properties:
+              request:
+                example: true
+                type: boolean
       responses:
+        202:
+          description: "The domain has been disabled and is enqueued for removal."
         204:
           description: "The domain is removed or not found."
         403:

--- a/priv/graphql/schemas/admin/domain.gql
+++ b/priv/graphql/schemas/admin/domain.gql
@@ -14,6 +14,9 @@ type DomainAdminMutation @protected{
   "Remove domain. Only for global admin"
   removeDomain(domain: String!, hostType: String!): RemoveDomainPayload
     @protected(type: GLOBAL)
+  "Remove domain asynchronously. Only for global admin"
+  requestRemoveDomain(domain: String!, hostType: String!): RemoveDomainPayload
+    @protected(type: GLOBAL)
   "Enable domain. Only for global admin"
   enableDomain(domain: String!): Domain
     @protected(type: GLOBAL)

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -340,6 +340,8 @@ set_status(Domain, Status) ->
                     case mongoose_domain_core:is_host_type_allowed(HostType) of
                         false ->
                             {error, unknown_host_type};
+                        true when deleting =:= CurrentStatus ->
+                            {error, domain_deleted};
                         true when Status =:= CurrentStatus ->
                             ok;
                         true ->

--- a/src/graphql/admin/mongoose_graphql_domain_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_domain_admin_mutation.erl
@@ -22,6 +22,14 @@ execute(_Ctx, admin, <<"removeDomain">>, #{<<"domain">> := Domain, <<"hostType">
         {error, Error} ->
             error_handler(Error, Domain, HostType)
     end;
+execute(_Ctx, admin, <<"requestRemoveDomain">>, #{<<"domain">> := Domain, <<"hostType">> := HostType}) ->
+    case mongoose_domain_api:request_delete_domain(Domain, HostType) of
+        ok ->
+            DomainObj = #domain{domain = Domain, host_type = HostType, status = deleting},
+            {ok, #{<<"domain">> => DomainObj, <<"msg">> => <<"Domain disabled and enqueued for deletion">>}};
+        {error, Error} ->
+            error_handler(Error, Domain, HostType)
+    end;
 execute(_Ctx, admin, <<"enableDomain">>, #{<<"domain">> := Domain}) ->
     case mongoose_domain_api:enable_domain(Domain) of
         ok ->


### PR DESCRIPTION
Most often, tenant deletion can incur in many many DB operations, which can introduce very long delays and timeout any HTTP connection. And when the HTTP connection times out, the cowboy process running the tenant deletion hook will timeout, and could potentially leave the DB in an inconsistent state.