### PR TITLE
Refactored hook handlers in acc_e2e_SUITE

### DIFF
--- a/big_tests/tests/acc_e2e_SUITE.erl
+++ b/big_tests/tests/acc_e2e_SUITE.erl
@@ -170,13 +170,13 @@ acc_test_helper_code(Config) ->
     binary_to_list(Code).
 
 add_handler(Hook, F, Seq) ->
-    rpc(mim(), ejabberd_hooks, add, handler(Hook, F, Seq)).
+    rpc(mim(), gen_hook, add_handler, handler(Hook, F, Seq)).
 
 remove_handler(Hook, F, Seq) ->
-    rpc(mim(), ejabberd_hooks, delete, handler(Hook, F, Seq)).
+    rpc(mim(), gen_hook, delete_handler, handler(Hook, F, Seq)).
 
 handler(Hook, F, Seq) ->
-    [Hook, domain_helper:host_type(mim), acc_test_helper, F, Seq].
+    [Hook, domain_helper:host_type(mim), fun acc_test_helper:F/3, #{}, Seq].
 
 %% creates a temporary ets table keeping refs and some attrs of accumulators created in c2s
 recreate_table() ->

--- a/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
+++ b/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
@@ -3,52 +3,75 @@
 
 -compile([export_all, nowarn_export_all]).
 
-test_save_acc(#{ stanza := #{ type := <<"chat">>} } = Acc, _State) ->
+-spec test_save_acc(Acc, Params, Extra) -> {ok, Acc} when
+    Acc :: mongoose_acc:t(),
+    Params :: map(),
+    Extra :: map().
+test_save_acc(#{ stanza := #{ type := <<"chat">>} } = Acc, _, _) ->
     Rand = rand:uniform(),
     Acc1 = mongoose_acc:set_permanent(test, random_prop, Rand, Acc),
     Acc2 = mongoose_acc:set(test, should_be_stripped, 123, Acc1),
     Data = {mongoose_acc:ref(Acc2), mongoose_acc:timestamp(Acc2), Rand},
     ets:insert(test_message_index, Data),
-    Acc2;
-test_save_acc(Acc, _State) -> Acc.
+    {ok, Acc2};
+test_save_acc(Acc, _, _) -> {ok, Acc}.
 
-test_check_acc({F, T, #{ stanza := #{ type := <<"chat">> } } = Acc, P}) ->
-    try
+-spec test_check_acc(Acc, Params, Extra) -> {ok, Acc} when
+    Acc :: mongoose_hooks:filter_packet_acc() | drop,
+    Params :: map(),
+    Extra :: map().
+test_check_acc({F, T, #{ stanza := #{ type := <<"chat">> } } = Acc, P}, _, _) ->
+    NewAcc = try
         check_acc(Acc),
         {F, T, Acc, P}
     catch error:{badmatch, _} ->
         drop
-    end;
-test_check_acc(Arg) ->
-    Arg.
+    end,
+    {ok, NewAcc};
+test_check_acc(Acc, _, _) ->
+    {ok, Acc}.
 
-test_check_final_acc(#{ stanza := #{ type := <<"chat">> } } = Acc, _Jid, _From, _To, _El) ->
-    try
+-spec test_check_final_acc(Acc, Params, Extra) -> {ok, Acc} when
+    Acc :: mongoose_hooks:filter_packet_acc() | drop,
+    Params :: map(),
+    Extra :: map().
+test_check_final_acc(#{ stanza := #{ type := <<"chat">> } } = Acc, _, _) ->
+    NewAcc = try
         check_acc(Acc, stripped),
         Acc
     catch error:{badmatch, _} ->
         drop
-    end;
-test_check_final_acc(Acc, _Jid, _From, _To, _El) ->
-    Acc.
+    end,
+    {ok, NewAcc};
+test_check_final_acc(Acc, _, _) ->
+    {ok, Acc}.
 
-save_my_jid(#{ stanza := #{ type := <<"chat">>} } = Acc, _State) ->
+-spec save_my_jid(Acc, Params, Extra) -> {ok, Acc} when
+    Acc :: mongoose_acc:t(),
+    Params :: map(),
+    Extra :: map().
+save_my_jid(#{ stanza := #{ type := <<"chat">>} } = Acc, _, _) ->
     Me = mongoose_acc:get(c2s, origin_jid, Acc),
     {_, Acc2} = cached_my_jid(Me, Acc),
-    Acc2;
-save_my_jid(Acc, _State) -> Acc.
+    {ok, Acc2};
+save_my_jid(Acc, _, _) -> {ok, Acc}.
 
-drop_if_jid_not_mine({F, T, #{ stanza := #{ type := <<"chat">> } } = Acc, P}) ->
+-spec drop_if_jid_not_mine(Acc, Params, Extra) -> {ok, Acc} when
+    Acc :: mongoose_hooks:filter_packet_acc() | drop,
+    Params :: map(),
+    Extra :: map().
+drop_if_jid_not_mine({F, T, #{ stanza := #{ type := <<"chat">> } } = Acc, P}, _, _) ->
     %% since we are in filter_local_packet, means we are just about to deliver the message
     %% sender-side processing is already completed and now we want the other guy values
-    case cached_my_jid(T, Acc) of
+    NewAcc = case cached_my_jid(T, Acc) of
         {T, Acc2} ->
             {F, T, Acc2, P};
         _ ->
             drop
-    end;
-drop_if_jid_not_mine(X) ->
-    X.
+    end,
+    {ok, NewAcc};
+drop_if_jid_not_mine(Acc, _, _) ->
+    {ok, Acc}.
 
 recreate_table() ->
     try ets:delete(test_message_index) catch _:_ -> ok end,
@@ -64,12 +87,17 @@ check_acc(Acc, stripped) ->
     undefined = mongoose_acc:get(test, should_be_stripped, undefined, Acc),
     check_acc(Acc).
 
-alter_message({From, To, Acc, Packet}) ->
+-spec alter_message(Acc, Params, Extra) -> {ok, Acc} when
+    Acc :: mongoose_hooks:filter_packet_acc(),
+    Params :: map(),
+    Extra :: map().
+alter_message({From, To, Acc, Packet}, _, _) ->
     % Not using #xmlel as it causes some strange error in dynamic compilation
     {xmlel, PName, PAttrs, PCh} = Packet,
     NewBody = {xmlel, <<"body">>, [], [{xmlcdata, <<"bye">> }]},
     PCh2 = lists:keyreplace(<<"body">>, 2, PCh, NewBody),
-    {From, To, Acc, {xmlel, PName, PAttrs, PCh2}}.
+    NewAcc = {From, To, Acc, {xmlel, PName, PAttrs, PCh2}},
+    {ok, NewAcc}.
 
 cached_my_jid(User, Acc) ->
     case mongoose_acc:get(test, my_jid, undefined, Acc) of


### PR DESCRIPTION
This PR changes all hook handlers in `acc_e2e_SUITE` to `gen_hook` format.