### PR TITLE
Improve error handling in metric API

### DIFF
--- a/src/graphql/admin/mongoose_graphql_metric_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_metric_admin_query.erl
@@ -5,8 +5,6 @@
 
 -ignore_xref([execute/4]).
 
--include("mongoose_logger.hrl").
-
 execute(_Ctx, _Obj, <<"getMetrics">>, Args) ->
     Name = get_name(Args),
     mongoose_metrics_api:get_metrics(Name);


### PR DESCRIPTION
This PR fixes a bug with querying host types, generates an error message for nonexistent nodes, and tests the new API behavior.