### PR TITLE
Inbox/full pagination xep

### DIFF
--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -400,9 +400,13 @@ rsm(Params) ->
     Max = maps:get(limit, Params, undefined),
     Before = maps:get(before, Params, undefined),
     After = maps:get('after', Params, undefined),
+    Index = maps:get(index, Params, undefined),
     Elems = [#xmlel{name = <<"max">>,
                     children = [#xmlcdata{content = to_bin(Max)}]}
              || _ <- [Max], undefined =/= Max ] ++
+            [#xmlel{name = <<"index">>,
+                    children = [#xmlcdata{content = to_bin(Index)}]}
+             || _ <- [Index], undefined =/= Index ] ++
             [#xmlel{name = <<"before">>,
                     children = [#xmlcdata{content = to_bin(Before)}]}
              || _ <- [Before], undefined =/= Before ] ++

--- a/doc/open-extensions/inbox.md
+++ b/doc/open-extensions/inbox.md
@@ -148,7 +148,7 @@ It can happen that the amount of inbox entries is too big for a given user, even
 ```
 where `Max` is a non-negative integer.
 
-Inbox also has partial support for pagination as described in [XEP-0059](https://xmpp.org/extensions/xep-0059.html). If specifying `before` or `after`, the `start` and `end` form fields will be overridden.
+Inbox also has partial support for pagination as described in [XEP-0059](https://xmpp.org/extensions/xep-0059.html). If specifying `before` or `after`, the `start` and `end` form fields will be overridden. However, inbox pagination does not support total count nor indexes as described in [XEP-0059: #2.6 Retrieving a Page Out of Order](https://xmpp.org/extensions/xep-0059.html#jump).
 
 ## Properties of an entry
 Given an entry, certain properties are defined for such an entry:

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -200,8 +200,8 @@ process_iq(Acc, From, _To, #iq{type = set, sub_el = QueryEl} = IQ, _Extra) ->
     LUser = From#jid.luser,
     LServer = From#jid.lserver,
     case query_to_params(HostType, QueryEl) of
-        {error, bad_request, Msg} ->
-            {Acc, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:bad_request(<<"en">>, Msg)]}};
+        {error, Error, Msg} ->
+            {Acc, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:Error(<<"en">>, Msg)]}};
         Params ->
             List0 = mod_inbox_backend:get_inbox(HostType, LUser, LServer, Params),
             List = with_rsm(List0, Params),
@@ -463,18 +463,20 @@ text_single_form_field(Var, DefaultValue) ->
 %%%%%%%%%%%%%%%%%%%
 %% iq-set
 -spec query_to_params(mongooseim:host_type(), QueryEl :: exml:element()) ->
-    get_inbox_params() | {error, bad_request, binary()}.
+    get_inbox_params() | {error, atom(), binary()}.
 query_to_params(HostType, QueryEl) ->
     Form = form_to_params(HostType, exml_query:subelement_with_ns(QueryEl, ?NS_XDATA)),
     Rsm = jlib:rsm_decode(QueryEl),
     build_params(Form, Rsm).
 
--spec build_params(get_inbox_params() | {error, bad_request, binary()}, none | jlib:rsm_in()) ->
-    get_inbox_params() | {error, bad_request, binary()}.
-build_params({error, bad_request, Msg}, _) ->
-    {error, bad_request, Msg};
+-spec build_params(get_inbox_params() | {error, atom(), binary()}, none | jlib:rsm_in()) ->
+    get_inbox_params() | {error, atom(), binary()}.
+build_params({error, Error, Msg}, _) ->
+    {error, Error, Msg};
 build_params(_, #rsm_in{max = Max, index = Index}) when Max =:= error; Index =:= error ->
     {error, bad_request, <<"bad-request">>};
+build_params(_, #rsm_in{index = Index}) when Index =/= undefined ->
+    {error, feature_not_implemented, <<"Inbox does not expose a total count and indexes">>};
 build_params(Params, none) ->
     Params;
 build_params(Params, #rsm_in{max = Max, id = undefined}) when Max =/= undefined ->


### PR DESCRIPTION
We simply choose to omit exposing total counts and pagination by index, it would complicate code too much, it is not that useful, and also MAM already showed that that doesn't scale.