### PR TITLE
Refactored hook handlers in mod_amp module

### DIFF
--- a/src/amp_strategy.erl
+++ b/src/amp_strategy.erl
@@ -6,25 +6,25 @@
 %% @copyright 2014 Erlang Solutions, Ltd.
 -module(amp_strategy).
 
--export([determine_strategy/5,
+-export([determine_strategy/3,
          null_strategy/0]).
-
--ignore_xref([determine_strategy/5]).
 
 -include("amp.hrl").
 -include("jlib.hrl").
 
--spec determine_strategy(amp_strategy(), jid:jid() | undefined, jid:jid() | undefined, #xmlel{}, amp_event()) ->
-                                amp_strategy().
-determine_strategy(_, _, undefined, _, _) -> null_strategy();
-determine_strategy(_, _, To, _, Event) ->
+-spec determine_strategy(StrategyAcc, Params, Extra) -> {ok, StrategyAcc} when
+      StrategyAcc :: mod_amp:amp_strategy(),
+      Params :: #{to := jid:jid() | undefined, event := mod_amp:amp_event()},
+      Extra :: map().
+determine_strategy(_, #{to := undefined}, _) -> {ok, null_strategy()};
+determine_strategy(_, #{to := To, event := Event}, _) ->
     TargetResources = get_target_resources(To),
     Deliver = deliver_strategy(TargetResources, Event),
     MatchResource = match_resource_strategy(TargetResources),
 
-    #amp_strategy{deliver = Deliver,
-                  'match-resource' = MatchResource,
-                  'expire-at' = undefined}.
+    {ok, #amp_strategy{deliver = Deliver,
+                       'match-resource' = MatchResource,
+                       'expire-at' = undefined}}.
 
 %% @doc This strategy will never be matched by any amp_rules.
 %% Use it as a seed parameter to `mongoose_hooks'.

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1413,8 +1413,11 @@ disco_info(Acc = #{host_type := HostType}) ->
     Rule :: mod_amp:amp_rule(),
     Result :: mod_amp:amp_match_result().
 amp_check_condition(HostType, Strategy, Rule) ->
+    Params = #{strategy => Strategy, rule => Rule},
+    Args = [Strategy, Rule],
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     InitialAcc = no_match, %% mod_amp:amp_match_result() type
-    run_hook_for_host_type(amp_check_condition, HostType, InitialAcc, [Strategy, Rule]).
+    run_hook_for_host_type(amp_check_condition, HostType, InitialAcc, ParamsWithLegacyArgs).
 
 %%% @doc The `amp_determine_strategy' hook is called when checking to determine
 %%% which strategy will be chosen when executing AMP rules.
@@ -1440,7 +1443,10 @@ amp_determine_strategy(HostType, From, To, Packet, Event) ->
     Rules :: mod_amp:amp_rules(),
     Result :: [mod_amp:amp_rule_support()].
 amp_verify_support(HostType, Rules) ->
-    run_hook_for_host_type(amp_verify_support, HostType, [], [Rules]).
+    Params = #{rules => Rules},
+    Args = [Rules],
+    ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
+    run_hook_for_host_type(amp_verify_support, HostType, [], ParamsWithLegacyArgs).
 
 %% MUC and MUC Light related hooks
 

--- a/test/amp_resolver_SUITE.erl
+++ b/test/amp_resolver_SUITE.erl
@@ -115,4 +115,5 @@ check_cond(Strategy, Rule) ->
 
 check_cond(HookAcc, Strategy, Rule) ->
     ct:log("check condition (acc: ~p)~nstrategy: ~p~nrule: ~p", [HookAcc, Strategy, Rule]),
-    amp_resolver:check_condition(HookAcc, Strategy, Rule).
+    {ok, Result} = amp_resolver:check_condition(HookAcc, #{strategy => Strategy, rule =>Rule}, #{}),
+    Result.


### PR DESCRIPTION
This PR changes all hook handlers in `mod_amp` module to `gen_hook` format.