### PR TITLE
Use the DomainName type in GraphQL

### DIFF
--- a/big_tests/tests/common_helper.erl
+++ b/big_tests/tests/common_helper.erl
@@ -6,3 +6,5 @@ get_bjid(UserSpec) ->
     Server = proplists:get_value(server, UserSpec),
     <<User/binary,"@",Server/binary>>.
 
+unprep(Bin) when is_binary(Bin) ->
+    list_to_binary(string:titlecase(binary_to_list(Bin))).

--- a/big_tests/tests/graphql_http_upload_SUITE.erl
+++ b/big_tests/tests/graphql_http_upload_SUITE.erl
@@ -2,6 +2,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
+-import(common_helper, [unprep/1]).
 -import(distributed_helper, [mim/0, require_rpc_nodes/1]).
 -import(domain_helper, [host_type/0, domain/0, secondary_domain/0]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, get_ok_value/2,
@@ -190,7 +191,11 @@ user_http_upload_not_configured(Config, Alice) ->
 % Admin test cases
 
 admin_get_url_test(Config) ->
-    Result = admin_get_url(domain(), <<"test">>, 123, <<"Test">>, 123, Config),
+    admin_get_url_test(Config, domain()),
+    admin_get_url_test(Config, unprep(domain())).
+
+admin_get_url_test(Config, Domain) ->
+    Result = admin_get_url(Domain, <<"test">>, 123, <<"Test">>, 123, Config),
     ParsedResult = get_ok_value([data, httpUpload, getUrl], Result),
     #{<<"PutUrl">> := PutURL, <<"GetUrl">> := GetURL, <<"Header">> := _Headers} = ParsedResult,
     ?assertMatch({_, _}, binary:match(PutURL, [?S3_HOSTNAME])),
@@ -217,7 +222,11 @@ admin_get_url_no_domain(Config) ->
     ?assertEqual(<<"domain does not exist">>, get_err_msg(Result)).
 
 admin_http_upload_not_configured(Config) ->
-    Result = admin_get_url(domain(), <<"test">>, 123, <<"Test">>, 123, Config),
+    admin_http_upload_not_configured(Config, domain()),
+    admin_http_upload_not_configured(Config, unprep(domain())).
+
+admin_http_upload_not_configured(Config, Domain) ->
+    Result = admin_get_url(Domain, <<"test">>, 123, <<"Test">>, 123, Config),
     ?assertEqual(<<"deps_not_loaded">>, get_err_code(Result)),
     ?assertEqual(<<"Some of required modules or services are not loaded">>, get_err_msg(Result)).
 

--- a/big_tests/tests/graphql_last_SUITE.erl
+++ b/big_tests/tests/graphql_last_SUITE.erl
@@ -2,6 +2,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
+-import(common_helper, [unprep/1]).
 -import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, user_to_bin/1, user_to_jid/1,
                          get_ok_value/2, get_err_msg/1, get_err_code/1, get_unauthorized/1,
@@ -311,6 +312,8 @@ admin_count_active_users_story(Config, Alice, Bob) ->
     set_last(Bob, now_dt_with_offset(10), Config),
     Res = admin_count_active_users(Domain, null, Config),
     ?assertEqual(2, get_ok_value(p(countActiveUsers), Res)),
+    Res1 = admin_count_active_users(unprep(Domain), null, Config),
+    ?assertEqual(2, get_ok_value(p(countActiveUsers), Res1)),
     Res2 = admin_count_active_users(Domain, now_dt_with_offset(30), Config),
     ?assertEqual(0, get_ok_value(p(countActiveUsers), Res2)).
 
@@ -561,13 +564,13 @@ admin_get_last_not_configured_story(Config, Alice) ->
 
 admin_count_active_users_last_not_configured(Config) ->
     Domain = domain_helper:domain(),
-    Res = admin_count_active_users(Domain, null, Config),
-    get_not_loaded(Res).
+    get_not_loaded(admin_count_active_users(Domain, null, Config)),
+    get_not_loaded(admin_count_active_users(unprep(Domain), null, Config)).
 
 admin_remove_old_users_domain_last_not_configured(Config) ->
     Domain = domain_helper:domain(),
-    Res = admin_remove_old_users(Domain, now_dt_with_offset(150), Config),
-    get_not_loaded(Res).
+    get_not_loaded(admin_remove_old_users(Domain, now_dt_with_offset(150), Config)),
+    get_not_loaded(admin_remove_old_users(unprep(Domain), now_dt_with_offset(150), Config)).
 
 admin_remove_old_users_global_last_not_configured(Config) ->
     Res = admin_remove_old_users(null, now_dt_with_offset(150), Config),
@@ -575,8 +578,8 @@ admin_remove_old_users_global_last_not_configured(Config) ->
 
 admin_list_old_users_domain_last_not_configured(Config) ->
     Domain = domain_helper:domain(),
-    Res = admin_list_old_users(Domain, now_dt_with_offset(150), Config),
-    get_not_loaded(Res).
+    get_not_loaded(admin_list_old_users(Domain, now_dt_with_offset(150), Config)),
+    get_not_loaded(admin_list_old_users(unprep(Domain), now_dt_with_offset(150), Config)).
 
 admin_list_old_users_global_last_not_configured(Config) ->
     Res = admin_list_old_users(null, now_dt_with_offset(150), Config),

--- a/big_tests/tests/graphql_offline_SUITE.erl
+++ b/big_tests/tests/graphql_offline_SUITE.erl
@@ -2,6 +2,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
+-import(common_helper, [unprep/1]).
 -import(distributed_helper, [mim/0, require_rpc_nodes/1]).
 -import(domain_helper, [host_type/0, domain/0]).
 -import(graphql_helper, [execute_command/4, get_ok_value/2, get_err_code/1, user_to_bin/1,
@@ -129,9 +130,13 @@ admin_delete_expired_messages2_test(Config) ->
                                     fun admin_delete_expired_messages2_test/3).
 
 admin_delete_expired_messages2_test(Config, JidMike, JidKate) ->
+    admin_delete_expired_messages2(Config, JidMike, JidKate, domain()),
+    admin_delete_expired_messages2(Config, JidMike, JidKate, unprep(domain())).
+
+admin_delete_expired_messages2(Config, JidMike, JidKate, Domain) ->
     generate_message(JidMike, JidKate, 2, 1),
     generate_message(JidMike, JidKate, 5, -1), % not expired yet
-    Result = delete_expired_messages(domain(), Config),
+    Result = delete_expired_messages(Domain, Config),
     ParsedResult = get_ok_value([data, offline, deleteExpiredMessages], Result),
     ?assertEqual(<<"Removed 1 messages">>, ParsedResult).
 
@@ -140,10 +145,14 @@ admin_delete_old_messages2_test(Config) ->
                                     fun admin_delete_old_messages2_test/3).
 
 admin_delete_old_messages2_test(Config, JidMike, JidKate) ->
+    admin_delete_old_messages2(Config, JidMike, JidKate, domain()),
+    admin_delete_old_messages2(Config, JidMike, JidKate, unprep(domain())).
+
+admin_delete_old_messages2(Config, JidMike, JidKate, Domain) ->
     generate_message(JidMike, JidKate, 2, 1), % not old enough
     generate_message(JidMike, JidKate, 5, -1),
     generate_message(JidMike, JidKate, 7, 5),
-    Result = delete_old_messages(domain(), 3, Config),
+    Result = delete_old_messages(Domain, 3, Config),
     ParsedResult = get_ok_value([data, offline, deleteOldMessages], Result),
     ?assertEqual(<<"Removed 2 messages">>, ParsedResult).
 
@@ -156,12 +165,12 @@ admin_delete_old_messages_no_domain_test(Config) ->
     ?assertEqual(<<"domain_not_found">>, get_err_code(Result)).
 
 admin_delete_expired_messages_offline_not_configured_test(Config) ->
-    Result = delete_expired_messages(domain(), Config),
-    get_not_loaded(Result).
+    get_not_loaded(delete_expired_messages(domain(), Config)),
+    get_not_loaded(delete_expired_messages(unprep(domain()), Config)).
 
 admin_delete_old_messages_offline_not_configured_test(Config) ->
-    Result = delete_old_messages(domain(), 2, Config),
-    get_not_loaded(Result).
+    get_not_loaded(delete_old_messages(domain(), 2, Config)),
+    get_not_loaded(delete_old_messages(unprep(domain()), 2, Config)).
 
 %% Domain admin test cases
 

--- a/big_tests/tests/graphql_stats_SUITE.erl
+++ b/big_tests/tests/graphql_stats_SUITE.erl
@@ -2,11 +2,13 @@
 
 -compile([export_all, nowarn_export_all]).
 
+-import(common_helper, [unprep/1]).
 -import(distributed_helper, [mim/0, require_rpc_nodes/1]).
 -import(domain_helper, [host_type/0, domain/0, secondary_domain/0]).
 -import(graphql_helper, [execute_command/4, get_ok_value/2, get_unauthorized/1]).
 -import(mongooseimctl_helper, [mongooseimctl/3, rpc_call/3]).
 
+-include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
@@ -26,16 +28,19 @@ admin_stats_tests() ->
     [admin_stats_global_test,
      admin_stats_global_with_users_test,
      admin_stats_domain_test,
-     admin_stats_domain_with_users_test].
+     admin_stats_domain_with_users_test,
+     admin_stats_domain_without_users_test].
 
 domain_admin_tests() ->
     [domain_admin_stats_global_test,
      admin_stats_domain_test,
+     admin_stats_domain_with_users_test,
      domain_admin_stats_domain_no_permission_test].
 
 init_per_suite(Config) ->
     Config1 = ejabberd_node_utils:init(mim(), Config),
-    escalus:init_per_suite(Config1).
+    Config2 = [{auth_mods, mongoose_helper:auth_modules()} | Config1],
+    escalus:init_per_suite(Config2).
 
 end_per_suite(Config) ->
     escalus:end_per_suite(Config).
@@ -51,6 +56,13 @@ end_per_group(_, _Config) ->
     graphql_helper:clean(),
     escalus_fresh:clean().
 
+init_per_testcase(CaseName = admin_stats_domain_without_users_test, Config) ->
+    case lists:member(ejabberd_auth_ldap, ?config(auth_mods, Config)) of
+        true ->
+            {skip, not_supported_with_ldap};
+        false ->
+            escalus:init_per_testcase(CaseName, Config)
+    end;
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
@@ -88,19 +100,28 @@ admin_stats_global_with_users_test(Config, _Alice) ->
     ?assert(is_not_negative_integer(OutgoingS2S)).
 
 admin_stats_domain_test(Config) ->
-    Result = get_ok_value([data, stat, domainStats], get_domain_stats(domain(), Config)),
-    #{<<"registeredUsers">> := RegisteredUsers, <<"onlineUsers">> := OnlineUsers} = Result,
-    ?assertEqual(0, RegisteredUsers),
-    ?assertEqual(0, OnlineUsers).
+    Result1 = get_ok_value([data, stat, domainStats], get_domain_stats(domain(), Config)),
+    ?assertMatch(#{<<"registeredUsers">> := 0, <<"onlineUsers">> := 0}, Result1),
+    Result2 = get_ok_value([data, stat, domainStats], get_domain_stats(unprep(domain()), Config)),
+    ?assertMatch(#{<<"registeredUsers">> := 0, <<"onlineUsers">> := 0}, Result2).
 
 admin_stats_domain_with_users_test(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_stats_domain_with_users_test/2).
 
 admin_stats_domain_with_users_test(Config, _Alice) ->
-    Result = get_ok_value([data, stat, domainStats], get_domain_stats(domain(), Config)),
-    #{<<"registeredUsers">> := RegisteredUsers, <<"onlineUsers">> := OnlineUsers} = Result,
-    ?assertEqual(1, RegisteredUsers),
-    ?assertEqual(1, OnlineUsers).
+    Result1 = get_ok_value([data, stat, domainStats], get_domain_stats(domain(), Config)),
+    ?assertMatch(#{<<"registeredUsers">> := 1, <<"onlineUsers">> := 1}, Result1),
+    Result2 = get_ok_value([data, stat, domainStats], get_domain_stats(unprep(domain()), Config)),
+    ?assertMatch(#{<<"registeredUsers">> := 1, <<"onlineUsers">> := 1}, Result2).
+
+admin_stats_domain_without_users_test(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_stats_domain_without_users_test/2).
+
+admin_stats_domain_without_users_test(Config, _Alice) ->
+    %% Alice's session is at domain, not secondary_domain
+    Result = get_ok_value([data, stat, domainStats], get_domain_stats(secondary_domain(), Config)),
+    ?assertMatch(#{<<"registeredUsers">> := 0, <<"onlineUsers">> := 0}, Result).
 
 % Domain admin test cases
 
@@ -108,7 +129,8 @@ domain_admin_stats_global_test(Config) ->
     get_unauthorized(get_stats(Config)).
 
 domain_admin_stats_domain_no_permission_test(Config) ->
-    get_unauthorized(get_domain_stats(secondary_domain(), Config)).
+    get_unauthorized(get_domain_stats(secondary_domain(), Config)),
+    get_unauthorized(get_domain_stats(unprep(secondary_domain()), Config)).
 
 % Commands
 

--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -1227,7 +1227,7 @@ expect_existing_commands(Res) ->
     ?assertMatch({match, _}, re:run(Res, "countUsers")).
 
 expect_command_arguments(Res) ->
-    ?assertMatch({match, _}, re:run(Res, "domain\s+String!")).
+    ?assertMatch({match, _}, re:run(Res, "domain\s+DomainName!")).
 
 %%-----------------------------------------------------------------
 %% Help tests

--- a/priv/graphql/schemas/admin/account.gql
+++ b/priv/graphql/schemas/admin/account.gql
@@ -3,10 +3,10 @@ Allow admin to get information about accounts.
 """
 type AccountAdminQuery @protected{
   "List users per domain"
-  listUsers(domain: String!): [String!]
+  listUsers(domain: DomainName!): [String!]
     @protected(type: DOMAIN, args: ["domain"])
   "Get number of users per domain"
-  countUsers(domain: String!): Int
+  countUsers(domain: DomainName!): Int
     @protected(type: DOMAIN, args: ["domain"])
   "Check if a password is correct"
   checkPassword(user: JID!, password: String!): CheckPasswordPayload
@@ -24,7 +24,7 @@ Allow admin to manage user accounts.
 """
 type AccountAdminMutation @protected{
   "Register a user. Username will be generated when skipped"
-  registerUser(domain: String!, username: String, password: String!): UserPayload
+  registerUser(domain: DomainName!, username: String, password: String!): UserPayload
     @protected(type: DOMAIN, args: ["domain"])
   "Remove the user's account along with all the associated personal data"
   removeUser(user: JID!): UserPayload

--- a/priv/graphql/schemas/admin/admin_auth_status.gql
+++ b/priv/graphql/schemas/admin/admin_auth_status.gql
@@ -1,7 +1,7 @@
 "Information about user request authorization"
 type AdminAuthInfo{
   "Authorized for a domain"
-  domain: String
+  domain: DomainName
   "Authorization status"
   authStatus: AuthStatus!
   "Authorization as a "

--- a/priv/graphql/schemas/admin/domain.gql
+++ b/priv/graphql/schemas/admin/domain.gql
@@ -1,6 +1,6 @@
 type DomainAdminQuery @use(services: ["service_domain_db"]) @protected{
   "Get all enabled domains by hostType. Only for global admin"
-  domainsByHostType(hostType: String!): [String!]
+  domainsByHostType(hostType: String!): [DomainName!]
     @protected(type: GLOBAL) @use
   "Get information about the domain"
   domainDetails(domain: DomainName!): Domain

--- a/priv/graphql/schemas/admin/gdpr.gql
+++ b/priv/graphql/schemas/admin/gdpr.gql
@@ -1,6 +1,6 @@
 "Retrieve user's presonal data"
 type GdprAdminQuery @protected{
     "Retrieves all personal data from MongooseIM for a given user"
-    retrievePersonalData(username: String!, domain: String!, resultFilepath: String!): String
+    retrievePersonalData(username: String!, domain: DomainName!, resultFilepath: String!): String
       @protected(type: DOMAIN, args: ["domain"])
 }

--- a/priv/graphql/schemas/admin/http_upload.gql
+++ b/priv/graphql/schemas/admin/http_upload.gql
@@ -3,6 +3,6 @@ Allow admin to generate upload/download URL for a file on user's behalf".
 """
 type HttpUploadAdminMutation @use(modules: ["mod_http_upload"]) @protected{
     "Allow admin to generate upload/download URLs for a file on user's behalf"
-    getUrl(domain: String!, filename: String!, size: Int!, contentType: String!, timeout: Int!): FileUrls
+    getUrl(domain: DomainName!, filename: String!, size: Int!, contentType: String!, timeout: Int!): FileUrls
       @use(arg: "domain") @protected(type: DOMAIN, args: ["domain"])
 }

--- a/priv/graphql/schemas/admin/inbox.gql
+++ b/priv/graphql/schemas/admin/inbox.gql
@@ -13,7 +13,7 @@ type InboxAdminMutation @use(modules: ["mod_inbox"]) @protected{
   "Flush the whole domain bin and return the number of deleted rows"
   flushDomainBin(
     "Domain to be cleared"
-    domain: String!,
+    domain: DomainName!,
     "Remove older than given days or all if null"
     days: PosInt
   ): Int @use(arg: "domain") @protected(type: DOMAIN, args: ["domain"])

--- a/priv/graphql/schemas/admin/last.gql
+++ b/priv/graphql/schemas/admin/last.gql
@@ -6,13 +6,13 @@ type LastAdminQuery @use(modules: ["mod_last"]) @protected{
   getLast(user: JID!): LastActivity
     @use(arg: "user") @protected(type: DOMAIN, args: ["user"])
   "Get the number of users active from the given timestamp"
-  countActiveUsers(domain: String!, timestamp: DateTime): Int
+  countActiveUsers(domain: DomainName!, timestamp: DateTime): Int
     @use(arg: "domain") @protected(type: DOMAIN, args: ["domain"])
   """
   List users that didn't log in the last days or have never logged in.
   Globally or for a specified domain
   """
-  listOldUsers(domain: String, timestamp: DateTime!): [OldUser!]
+  listOldUsers(domain: DomainName, timestamp: DateTime!): [OldUser!]
    @use(arg: "domain") @protected(type: DOMAIN, args: ["domain"])
 }
 
@@ -27,7 +27,7 @@ type LastAdminMutation @use(modules: ["mod_last"]) @protected{
   Delete users that didn't log in the last days or have never logged in.
   Globally or for a specified domain. Please use listOldUsers to check which users will be deleted
   """
-  removeOldUsers(domain: String, timestamp: DateTime!): [OldUser!]
+  removeOldUsers(domain: DomainName, timestamp: DateTime!): [OldUser!]
     @use(arg: "domain") @protected(type: DOMAIN, args: ["domain"])
 }
 

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -4,7 +4,7 @@ Allow admin to manage Multi-User Chat rooms.
 type MUCAdminMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createInstantRoom(mucDomain: String!, name: String!, owner: JID!, nick: String!): MUCRoomDesc
+  createInstantRoom(mucDomain: DomainName!, name: String!, owner: JID!, nick: String!): MUCRoomDesc
     @protected(type: DOMAIN, args: ["owner"])
   "Invite a user to a MUC room"
   inviteUser(room: JID!, sender: JID!, recipient: JID!, reason: String): String
@@ -44,7 +44,7 @@ Allow admin to get information about Multi-User Chat rooms.
 type MUCAdminQuery @protected @use(modules: ["mod_muc"]){
   "Get MUC rooms under the given MUC domain"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  listRooms(mucDomain: String!, from: JID!, limit: Int, index: Int): MUCRoomsPayload!
+  listRooms(mucDomain: DomainName!, from: JID!, limit: Int, index: Int): MUCRoomsPayload!
     @protected(type: DOMAIN, args: ["from"])
   "Get configuration of the MUC room"
   getRoomConfig(room: JID!): MUCRoomConfig

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -4,7 +4,7 @@ Allow admin to manage Multi-User Chat Light rooms.
 type MUCLightAdminMutation @use(modules: ["mod_muc_light"]) @protected{
   "Create a MUC light room under the given XMPP hostname"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createRoom(mucDomain: String!, name: String!, owner: JID!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
+  createRoom(mucDomain: DomainName!, name: String!, owner: JID!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
     @protected(type: DOMAIN, args: ["owner"])
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, owner: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room

--- a/priv/graphql/schemas/admin/offline.gql
+++ b/priv/graphql/schemas/admin/offline.gql
@@ -3,9 +3,9 @@ Allow admin to delete offline messages from specified domain
 """
 type OfflineAdminMutation @protected @use(modules: ["mod_offline"]){
     "Delete offline messages whose date has expired"
-    deleteExpiredMessages(domain: String!): String @use(arg: "domain")
+    deleteExpiredMessages(domain: DomainName!): String @use(arg: "domain")
       @protected(type: DOMAIN, args: ["domain"])
     "Delete messages at least as old as the number of days specified in the parameter"
-    deleteOldMessages(domain: String!, days: Int!): String
+    deleteOldMessages(domain: DomainName!, days: Int!): String
       @protected(type: DOMAIN, args: ["domain"]) @use(arg: "domain")
 }

--- a/priv/graphql/schemas/admin/session.gql
+++ b/priv/graphql/schemas/admin/session.gql
@@ -3,10 +3,10 @@ Allow admin to get information about sessions.
 """
 type SessionAdminQuery @protected{
   "Get the list of established sessions for a specified domain or globally"
-  listSessions(domain: String): [Session!]
+  listSessions(domain: DomainName): [Session!]
     @protected(type: DOMAIN, args: ["domain"])
   "Get the number of established sessions for a specified domain or globally"
-  countSessions(domain: String): Int
+  countSessions(domain: DomainName): Int
     @protected(type: DOMAIN, args: ["domain"])
   "Get information about all sessions of a user"
   listUserSessions(user: JID!): [Session!]
@@ -18,10 +18,10 @@ type SessionAdminQuery @protected{
   getUserResource(user: JID!, number: Int): String
     @protected(type: DOMAIN, args: ["user"])
   "Get the list of logged users with this status for a specified domain or globally"
-  listUsersWithStatus(domain: String, status: String!): [UserStatus!]
+  listUsersWithStatus(domain: DomainName, status: String!): [UserStatus!]
     @protected(type: DOMAIN, args: ["domain"])
   "Get the number of logged users with this status for a specified domain or globally"
-  countUsersWithStatus(domain: String, status: String!): Int
+  countUsersWithStatus(domain: DomainName, status: String!): Int
     @protected(type: DOMAIN, args: ["domain"])
 }
 

--- a/priv/graphql/schemas/admin/stats.gql
+++ b/priv/graphql/schemas/admin/stats.gql
@@ -4,7 +4,7 @@ type StatsAdminQuery @protected{
     globalStats: GlobalStats
       @protected(type: GLOBAL)
     "Get statistics from a specific domain"
-    domainStats(domain: String!): DomainStats
+    domainStats(domain: DomainName!): DomainStats
       @protected(type: DOMAIN, args: ["domain"])
 }
 

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -4,7 +4,7 @@ Allow user to manage Multi-User Chat rooms.
 type MUCUserMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createInstantRoom(mucDomain: String!, name: String!, nick: String!): MUCRoomDesc
+  createInstantRoom(mucDomain: DomainName!, name: String!, nick: String!): MUCRoomDesc
   "Invite a user to a MUC room"
   inviteUser(room: JID!, recipient: JID!, reason: String): String @use(arg: "room")
   "Kick a user from a MUC room"
@@ -33,7 +33,7 @@ Allow user to get information about Multi-User Chat rooms.
 type MUCUserQuery @protected @use(modules: ["mod_muc"]){
   "Get MUC rooms under the given MUC domain"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  listRooms(mucDomain: String!, limit: Int, index: Int): MUCRoomsPayload!
+  listRooms(mucDomain: DomainName!, limit: Int, index: Int): MUCRoomsPayload!
   "Get configuration of the MUC room"
   getRoomConfig(room: JID!): MUCRoomConfig @use(arg: "room")
   "Get the user list of a given MUC room"

--- a/priv/graphql/schemas/user/muc_light.gql
+++ b/priv/graphql/schemas/user/muc_light.gql
@@ -4,7 +4,7 @@ Allow user to manage Multi-User Chat Light rooms.
 type MUCLightUserMutation @protected @use(modules: ["mod_muc_light"]){
   "Create a MUC light room under the given XMPP hostname"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createRoom(mucDomain: String!, name: String!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
+  createRoom(mucDomain: DomainName!, name: String!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room @use(arg: "room")
   "Invite a user to a MUC Light room"


### PR DESCRIPTION
The main goal is to use the `DomainName` instead of `String` for all fields containing XMPP doman names in the GraphQL schema. This ensures that the domain is string-prepped:
- for the checks of `@use` and `@protected` directives.
- for the API logic itself. Here we might have already existing stringprepping, which we could remove as we rework the individual API modules.

Appropriate tests are added with an "unprepped" domain, that starts with a capital letter.

### Other changes
`inbox_helper` contained nested `wait_until` calls, which resulted in an almost never-ending loop of retries in case of a permanent failure. The checking logic is flattened to a single `wait_until` now.