### PR TITLE
Improve error handling in API module last

### DIFF
--- a/src/admin_extra/service_admin_extra_accounts.erl
+++ b/src/admin_extra/service_admin_extra_accounts.erl
@@ -133,7 +133,7 @@ num_active_users(Domain, Days) ->
 -spec delete_old_users(integer()) -> {ok, iolist()}.
 delete_old_users(Days) ->
     Timestamp = days_to_timestamp(Days),
-    OldUsers = mod_last_api:remove_old_users(Timestamp),
+    {ok, OldUsers} = mod_last_api:remove_old_users(Timestamp),
     {ok, format_deleted_users(OldUsers)}.
 
 -spec delete_old_users_for_domain(jid:server(), integer()) -> {ok | domain_not_found, iolist()}.

--- a/src/graphql/admin/mongoose_graphql_last_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_last_admin_mutation.erl
@@ -26,7 +26,7 @@ set_last(#{<<"user">> := JID, <<"timestamp">> := Timestamp, <<"status">> := Stat
 -spec remove_old_users(args()) -> {ok, old_users()} | {error, resolver_error()}.
 remove_old_users(#{<<"domain">> := null, <<"timestamp">> := Timestamp}) ->
     Timestamp2 = mongoose_graphql_last_helper:microseconds_to_seconds(Timestamp),
-    OldUsers = mod_last_api:remove_old_users(Timestamp2),
+    {ok, OldUsers} = mod_last_api:remove_old_users(Timestamp2),
     {ok, format_old_users(OldUsers)};
 remove_old_users(#{<<"domain">> := Domain, <<"timestamp">> := Timestamp}) ->
     Timestamp2 = mongoose_graphql_last_helper:microseconds_to_seconds(Timestamp),

--- a/src/graphql/admin/mongoose_graphql_last_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_last_admin_query.erl
@@ -35,7 +35,7 @@ count_active_users(#{<<"domain">> := Domain, <<"timestamp">> := Timestamp}) ->
 -spec list_old_users(args()) -> {ok, old_users()} | {error, resolver_error()}.
 list_old_users(#{<<"domain">> := null, <<"timestamp">> := Timestamp}) ->
     Timestamp2 = mongoose_graphql_last_helper:microseconds_to_seconds(Timestamp),
-    OldUsers = mod_last_api:list_old_users(Timestamp2),
+    {ok, OldUsers} = mod_last_api:list_old_users(Timestamp2),
     {ok, format_old_users(OldUsers)};
 list_old_users(#{<<"domain">> := Domain, <<"timestamp">> := Timestamp}) ->
     Timestamp2 = mongoose_graphql_last_helper:microseconds_to_seconds(Timestamp),

--- a/src/mod_last_api.erl
+++ b/src/mod_last_api.erl
@@ -57,11 +57,12 @@ count_active_users(Domain, Timestamp) ->
             ?DOMAIN_NOT_FOUND_RESULT
     end.
 
--spec list_old_users(timestamp()) -> [old_user()].
+-spec list_old_users(timestamp()) -> {ok, [old_user()]}.
 list_old_users(Timestamp) ->
-    lists:append([list_old_users(HostType, Domain, Timestamp) ||
-                  HostType <- ?ALL_HOST_TYPES,
-                  Domain <- mongoose_domain_api:get_domains_by_host_type(HostType)]).
+    OldUsers = lists:append([list_old_users(HostType, Domain, Timestamp) ||
+                             HostType <- ?ALL_HOST_TYPES,
+                             Domain <- mongoose_domain_api:get_domains_by_host_type(HostType)]),
+    {ok, OldUsers}.
 
 -spec list_old_users(jid:server(), timestamp()) ->
     {ok, [old_user()]} | {domain_not_found, binary()}.
@@ -74,11 +75,11 @@ list_old_users(Domain, Timestamp) ->
             ?DOMAIN_NOT_FOUND_RESULT
     end.
 
--spec remove_old_users(timestamp()) -> [old_user()].
+-spec remove_old_users(timestamp()) -> {ok, [old_user()]}.
 remove_old_users(Timestamp) ->
-    OldUsers = list_old_users(Timestamp),
+    {ok, OldUsers} = list_old_users(Timestamp),
     ok = remove_users(OldUsers),
-    OldUsers.
+    {ok, OldUsers}.
 
 -spec remove_old_users(jid:server(), timestamp()) ->
     {ok, [old_user()]} | {domain_not_found, binary()}.


### PR DESCRIPTION
This PR changes some of the returned values from "last" module's functions to be more consistent with the whole GraphQL API