### PR TITLE
Inbox/pagination — part 1

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -1229,12 +1229,14 @@ timestamp_is_updated_on_new_message(Config) ->
          %% We capture the timestamp after the first message
          escalus:send(Alice, escalus_stanza:chat_to(Bob, Body1)),
          _M1 = escalus:wait_for_stanza(Bob),
-         [Item1] = check_inbox(Bob, [#conv{unread = 1, from = Alice, to = Bob, content = Body1}]),
+         #{respond_messages := [Item1]}
+             = check_inbox(Bob, [#conv{unread = 1, from = Alice, to = Bob, content = Body1}]),
          TStamp1 = inbox_helper:timestamp_from_item(Item1),
          %% We capture the timestamp after the second message
          escalus:send(Alice, escalus_stanza:chat_to(Bob, Body2)),
          _M2 = escalus:wait_for_stanza(Bob),
-         [Item2] = check_inbox(Bob, [#conv{unread = 2, from = Alice, to = Bob, content = Body2}]),
+         #{respond_messages := [Item2]}
+             = check_inbox(Bob, [#conv{unread = 2, from = Alice, to = Bob, content = Body2}]),
          TStamp2 = inbox_helper:timestamp_from_item(Item2),
          %% Timestamp after second message must be higher
          case TStamp2 > TStamp1 of

--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -100,6 +100,7 @@ groups() ->
         properties_many_can_be_set,
         properties_many_can_be_set_queryid,
         inbox_can_paginate_forwards,
+        inbox_can_paginate_backwards,
         max_queries_can_be_limited,
         max_queries_can_fetch_ahead,
         timestamp_is_not_reset_with_setting_properties
@@ -688,6 +689,30 @@ inbox_can_paginate_forwards(Config) ->
         inbox_helper:check_inbox(Alice, [ConvWithMike, ConvWithKate], Params1),
         Params2 = #{box => inbox, start => TimeAfterKate, 'end' => TimeAfterMike,
                     'after' => to_int(TimeAfterBob) - 99999},
+        inbox_helper:check_inbox(Alice, [ConvWithMike, ConvWithKate, ConvWithBob], Params2)
+    end).
+
+inbox_can_paginate_backwards(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}, {kate, 1}, {mike, 1}],
+                        fun(Alice, Bob, Kate, Mike) ->
+        % Several people write to Alice
+        #{Alice := AliceConvs} =
+            inbox_helper:given_conversations_between(Alice, [Bob, Kate, Mike]),
+        % Alice has some messages in her inbox
+        inbox_helper:check_inbox(Alice, AliceConvs),
+        % Extract all the helper values
+        ConvWithBob = lists:keyfind(Bob, #conv.to, AliceConvs),
+        ConvWithKate = lists:keyfind(Kate, #conv.to, AliceConvs),
+        ConvWithMike = lists:keyfind(Mike, #conv.to, AliceConvs),
+        TimeAfterBob = ConvWithBob#conv.time_after,
+        TimeAfterKate = ConvWithKate#conv.time_after,
+        TimeAfterMike = ConvWithMike#conv.time_after,
+        % We set end to return Convs with Mike, but using RSM we override that
+        Params1 = #{box => inbox, 'end' => TimeAfterMike,
+                    before => to_int(TimeAfterBob)},
+        inbox_helper:check_inbox(Alice, [ConvWithBob], Params1),
+        Params2 = #{box => inbox, 'end' => TimeAfterMike,
+                    before => to_int(TimeAfterMike) + 99999},
         inbox_helper:check_inbox(Alice, [ConvWithMike, ConvWithKate, ConvWithBob], Params2)
     end).
 

--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -99,6 +99,7 @@ groups() ->
         properties_full_entry_can_be_get,
         properties_many_can_be_set,
         properties_many_can_be_set_queryid,
+        inbox_pagination_overrides_form,
         inbox_can_paginate_forwards,
         inbox_can_paginate_backwards,
         max_queries_can_be_limited,
@@ -668,7 +669,7 @@ properties_many_can_be_set(Config, QueryId) ->
                                                 end}], #{box => archive})
     end).
 
-inbox_can_paginate_forwards(Config) ->
+inbox_pagination_overrides_form(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}, {kate, 1}, {mike, 1}],
                         fun(Alice, Bob, Kate, Mike) ->
         % Several people write to Alice
@@ -677,19 +678,29 @@ inbox_can_paginate_forwards(Config) ->
         % Alice has some messages in her inbox
         inbox_helper:check_inbox(Alice, AliceConvs),
         % Extract all the helper values
-        ConvWithBob = lists:keyfind(Bob, #conv.to, AliceConvs),
         ConvWithKate = lists:keyfind(Kate, #conv.to, AliceConvs),
         ConvWithMike = lists:keyfind(Mike, #conv.to, AliceConvs),
-        TimeAfterBob = ConvWithBob#conv.time_after,
         TimeAfterKate = ConvWithKate#conv.time_after,
         TimeAfterMike = ConvWithMike#conv.time_after,
         % We set start and end to return Convs with Mike, but using RSM we override that
-        Params1 = #{box => inbox, start => TimeAfterKate, 'end' => TimeAfterMike,
-                    'after' => to_int(TimeAfterBob)},
-        inbox_helper:check_inbox(Alice, [ConvWithMike, ConvWithKate], Params1),
-        Params2 = #{box => inbox, start => TimeAfterKate, 'end' => TimeAfterMike,
-                    'after' => to_int(TimeAfterBob) - 99999},
-        inbox_helper:check_inbox(Alice, [ConvWithMike, ConvWithKate, ConvWithBob], Params2)
+        Params = #{box => inbox, start => TimeAfterKate, 'end' => TimeAfterMike, before => <<>>},
+        inbox_helper:check_inbox(Alice, AliceConvs, Params)
+    end).
+
+inbox_can_paginate_forwards(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}, {kate, 1}, {mike, 1}],
+                        fun(Alice, Bob, Kate, Mike) ->
+        % Several people write to Alice
+        #{Alice := [ConvWithMike, ConvWithKate, ConvWithBob] = AliceConvs} =
+            inbox_helper:given_conversations_between(Alice, [Bob, Kate, Mike]),
+        % Alice has some messages in her inbox
+        inbox_helper:check_inbox(Alice, AliceConvs),
+        Params1 = #{box => inbox, limit => 1},
+        #{respond_iq := Iq} = inbox_helper:check_inbox(Alice, [ConvWithMike], Params1),
+        AfterPrevious = exml_query:path(Iq, [{element_with_ns, <<"fin">>, inbox_helper:inbox_ns()},
+                                             {element, <<"set">>}, {element, <<"last">>}, cdata]),
+        Params2 = #{box => inbox, 'after' => AfterPrevious},
+        inbox_helper:check_inbox(Alice, [ConvWithKate, ConvWithBob], Params2)
     end).
 
 inbox_can_paginate_backwards(Config) ->
@@ -704,16 +715,12 @@ inbox_can_paginate_backwards(Config) ->
         ConvWithBob = lists:keyfind(Bob, #conv.to, AliceConvs),
         ConvWithKate = lists:keyfind(Kate, #conv.to, AliceConvs),
         ConvWithMike = lists:keyfind(Mike, #conv.to, AliceConvs),
-        TimeAfterBob = ConvWithBob#conv.time_after,
-        TimeAfterKate = ConvWithKate#conv.time_after,
-        TimeAfterMike = ConvWithMike#conv.time_after,
-        % We set end to return Convs with Mike, but using RSM we override that
-        Params1 = #{box => inbox, 'end' => TimeAfterMike,
-                    before => to_int(TimeAfterBob)},
-        inbox_helper:check_inbox(Alice, [ConvWithBob], Params1),
-        Params2 = #{box => inbox, 'end' => TimeAfterMike,
-                    before => to_int(TimeAfterMike) + 99999},
-        inbox_helper:check_inbox(Alice, [ConvWithMike, ConvWithKate, ConvWithBob], Params2)
+        Params1 = #{box => inbox, limit => 1, before => <<>>},
+        #{respond_iq := Iq} = inbox_helper:check_inbox(Alice, [ConvWithBob], Params1),
+        BeforeLast = exml_query:path(Iq, [{element_with_ns, <<"fin">>, inbox_helper:inbox_ns()},
+                                          {element, <<"set">>}, {element, <<"first">>}, cdata]),
+        Params2 = #{box => inbox, before => BeforeLast},
+        inbox_helper:check_inbox(Alice, [ConvWithMike, ConvWithKate], Params2)
     end).
 
 max_queries_can_be_limited(Config) ->

--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -701,12 +701,12 @@ timestamp_is_not_reset_with_setting_properties(Config) ->
         % Alice sends a message to Bob
         inbox_helper:send_msg(Alice, Bob),
         %% We capture the timestamp
-        [Item1] = inbox_helper:get_inbox(Bob, #{count => 1}),
+        #{respond_messages := [Item1]} = inbox_helper:get_inbox(Bob, #{count => 1}),
         TStamp1 = inbox_helper:timestamp_from_item(Item1),
         % Bob sets a bunch of properties
         set_inbox_properties(Bob, Alice, [{read, true}, {mute, 24*?HOUR}]),
         % Bob gets the inbox again, and timestamp should be the same
-        [Item2] = inbox_helper:get_inbox(Bob, #{count => 1}),
+        #{respond_messages := [Item2]} = inbox_helper:get_inbox(Bob, #{count => 1}),
         TStamp2 = inbox_helper:timestamp_from_item(Item2),
         ?assertEqual(TStamp1, TStamp2)
   end).
@@ -750,6 +750,12 @@ groupchat_setunread_stanza_sets_inbox(Config) ->
 %%--------------------------------------------------------------------
 
 -type maybe_client() :: undefined | escalus:client().
+
+verify_rsm(#{respond_iq := Iq}) ->
+    Set = exml_query:path(Iq, [{element_with_ns, <<"fin">>, inbox_helper:inbox_ns()},
+                               {element_with_ns, <<"set">>, ?NS_RSM}]),
+    ?assertNotEqual(undefined, exml_query:subelement(Set, <<"first">>)),
+    ?assertNotEqual(undefined, exml_query:subelement(Set, <<"last">>)).
 
 -spec query_properties(escalus:client(), escalus:client(), proplists:proplist()) -> [exml:element()].
 query_properties(From, To, Expected) ->

--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -677,10 +677,12 @@ max_queries_can_be_limited(Config) ->
         % Then Alice queries her inbox setting a limit to only one conversation,
         % and she gets the newest one
         ConvWithMike = lists:keyfind(Mike, #conv.to, AliceConvs),
-        inbox_helper:check_inbox(Alice, [ConvWithMike], #{limit => 1, box => inbox}),
+        Inbox1 = inbox_helper:check_inbox(Alice, [ConvWithMike], #{limit => 1, box => inbox}),
+        verify_rsm(Inbox1),
         % And a limit to two also works fine
         ConvWithKate = lists:keyfind(Kate, #conv.to, AliceConvs),
-        inbox_helper:check_inbox(Alice, [ConvWithMike, ConvWithKate], #{limit => 2, box => inbox})
+        Inbox2 = inbox_helper:check_inbox(Alice, [ConvWithMike, ConvWithKate], #{limit => 2, box => inbox}),
+        verify_rsm(Inbox2)
     end).
 
 max_queries_can_fetch_ahead(Config) ->

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -401,13 +401,13 @@ rsm(Params) ->
     Before = maps:get(before, Params, undefined),
     After = maps:get('after', Params, undefined),
     Elems = [#xmlel{name = <<"max">>,
-                    children = [#xmlcdata{content = itb(Max)}]}
+                    children = [#xmlcdata{content = to_bin(Max)}]}
              || _ <- [Max], undefined =/= Max ] ++
             [#xmlel{name = <<"before">>,
-                    children = [#xmlcdata{content = itb(Before)}]}
+                    children = [#xmlcdata{content = to_bin(Before)}]}
              || _ <- [Before], undefined =/= Before ] ++
             [#xmlel{name = <<"after">>,
-                    children = [#xmlcdata{content = itb(After)}]}
+                    children = [#xmlcdata{content = to_bin(After)}]}
              || _ <- [After], undefined =/= After ],
     case Elems of
         [] -> [];
@@ -416,8 +416,8 @@ rsm(Params) ->
                      children = Elems}]
     end.
 
-itb(N) when is_integer(N) -> integer_to_binary(N);
-itb(Bin) when is_binary(Bin) -> Bin.
+to_bin(N) when is_integer(N) -> integer_to_binary(N);
+to_bin(Bin) when is_binary(Bin) -> Bin.
 
 
 -spec reset_inbox(

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -395,8 +395,18 @@ build_result_iq(List) ->
     ResultBinary = maps:map(fun(K, V) ->
                                     #xmlel{name = K, children = [#xmlcdata{content = integer_to_binary(V)}]}
                             end, Result),
+    ResultSetEl = result_set(List),
     #xmlel{name = <<"fin">>, attrs = [{<<"xmlns">>, ?NS_ESL_INBOX}],
-           children = maps:values(ResultBinary)}.
+           children = [ResultSetEl | maps:values(ResultBinary)]}.
+
+-spec result_set([inbox_res()]) -> exml:element().
+result_set([]) ->
+    #xmlel{name = <<"set">>, attrs = [{<<"xmlns">>, ?NS_RSM}]};
+result_set([#{timestamp := First} | _] = List) ->
+    #{timestamp := Last} = lists:last(List),
+    BFirst = integer_to_binary(First),
+    BLast = integer_to_binary(Last),
+    mod_mam_utils:result_set(BFirst, BLast, undefined, undefined).
 
 %%%%%%%%%%%%%%%%%%%
 %% iq-get

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -458,6 +458,7 @@ build_params(Params, #rsm_in{max = Max, id = undefined}) when Max =/= undefined 
     Params#{limit => Max};
 build_params(Params, #rsm_in{max = Max, id = ISO, direction = Dir}) when is_binary(ISO) ->
     case {mod_inbox_utils:maybe_binary_to_positive_integer(ISO), Dir} of
+        {{error, _}, before} -> Params#{limit => Max, 'end' => (1 bsl 63 - 1)};
         {{error, _}, _} -> {error, bad_request, <<"bad-request">>};
         {Stamp, aft} -> Params#{limit => Max, start => Stamp + 1};
         {Stamp, undefined} -> Params#{limit => Max, start => Stamp + 1};

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -395,8 +395,8 @@ parse_xdata_values([#xmlel{name = <<"value">> } = ValueEl | REls]) ->
 parse_xdata_values([_ | REls]) ->
     parse_xdata_values(REls).
 
--spec rsm_decode(exml:element() | iq()) -> 'none' | #rsm_in{}.
-rsm_decode(#iq{sub_el=SubEl})->
+-spec rsm_decode(exml:element() | iq()) -> none | #rsm_in{}.
+rsm_decode(#iq{sub_el = SubEl})->
     rsm_decode(SubEl);
 rsm_decode(#xmlel{}=SubEl) ->
     case xml:get_subtag(SubEl, <<"set">>) of
@@ -406,41 +406,36 @@ rsm_decode(#xmlel{}=SubEl) ->
             lists:foldl(fun rsm_parse_element/2, #rsm_in{}, SubEls)
     end.
 
-
 -spec rsm_parse_element(exml:element(), rsm_in()) -> rsm_in().
-rsm_parse_element(#xmlel{name = <<"max">>, attrs = []}=Elem, RsmIn) ->
+rsm_parse_element(#xmlel{name = <<"max">>, attrs = []} = Elem, RsmIn) ->
     CountStr = xml:get_tag_cdata(Elem),
     {Count, _} = string:to_integer(binary_to_list(CountStr)),
-    RsmIn#rsm_in{max=Count};
-rsm_parse_element(#xmlel{name = <<"before">>,
-                         attrs = []}=Elem, RsmIn) ->
+    RsmIn#rsm_in{max = Count};
+rsm_parse_element(#xmlel{name = <<"before">>, attrs = []} = Elem, RsmIn) ->
     UID = xml:get_tag_cdata(Elem),
-    RsmIn#rsm_in{direction=before, id=UID};
-rsm_parse_element(#xmlel{name = <<"after">>, attrs = []}=Elem, RsmIn) ->
+    RsmIn#rsm_in{direction = before, id = UID};
+rsm_parse_element(#xmlel{name = <<"after">>, attrs = []} = Elem, RsmIn) ->
     UID = xml:get_tag_cdata(Elem),
-    RsmIn#rsm_in{direction=aft, id=UID};
-rsm_parse_element(#xmlel{name = <<"index">>, attrs = []}=Elem, RsmIn) ->
+    RsmIn#rsm_in{direction = aft, id = UID};
+rsm_parse_element(#xmlel{name = <<"index">>, attrs = []} = Elem, RsmIn) ->
     IndexStr = xml:get_tag_cdata(Elem),
     {Index, _} = string:to_integer(binary_to_list(IndexStr)),
-    RsmIn#rsm_in{index=Index};
+    RsmIn#rsm_in{index = Index};
 rsm_parse_element(_, RsmIn)->
     RsmIn.
 
-
--spec rsm_encode('none' | rsm_out()) -> [exml:element()].
-rsm_encode(none)->
+-spec rsm_encode(none | rsm_out()) -> [exml:element()].
+rsm_encode(none) ->
     [];
-rsm_encode(RsmOut)->
+rsm_encode(RsmOut) ->
     [#xmlel{name = <<"set">>, attrs = [{<<"xmlns">>, ?NS_RSM}],
             children = lists:reverse(rsm_encode_out(RsmOut))}].
 
-
 -spec rsm_encode_out(rsm_out()) -> [exml:element()].
-rsm_encode_out(#rsm_out{count=Count, index=Index, first=First, last=Last})->
+rsm_encode_out(#rsm_out{count = Count, index = Index, first = First, last = Last})->
     El = rsm_encode_first(First, Index, []),
     El2 = rsm_encode_last(Last, El),
     rsm_encode_count(Count, El2).
-
 
 -spec rsm_encode_first(First :: undefined | binary(),
                        Index :: 'undefined' | integer(),
@@ -448,22 +443,20 @@ rsm_encode_out(#rsm_out{count=Count, index=Index, first=First, last=Last})->
 rsm_encode_first(undefined, undefined, Arr) ->
     Arr;
 rsm_encode_first(First, undefined, Arr) ->
-    [#xmlel{name = <<"first">>, children = [#xmlcdata{content = First}]}|Arr];
+    [#xmlel{name = <<"first">>, children = [#xmlcdata{content = First}]} | Arr];
 rsm_encode_first(First, Index, Arr) ->
     [#xmlel{name = <<"first">>, attrs = [{<<"index">>, i2b(Index)}],
             children = [#xmlcdata{content = First}]}|Arr].
 
-
 -spec rsm_encode_last(Last :: 'undefined', Arr :: [exml:element()]) -> [exml:element()].
 rsm_encode_last(undefined, Arr) -> Arr;
 rsm_encode_last(Last, Arr) ->
-    [#xmlel{name = <<"last">>, children = [#xmlcdata{content = Last}]}|Arr].
-
+    [#xmlel{name = <<"last">>, children = [#xmlcdata{content = Last}]} | Arr].
 
 -spec rsm_encode_count(Count :: 'undefined' | pos_integer(),
                        Arr :: [exml:element()]) -> [exml:element()].
-rsm_encode_count(undefined, Arr)-> Arr;
-rsm_encode_count(Count, Arr)->
+rsm_encode_count(undefined, Arr) -> Arr;
+rsm_encode_count(Count, Arr) ->
     [#xmlel{name = <<"count">>, children = [#xmlcdata{content = i2b(Count)}]} | Arr].
 
 -spec i2b(integer()) -> binary().


### PR DESCRIPTION
Currently inbox introduces only the max key of the [RSM XEP](https://xmpp.org/extensions/xep-0059.html), and within the inbox form we also allow for setting something equivalent to the RSM’s before and after. But there’s no RSM payload in the iq-fin-result, and also, helper libraries might be used on the client side for more complex pagination, provided full support for RSM is available.

This PR introduces support for points:
- [Limiting the Number of Items](https://xmpp.org/extensions/xep-0059.html#limit)
- [Paging Forwards Through a Result Set](https://xmpp.org/extensions/xep-0059.html#forwards)
- [Paging Backwards Through a Result Set](https://xmpp.org/extensions/xep-0059.html#backwards)

Other points in the document might be implemented fully or partially but I haven't taken them into consideration for this PR and are therefore not verified nor tested.

Note that the `count` is not introduced, the document specifies that:

> The responding entity SHOULD also include the number of items in the full result set (which MAY be approximate) encapsulated in a <count/> element. The <first/> element SHOULD include an 'index' attribute. This integer specifies the position within the full set (which MAY be approximate) of the first item in the page. If that item is the first in the full set, then the index SHOULD be '0'. If the last item in the page is the last item in the full set, then the value of the <first/> element's 'index' attribute SHOULD be the specified count minus the number of items in the last page.

> Note: The <count/> element and 'index' attribute enable important functionality for requesting entities (for example, a scroll-bar user-interface component). They MAY be omitted, but only if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.

Also not yet fully perfected is the fact that the UIDs as specified in the document are not unique, currently it is using the integer representation of the timestamp of the inbox row, which can potentially collide. Left is to ensure timestamps are unique, or use a hash of the jid which are known to be unique, though in that case it'd need to make more complex queries to find out about the order by timestamp.

This is for now experimental and therefore not yet fully documented, I plan to do so in a subsequent PR, but it is as of this PR pretty much the requirement I currently have.