### PR TITLE
Improve GraphQL error handling for MUC

### DIFF
--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4, subhost_pattern/1]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, get_ok_value/2, get_err_msg/1,
                          get_coercion_err_msg/1, user_to_bin/1, user_to_full_bin/1, user_to_jid/1,
                          get_unauthorized/1, get_not_loaded/1]).
@@ -11,6 +11,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("exml/include/exml.hrl").
+-include_lib("jid/include/jid.hrl").
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
@@ -26,17 +27,21 @@ groups() ->
      {admin_http, [], admin_groups()},
      {admin_cli, [], admin_groups()},
      {admin_muc_configured, [], admin_muc_tests()},
+     {admin_muc_and_mam_configured, [], admin_muc_with_mam_tests()},
      {admin_muc_not_configured, [], admin_muc_not_configured_tests()},
-     {user_muc_not_configured, [parallel], user_muc_not_configured_tests()},
      {user_muc_configured, [parallel], user_muc_tests()},
+     {user_muc_and_mam_configured, [parallel], user_muc_with_mam_tests()},
+     {user_muc_not_configured, [parallel], user_muc_not_configured_tests()},
      {domain_admin_muc, [], domain_admin_muc_tests()}].
 
 user_groups() ->
     [{group, user_muc_configured},
+     {group, user_muc_and_mam_configured},
      {group, user_muc_not_configured}].
 
 admin_groups() ->
     [{group, admin_muc_configured},
+     {group, admin_muc_and_mam_configured},
      {group, admin_muc_not_configured}].
 
 user_muc_tests() ->
@@ -45,8 +50,9 @@ user_muc_tests() ->
      user_try_delete_nonexistent_room,
      user_try_delete_room_by_not_owner,
      user_try_create_instant_room_with_nonexistent_domain,
-     user_try_create_instant_room_with_invalid_name,
+     user_try_create_instant_room_with_invalid_args,
      user_list_rooms,
+     user_try_list_rooms_for_nonexistent_domain,
      user_list_room_users,
      user_list_room_users_without_anonymous_mode,
      user_try_list_room_users_without_permission,
@@ -63,9 +69,6 @@ user_muc_tests() ->
      user_send_message_to_room_with_specified_res,
      user_send_private_message,
      user_without_session_send_message_to_room,
-     user_get_room_messages,
-     user_try_get_nonexistent_room_messages,
-     user_try_get_room_messages_without_permission,
      user_owner_set_user_affiliation,
      user_admin_set_user_affiliation,
      user_member_set_user_affiliation,
@@ -79,8 +82,14 @@ user_muc_tests() ->
      user_can_exit_room,
      user_list_room_affiliations,
      user_try_list_room_affiliations_without_permission,
-     user_try_list_nonexistent_room_affiliations
+     user_try_list_nonexistent_room_affiliations,
+     user_get_room_messages_muc_or_mam_not_configured
     ].
+
+user_muc_with_mam_tests() ->
+    [user_get_room_messages,
+     user_try_get_nonexistent_room_messages,
+     user_try_get_room_messages_without_permission].
 
 user_muc_not_configured_tests() ->
     [user_delete_room_muc_not_configured,
@@ -91,7 +100,7 @@ user_muc_not_configured_tests() ->
      user_kick_user_muc_not_configured,
      user_send_message_to_room_muc_not_configured,
      user_send_private_message_muc_not_configured,
-     user_get_room_messages_muc_not_configured,
+     user_get_room_messages_muc_or_mam_not_configured,
      user_owner_set_user_affiliation_muc_not_configured,
      user_moderator_set_user_role_muc_not_configured,
      user_can_enter_room_muc_not_configured,
@@ -99,13 +108,16 @@ user_muc_not_configured_tests() ->
      user_list_room_affiliations_muc_not_configured].
 
 admin_muc_tests() ->
-    [admin_create_and_delete_room,
+    [admin_list_rooms,
+     admin_list_rooms_with_invalid_args,
+     admin_create_and_delete_room,
      admin_create_room_with_unprepped_name,
      admin_try_create_instant_room_with_nonexistent_domain,
      admin_try_create_instant_room_with_nonexistent_user,
+     admin_try_create_instant_room_with_invalid_args,
      admin_try_delete_nonexistent_room,
      admin_try_delete_room_with_nonexistent_domain,
-     admin_list_rooms,
+     admin_try_list_rooms_for_nonexistent_domain,
      admin_list_room_users,
      admin_try_list_users_from_nonexistent_room,
      admin_change_room_config,
@@ -120,8 +132,6 @@ admin_muc_tests() ->
      admin_try_kick_user_from_room_without_moderators,
      admin_send_message_to_room,
      admin_send_private_message,
-     admin_get_room_messages,
-     admin_try_get_nonexistent_room_messages,
      admin_set_user_affiliation,
      admin_try_set_nonexistent_room_user_affiliation,
      admin_set_user_role,
@@ -134,8 +144,13 @@ admin_muc_tests() ->
      admin_make_user_exit_room,
      admin_make_user_exit_room_bare_jid,
      admin_list_room_affiliations,
-     admin_try_list_nonexistent_room_affiliations
+     admin_try_list_nonexistent_room_affiliations,
+     admin_get_room_messages_muc_or_mam_not_configured
     ].
+
+admin_muc_with_mam_tests() ->
+    [admin_get_room_messages,
+     admin_try_get_nonexistent_room_messages].
 
 admin_muc_not_configured_tests() ->
     [admin_delete_room_muc_not_configured,
@@ -146,7 +161,7 @@ admin_muc_not_configured_tests() ->
      admin_kick_user_muc_not_configured,
      admin_send_message_to_room_muc_not_configured,
      admin_send_private_message_muc_not_configured,
-     admin_get_room_messages_muc_not_configured,
+     admin_get_room_messages_muc_or_mam_not_configured,
      admin_set_user_affiliation_muc_not_configured,
      admin_set_user_role_muc_not_configured,
      admin_make_user_enter_room_muc_not_configured,
@@ -154,12 +169,12 @@ admin_muc_not_configured_tests() ->
      admin_list_room_affiliations_muc_not_configured].
 
 domain_admin_muc_tests() ->
-    [admin_create_and_delete_room,
+    [admin_list_rooms,
+     admin_create_and_delete_room,
      admin_create_room_with_unprepped_name,
      admin_try_create_instant_room_with_nonexistent_domain,
      admin_try_delete_nonexistent_room,
      domain_admin_create_and_delete_room_no_permission,
-     admin_list_rooms,
      domain_admin_list_rooms_no_permission,
      admin_list_room_users,
      domain_admin_list_room_users_no_permission,
@@ -203,11 +218,10 @@ init_per_suite(Config) ->
     Config2 = escalus:init_per_suite(Config),
     Config3 = dynamic_modules:save_modules(HostType, Config2),
     Config4 = dynamic_modules:save_modules(SecondaryHostType, Config3),
-    Config5 = rest_helper:maybe_enable_mam(mam_helper:backend(), HostType, Config4),
-    Config6 = ejabberd_node_utils:init(mim(), Config5),
+    Config5 = ejabberd_node_utils:init(mim(), Config4),
     dynamic_modules:restart(HostType, mod_disco,
                             config_parser_helper:default_mod_config(mod_disco)),
-    Config6.
+    Config5.
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
@@ -221,29 +235,57 @@ init_per_group(admin_http, Config) ->
 init_per_group(admin_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
 init_per_group(domain_admin_muc, Config) ->
-    Config1 = ensure_muc_started(Config),
-    graphql_helper:init_domain_admin_handler(Config1);
+    maybe_enable_mam(),
+    ensure_muc_started(),
+    graphql_helper:init_domain_admin_handler(Config);
+init_per_group(user, Config) ->
+    graphql_helper:init_user(Config);
 init_per_group(Group, Config) when Group =:= admin_muc_configured;
                                    Group =:= user_muc_configured ->
-    ensure_muc_started(Config);
+    disable_mam(),
+    ensure_muc_started(),
+    Config;
+init_per_group(Group, Config) when Group =:= admin_muc_and_mam_configured;
+                                   Group =:= user_muc_and_mam_configured ->
+    case maybe_enable_mam() of
+        true ->
+            ensure_muc_started(),
+            Config;
+        false ->
+            {skip, "No MAM backend available"}
+    end;
 init_per_group(Group, Config) when Group =:= admin_muc_not_configured;
                                    Group =:= user_muc_not_configured ->
-    ensure_muc_stopped(Config);
-init_per_group(user, Config) ->
-    graphql_helper:init_user(Config).
+    maybe_enable_mam(),
+    ensure_muc_stopped(),
+    Config.
 
-ensure_muc_started(Config) ->
+disable_mam() ->
+    dynamic_modules:ensure_modules(domain_helper:host_type(), [{mod_mam, stopped}]).
+
+maybe_enable_mam() ->
+    case mam_helper:backend() of
+        disabled ->
+            false;
+        Backend ->
+            MAMOpts = mam_helper:config_opts(
+                        #{backend => Backend,
+                          muc => #{host => subhost_pattern(muc_light_helper:muc_host_pattern())},
+                          async_writer => #{enabled => false}}),
+            dynamic_modules:ensure_modules(domain_helper:host_type(), [{mod_mam, MAMOpts}]),
+            true
+    end.
+
+ensure_muc_started() ->
     SecondaryHostType = domain_helper:secondary_host_type(),
     muc_helper:load_muc(),
     muc_helper:load_muc(SecondaryHostType),
-    mongoose_helper:ensure_muc_clean(),
-    Config.
+    mongoose_helper:ensure_muc_clean().
 
-ensure_muc_stopped(Config) ->
+ensure_muc_stopped() ->
     SecondaryHostType = domain_helper:secondary_host_type(),
     muc_helper:unload_muc(),
-    muc_helper:unload_muc(SecondaryHostType),
-    Config.
+    muc_helper:unload_muc(SecondaryHostType).
 
 end_per_group(Group, _Config) when Group =:= user;
                                    Group =:= admin_http;
@@ -254,8 +296,7 @@ end_per_group(_Group, _Config) ->
     escalus_fresh:clean().
 
 init_per_testcase(TC, Config) ->
-    rest_helper:maybe_skip_mam_test_cases(TC, [user_get_room_messages,
-                                               admin_get_room_messages], Config).
+    escalus:init_per_testcase(TC, Config).
 
 end_per_testcase(TC, Config) ->
     escalus:end_per_testcase(TC, Config).
@@ -286,6 +327,8 @@ admin_list_rooms(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}], fun admin_list_rooms_story/3).
 
 admin_list_rooms_story(Config, Alice, Bob) ->
+    Res0 = list_rooms(muc_helper:muc_host(), Alice, null, null, Config),
+    ?assertEqual([], extract_rooms(get_ok_value(?LIST_ROOMS_PATH, Res0))),
     AliceJID = jid:from_binary(escalus_client:short_jid(Alice)),
     BobJID = jid:from_binary(escalus_client:short_jid(Bob)),
     AliceRoom = rand_name(),
@@ -293,11 +336,32 @@ admin_list_rooms_story(Config, Alice, Bob) ->
     muc_helper:create_instant_room(AliceRoom, AliceJID, <<"Ali">>, []),
     muc_helper:create_instant_room(BobRoom, BobJID, <<"Bob">>, [{public_list, false}]),
     Res1 = list_rooms(muc_helper:muc_host(), Alice, null, null, Config),
-    #{<<"rooms">> := Rooms } = get_ok_value(?LIST_ROOMS_PATH, Res1),
+    Rooms1 = [_, RoomB] = extract_rooms(get_ok_value(?LIST_ROOMS_PATH, Res1)),
+    ?assertEqual(lists:sort([AliceRoom, BobRoom]), lists:sort(Rooms1)),
     Res2 = list_rooms(unprep(muc_helper:muc_host()), Alice, null, null, Config),
-    #{<<"rooms">> := Rooms } = get_ok_value(?LIST_ROOMS_PATH, Res2),
-    ?assert(contain_room(AliceRoom, Rooms)),
-    ?assert(contain_room(BobRoom, Rooms)).
+    ?assertEqual(Rooms1, extract_rooms(get_ok_value(?LIST_ROOMS_PATH, Res2))),
+    Res3 = list_rooms(muc_helper:muc_host(), Alice, 1, 1, Config),
+    ?assertEqual([RoomB], extract_rooms(get_ok_value(?LIST_ROOMS_PATH, Res3))).
+
+admin_list_rooms_with_invalid_args(Config) ->
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}]),
+    AliceJid = escalus_users:get_jid(Config1, alice),
+    AliceDomain = escalus_users:get_host(Config1, alice),
+    Res1 = list_rooms(muc_helper:muc_host(), AliceDomain, null, null, Config1),
+    assert_coercion_err(Res1, <<"jid_without_local_part">>),
+    Res2 = list_rooms(muc_helper:muc_host(), AliceJid, 0, null, Config1),
+    assert_coercion_err(Res2, <<"Value is not a positive integer">>),
+    Res3 = list_rooms(muc_helper:muc_host(), AliceJid, null, -1, Config1),
+    assert_coercion_err(Res3, <<"Value is not a non-negative integer">>).
+
+admin_try_list_rooms_for_nonexistent_domain(Config) ->
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}]),
+    AliceJID = escalus_users:get_jid(Config1, alice),
+    Res1 = list_rooms(<<"baddomain">>, AliceJID, null, null, Config1),
+    ?assertMatch({_, _}, binary:match(get_err_msg(Res1), <<"not found">>)),
+    %% Domain instead of the MUC subdomain
+    Res2 = list_rooms(domain_helper:domain(), AliceJID, null, null, Config1),
+    ?assertMatch({_, _}, binary:match(get_err_msg(Res2), <<"not found">>)).
 
 admin_create_and_delete_room(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_create_and_delete_room_story/2).
@@ -307,7 +371,7 @@ admin_create_and_delete_room_story(Config, Alice) ->
     MUCServer = muc_helper:muc_host(),
     RoomJID = jid:make_bare(Name, MUCServer),
     % Create instant room
-    Res = create_instant_room(MUCServer, Name, Alice, <<"Ali">>, Config),
+    Res = create_instant_room(RoomJID, Alice, <<"Ali">>, Config),
     ?assertMatch(#{<<"title">> := Name, <<"private">> := false, <<"usersNumber">> := 0},
                  get_ok_value(?CREATE_INSTANT_ROOM_PATH, Res)),
     Res2 = list_rooms(MUCServer, Alice, null, null, Config),
@@ -324,7 +388,8 @@ admin_create_room_with_unprepped_name(Config) ->
     AliceJid = escalus_users:get_jid(FreshConfig, alice),
     Name = <<$a, (rand_name())/binary>>, % make it start with a letter
     MUCServer = muc_helper:muc_host(),
-    Res = create_instant_room(unprep(MUCServer), unprep(Name), AliceJid, <<"Ali">>, FreshConfig),
+    RoomJID = jid:make_noprep(unprep(Name), unprep(MUCServer), <<>>),
+    Res = create_instant_room(RoomJID, AliceJid, <<"Ali">>, FreshConfig),
     ?assertMatch(#{<<"title">> := Name, <<"private">> := false, <<"usersNumber">> := 0},
                  get_ok_value(?CREATE_INSTANT_ROOM_PATH, Res)),
     Res2 = list_rooms(MUCServer, AliceJid, null, null, Config),
@@ -335,15 +400,30 @@ admin_try_create_instant_room_with_nonexistent_domain(Config) ->
                                     fun admin_try_create_instant_room_with_nonexistent_domain_story/2).
 
 admin_try_create_instant_room_with_nonexistent_domain_story(Config, Alice) ->
-    Res = create_instant_room(<<"unknown">>, rand_name(), Alice, <<"Ali">>, Config),
+    Res = create_instant_room(jid:make_bare(rand_name(), <<"unknown">>), Alice, <<"Ali">>, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 admin_try_create_instant_room_with_nonexistent_user(Config) ->
-    Name = rand_name(),
-    MUCServer = muc_helper:muc_host(),
+    RoomJID = jid:make_bare(rand_name(), muc_helper:muc_host()),
     JID = <<(rand_name())/binary, "@localhost">>,
-    Res = create_instant_room(MUCServer, Name, JID, <<"Ali">>, Config),
+    Res = create_instant_room(RoomJID, JID, <<"Ali">>, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
+
+admin_try_create_instant_room_with_invalid_args(Config) ->
+    Config1 = escalus_fresh:create_users(Config, [{alice, 1}]),
+    AliceJid = escalus_users:get_jid(Config1, alice),
+    AliceDomain = escalus_users:get_host(Config1, alice),
+    Domain = muc_helper:muc_host(),
+    Res1 = create_instant_room(<<"test room@", Domain/binary>>, AliceJid, <<"Ali">>, Config1),
+    assert_coercion_err(Res1, <<"failed_to_parse_jid">>),
+    Res2 = create_instant_room(<<"testroom@", Domain/binary, "/res1">>, AliceJid, <<"Ali">>, Config1),
+    assert_coercion_err(Res2, <<"jid_with_resource">>),
+    Res3 = create_instant_room(Domain, AliceJid, <<"Ali">>, Config1),
+    assert_coercion_err(Res3, <<"jid_without_local_part">>),
+    Res4 = create_instant_room(<<"testroom@", Domain/binary>>, AliceDomain, <<"Ali">>, Config1),
+    assert_coercion_err(Res4, <<"jid_without_local_part">>),
+    Res5 = create_instant_room(<<"testroom@", Domain/binary>>, AliceJid, <<>>, Config1),
+    assert_coercion_err(Res5, <<"empty_resource_name">>).
 
 admin_try_delete_nonexistent_room(Config) ->
     RoomJID = jid:make_bare(<<"unknown">>, muc_helper:muc_host()),
@@ -465,9 +545,12 @@ admin_send_private_message(Config, Alice, Bob) ->
     BareAlice = escalus_client:short_jid(Alice),
     Res = send_private_message(RoomJID, BareAlice, BobNick, Message, Config),
     assert_no_full_jid(Res),
+    % Try send private message to empty nick
+    Res1 = send_private_message(RoomJID, Alice, <<>>, Message, Config),
+    assert_coercion_err(Res1, <<"empty_resource_name">>),
     % Send message
-    Res1 = send_private_message(RoomJID, Alice, BobNick, Message, Config),
-    assert_success(?SEND_PRIV_MESG_PATH, Res1),
+    Res2 = send_private_message(RoomJID, Alice, BobNick, Message, Config),
+    assert_success(?SEND_PRIV_MESG_PATH, Res2),
     assert_is_message_correct(RoomJID, AliceNick, <<"chat">>, Message,
                               escalus:wait_for_stanza(Bob)).
 
@@ -526,13 +609,14 @@ admin_get_room_messages(Config) ->
                                fun admin_get_room_messages_story/3).
 
 admin_get_room_messages_story(Config, Alice, Bob) ->
-    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    RoomJID = #jid{luser = RoomName, lserver = MUCDomain} =
+        jid:from_binary(?config(room_jid, Config)),
     enter_room(RoomJID, Bob, <<"Bobek">>),
     enter_room(RoomJID, Alice, <<"Ali">>),
     escalus:wait_for_stanzas(Bob, 2),
     send_message_to_room(RoomJID, Bob, <<"Hi!">>, Config),
     escalus:wait_for_stanzas(Bob, 1),
-    mam_helper:maybe_wait_for_archive(Config),
+    mam_helper:wait_for_room_archive_size(MUCDomain, RoomName, 1),
     Res = get_room_messages(RoomJID, 50, null, Config),
     #{<<"stanzas">> := [#{<<"stanza">> := StanzaXML}], <<"limit">> := 50} =
         get_ok_value(?GET_MESSAGES_PATH, Res),
@@ -759,15 +843,15 @@ admin_send_message_to_room_muc_not_configured_story(Config, Alice) ->
     get_not_loaded(Res).
 
 admin_send_private_message_muc_not_configured(Config) ->
-    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
-        fun admin_send_private_message_muc_not_configured_story/3).
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+        fun admin_send_private_message_muc_not_configured_story/2).
 
-admin_send_private_message_muc_not_configured_story(Config, Alice, Bob) ->
+admin_send_private_message_muc_not_configured_story(Config, Alice) ->
     Nick = <<"ali">>,
     Res = send_private_message(get_room_name(), Alice, Nick, <<"body">>, Config),
     get_not_loaded(Res).
 
-admin_get_room_messages_muc_not_configured(Config) ->
+admin_get_room_messages_muc_or_mam_not_configured(Config) ->
     Res = get_room_messages(get_room_name(), 4, null, Config),
     get_not_loaded(Res).
 
@@ -820,17 +904,16 @@ domain_admin_create_and_delete_room_no_permission(Config) ->
                                     fun domain_admin_create_and_delete_room_no_permission_story/2).
 
 domain_admin_create_and_delete_room_no_permission_story(Config, AliceBis) ->
-    Name = rand_name(),
     ExternalDomain = domain_helper:secondary_domain(),
     UnknownDomain = <<"unknown">>,
-    MUCServer = muc_helper:muc_host(),
+    RoomJid = jid:make_bare(rand_name(), muc_helper:muc_host()),
     ExternalServer = <<"muc.", ExternalDomain/binary>>,
     % Create instant room with a non-existent domain
     UnknownJID = <<(rand_name())/binary, "@", UnknownDomain/binary>>,
-    Res = create_instant_room(MUCServer, Name, UnknownJID, <<"Ali">>, Config),
+    Res = create_instant_room(RoomJid, UnknownJID, <<"Ali">>, Config),
     get_unauthorized(Res),
     % Create instant room with an external domain
-    Res2 = create_instant_room(MUCServer, Name, AliceBis, <<"Ali">>, Config),
+    Res2 = create_instant_room(RoomJid, AliceBis, <<"Ali">>, Config),
     get_unauthorized(Res2),
     % Delete instant room with a non-existent domain
     UnknownRoomJID = jid:make_bare(<<"unknown_room">>, UnknownDomain),
@@ -973,6 +1056,17 @@ user_list_rooms_story(Config, Alice, Bob) ->
     ?assert(contain_room(AliceRoom, Rooms)),
     ?assert(contain_room(BobRoom, Rooms)).
 
+user_try_list_rooms_for_nonexistent_domain(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun user_try_list_rooms_for_nonexistent_domain_story/2).
+
+user_try_list_rooms_for_nonexistent_domain_story(Config, Alice) ->
+    Res1 = user_list_rooms(Alice, <<"baddomain">>, null, null, Config),
+    ?assertMatch({_, _}, binary:match(get_err_msg(Res1), <<"not found">>)),
+    %% Domain instead of the MUC subdomain
+    Res2 = user_list_rooms(Alice, domain_helper:domain(), null, null, Config),
+    ?assertMatch({_, _}, binary:match(get_err_msg(Res2), <<"not found">>)).
+
 user_create_and_delete_room(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun user_create_and_delete_room_story/2).
 
@@ -981,7 +1075,7 @@ user_create_and_delete_room_story(Config, Alice) ->
     MUCServer = muc_helper:muc_host(),
     RoomJID = jid:make_bare(Name, MUCServer),
     % Create instant room
-    Res = user_create_instant_room(Alice, MUCServer, Name, <<"Ali">>, Config),
+    Res = user_create_instant_room(Alice, RoomJID, <<"Ali">>, Config),
     ?assertMatch(#{<<"title">> := Name, <<"private">> := false, <<"usersNumber">> := 0},
                  get_ok_value(?CREATE_INSTANT_ROOM_PATH, Res)),
     Res2 = user_list_rooms(Alice, MUCServer, null, null, Config),
@@ -1000,7 +1094,8 @@ user_create_room_with_unprepped_name(Config) ->
 user_create_room_with_unprepped_name_story(Config, Alice) ->
     Name = <<$a, (rand_name())/binary>>, % make it start with a letter
     MUCServer = muc_helper:muc_host(),
-    Res = user_create_instant_room(Alice, unprep(MUCServer), unprep(Name), <<"Ali">>, Config),
+    RoomJid = jid:make_noprep(unprep(Name), unprep(MUCServer), <<>>),
+    Res = user_create_instant_room(Alice, RoomJid, <<"Ali">>, Config),
     ?assertMatch(#{<<"title">> := Name, <<"private">> := false, <<"usersNumber">> := 0},
                  get_ok_value(?CREATE_INSTANT_ROOM_PATH, Res)).
 
@@ -1009,16 +1104,22 @@ user_try_create_instant_room_with_nonexistent_domain(Config) ->
                                     fun user_try_create_instant_room_with_nonexistent_domain_story/2).
 
 user_try_create_instant_room_with_nonexistent_domain_story(Config, Alice) ->
-    Res = user_create_instant_room(Alice, <<"unknown">>, rand_name(), <<"Ali">>, Config),
+    RoomJID = jid:make_bare(rand_name(), <<"unknown">>),
+    Res = user_create_instant_room(Alice, RoomJID, <<"Ali">>, Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
-user_try_create_instant_room_with_invalid_name(Config) ->
+user_try_create_instant_room_with_invalid_args(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
-                                    fun user_try_create_instant_room_with_invalid_name_story/2).
+                                    fun user_try_create_instant_room_with_invalid_args_story/2).
 
-user_try_create_instant_room_with_invalid_name_story(Config, Alice) ->
-    Res = user_create_instant_room(Alice, muc_helper:muc_host(), <<"test room">>, <<"Ali">>, Config),
-    assert_coercion_err(Res, <<"failed_to_parse_room_name">>).
+user_try_create_instant_room_with_invalid_args_story(Config, Alice) ->
+    Domain = muc_helper:muc_host(),
+    Res1 = user_create_instant_room(Alice, <<"test room@", Domain/binary>>, <<"Ali">>, Config),
+    assert_coercion_err(Res1, <<"failed_to_parse_jid">>),
+    Res2 = user_create_instant_room(Alice, <<"testroom@", Domain/binary, "/res1">>, <<"Ali">>, Config),
+    assert_coercion_err(Res2, <<"jid_with_resource">>),
+    Res3 = user_create_instant_room(Alice, <<"testroom@", Domain/binary>>, <<>>, Config),
+    assert_coercion_err(Res3, <<"empty_resource_name">>).
 
 user_try_delete_nonexistent_room(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
@@ -1273,13 +1374,14 @@ user_get_room_messages(Config) ->
                                fun user_get_room_messages_story/3).
 
 user_get_room_messages_story(Config, Alice, Bob) ->
-    RoomJID = jid:from_binary(?config(room_jid, Config)),
+    RoomJID = #jid{luser = RoomName, lserver = MUCDomain} =
+        jid:from_binary(?config(room_jid, Config)),
     enter_room(RoomJID, Bob, <<"Bobek">>),
     enter_room(RoomJID, Alice, <<"Ali">>),
     escalus:wait_for_stanzas(Bob, 2),
     user_send_message_to_room(Bob, RoomJID, <<"Hi!">>, null, Config),
     escalus:wait_for_stanzas(Bob, 1),
-    mam_helper:maybe_wait_for_archive(Config),
+    mam_helper:wait_for_room_archive_size(MUCDomain, RoomName, 1),
     Res = user_get_room_messages(Alice, RoomJID, 50, null, Config),
     #{<<"stanzas">> := [#{<<"stanza">> := StanzaXML}], <<"limit">> := 50} =
         get_ok_value(?GET_MESSAGES_PATH, Res),
@@ -1617,11 +1719,11 @@ user_send_private_message_muc_not_configured_story(Config, Alice) ->
     Res = user_send_private_message(Alice, get_room_name(), Message, BobNick, null, Config),
     get_not_loaded(Res).
 
-user_get_room_messages_muc_not_configured(Config) ->
+user_get_room_messages_muc_or_mam_not_configured(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
-        fun user_get_room_messages_muc_not_configured_story/2).
+        fun user_get_room_messages_muc_or_mam_not_configured_story/2).
 
-user_get_room_messages_muc_not_configured_story(Config, Alice) ->
+user_get_room_messages_muc_or_mam_not_configured_story(Config, Alice) ->
     Res = user_get_room_messages(Alice, get_room_name(), 10, null, Config),
     get_not_loaded(Res).
 
@@ -1630,7 +1732,7 @@ user_owner_set_user_affiliation_muc_not_configured(Config) ->
         fun user_owner_set_user_affiliation_muc_not_configured_story/2).
 
 user_owner_set_user_affiliation_muc_not_configured_story(Config, Alice) ->
-    Res = user_set_user_affiliation(Alice, get_room_name(), <<"eddie@localhost">>, member, Config),
+    Res = user_set_user_affiliation(Alice, get_room_name(), Alice, member, Config),
     get_not_loaded(Res).
 
 user_moderator_set_user_role_muc_not_configured(Config) ->
@@ -1732,6 +1834,21 @@ contain_room(Name, #{<<"rooms">> := Rooms}) ->
 contain_room(Name, Rooms) when is_list(Rooms) ->
     lists:any(fun(#{<<"title">> := T}) -> T =:= Name end, Rooms).
 
+extract_rooms(#{<<"rooms">> := [], <<"index">> := null, <<"count">> := 0,
+                <<"first">> := null, <<"last">> := null}) ->
+    [];
+extract_rooms(#{<<"rooms">> := Rooms, <<"index">> := Index, <<"count">> := Count,
+                <<"first">> := First, <<"last">> := Last}) ->
+    Titles = lists:map(fun(#{<<"title">> := Title}) -> Title end, Rooms),
+    ?assertEqual(hd(Titles), First),
+    ?assertEqual(lists:last(Titles), Last),
+    ?assert(is_integer(Count) andalso Count >= length(Titles)),
+    ?assert(is_integer(Index) andalso Index >= 0),
+    Titles.
+
+returned_rooms(#{<<"rooms">> := Rooms}) ->
+    [Title || #{<<"title">> := Title} <- Rooms].
+
 assert_default_room_config(Response) ->
     ?assertMatch(#{<<"title">> := <<>>,
                    <<"description">> := <<>>,
@@ -1764,8 +1881,8 @@ get_room_name() ->
 
 %% Commands
 
-create_instant_room(MUCDomain, Name, Owner, Nick, Config) ->
-    Vars = #{mucDomain => MUCDomain, name => Name, owner => user_to_bin(Owner), nick => Nick},
+create_instant_room(Room, Owner, Nick, Config) ->
+    Vars = #{room => room_to_bin(Room), owner => user_to_bin(Owner), nick => Nick},
     execute_command(<<"muc">>, <<"createInstantRoom">>, Vars, Config).
 
 invite_user(Room, Sender, Recipient, Reason, Config) ->
@@ -1875,8 +1992,8 @@ user_send_private_message(User, Room, Body, ToNick, Resource, Config) ->
     Vars = #{room => jid:to_binary(Room), body => Body, toNick => ToNick, resource => Resource},
     execute_user_command(<<"muc">>, <<"sendPrivateMessage">>, User, Vars, Config).
 
-user_create_instant_room(User, MUCDomain, Name, Nick, Config) ->
-    Vars = #{mucDomain => MUCDomain, name => Name, nick => Nick},
+user_create_instant_room(User, Room, Nick, Config) ->
+    Vars = #{room => room_to_bin(Room), nick => Nick},
     execute_user_command(<<"muc">>, <<"createInstantRoom">>, User, Vars, Config).
 
 user_invite_user(User, Room, Recipient, Reason, Config) ->
@@ -1900,3 +2017,6 @@ user_exit_room(User, Room, Nick, Resource, Config) ->
 user_list_room_affiliations(User, Room, Aff, Config) ->
     Vars = #{room => jid:to_binary(Room), affiliation => atom_to_enum_item(Aff)},
     execute_user_command(<<"muc">>, <<"listRoomAffiliations">>, User, Vars, Config).
+
+room_to_bin(RoomJIDBin) when is_binary(RoomJIDBin) ->RoomJIDBin;
+room_to_bin(RoomJID) -> jid:to_binary(RoomJID).

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -16,7 +16,6 @@
 -module(mam_helper).
 
 -include("mam_helper.hrl").
--include_lib("escalus/include/escalus.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml_stream.hrl").

--- a/priv/graphql/schemas/admin/muc.gql
+++ b/priv/graphql/schemas/admin/muc.gql
@@ -3,38 +3,37 @@ Allow admin to manage Multi-User Chat rooms.
 """
 type MUCAdminMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
-  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createInstantRoom(mucDomain: DomainName!, name: RoomName!, owner: JID!, nick: String!): MUCRoomDesc
-    @protected(type: DOMAIN, args: ["owner"])
+  createInstantRoom(room: BareJID!, owner: JID!, nick: ResourceName!): MUCRoomDesc
+    @protected(type: DOMAIN, args: ["owner"]) @use(arg: "room")
   "Invite a user to a MUC room"
-  inviteUser(room: JID!, sender: JID!, recipient: JID!, reason: String): String
+  inviteUser(room: BareJID!, sender: JID!, recipient: JID!, reason: String): String
     @protected(type: DOMAIN, args: ["sender"]) @use(arg: "room")
   "Kick a user from a MUC room"
-  kickUser(room: JID!, nick: String!, reason: String): String
+  kickUser(room: BareJID!, nick: ResourceName!, reason: String): String
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Send a message to a MUC room"
-  sendMessageToRoom(room: JID!, from: FullJID!, body: String!): String
+  sendMessageToRoom(room: BareJID!, from: FullJID!, body: String!): String
     @protected(type: DOMAIN, args: ["from"]) @use(arg: "room")
   "Send a private message to a MUC room user"
-  sendPrivateMessage(room: JID!, from: FullJID!, toNick: String!, body: String!): String
+  sendPrivateMessage(room: BareJID!, from: FullJID!, toNick: ResourceName!, body: String!): String
     @protected(type: DOMAIN, args: ["from"]) @use(arg: "room")
   "Remove a MUC room"
-  deleteRoom(room: JID!, reason: String): String
+  deleteRoom(room: BareJID!, reason: String): String
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Change configuration of a MUC room"
-  changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig
+  changeRoomConfiguration(room: BareJID!, config: MUCRoomConfigInput!): MUCRoomConfig
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Change a user role"
-  setUserRole(room: JID!, nick: String!, role: MUCRole!): String
+  setUserRole(room: BareJID!, nick: ResourceName!, role: MUCRole!): String
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Change a user affiliation"
-  setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String
+  setUserAffiliation(room: BareJID!, user: JID!, affiliation: MUCAffiliation!): String
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Make a user enter the room with a given nick"
-  enterRoom(room: JID!, user: FullJID!, nick: String!, password: String): String
+  enterRoom(room: BareJID!, user: FullJID!, nick: ResourceName!, password: String): String
     @protected(type: DOMAIN, args: ["user"]) @use(arg: "room")
   "Make a user with the given nick exit the room"
-  exitRoom(room: JID!, user: FullJID!, nick: String!): String
+  exitRoom(room: BareJID!, user: FullJID!, nick: ResourceName!): String
     @protected(type: DOMAIN, args: ["user"]) @use(arg: "room")
 }
 
@@ -43,19 +42,18 @@ Allow admin to get information about Multi-User Chat rooms.
 """
 type MUCAdminQuery @protected @use(modules: ["mod_muc"]){
   "Get MUC rooms under the given MUC domain"
-  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  listRooms(mucDomain: DomainName!, from: JID!, limit: Int, index: Int): MUCRoomsPayload!
-    @protected(type: DOMAIN, args: ["from"])
+  listRooms(mucDomain: DomainName!, from: JID!, limit: PosInt, index: NonNegInt): MUCRoomsPayload
+    @protected(type: DOMAIN, args: ["from"]) @use(arg: "mucDomain")
   "Get configuration of the MUC room"
-  getRoomConfig(room: JID!): MUCRoomConfig
+  getRoomConfig(room: BareJID!): MUCRoomConfig
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get the user list of a given MUC room"
-  listRoomUsers(room: JID!): [MUCRoomUser!]
+  listRoomUsers(room: BareJID!): [MUCRoomUser!]
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get the affiliation list of given MUC room"
-  listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
+  listRoomAffiliations(room: BareJID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get the MUC room archived messages"
-  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
-    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
+  getRoomMessages(room: BareJID!, pageSize: PosInt, before: DateTime): StanzasPayload
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room", modules: ["mod_mam_muc"])
 }

--- a/priv/graphql/schemas/global/muc.gql
+++ b/priv/graphql/schemas/global/muc.gql
@@ -49,7 +49,7 @@ type MUCRoomDesc{
   "Is the room private?"
   private: Boolean
   "Number of the users"
-  usersNumber: Int
+  usersNumber: NonNegInt
 }
 
 "MUC room configuration"
@@ -93,7 +93,7 @@ type MUCRoomConfig{
   "Array of roles and/or privileges that enable retrieving the room's member list"
   mayGetMemberList: [String!]!
   "Maximum number of users in the room"
-  maxUsers: Int,
+  maxUsers: PosInt,
   "Does the room enabled logging events to a file on the disk?"
   logging: Boolean!,
 }
@@ -139,7 +139,7 @@ input MUCRoomConfigInput{
   "Array of roles and/or privileges that enable retrieving the room's member list"
   mayGetMemberList: [String!],
   "Maximum number of users in the room"
-  maxUsers: Int
+  maxUsers: PosInt
   "Does the room enabled logging events to a file on the disk?"
   logging: Boolean,
 }
@@ -149,9 +149,9 @@ type MUCRoomsPayload{
   "List of rooms descriptions"
   rooms: [MUCRoomDesc!]
   "Number of the rooms"
-  count: Int
+  count: NonNegInt
   "Index of the room"
-  index: Int
+  index: NonNegInt
   "First room title"
   first: String
   "Last room title"

--- a/priv/graphql/schemas/global/scalar_types.gql
+++ b/priv/graphql/schemas/global/scalar_types.gql
@@ -2,9 +2,11 @@
 scalar DateTime
 "Body of a data structure exchanged by XMPP entities in XML streams"
 scalar Stanza @spectaql(options: [{ key: "example", value: "Hi!" }])
-"Unique identifier in the form of **node@domain**"
+"Unique XMPP identifier in the form of **node@domain** or **node@domain/resource"
 scalar JID @spectaql(options: [{ key: "example", value: "alice@localhost" }])
-"The JID with resource"
+"JID without a resource"
+scalar BareJID @spectaql(options: [{ key: "example", value: "alice@localhost" }])
+"JID with a resource"
 scalar FullJID @spectaql(options: [{ key: "example", value: "alice@localhost/res1" }])
 "XMPP user name (local part of a JID)"
 scalar UserName @spectaql(options: [{ key: "example", value: "alice" }])
@@ -18,3 +20,5 @@ scalar ResourceName @spectaql(options: [{ key: "example", value: "res1" }])
 scalar NonEmptyString @spectaql(options: [{ key: "example", value: "xyz789" }])
 "Integer that has a value above zero"
 scalar PosInt @spectaql(options: [{ key: "example", value: "2" }])
+"Integer that has a value above or equal to zero"
+scalar NonNegInt @spectaql(options: [{ key: "example", value: "0" }])

--- a/priv/graphql/schemas/user/muc.gql
+++ b/priv/graphql/schemas/user/muc.gql
@@ -3,28 +3,38 @@ Allow user to manage Multi-User Chat rooms.
 """
 type MUCUserMutation @protected @use(modules: ["mod_muc"]){
   "Create a MUC room under the given XMPP hostname"
-  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createInstantRoom(mucDomain: DomainName!, name: RoomName!, nick: String!): MUCRoomDesc
+  createInstantRoom(room: BareJID!, nick: ResourceName!): MUCRoomDesc
+    @use(arg: "room")
   "Invite a user to a MUC room"
-  inviteUser(room: JID!, recipient: JID!, reason: String): String @use(arg: "room")
+  inviteUser(room: BareJID!, recipient: JID!, reason: String): String
+    @use(arg: "room")
   "Kick a user from a MUC room"
-  kickUser(room: JID!, nick: String!, reason: String): String @use(arg: "room")
+  kickUser(room: BareJID!, nick: ResourceName!, reason: String): String
+    @use(arg: "room")
   "Send a message to a MUC room"
-  sendMessageToRoom(room: JID!, body: String!, resource: ResourceName): String @use(arg: "room")
+  sendMessageToRoom(room: BareJID!, body: String!, resource: ResourceName): String
+    @use(arg: "room")
   "Send a private message to a MUC room user from the given resource"
-  sendPrivateMessage(room: JID!, toNick: String!, body: String!, resource: ResourceName): String @use(arg: "room")
+  sendPrivateMessage(room: BareJID!, toNick: ResourceName!, body: String!, resource: ResourceName): String
+    @use(arg: "room")
   "Remove a MUC room"
-  deleteRoom(room: JID!, reason: String): String @use(arg: "room")
+  deleteRoom(room: BareJID!, reason: String): String
+    @use(arg: "room")
   "Change configuration of a MUC room"
-  changeRoomConfiguration(room: JID!, config: MUCRoomConfigInput!): MUCRoomConfig @use(arg: "room")
+  changeRoomConfiguration(room: BareJID!, config: MUCRoomConfigInput!): MUCRoomConfig
+    @use(arg: "room")
   "Change a user role"
-  setUserRole(room: JID!, nick: String!, role: MUCRole!): String @use(arg: "room")
+  setUserRole(room: BareJID!, nick: ResourceName!, role: MUCRole!): String
+    @use(arg: "room")
   "Change a user affiliation"
-  setUserAffiliation(room: JID!, user: JID!, affiliation: MUCAffiliation!): String @use(arg: "room")
+  setUserAffiliation(room: BareJID!, user: JID!, affiliation: MUCAffiliation!): String
+    @use(arg: "room")
   "Enter the room with given resource and nick"
-  enterRoom(room: JID!, nick: String!, resource: ResourceName!, password: String): String @use(arg: "room")
+  enterRoom(room: BareJID!, nick: ResourceName!, resource: ResourceName!, password: String): String
+    @use(arg: "room")
   "Exit the room with given resource and nick"
-  exitRoom(room: JID!, nick: String!, resource: ResourceName!): String @use(arg: "room")
+  exitRoom(room: BareJID!, nick: ResourceName!, resource: ResourceName!): String
+    @use(arg: "room")
 }
 
 """
@@ -32,14 +42,18 @@ Allow user to get information about Multi-User Chat rooms.
 """
 type MUCUserQuery @protected @use(modules: ["mod_muc"]){
   "Get MUC rooms under the given MUC domain"
-  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  listRooms(mucDomain: DomainName!, limit: Int, index: Int): MUCRoomsPayload!
+  listRooms(mucDomain: DomainName!, limit: PosInt, index: NonNegInt): MUCRoomsPayload
+    @use(arg: "mucDomain")
   "Get configuration of the MUC room"
-  getRoomConfig(room: JID!): MUCRoomConfig @use(arg: "room")
+  getRoomConfig(room: BareJID!): MUCRoomConfig
+    @use(arg: "room")
   "Get the user list of a given MUC room"
-  listRoomUsers(room: JID!): [MUCRoomUser!] @use(arg: "room")
+  listRoomUsers(room: BareJID!): [MUCRoomUser!]
+    @use(arg: "room")
   "Get the affiliation list of given MUC room"
-  listRoomAffiliations(room: JID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!] @use(arg: "room")
+  listRoomAffiliations(room: BareJID!, affiliation: MUCAffiliation): [MUCRoomAffiliation!]
+    @use(arg: "room")
   "Get the MUC room archived messages"
-  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload @use(arg: "room")
+  getRoomMessages(room: BareJID!, pageSize: PosInt, before: DateTime): StanzasPayload
+    @use(arg: "room", modules: ["mod_mam_muc"])
 }

--- a/src/graphql/admin/mongoose_graphql_muc_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_admin_mutation.erl
@@ -34,14 +34,12 @@ execute(_Ctx, _Obj, <<"exitRoom">>, Args) ->
     exit_room(Args).
 
 -spec create_instant_room(map()) -> {ok, map()} | {error, resolver_error()}.
-create_instant_room(#{<<"mucDomain">> := MUCDomain, <<"name">> := Name,
-                      <<"owner">> := OwnerJID, <<"nick">> := Nick}) ->
-    case mod_muc_api:create_instant_room(MUCDomain, Name, OwnerJID, Nick) of
+create_instant_room(#{<<"room">> := RoomJID, <<"owner">> := OwnerJID, <<"nick">> := Nick}) ->
+    case mod_muc_api:create_instant_room(RoomJID, OwnerJID, Nick) of
         {ok, Room} ->
             {ok, mongoose_graphql_muc_helper:make_room_desc(Room)};
         Error ->
-            make_error(Error, #{mucDomain => MUCDomain,
-                                owner => jid:to_binary(OwnerJID)})
+            make_error(Error, #{room => jid:to_binary(RoomJID), owner => jid:to_binary(OwnerJID)})
     end.
 
 -spec invite_user(map()) -> {ok, binary()} | {error, resolver_error()}.

--- a/src/graphql/admin/mongoose_graphql_muc_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_admin_query.erl
@@ -26,8 +26,12 @@ list_rooms(#{<<"mucDomain">> := MUCDomain, <<"from">> := FromJID,
              <<"limit">> := Limit, <<"index">> := Index}) ->
     Limit2 = null_to_undefined(Limit),
     Index2 = null_to_undefined(Index),
-    {Rooms, RSM} = mod_muc_api:get_rooms(MUCDomain, FromJID, Limit2, Index2),
-    {ok, mongoose_graphql_muc_helper:make_rooms_payload(Rooms, RSM)}.
+    case mod_muc_api:get_rooms(MUCDomain, FromJID, Limit2, Index2) of
+        {ok, {Rooms, RSM}} ->
+            {ok, mongoose_graphql_muc_helper:make_rooms_payload(Rooms, RSM)};
+        Error ->
+            make_error(Error, #{mucDomain => MUCDomain})
+    end.
 
 -spec list_room_users(map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
 list_room_users(#{<<"room">> := RoomJID}) ->

--- a/src/graphql/mongoose_graphql_commands.erl
+++ b/src/graphql/mongoose_graphql_commands.erl
@@ -155,8 +155,9 @@ parse_arg(Value, ArgSpec = #{type := Type}) ->
     end.
 
 %% Used input types that are not parsed from binaries should be handled here
-convert_input_type(<<"Int">>, Value) -> binary_to_integer(Value);
-convert_input_type(<<"PosInt">>, Value) -> binary_to_integer(Value);
+convert_input_type(Type, Value) when Type =:= <<"Int">>;
+                                     Type =:= <<"PosInt">>;
+                                     Type =:= <<"NonNegInt">> -> binary_to_integer(Value);
 convert_input_type(_, Value) -> Value.
 
 %% Complex argument values should be provided in JSON

--- a/src/graphql/mongoose_graphql_helper.erl
+++ b/src/graphql/mongoose_graphql_helper.erl
@@ -1,6 +1,6 @@
 -module(mongoose_graphql_helper).
 
--export([null_to_default/2, null_to_undefined/1]).
+-export([null_to_default/2, null_to_undefined/1, undefined_to_null/1]).
 
 -export([format_result/2, make_error/2, make_error/3]).
 
@@ -32,3 +32,6 @@ null_to_default(Value, _Default) ->
 
 null_to_undefined(null) -> undefined;
 null_to_undefined(V) -> V.
+
+undefined_to_null(undefined) -> null;
+undefined_to_null(V) -> V.

--- a/src/graphql/mongoose_graphql_muc_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_helper.erl
@@ -7,6 +7,8 @@
 
 -ignore_xref(format_user/1).
 
+-import(mongoose_graphql_helper, [undefined_to_null/1]).
+
 -include("mongoose_rsm.hrl").
 -include("mod_muc_room.hrl").
 
@@ -24,8 +26,9 @@ add_user_resource(JID, Resource) ->
 
 make_rooms_payload(Rooms, #rsm_out{count = Count, index = Index, first = First, last = Last}) ->
     Rooms2 = [{ok, make_room_desc(R)} || R <- Rooms],
-    #{<<"rooms">> => Rooms2, <<"count">> => Count, <<"index">> => Index,
-      <<"first">> => First, <<"last">> => Last}.
+    #{<<"rooms">> => Rooms2,
+      <<"count">> => undefined_to_null(Count), <<"index">> => undefined_to_null(Index),
+      <<"first">> => undefined_to_null(First), <<"last">> => undefined_to_null(Last)}.
 
 make_room_desc(#{jid := JID, title := Title} = Room) ->
     Private = maps:get(private, Room, null),

--- a/src/graphql/user/mongoose_graphql_muc_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_muc_user_mutation.erl
@@ -51,13 +51,12 @@ exit_room(#{user := UserJID}, #{<<"room">> := RoomJID, <<"nick">> := Nick,
     format_result(Res, #{room => jid:to_binary(RoomJID)}).
 
 -spec create_instant_room(map(), map()) -> {ok, map()} | {error, resolver_error()}.
-create_instant_room(#{user := UserJID}, #{<<"mucDomain">> := MUCDomain, <<"name">> := Name,
-                                          <<"nick">> := Nick}) ->
-    case mod_muc_api:create_instant_room(MUCDomain, Name, UserJID, Nick) of
+create_instant_room(#{user := UserJID}, #{<<"room">> := RoomJID, <<"nick">> := Nick}) ->
+    case mod_muc_api:create_instant_room(RoomJID, UserJID, Nick) of
         {ok, Room} ->
             {ok, mongoose_graphql_muc_helper:make_room_desc(Room)};
         Error ->
-            make_error(Error, #{mucDomain => MUCDomain})
+            make_error(Error, #{room => jid:to_binary(RoomJID)})
     end.
 
 -spec invite_user(map(), map()) -> {ok, binary()} | {error, resolver_error()}.

--- a/src/graphql/user/mongoose_graphql_muc_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_muc_user_query.erl
@@ -26,8 +26,12 @@ list_rooms(#{user := UserJID}, #{<<"mucDomain">> := MUCDomain, <<"limit">> := Li
                                  <<"index">> := Index}) ->
     Limit2 = null_to_undefined(Limit),
     Index2 = null_to_undefined(Index),
-    {Rooms, RSM} = mod_muc_api:get_rooms(MUCDomain, UserJID, Limit2, Index2),
-    {ok, mongoose_graphql_muc_helper:make_rooms_payload(Rooms, RSM)}.
+    case mod_muc_api:get_rooms(MUCDomain, UserJID, Limit2, Index2) of
+        {ok, {Rooms, RSM}} ->
+            {ok, mongoose_graphql_muc_helper:make_rooms_payload(Rooms, RSM)};
+        Error ->
+            make_error(Error, #{mucDomain => MUCDomain})
+    end.
 
 -spec list_room_users(map(), map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
 list_room_users(#{user := UserJID}, #{<<"room">> := RoomJID}) ->

--- a/src/mongoose_admin_api/mongoose_admin_api_muc.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api_muc.erl
@@ -84,9 +84,8 @@ handle_post(Req, State, #{domain := Domain}) ->
     RoomName = get_room_name(Args),
     OwnerJid = get_owner_jid(Args),
     Nick = get_nick(Args),
-    %% TODO This check should be done in the API module to work for GraphQL as well
-    #jid{lserver = MUCDomain} = make_room_jid(RoomName, get_muc_domain(Domain)),
-    case mod_muc_api:create_instant_room(MUCDomain, RoomName, OwnerJid, Nick) of
+    RoomJid = make_room_jid(RoomName, get_muc_domain(Domain)),
+    case mod_muc_api:create_instant_room(RoomJid, OwnerJid, Nick) of
         {ok, #{title := R}} ->
             Path = [cowboy_req:uri(Req), "/", R],
             resource_created(Req, State, Path, R);


### PR DESCRIPTION
The goal is to check and test error conditions in the MUC GraphQL API.

Main changes:
- Pass the whole room JID on room creation. It is more straightforward than passing both JID parts separately.
- Room JIDs should be bare.
- Nicks should be valid resource names.
- MAM-related operations check if the module is enabled.
- All JID types require the local part now.

Discovered bugs that should be fixed separately:
- If `mod_mam_muc` is enabled for `muclight.localhost`, it also stores messages for `muc.localhost`. Actually this misconfiguration was present in the tests, which were passing because of the bug.