### PR TITLE
Add GraphQL types for JID parts

### DIFF
--- a/big_tests/tests/graphql_account_SUITE.erl
+++ b/big_tests/tests/graphql_account_SUITE.erl
@@ -312,12 +312,15 @@ admin_register_user(Config) ->
     % Try to register a user with existing name
     Resp2 = register_user(Domain, Username, Password, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp2), <<"already registered">>)),
-    % Try again, this time with a domain name that is not stringprepped
-    Resp3 = register_user(unprep(Domain), Username, Password, Config),
+    % Try again, this time with a name that is not stringprepped
+    Resp3 = register_user(unprep(Domain), unprep(Username), Password, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp3), <<"already registered">>)),
     % Try to register a user without any name
     Resp4 = register_user(Domain, <<>>, Password, Config),
-    ?assertNotEqual(nomatch, binary:match(get_err_msg(Resp4), <<"Invalid JID">>)).
+    ?assertMatch({_, _}, binary:match(get_coercion_err_msg(Resp4), <<"empty_user_name">>)),
+    % Try to register a user with an invalid name
+    Resp5 = register_user(Domain, <<"@invalid">>, Password, Config),
+    ?assertMatch({_, _}, binary:match(get_coercion_err_msg(Resp5), <<"failed_to_parse_user_name">>)).
 
 admin_register_random_user(Config) ->
     Password = <<"my_password">>,

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -66,6 +66,7 @@ user_muc_light_tests() ->
      user_create_room_with_unprepped_domain,
      user_create_room_with_custom_fields,
      user_create_identified_room,
+     user_create_room_with_unprepped_id,
      user_change_room_config,
      user_change_room_config_errors,
      user_invite_user,
@@ -99,6 +100,7 @@ admin_muc_light_tests() ->
      admin_create_room_with_unprepped_domain,
      admin_create_room_with_custom_fields,
      admin_create_identified_room,
+     admin_create_room_with_unprepped_id,
      admin_change_room_config,
      admin_change_room_config_with_custom_fields,
      admin_change_room_config_errors,
@@ -129,6 +131,7 @@ domain_admin_muc_light_tests() ->
      admin_create_room_with_custom_fields,
      domain_admin_create_room_no_permission,
      admin_create_identified_room,
+     admin_create_room_with_unprepped_id,
      domain_admin_create_identified_room_no_permission,
      admin_change_room_config,
      admin_change_room_config_with_custom_fields,
@@ -313,7 +316,21 @@ user_create_identified_room_story(Config, Alice) ->
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)),
     % Try with an empty string passed as ID
     Res4 = user_create_room(Alice, MucServer, <<"name">>, Subject, <<>>, Config),
-    ?assertNotEqual(nomatch, binary:match(get_coercion_err_msg(Res4), <<"Given string is empty">>)).
+    ?assertMatch({_, _}, binary:match(get_coercion_err_msg(Res4), <<"empty_room_name">>)).
+
+user_create_room_with_unprepped_id(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun user_create_room_with_unprepped_id_story/2).
+
+user_create_room_with_unprepped_id_story(Config, Alice) ->
+    MucServer = ?config(muc_light_host, Config),
+    Name = <<"first room">>,
+    Subject = <<"testing">>,
+    Id = <<"user_room_with_unprepped_id">>,
+    Res = user_create_room(Alice, unprep(MucServer), Name, Subject, unprep(Id), Config),
+    #{<<"jid">> := JID, <<"name">> := Name, <<"subject">> := Subject} =
+        get_ok_value(?CREATE_ROOM_PATH, Res),
+    ?assertMatch(#jid{luser = Id, lserver = MucServer}, jid:from_binary_noprep(JID)).
 
 user_change_room_config(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_change_room_config_story/2).
@@ -1001,7 +1018,19 @@ admin_create_identified_room_story(Config, Alice) ->
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res3), <<"not found">>)),
     % Try with an empty string passed as ID
     Res4 = create_room(MucServer, <<"name">>, AliceBin, Subject, <<>>, Config),
-    ?assertNotEqual(nomatch, binary:match(get_coercion_err_msg(Res4), <<"Given string is empty">>)).
+    ?assertMatch({_, _}, binary:match(get_coercion_err_msg(Res4), <<"empty_room_name">>)).
+
+admin_create_room_with_unprepped_id(Config) ->
+    FreshConfig = escalus_fresh:create_users(Config, [{alice, 1}]),
+    AliceBin = escalus_users:get_jid(FreshConfig, alice),
+    MucServer = ?config(muc_light_host, FreshConfig),
+    Name = <<"first room">>,
+    Subject = <<"testing">>,
+    Id = <<"room_with_unprepped_id">>,
+    Res = create_room(unprep(MucServer), Name, AliceBin, Subject, unprep(Id), FreshConfig),
+    #{<<"jid">> := JID, <<"name">> := Name, <<"subject">> := Subject} =
+        get_ok_value(?CREATE_ROOM_PATH, Res),
+    ?assertMatch(#jid{luser = Id, lserver = MucServer}, jid:from_binary_noprep(JID)).
 
 admin_change_room_config(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_change_room_config_story/2).

--- a/priv/graphql/schemas/admin/account.gql
+++ b/priv/graphql/schemas/admin/account.gql
@@ -24,7 +24,7 @@ Allow admin to manage user accounts.
 """
 type AccountAdminMutation @protected{
   "Register a user. Username will be generated when skipped"
-  registerUser(domain: DomainName!, username: String, password: String!): UserPayload
+  registerUser(domain: DomainName!, username: UserName, password: String!): UserPayload
     @protected(type: DOMAIN, args: ["domain"])
   "Remove the user's account along with all the associated personal data"
   removeUser(user: JID!): UserPayload

--- a/priv/graphql/schemas/admin/gdpr.gql
+++ b/priv/graphql/schemas/admin/gdpr.gql
@@ -1,6 +1,6 @@
 "Retrieve user's presonal data"
 type GdprAdminQuery @protected{
     "Retrieves all personal data from MongooseIM for a given user"
-    retrievePersonalData(username: String!, domain: DomainName!, resultFilepath: String!): String
+    retrievePersonalData(username: UserName!, domain: DomainName!, resultFilepath: String!): String
       @protected(type: DOMAIN, args: ["domain"])
 }

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -4,7 +4,7 @@ Allow admin to manage Multi-User Chat rooms.
 type MUCAdminMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createInstantRoom(mucDomain: DomainName!, name: String!, owner: JID!, nick: String!): MUCRoomDesc
+  createInstantRoom(mucDomain: DomainName!, name: RoomName!, owner: JID!, nick: String!): MUCRoomDesc
     @protected(type: DOMAIN, args: ["owner"])
   "Invite a user to a MUC room"
   inviteUser(room: JID!, sender: JID!, recipient: JID!, reason: String): String

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -4,7 +4,7 @@ Allow admin to manage Multi-User Chat Light rooms.
 type MUCLightAdminMutation @use(modules: ["mod_muc_light"]) @protected{
   "Create a MUC light room under the given XMPP hostname"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createRoom(mucDomain: DomainName!, name: String!, owner: JID!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
+  createRoom(mucDomain: DomainName!, name: String!, owner: JID!, subject: String!, id: RoomName, options: [RoomConfigDictEntryInput!]): Room
     @protected(type: DOMAIN, args: ["owner"])
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, owner: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room

--- a/priv/graphql/schemas/admin/session.gql
+++ b/priv/graphql/schemas/admin/session.gql
@@ -15,7 +15,7 @@ type SessionAdminQuery @protected{
   countUserResources(user: JID!): Int
     @protected(type: DOMAIN, args: ["user"])
   "Get the resource string of the n-th session of a user"
-  getUserResource(user: JID!, number: Int): String
+  getUserResource(user: JID!, number: Int): ResourceName
     @protected(type: DOMAIN, args: ["user"])
   "Get the list of logged users with this status for a specified domain or globally"
   listUsersWithStatus(domain: DomainName, status: String!): [UserStatus!]

--- a/priv/graphql/schemas/global/scalar_types.gql
+++ b/priv/graphql/schemas/global/scalar_types.gql
@@ -8,6 +8,9 @@ scalar JID @spectaql(options: [{ key: "example", value: "alice@localhost" }])
 scalar FullJID @spectaql(options: [{ key: "example", value: "alice@localhost/res1" }])
 "XMPP user name (local part of a JID)"
 scalar UserName @spectaql(options: [{ key: "example", value: "alice" }])
+"XMPP room name (local part of a JID)"
+scalar RoomName @spectaql(options: [{ key: "example", value: "my-chat-room" }])
+"XMPP domain name (domain part of a JID)"
 scalar DomainName @spectaql(options: [{ key: "example", value: "localhost" }])
 "String that contains at least one character"
 scalar NonEmptyString @spectaql(options: [{ key: "example", value: "xyz789" }])

--- a/priv/graphql/schemas/global/scalar_types.gql
+++ b/priv/graphql/schemas/global/scalar_types.gql
@@ -12,6 +12,8 @@ scalar UserName @spectaql(options: [{ key: "example", value: "alice" }])
 scalar RoomName @spectaql(options: [{ key: "example", value: "my-chat-room" }])
 "XMPP domain name (domain part of a JID)"
 scalar DomainName @spectaql(options: [{ key: "example", value: "localhost" }])
+"XMPP resource name (resource part of a JID)"
+scalar ResourceName @spectaql(options: [{ key: "example", value: "res1" }])
 "String that contains at least one character"
 scalar NonEmptyString @spectaql(options: [{ key: "example", value: "xyz789" }])
 "Integer that has a value above zero"

--- a/priv/graphql/schemas/global/scalar_types.gql
+++ b/priv/graphql/schemas/global/scalar_types.gql
@@ -6,7 +6,8 @@ scalar Stanza @spectaql(options: [{ key: "example", value: "Hi!" }])
 scalar JID @spectaql(options: [{ key: "example", value: "alice@localhost" }])
 "The JID with resource"
 scalar FullJID @spectaql(options: [{ key: "example", value: "alice@localhost/res1" }])
-"XMPP Domain name (domain part of a JID)"
+"XMPP user name (local part of a JID)"
+scalar UserName @spectaql(options: [{ key: "example", value: "alice" }])
 scalar DomainName @spectaql(options: [{ key: "example", value: "localhost" }])
 "String that contains at least one character"
 scalar NonEmptyString @spectaql(options: [{ key: "example", value: "xyz789" }])

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -10,9 +10,9 @@ type MUCUserMutation @protected @use(modules: ["mod_muc"]){
   "Kick a user from a MUC room"
   kickUser(room: JID!, nick: String!, reason: String): String @use(arg: "room")
   "Send a message to a MUC room"
-  sendMessageToRoom(room: JID!, body: String!, resource: String): String @use(arg: "room")
+  sendMessageToRoom(room: JID!, body: String!, resource: ResourceName): String @use(arg: "room")
   "Send a private message to a MUC room user from the given resource"
-  sendPrivateMessage(room: JID!, toNick: String!, body: String!, resource: String): String @use(arg: "room")
+  sendPrivateMessage(room: JID!, toNick: String!, body: String!, resource: ResourceName): String @use(arg: "room")
   "Remove a MUC room"
   deleteRoom(room: JID!, reason: String): String @use(arg: "room")
   "Change configuration of a MUC room"
@@ -22,9 +22,9 @@ type MUCUserMutation @protected @use(modules: ["mod_muc"]){
   "Change a user affiliation"
   setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String @use(arg: "room")
   "Enter the room with given resource and nick"
-  enterRoom(room: JID!, nick: String!, resource: String!, password: String): String @use(arg: "room")
+  enterRoom(room: JID!, nick: String!, resource: ResourceName!, password: String): String @use(arg: "room")
   "Exit the room with given resource and nick"
-  exitRoom(room: JID!, nick: String!, resource: String!): String @use(arg: "room")
+  exitRoom(room: JID!, nick: String!, resource: ResourceName!): String @use(arg: "room")
 }
 
 """

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -4,7 +4,7 @@ Allow user to manage Multi-User Chat rooms.
 type MUCUserMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createInstantRoom(mucDomain: DomainName!, name: String!, nick: String!): MUCRoomDesc
+  createInstantRoom(mucDomain: DomainName!, name: RoomName!, nick: String!): MUCRoomDesc
   "Invite a user to a MUC room"
   inviteUser(room: JID!, recipient: JID!, reason: String): String @use(arg: "room")
   "Kick a user from a MUC room"

--- a/priv/graphql/schemas/user/muc_light.gql
+++ b/priv/graphql/schemas/user/muc_light.gql
@@ -4,7 +4,7 @@ Allow user to manage Multi-User Chat Light rooms.
 type MUCLightUserMutation @protected @use(modules: ["mod_muc_light"]){
   "Create a MUC light room under the given XMPP hostname"
   #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createRoom(mucDomain: DomainName!, name: String!, subject: String!, id: NonEmptyString, options: [RoomConfigDictEntryInput!]): Room
+  createRoom(mucDomain: DomainName!, name: String!, subject: String!, id: RoomName, options: [RoomConfigDictEntryInput!]): Room
   "Change configuration of a MUC Light room"
   changeRoomConfiguration(room: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room @use(arg: "room")
   "Invite a user to a MUC Light room"

--- a/priv/graphql/schemas/user/session.gql
+++ b/priv/graphql/schemas/user/session.gql
@@ -3,7 +3,7 @@ Allow user to get information about sessions.
 """
 type SessionUserQuery @protected{
   "List connected resources"
-  listResources: [String!]
+  listResources: [ResourceName!]
   "Count connected resources"
   countResources: Int
   "Get information about all sessions"

--- a/priv/graphql/schemas/user/user_auth_status.gql
+++ b/priv/graphql/schemas/user/user_auth_status.gql
@@ -1,7 +1,7 @@
 "Inforamtion about user request authorization"
 type UserAuthInfo{
   "Authorized as user with name"
-  username: String
+  username: UserName
   "Authorization status"
   authStatus: AuthStatus
 }

--- a/src/graphql/mongoose_graphql_scalar.erl
+++ b/src/graphql/mongoose_graphql_scalar.erl
@@ -16,6 +16,7 @@ input(<<"JID">>, Jid) -> jid_from_binary(Jid);
 input(<<"UserName">>, User) -> user_from_binary(User);
 input(<<"RoomName">>, Room) -> room_from_binary(Room);
 input(<<"DomainName">>, Domain) -> domain_from_binary(Domain);
+input(<<"ResourceName">>, Res) -> resource_from_binary(Res);
 input(<<"FullJID">>, Jid) -> full_jid_from_binary(Jid);
 input(<<"NonEmptyString">>, Value) -> non_empty_string_to_binary(Value);
 input(<<"PosInt">>, Value) -> validate_pos_integer(Value);
@@ -35,6 +36,7 @@ output(<<"JID">>, Jid) -> {ok, jid:to_binary(Jid)};
 output(<<"UserName">>, User) -> {ok, User};
 output(<<"RoomName">>, Room) -> {ok, Room};
 output(<<"DomainName">>, Domain) -> {ok, Domain};
+output(<<"ResourceName">>, Res) -> {ok, Res};
 output(<<"NonEmptyString">>, Value) -> binary_to_non_empty_string(Value);
 output(<<"PosInt">>, Value) -> validate_pos_integer(Value);
 output(Ty, V) ->
@@ -77,6 +79,16 @@ domain_from_binary(Value) ->
             {error, failed_to_parse_domain_name};
         Domain ->
             {ok, Domain}
+    end.
+
+resource_from_binary(<<>>) ->
+    {error, empty_resource_name};
+resource_from_binary(Value) ->
+    case jid:resourceprep(Value) of
+        error ->
+            {error, failed_to_parse_resource_name};
+        Res ->
+            {ok, Res}
     end.
 
 full_jid_from_binary(Value) ->

--- a/src/graphql/mongoose_graphql_scalar.erl
+++ b/src/graphql/mongoose_graphql_scalar.erl
@@ -13,6 +13,7 @@
 input(<<"DateTime">>, DT) -> binary_to_microseconds(DT);
 input(<<"Stanza">>, Value) -> exml:parse(Value);
 input(<<"JID">>, Jid) -> jid_from_binary(Jid);
+input(<<"UserName">>, User) -> user_from_binary(User);
 input(<<"DomainName">>, Domain) -> domain_from_binary(Domain);
 input(<<"FullJID">>, Jid) -> full_jid_from_binary(Jid);
 input(<<"NonEmptyString">>, Value) -> non_empty_string_to_binary(Value);
@@ -30,6 +31,7 @@ input(Ty, V) ->
 output(<<"DateTime">>, DT) -> {ok, microseconds_to_binary(DT)};
 output(<<"Stanza">>, Elem) -> {ok, exml:to_binary(Elem)};
 output(<<"JID">>, Jid) -> {ok, jid:to_binary(Jid)};
+output(<<"UserName">>, User) -> {ok, User};
 output(<<"DomainName">>, Domain) -> {ok, Domain};
 output(<<"NonEmptyString">>, Value) -> binary_to_non_empty_string(Value);
 output(<<"PosInt">>, Value) -> validate_pos_integer(Value);
@@ -43,6 +45,16 @@ jid_from_binary(Value) ->
             {error, failed_to_parse_jid};
         Jid ->
             {ok, Jid}
+    end.
+
+user_from_binary(<<>>) ->
+    {error, empty_user_name};
+user_from_binary(Value) ->
+    case jid:nodeprep(Value) of
+        error ->
+            {error, failed_to_parse_user_name};
+        User ->
+            {ok, User}
     end.
 
 domain_from_binary(<<>>) ->

--- a/src/graphql/mongoose_graphql_scalar.erl
+++ b/src/graphql/mongoose_graphql_scalar.erl
@@ -14,6 +14,7 @@ input(<<"DateTime">>, DT) -> binary_to_microseconds(DT);
 input(<<"Stanza">>, Value) -> exml:parse(Value);
 input(<<"JID">>, Jid) -> jid_from_binary(Jid);
 input(<<"UserName">>, User) -> user_from_binary(User);
+input(<<"RoomName">>, Room) -> room_from_binary(Room);
 input(<<"DomainName">>, Domain) -> domain_from_binary(Domain);
 input(<<"FullJID">>, Jid) -> full_jid_from_binary(Jid);
 input(<<"NonEmptyString">>, Value) -> non_empty_string_to_binary(Value);
@@ -32,6 +33,7 @@ output(<<"DateTime">>, DT) -> {ok, microseconds_to_binary(DT)};
 output(<<"Stanza">>, Elem) -> {ok, exml:to_binary(Elem)};
 output(<<"JID">>, Jid) -> {ok, jid:to_binary(Jid)};
 output(<<"UserName">>, User) -> {ok, User};
+output(<<"RoomName">>, Room) -> {ok, Room};
 output(<<"DomainName">>, Domain) -> {ok, Domain};
 output(<<"NonEmptyString">>, Value) -> binary_to_non_empty_string(Value);
 output(<<"PosInt">>, Value) -> validate_pos_integer(Value);
@@ -55,6 +57,16 @@ user_from_binary(Value) ->
             {error, failed_to_parse_user_name};
         User ->
             {ok, User}
+    end.
+
+room_from_binary(<<>>) ->
+    {error, empty_room_name};
+room_from_binary(Value) ->
+    case jid:nodeprep(Value) of
+        error ->
+            {error, failed_to_parse_room_name};
+        Room ->
+            {ok, Room}
     end.
 
 domain_from_binary(<<>>) ->


### PR DESCRIPTION
Add GraphQL types: `UserName`, `RoomName` and `ResourceName`. We already have `DomainName`.
The new types ensure that the input data is string-prepped correctly, and that no empty strings are allowed.

`RoomName` and `UserName` have the same syntax, but I think that their semantics are different enough to separate them. I tried to have one type called `LocalName`, but it was confusing. Something like `LocalPart` would be even more cryptic.

Added tests for the new types.