### PR TITLE
GraphQL subscriptions for stanzas

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -26,6 +26,7 @@
 {suites, "tests", extdisco_SUITE}.
 {suites, "tests", gdpr_SUITE}.
 {suites, "tests", graphql_SUITE}.
+{suites, "tests", graphql_sse_SUITE}.
 {suites, "tests", graphql_account_SUITE}.
 {suites, "tests", graphql_domain_SUITE}.
 {suites, "tests", graphql_inbox_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -42,6 +42,7 @@
  "at the moment mod_pubsub doesn't support dynamic domains"}.
 
 {suites, "tests", graphql_SUITE}.
+{suites, "tests", graphql_sse_SUITE}.
 {suites, "tests", graphql_account_SUITE}.
 {suites, "tests", graphql_domain_SUITE}.
 {suites, "tests", graphql_inbox_SUITE}.

--- a/big_tests/tests/graphql_sse_SUITE.erl
+++ b/big_tests/tests/graphql_sse_SUITE.erl
@@ -1,0 +1,138 @@
+%% @doc Tests for the SSE handling of GraphQL subscriptions
+-module(graphql_sse_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(graphql_helper, [get_bad_request/1, get_unauthorized/1, get_method_not_allowed/1,
+                         build_request/4, make_creds/1, execute_auth/2,
+                         execute_sse/3, execute_user_sse/3, execute_auth_sse/2]).
+
+%% common_test callbacks
+
+suite() ->
+    require_rpc_nodes([mim]) ++ escalus:suite().
+
+all() ->
+    [{group, admin},
+     {group, user}].
+
+groups() ->
+    [{admin, [parallel], admin_tests()},
+     {user, [parallel], user_tests()}].
+
+init_per_suite(Config) ->
+    Config1 = escalus:init_per_suite(Config),
+    application:ensure_all_started(gun),
+    Config1.
+
+end_per_suite(Config) ->
+    escalus:end_per_suite(Config).
+
+init_per_group(user, Config) ->
+    graphql_helper:init_user(Config);
+init_per_group(admin, Config) ->
+    graphql_helper:init_admin_handler(Config).
+
+end_per_group(user, _Config) ->
+    escalus_fresh:clean(),
+    graphql_helper:clean();
+end_per_group(admin, _Config) ->
+    graphql_helper:clean().
+
+init_per_testcase(CaseName, Config) ->
+    escalus:init_per_testcase(CaseName, Config).
+
+end_per_testcase(CaseName, Config) ->
+    escalus:end_per_testcase(CaseName, Config).
+
+admin_tests() ->
+    [admin_missing_query,
+     admin_invalid_query_string,
+     admin_missing_creds,
+     admin_invalid_creds,
+     admin_invalid_method,
+     admin_invalid_operation_type].
+
+user_tests() ->
+    [user_missing_query,
+     user_invalid_query_string,
+     user_missing_creds,
+     user_invalid_creds,
+     user_invalid_method,
+     user_invalid_operation_type].
+
+%% Test cases and stories
+
+admin_missing_query(Config) ->
+    get_bad_request(execute_auth_sse(#{}, Config)).
+
+user_missing_query(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_missing_query_story/2).
+
+user_missing_query_story(Config, Alice) ->
+    get_bad_request(execute_user_sse(#{}, Alice, Config)).
+
+admin_invalid_query_string(_Config) ->
+    Port = graphql_helper:get_listener_port(admin),
+    get_bad_request(sse_helper:connect_to_sse(Port, "/api/graphql/sse?=invalid", undefined, #{})).
+
+user_invalid_query_string(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun user_invalid_query_string_story/1).
+
+user_invalid_query_string_story(Alice) ->
+    Port = graphql_helper:get_listener_port(user),
+    Creds = make_creds(Alice),
+    get_bad_request(sse_helper:connect_to_sse(Port, "/api/graphql/sse?=invalid", Creds, #{})).
+
+admin_missing_creds(_Config) ->
+    get_unauthorized(execute_sse(admin, #{query => doc(), variables => args()}, undefined)).
+
+user_missing_creds(_Config) ->
+    get_unauthorized(execute_sse(user, #{query => doc()}, undefined)).
+
+admin_invalid_creds(_Config) ->
+    Creds = {<<"invalid">>, <<"creds">>},
+    get_unauthorized(execute_sse(admin, #{query => doc(), variables => args()}, Creds)).
+
+user_invalid_creds(_Config) ->
+    get_unauthorized(execute_sse(user, #{query => doc()}, {<<"invalid">>, <<"creds">>})).
+
+admin_invalid_method(_Config) ->
+    #{node := Node} = mim(),
+    Request = build_request(Node, admin, #{query => doc(), variables => args()}, undefined),
+    %% POST was used, while SSE accepts only GET
+    get_method_not_allowed(rest_helper:make_request(Request#{path => "/graphql/sse"})).
+
+user_invalid_method(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun user_invalid_method_story/1).
+
+user_invalid_method_story(Alice) ->
+    #{node := Node} = mim(),
+    Request = build_request(Node, user, #{query => doc()}, make_creds(Alice)),
+    %% POST was used, while SSE accepts only GET
+    get_method_not_allowed(rest_helper:make_request(Request#{path => "/graphql/sse"})).
+
+admin_invalid_operation_type(Config) ->
+    Creds = graphql_helper:make_admin_creds(admin, Config),
+    get_bad_request(execute_sse(admin, #{query => query_doc(), variables => args()}, Creds)).
+
+user_invalid_operation_type(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun user_invalid_operation_type_story/1).
+
+user_invalid_operation_type_story(Alice) ->
+    get_bad_request(execute_sse(user, #{query => query_doc()}, make_creds(Alice))).
+
+%% Helpers
+
+%% Subscription - works only with the SSE handler
+doc() ->
+    graphql_helper:get_doc(<<"stanza">>, <<"subscribeForMessages">>).
+
+%% Query - works only with the REST handler
+query_doc() ->
+    graphql_helper:get_doc(<<"stanza">>, <<"getLastMessages">>).
+
+%% Same args used by both operations - only for Admin
+args() ->
+    #{caller => <<"alice@localhost">>}.

--- a/big_tests/tests/sse_helper.erl
+++ b/big_tests/tests/sse_helper.erl
@@ -1,0 +1,41 @@
+-module(sse_helper).
+
+-compile([export_all, nowarn_export_all]).
+
+connect_to_sse(Port, Path, Creds, ExtraOpts) ->
+    ct:log("Connect to SSE, port: ~p, path: ~s, creds: ~p, extra opts: ~p",
+           [Port, Path, Creds, ExtraOpts]),
+    Headers = auth_headers(Creds) ++ [{<<"host">>, <<"localhost">>},
+                                      {<<"accept">>, <<"text/event-stream">>}],
+    Opts = maps:merge(basic_opts(), ExtraOpts),
+    {ok, ConnPid} = gun:open("localhost", Port, Opts),
+    {ok, _} = gun:await_up(ConnPid),
+    StreamRef = gun:get(ConnPid, Path, Headers),
+    {response, nofin, Status, RespHeaders} = gun:await(ConnPid, StreamRef),
+    Result = case {Status, maps:from_list(RespHeaders)} of
+                 {200, #{<<"content-type">> := <<"text/event-stream">>}} ->
+                     #{pid => ConnPid, stream_ref => StreamRef};
+                 _ ->
+                     {ok, Body} = gun:await_body(ConnPid, StreamRef),
+                     jiffy:decode(Body, [return_maps])
+             end,
+    ct:log("SSE response code: ~p, headers: ~p, result: ~p", [Status, RespHeaders, Result]),
+    {Status, Result}.
+
+wait_for_event(#{pid := Pid, stream_ref := StreamRef}) ->
+    {sse, #{data := [Response]} = Event} = gun:await(Pid, StreamRef),
+    ct:log("Received SSE event: ~p", [Event]),
+    jiffy:decode(Response, [return_maps]).
+
+stop_sse(#{pid := Pid}) ->
+    gun:close(Pid).
+
+auth_headers({Username, Password}) ->
+    Base64 = base64:encode(binary_to_list(Username) ++ [$: | binary_to_list(Password)]),
+    [{<<"authorization">>, <<"basic ", Base64/binary>>}];
+auth_headers(undefined) ->
+    [].
+
+basic_opts() ->
+    #{protocols => [http],
+      http_opts => #{content_handlers => [gun_sse_h, gun_data_h]}}.

--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -643,7 +643,7 @@ GraphQL API for administration, the listener is bound to 127.0.0.1 for increased
 ```toml
 [[listen.http]]
   ip_address = "127.0.0.1"
-  port = 8088
+  port = 5551
   transport.num_acceptors = 5
   transport.max_connections = 10
 
@@ -662,7 +662,7 @@ GraphQL API for the domain admin.
 ```toml
 [[listen.http]]
   ip_address = "0.0.0.0"
-  port = 5041
+  port = 5541
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
@@ -679,7 +679,7 @@ GraphQL API for the user.
 ```toml
 [[listen.http]]
   ip_address = "0.0.0.0"
-  port = 5061
+  port = 5561
   transport.num_acceptors = 10
   transport.max_connections = 1024
 

--- a/doc/graphql-api/Admin-GraphQL.md
+++ b/doc/graphql-api/Admin-GraphQL.md
@@ -6,6 +6,10 @@ We can distinguish two levels of the administration. A global admin (has access 
 
 There is only one schema for both admin types. Admin per domain simply has no permissions to execute global commands or commands with not owned domain. The API documentation clearly says which commands are global.
 
+**Queries** and **mutations** can be executed with the POST or GET method, as specified in the [GraphQL documentation](https://graphql.org/learn/serving-over-http/). The endpoint URL is as configured in the Listen section, e.g. `http://localhost:5551/api/graphql` for the global admin.
+
+**Subscriptions** can be executed with the GET method, and are handled with [Server-Sent Events (SSE)](https://html.spec.whatwg.org/multipage/server-sent-events.html). The endpoint URL is the same as for regular queries with the addition of `/sse`, e.g. `http://localhost:5551/api/graphql/sse` for the global admin.
+
 ## Domain admin configuration
 
 Out of the box, domains are created with a disabled admin account. Admin per domain can be enabled only by the global admin with the command

--- a/doc/graphql-api/User-GraphQL.md
+++ b/doc/graphql-api/User-GraphQL.md
@@ -2,6 +2,10 @@
 
 The new GraphQL user API contains all commands from the client REST API and provides plenty of new ones. Multiple commands previously available only for the admin have their counterparts for the user.
 
+**Queries** and **mutations** can be executed with the POST or GET method, as specified in the [GraphQL documentation](https://graphql.org/learn/serving-over-http/). The endpoint URL is as configured in the Listen section, e.g. `http://localhost:5561/api/graphql`.
+
+**Subscriptions** can be executed with the GET method, and are handled with [Server-Sent Events (SSE)](https://html.spec.whatwg.org/multipage/server-sent-events.html). The endpoint URL is the same as for regular queries with the addition of `/sse`, e.g. `http://localhost:5561/api/graphql/sse`.
+
 ## Authentication
 
 MongooseIM uses *Basic Authentication* as the authentication method for the GraphQL API.

--- a/priv/graphql/schemas/admin/admin_schema.gql
+++ b/priv/graphql/schemas/admin/admin_schema.gql
@@ -1,6 +1,7 @@
 schema{
   query: AdminQuery,
-  mutation: AdminMutation
+  mutation: AdminMutation,
+  subscription: AdminSubscription
 }
 
 """
@@ -79,4 +80,8 @@ type AdminMutation @protected{
   mnesia: MnesiaAdminMutation
   "Server info and management"
   server: ServerAdminMutation
+}
+
+type AdminSubscription {
+  stanza: StanzaAdminSubscription
 }

--- a/priv/graphql/schemas/admin/stanza.gql
+++ b/priv/graphql/schemas/admin/stanza.gql
@@ -19,3 +19,9 @@ type StanzaAdminMutation @protected{
   sendStanza(stanza: Stanza): SendStanzaPayload
     @protected(type: GLOBAL)
 }
+
+type StanzaAdminSubscription @protected{
+  "Subscribe for the given user's incoming messages"
+  subscribeForMessages(caller: JID!): StanzaMap
+    @protected(type: DOMAIN, args: ["caller"])
+}

--- a/priv/graphql/schemas/user/stanza.gql
+++ b/priv/graphql/schemas/user/stanza.gql
@@ -18,3 +18,8 @@ type StanzaUserMutation @protected{
   "Send an arbitrary stanza"
   sendStanza(stanza: Stanza): SendStanzaPayload
 }
+
+type StanzaUserSubscription @protected{
+  "Subscribe to incoming messages"
+  subscribeForMessages: StanzaMap
+}

--- a/priv/graphql/schemas/user/user_schema.gql
+++ b/priv/graphql/schemas/user/user_schema.gql
@@ -1,6 +1,7 @@
 schema{
   query: UserQuery,
-  mutation: UserMutation
+  mutation: UserMutation,
+  subscription: UserSubscription
 }
 
 """
@@ -57,4 +58,8 @@ type UserMutation @protected{
   httpUpload: HttpUploadUserMutation
   "OAUTH token management"
   token: TokenUserMutation
+}
+
+type UserSubscription {
+  stanza: StanzaUserSubscription
 }

--- a/src/graphql/admin/mongoose_graphql_admin_subscription.erl
+++ b/src/graphql/admin/mongoose_graphql_admin_subscription.erl
@@ -1,0 +1,11 @@
+-module(mongoose_graphql_admin_subscription).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
+    {ok, stanza}.

--- a/src/graphql/admin/mongoose_graphql_stanza_admin_subscription.erl
+++ b/src/graphql/admin/mongoose_graphql_stanza_admin_subscription.erl
@@ -1,0 +1,26 @@
+-module(mongoose_graphql_stanza_admin_subscription).
+-behaviour(mongoose_graphql).
+
+-import(mongoose_graphql_helper, [format_result/2]).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+execute(Ctx, _Obj, <<"subscribeForMessages">>, Args) ->
+    subscribe_for_messages(Ctx, Args).
+
+subscribe_for_messages(#{event := terminate, stream := Session}, _) ->
+    mongoose_stanza_api:close_session(Session),
+    {ok, null, [{stream, closed}]};
+subscribe_for_messages(#{event := Event}, _) ->
+    mongoose_graphql_stanza_helper:handle_event(Event);
+subscribe_for_messages(_Ctx, #{<<"caller">> := Jid}) ->
+    case mongoose_stanza_api:open_session(Jid, true) of
+        {ok, Stream} ->
+            {ok, null, [{stream, Stream}]};
+        Error ->
+            format_result(Error, #{caller => Jid})
+    end.

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -161,10 +161,11 @@ remove_null_args(Vars) ->
 admin_mapping_rules() ->
     #{objects => #{
         'AdminQuery' => mongoose_graphql_admin_query,
+        'AdminMutation' => mongoose_graphql_admin_mutation,
+        'AdminSubscription' => mongoose_graphql_admin_subscription,
         'AdminAuthInfo' => mongoose_graphql_admin_auth_info,
         'DomainAdminQuery' => mongoose_graphql_domain_admin_query,
         'GdprAdminQuery' => mongoose_graphql_gdpr_admin_query,
-        'AdminMutation' => mongoose_graphql_admin_mutation,
         'DomainAdminMutation' => mongoose_graphql_domain_admin_mutation,
         'InboxAdminMutation' => mongoose_graphql_inbox_admin_mutation,
         'SessionAdminMutation' => mongoose_graphql_session_admin_mutation,
@@ -175,6 +176,7 @@ admin_mapping_rules() ->
         'GlobalStats' => mongoose_graphql_stats_global,
         'DomainStats' => mongoose_graphql_stats_domain,
         'StanzaAdminQuery' => mongoose_graphql_stanza_admin_query,
+        'StanzaAdminSubscription' => mongoose_graphql_stanza_admin_subscription,
         'ServerAdminQuery' => mongoose_graphql_server_admin_query,
         'ServerAdminMutation' => mongoose_graphql_server_admin_mutation,
         'LastAdminMutation' => mongoose_graphql_last_admin_mutation,
@@ -207,6 +209,7 @@ user_mapping_rules() ->
     #{objects => #{
         'UserQuery' => mongoose_graphql_user_query,
         'UserMutation' => mongoose_graphql_user_mutation,
+        'UserSubscription' => mongoose_graphql_user_subscription,
         'AccountUserQuery' => mongoose_graphql_account_user_query,
         'AccountUserMutation' => mongoose_graphql_account_user_mutation,
         'InboxUserMutation' => mongoose_graphql_inbox_user_mutation,
@@ -226,6 +229,7 @@ user_mapping_rules() ->
         'StanzaUserMutation' => mongoose_graphql_stanza_user_mutation,
         'TokenUserMutation' => mongoose_graphql_token_user_mutation,
         'StanzaUserQuery' => mongoose_graphql_stanza_user_query,
+        'StanzaUserSubscription' => mongoose_graphql_stanza_user_subscription,
         'HttpUploadUserMutation' => mongoose_graphql_http_upload_user_mutation,
         'UserAuthInfo' => mongoose_graphql_user_auth_info,
         default => mongoose_graphql_default},

--- a/src/graphql/mongoose_graphql_operations.erl
+++ b/src/graphql/mongoose_graphql_operations.erl
@@ -1,0 +1,30 @@
+-module(mongoose_graphql_operations).
+
+-export([verify_operations/2]).
+
+-include_lib("graphql/src/graphql_schema.hrl").
+-include_lib("graphql/src/graphql_internal.hrl").
+
+verify_operations(Ctx, #document{definitions = Definitions}) ->
+    Method = maps:get(method, Ctx, undefined),
+    [verify_op_type(Method, op_type(Ty)) || #op{id = Id, ty = Ty} <- Definitions,
+                                            is_requested_op(Ctx, Id)],
+    ok.
+
+verify_op_type(Method, OpType) ->
+    case is_supported(Method, OpType) of
+        true ->
+            ok;
+        false ->
+            Error = {unsupported_operation, Method, OpType},
+            graphql_err:abort([], verify, Error)
+    end.
+
+is_supported(Method, subscription) -> Method =:= sse;
+is_supported(Method, _) -> Method =/= sse.
+
+is_requested_op(#{operation_name := undefined}, _) -> true;
+is_requested_op(#{operation_name := OpName}, {name, _, Name}) -> OpName =:= Name.
+
+op_type(undefined) -> query;
+op_type({OpType, _}) -> OpType.

--- a/src/graphql/mongoose_graphql_sse_handler.erl
+++ b/src/graphql/mongoose_graphql_sse_handler.erl
@@ -1,0 +1,108 @@
+%% @doc An SSE handler for GraphQL subscriptions.
+%% The graphql request is prepared, and then executed.
+%%
+%% 1. The first execution should return 'null' in 'data', and a new Stream in 'aux'.
+%% 2. Then, whenever an Event is received, the prepared GraphQL request
+%%    is executed again, this time with the Stream and the Event in the context.
+%%    The resolver should then return either 'null' or the processed Event to send to the client.
+%% 3. Upon termination, the request is executed one last time with the 'terminate' event.
+%%    This is an opportunity to clean up all stream resources.
+-module(mongoose_graphql_sse_handler).
+
+-behaviour(lasse_handler).
+-export([init/3,
+         handle_notify/2,
+         handle_info/2,
+         handle_error/3,
+         terminate/3]).
+
+-include("mongoose.hrl").
+
+-type req() :: cowboy_req:req().
+-type state() :: #{atom() => term()}.
+
+-spec init(state(), any(), cowboy_req:req()) ->
+          {ok, req(), state()} |
+          {shutdown, cowboy:http_status(), cowboy:http_headers(), iodata(), req(), state()}.
+init(State, _LastEvtId, Req) ->
+    process_flag(trap_exit, true), % needed for 'terminate' to be called
+    case cowboy_req:method(Req) of
+        <<"GET">> ->
+            case mongoose_graphql_cowboy_handler:check_auth_header(Req, State) of
+                {ok, State2} ->
+                    case mongoose_graphql_cowboy_handler:gather(Req) of
+                        {ok, Req2, Decoded} ->
+                            run_request(Decoded, Req2, State2);
+                        {error, Reason} ->
+                            reply_error(Reason, Req, State)
+                    end;
+                {error, Reason} ->
+                    reply_error(Reason, Req, State)
+            end;
+        _ ->
+            {ok, Req, State} % lasse returns 405: Method Not Allowed
+    end.
+
+run_request(#{document := undefined}, Req, State) ->
+    reply_error(make_error(decode, no_query_supplied), Req, State);
+run_request(GQLReq, Req, #{schema_endpoint := EpName, authorized := AuthStatus} = State) ->
+    Ep = mongoose_graphql:get_endpoint(EpName),
+    Ctx = maps:get(schema_ctx, State, #{}),
+    GQLReq2 = GQLReq#{authorized => AuthStatus, ctx => Ctx#{method => sse}},
+    case mongoose_graphql:prepare(Ep, GQLReq2) of
+        {error, Reason} ->
+            reply_error(Reason, Req, State);
+        {ok, GQLReq3 = #{ctx := Ctx2}} ->
+            case mongoose_graphql:execute(Ep, GQLReq3) of
+                {ok, #{aux := [{stream, Stream}]}} ->
+                    Ctx3 = Ctx2#{stream => Stream},
+                    {ok, Req, State#{id => 1, ep => Ep, req => GQLReq3#{ctx := Ctx3}}};
+                {ok, Response} ->
+                    Body = mongoose_graphql_response:term_to_json(Response),
+                    {shutdown, 200, #{}, Body, Req, State}
+            end
+    end.
+
+-spec handle_notify(term(), state()) -> {nosend, state()}.
+handle_notify(Msg, State) ->
+    ?UNEXPECTED_INFO(Msg),
+    {nosend, State}.
+
+-spec handle_info(term(), state()) -> {nosend, state()} | {send, lasse_handler:event(), state()}.
+handle_info(Event, State = #{ep := Ep, req := Req = #{ctx := Ctx}, id := Id}) ->
+    Ctx1 = Ctx#{event => Event},
+    {ok, #{data := Data} = Response} = mongoose_graphql:execute(Ep, Req#{ctx := Ctx1}),
+    case has_non_null_value(Data) of
+        false ->
+            {nosend, State};
+        true ->
+            EventData = mongoose_graphql_response:term_to_json(Response),
+            SseEvent = #{id => integer_to_binary(Id), data => EventData},
+            {send, SseEvent, State#{id := Id + 1}}
+    end.
+
+%% Check if there is any value that is non-null. Any list is considered non-null.
+has_non_null_value(M) when is_map(M) ->
+    lists:any(fun has_non_null_value/1, maps:values(M));
+has_non_null_value(V) -> V =/= null.
+
+-spec handle_error(iodata(), term(), state()) -> ok.
+handle_error(Msg, Reason, _State) ->
+    ?LOG_ERROR(#{what => mongoose_graphql_sse_handler_failed,
+                 reason => Reason, text => Msg}).
+
+-spec terminate(term(), req(), state()) -> ok.
+terminate(_Reason, _Req, #{ep := Ep, req := Req = #{ctx := Ctx}}) ->
+    Ctx1 = Ctx#{event => terminate},
+    {ok, #{aux := [{stream, closed}]}} = mongoose_graphql:execute(Ep, Req#{ctx := Ctx1}),
+    ok;
+terminate(_Reason, _Req, #{}) ->
+    ok.
+
+make_error(Phase, Term) ->
+    #{error_term => Term, phase => Phase}.
+
+reply_error(Reason, Req, State) ->
+    {Code, Error} = mongoose_graphql_errors:format_error(Reason),
+    Body = jiffy:encode(#{errors => [Error]}),
+    {shutdown, Code, #{}, Body, Req, State}.

--- a/src/graphql/mongoose_graphql_stanza_helper.erl
+++ b/src/graphql/mongoose_graphql_stanza_helper.erl
@@ -2,7 +2,10 @@
 
 -import(mongoose_graphql_helper, [null_to_undefined/1, make_error/2]).
 
--export([get_last_messages/5, row_to_map/1]).
+-export([get_last_messages/5, row_to_map/1, handle_event/1]).
+
+-include("mongoose.hrl").
+-include("jlib.hrl").
 
 -spec get_last_messages(Caller :: jid:jid(),
                         Limit :: null | non_neg_integer(),
@@ -20,10 +23,27 @@ get_last_messages(Caller, Limit, With, Before, CheckUser) ->
             Error
     end.
 
+-spec handle_event(term()) -> {ok, map() | null}.
+handle_event({route, From, _To, Acc}) ->
+    case mongoose_acc:element(Acc) of
+        Stanza = #xmlel{name = <<"message">>} ->
+            StanzaID = exml_query:attr(Stanza, <<"id">>, <<>>),
+            Timestamp = os:system_time(microsecond),
+            stanza_result(From, Timestamp, StanzaID, Stanza);
+        _ ->
+            {ok, null} % Skip other stanza types
+    end;
+handle_event(Msg) ->
+    ?UNEXPECTED_INFO(Msg),
+    {ok, null}.
+
 -spec row_to_map(mod_mam:message_row()) -> {ok, map()}.
-row_to_map(#{id := Id, jid := From, packet := Msg}) ->
+row_to_map(#{id := Id, jid := From, packet := Stanza}) ->
     {Microseconds, _} = mod_mam_utils:decode_compact_uuid(Id),
     StanzaID = mod_mam_utils:mess_id_to_external_binary(Id),
-    Map = #{<<"sender">> => From, <<"timestamp">> => Microseconds,
-            <<"stanza_id">> => StanzaID, <<"stanza">> => Msg},
+    stanza_result(From, Microseconds, StanzaID, Stanza).
+
+stanza_result(From, Timestamp, StanzaID, Stanza) ->
+    Map = #{<<"sender">> => From, <<"timestamp">> => Timestamp,
+            <<"stanza_id">> => StanzaID, <<"stanza">> => Stanza},
     {ok, Map}.

--- a/src/graphql/user/mongoose_graphql_stanza_user_subscription.erl
+++ b/src/graphql/user/mongoose_graphql_stanza_user_subscription.erl
@@ -1,0 +1,22 @@
+-module(mongoose_graphql_stanza_user_subscription).
+-behaviour(mongoose_graphql).
+
+-import(mongoose_graphql_helper, [format_result/2]).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+execute(Ctx, _Obj, <<"subscribeForMessages">>, #{}) ->
+    subscribe_for_messages(Ctx).
+
+subscribe_for_messages(#{event := terminate, stream := Session}) ->
+    mongoose_stanza_api:close_session(Session),
+    {ok, null, [{stream, closed}]};
+subscribe_for_messages(#{event := Event}) ->
+    mongoose_graphql_stanza_helper:handle_event(Event);
+subscribe_for_messages(#{user := Jid}) ->
+    {ok, Stream} = mongoose_stanza_api:open_session(Jid, false),
+    {ok, null, [{stream, Stream}]}.

--- a/src/graphql/user/mongoose_graphql_user_subscription.erl
+++ b/src/graphql/user/mongoose_graphql_user_subscription.erl
@@ -1,0 +1,11 @@
+-module(mongoose_graphql_user_subscription).
+-behaviour(mongoose_graphql).
+
+-export([execute/4]).
+
+-ignore_xref([execute/4]).
+
+-include("../mongoose_graphql_types.hrl").
+
+execute(_Ctx, _Obj, <<"stanza">>, _Args) ->
+    {ok, stanza}.

--- a/src/mongoose_stanza_api.erl
+++ b/src/mongoose_stanza_api.erl
@@ -1,9 +1,18 @@
 -module(mongoose_stanza_api).
+
+%% API
 -export([send_chat_message/4, send_headline_message/5, send_stanza/2, lookup_recent_messages/5]).
+
+%% Event API
+-export([open_session/2, close_session/1]).
 
 -include("jlib.hrl").
 -include("mongoose_rsm.hrl").
 -include("mongoose_logger.hrl").
+
+-type stream() :: #{jid := jid:jid(),
+                    sid := ejabberd_sm:sid(),
+                    host_type := mongooseim:host_type()}.
 
 %% API
 
@@ -39,6 +48,23 @@ send_stanza(User, Stanza) ->
 lookup_recent_messages(User, With, Before, Limit, CheckUser) ->
     M = #{user => User, with => With, before => Before, limit => Limit, check_user => CheckUser},
     fold(M, [fun get_host_type/1, fun check_user/1, fun lookup_messages/1]).
+
+%% Event API
+
+-spec open_session(jid:jid(), boolean()) -> {unknown_user, iodata()} | {ok, stream()}.
+open_session(User, CheckUser) ->
+    M = #{user => User, check_user => CheckUser},
+    fold(M, [fun get_host_type/1, fun check_user/1, fun do_open_session/1]).
+
+-spec close_session(stream()) -> {ok, closed}.
+close_session(#{jid := Jid = #jid{lserver = S}, sid := Sid, host_type := HostType}) ->
+    Acc = mongoose_acc:new(
+            #{location => ?LOCATION,
+              lserver => S,
+              host_type => HostType,
+              element => undefined}),
+    ejabberd_sm:close_session(Acc, Sid, Jid, normal),
+    {ok, closed}.
 
 %% Steps
 
@@ -141,6 +167,14 @@ lookup_messages(#{user := UserJid, with := WithJid, before := Before, limit := L
                is_simple => true},
     {ok, {_, _, Rows}} = mod_mam_pm:lookup_messages(HostType, Params),
     {ok, {Rows, Limit2}}.
+
+do_open_session(#{host_type := HostType, user := JID}) ->
+    SID = ejabberd_sm:make_new_sid(),
+    UUID = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
+    Resource = <<"sse-", UUID/binary>>,
+    NewJid = jid:replace_resource(JID, Resource),
+    ejabberd_sm:open_session(HostType, SID, NewJid, 1, #{}),
+    {ok, #{sid => SID, jid => NewJid, host_type => HostType}}.
 
 %% Helpers
 


### PR DESCRIPTION
The goal of this PR is to deliver incoming messages with the use of GraphQL **subscriptions**.
Such functionality existed for REST API, and it used SSE (Server-Sent Events) with [Lasse](https://github.com/inaka/lasse).
This GraphQL solution is using SSE as well.

### Subscription execution
According to [GraphQL specification](https://spec.graphql.org/draft/#sec-Subscription), executing a subscription should return a *Response Stream*, that will deliver the events to the subscriber. As the `graphql` library executes subscriptions the same way as queries, the subscription needs to be executed several times:
1. The first execution should return `null` in `data`, and a new Stream in `aux`, which corresponds to the *Source Stream* from the GraphQL docs.
2. Then, whenever an Event is received, the already processed and prepared GraphQL AST is executed again, this time with the Stream and the Event in the context. The resolver should then return either `null` or the processed Event to send to the client. This step is roughly equivalent to [MapSourceToResponseEvent](https://spec.graphql.org/draft/#MapSourceToResponseEvent()) - to implement it fully according to the specs, one would need to reimplement query execution in the `graphql` library, which seems too complicated for now.
3. Upon termination, the request is executed one last time with the `terminate` event. This is an opportunity to clean up all stream resources. It implements [unsubscribe](https://spec.graphql.org/draft/#sec-Unsubscribe) from the specs.

### SSE Handler
The new `mongoose_graphql_sse_handler` module handles requests to the `/sse` sub-path. It prepares and executes the requested subscription, and then listens for incoming messages. Each received message triggers delivery of the event. Only GET requests are accepted, which follows the specs, and is enforced by `lasse_handler`.

### `subscribeForMessages`
This subscription is added to both Client and Admin API. It returns messages in the same format as `getLastMessages`. It skips stanzas other than messages, just like the REST API. We could extend it when needed.

Data structures:
- Stream represents an open SM session, and it is a map with the User JID, Session ID, and the Host Type as keys.
- Events are received as `{route, From, To, Acc}`, just like in the REST API. We could amend it later.

### Other changes
GET and POST requests are now accepted for queries and mutations, and they accept the parameters in a query string and request body, respectively. This follows the [GraphQL recommendation](https://graphql.org/learn/serving-over-http/).

