### PR TITLE
Refactored hook handlers in mod_cache_users

### DIFF
--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -172,7 +172,7 @@ cache_removal(Config) ->
     ?assertEqual({stop, true}, does_cached_user_exist(FreshConfig, alice_bis)),
     run_remove_domain(),
     %% Cache removed only for Alice's domain
-    ?assertEqual(false, does_cached_user_exist(FreshConfig, alice)),
+    ?assertEqual({ok, false}, does_cached_user_exist(FreshConfig, alice)),
     ?assertEqual({stop, true}, does_cached_user_exist(FreshConfig, alice_bis)).
 
 mam_pm_removal(Config) ->
@@ -472,7 +472,7 @@ connect_and_disconnect(Spec) ->
 does_cached_user_exist(Config, User) ->
     Jid = #jid{lserver = Domain} = jid:from_binary(escalus_users:get_jid(Config, User)),
     HostType = domain_to_host_type(mim(), Domain),
-    rpc(mim(), mod_cache_users, does_cached_user_exist, [false, HostType, Jid, stored]).
+    rpc(mim(), mod_cache_users, does_cached_user_exist, [false, #{jid =>Jid, request_type => stored}, #{host_type => HostType}]).
 
 search_vcard_fields(DirJID, Filters) ->
     escalus_stanza:search_iq(DirJID, escalus_stanza:search_fields(Filters)).

--- a/src/mod_cache_users.erl
+++ b/src/mod_cache_users.erl
@@ -9,11 +9,8 @@
 -export([start/2, stop/1, config_spec/0, supported_features/0]).
 
 %% Hooks.
--export([does_cached_user_exist/4, maybe_put_user_into_cache/4,
+-export([does_cached_user_exist/3, maybe_put_user_into_cache/3,
          remove_user/3, remove_domain/3]).
-
--ignore_xref([does_cached_user_exist/4, maybe_put_user_into_cache/4,
-              remove_domain/3, remove_user/3]).
 
 %%====================================================================
 %% gen_mod callbacks
@@ -22,12 +19,12 @@
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, Opts) ->
     mongoose_user_cache:start_new_cache(HostType, ?MODULE, Opts),
-    ejabberd_hooks:add(hooks(HostType)),
+    gen_hook:add_handlers(hooks(HostType)),
     ok.
 
 -spec stop(mongooseim:host_type()) -> ok.
 stop(HostType) ->
-    ejabberd_hooks:delete(hooks(HostType)),
+    gen_hook:delete_handlers(hooks(HostType)),
     mongoose_user_cache:stop_cache(HostType, ?MODULE),
     ok.
 
@@ -45,58 +42,56 @@ supported_features() ->
 hooks(HostType) ->
     [
      %% These hooks must run before and after the ejabberd_auth does_user_exist hook
-     {does_user_exist, HostType, ?MODULE, does_cached_user_exist, 30},
-     {does_user_exist, HostType, ?MODULE, maybe_put_user_into_cache, 70},
+     {does_user_exist, HostType, fun ?MODULE:does_cached_user_exist/3, #{}, 30},
+     {does_user_exist, HostType, fun ?MODULE:maybe_put_user_into_cache/3, #{}, 70},
      %% It is important that these two handlers happen _after_ ejabberd_auth
      %% but _before_ all other modules
-     {remove_user, HostType, ?MODULE, remove_user, 10},
-     {remove_domain, HostType, ?MODULE, remove_domain, 20}
+     {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 10},
+     {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 20}
     ].
 
 %%====================================================================
 %% Hooks
 %%====================================================================
 
--spec remove_user(Acc :: mongoose_acc:t(),
-                  LUser :: jid:luser(),
-                  LServer :: jid:lserver() | string()) -> mongoose_acc:t().
-remove_user(Acc, LUser, LServer) ->
-    HostType = mongoose_acc:host_type(Acc),
-    Jid = jid:make_noprep(LUser, LServer, <<>>),
+-spec remove_user(Acc, Params, Extra) -> {ok, Acc} when
+      Acc :: mongoose_acc:t(),
+      Params :: #{jid := jid:jid()},
+      Extra :: #{host_type := mongooseim:host_type()}.
+remove_user(Acc, #{jid := Jid}, #{host_type := HostType}) ->
     mongoose_user_cache:delete_user(HostType, ?MODULE, Jid),
-    Acc.
+    {ok, Acc}.
 
--spec remove_domain(mongoose_hooks:simple_acc(),
-                    mongooseim:host_type(), jid:lserver()) ->
-    mongoose_hooks:simple_acc().
-remove_domain(Acc, HostType, Domain) ->
+-spec remove_domain(Acc, Params, Extra) -> {ok , Acc} when
+      Acc :: mongoose_domain_api:remove_domain_acc(),
+      Params :: #{domain := jid:lserver()},
+      Extra :: #{host_type := mongooseim:host_type()}.
+remove_domain(Acc, #{domain := Domain}, #{host_type := HostType}) ->
     mongoose_user_cache:delete_domain(HostType, ?MODULE, Domain),
-    Acc.
+    {ok, Acc}.
 
-%%====================================================================
-%% Helpers
-%%====================================================================
-
--spec does_cached_user_exist(Status :: boolean(),
-                             HostType :: mongooseim:host_type(),
-                             Jid :: jid:jid(),
-                             RequestType :: ejabberd_auth:exist_type()) ->
-    boolean() | {stop, true}.
-does_cached_user_exist(false, HostType, Jid, stored) ->
+-spec does_cached_user_exist(Acc, Params, Extra) -> {stop | ok , Acc} when
+      Acc :: boolean(),
+      Params :: #{jid := jid:jid(), request_type := ejabberd_auth:exist_type()},
+      Extra :: #{host_type := mongooseim:host_type()}.
+does_cached_user_exist(false,
+                       #{jid := Jid, request_type := stored},
+                       #{host_type := HostType}) ->
     case mongoose_user_cache:is_member(HostType, ?MODULE, Jid) of
         true -> {stop, true};
-        false -> false
+        false -> {ok, false}
     end;
-does_cached_user_exist(Status, _, _, _) ->
-    Status.
+does_cached_user_exist(Acc, _, _) ->
+    {ok, Acc}.
 
--spec maybe_put_user_into_cache(Status :: boolean(),
-                                HostType :: mongooseim:host_type(),
-                                Jid :: jid:jid(),
-                                RequestType :: ejabberd_auth:exist_type()) ->
-    boolean().
-maybe_put_user_into_cache(true, HostType, Jid, stored) ->
+-spec maybe_put_user_into_cache(Acc, Params, Extra) -> {ok , Acc} when
+      Acc :: boolean(),
+      Params :: #{jid := jid:jid(), request_type := ejabberd_auth:exist_type()},
+      Extra :: #{host_type := mongooseim:host_type()}.
+maybe_put_user_into_cache(true,
+                          #{jid := Jid, request_type := stored},
+                          #{host_type := HostType}) ->
     mongoose_user_cache:merge_entry(HostType, ?MODULE, Jid, #{}),
-    true;
-maybe_put_user_into_cache(Status, _, _, _) ->
-    Status.
+    {ok, true};
+maybe_put_user_into_cache(Acc, _, _) ->
+    {ok, Acc}.


### PR DESCRIPTION
This PR changes all hook handlers in `mod_cache_users` module to `gen_hook` format.