### PR TITLE
Fix tabbed content in the documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,8 @@ markdown_extensions:
       linenums: true
   - pymdownx.superfences
   - admonition
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
 
 nav:
   - 'Home': 'index.md'


### PR DESCRIPTION
I've noticed that the tabbed content was not rendering properly. Seems like a new configuration option is required for the tabbed plugin, so I've added it.

Before:
<img width="751" alt="Screenshot 2022-11-22 at 12 06 58" src="https://user-images.githubusercontent.com/34194983/203299620-88588021-5488-4c8a-abeb-52a9d3b7a501.png">

After:
<img width="751" alt="Screenshot 2022-11-22 at 12 06 38" src="https://user-images.githubusercontent.com/34194983/203299659-652f2b9d-1888-424c-8f7a-53619310402c.png">
