### PR TITLE
Fix cassandra auth parameters parsing

### DIFF
--- a/src/wpool/mongoose_wpool_cassandra.erl
+++ b/src/wpool/mongoose_wpool_cassandra.erl
@@ -5,6 +5,10 @@
 -export([start/4]).
 -export([stop/2]).
 
+-ifdef(TEST).
+-export([prepare_cqerl_opts/1]).
+-endif.
+
 %% --------------------------------------------------------------
 %% mongoose_wpool callbacks
 -spec init() -> ok.
@@ -50,7 +54,7 @@ prepare_cqerl_opts(ConnOpts) ->
 cqerl_opts(keyspace, #{keyspace := Keyspace}) ->
     [{keyspace, Keyspace}];
 cqerl_opts(auth, #{auth := #{plain := #{username := UserName, password := Password}}}) ->
-    [{cqerl_auth_plain_handler, [{UserName, Password}]}];
+    [{auth, {cqerl_auth_plain_handler, [{UserName, Password}]}}];
 cqerl_opts(tcp, #{}) ->
     [{tcp_opts, [{keepalive, true}]}]; % always set
 cqerl_opts(tls, #{tls := TLSOpts}) ->

--- a/test/mongoose_wpool_SUITE.erl
+++ b/test/mongoose_wpool_SUITE.erl
@@ -39,7 +39,8 @@ all() ->
      dead_pool_is_restarted,
      dead_pool_is_stopped_before_restarted,
      riak_pool_cant_be_started_with_available_worker_strategy,
-     redis_pool_cant_be_started_with_available_worker_strategy
+     redis_pool_cant_be_started_with_available_worker_strategy,
+     cassandra_prepare_opts
     ].
 
 %%--------------------------------------------------------------------
@@ -268,6 +269,13 @@ pool_cant_be_started_with_available_worker_strategy(Type) ->
                  conn_opts => #{address => "localhost", port => 1805}}],
     ?assertError({strategy_not_supported, Type, Host, Tag, available_worker},
                  mongoose_wpool:start_configured_pools(PoolDef)).
+
+cassandra_prepare_opts(_Config) ->
+    %% Check that we pass auth options in the correct format to the Cassandra driver
+    AuthCfg = #{auth => #{plain => #{username => <<"user">>, password => <<"password">>}}},
+    ?assertEqual([{auth, {cqerl_auth_plain_handler, [{<<"user">>, <<"password">>}]}},
+                  {tcp_opts, [{keepalive, true}]}],
+                  mongoose_wpool_cassandra:prepare_cqerl_opts(AuthCfg)).
 
 %%--------------------------------------------------------------------
 %% Helpers


### PR DESCRIPTION
This PR addresses:
```
12:57:11.359 [error] Supervisor {<0.559.0>,cqerl_client_sup} had child {cqerl_client,
    {{"cassandra.default.svc.cluster.local",9042},
     [{cassandra_clusters,
          [{default,
               {[{"cassandra.default.svc.cluster.local",9042}],
                [{keyspace,mongooseim},
                 {cqerl_auth_plain_handler,
                     [{<<"admin">>,<<"SECRET">>}]},
                 {tcp_opts,[{keepalive,true}]}]}}]},
      {cqerl_auth_plain_handler,[{<<"admin">>,<<"SECRET">>}]},
      {keyspace,mongooseim},
      {maps,true},
      {num_clients,5},
      {tcp_opts,[{keepalive,true}]}]},
    2} started with cqerl_client:start_link({"cassandra.default.svc.cluster.local",9042}, [{ssl,false},{keyspace,mongooseim}], #Fun<cqerl.3.76336564>, {{"cassandra.default.svc.cluster.local",9042},[{cassandra_clusters,[{default,{[{"cassandra....",...}],...}}]},...]}) at <0.573.0> exit with reason {auth_client_closed,no_credentials_provided} in context shutdown_error
```
    
Proposed changes include:
* fix