### PR TITLE
Put hooks into persistent_term using batching

### DIFF
--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -80,6 +80,7 @@ do_start() ->
     mongoose_listener:start(),
     ejabberd_admin:start(),
     mongoose_metrics:init_mongooseim_metrics(),
+    gen_hook:reload_hooks(),
     update_status_file(started),
     ?LOG_NOTICE(#{what => mongooseim_node_started, version => ?MONGOOSE_VERSION, node => node()}),
     Sup.

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -145,7 +145,7 @@ get_global_metric_names() ->
 get_aggregated_values(Metric) ->
     exometer:aggregate([{{['_', Metric], '_', '_'}, [], [true]}], [one, count, value]).
 
--spec increment_generic_hook_metric(mongooseim:host_type(), atom()) -> ok | {error, any()}.
+-spec increment_generic_hook_metric(mongooseim:host_type_or_global(), atom()) -> ok | {error, any()}.
 increment_generic_hook_metric(HostType, Hook) ->
     UseOrSkip = filter_hook(Hook),
     do_increment_generic_hook_metric(HostType, Hook, UseOrSkip).

--- a/test/auth_tokens_SUITE.erl
+++ b/test/auth_tokens_SUITE.erl
@@ -56,7 +56,7 @@ init_per_testcase(Test, Config)
              Test =:= validation_property;
              Test =:= choose_key_by_token_type ->
     mock_mongoose_metrics(),
-    Config1 = async_helper:start(Config, [{gen_hook, start_link, []}]),
+    Config1 = async_helper:start(Config, [{mongooseim_helper, start_link_loaded_hooks, []}]),
     mock_keystore(),
     mock_rdbms_backend(),
     Config1;
@@ -66,12 +66,12 @@ init_per_testcase(validity_period_test, Config) ->
     mock_mongoose_metrics(),
     mock_gen_iq_handler(),
     mock_ejabberd_commands(),
-    async_helper:start(Config, [{gen_hook, start_link, []}]);
+    async_helper:start(Config, [{mongooseim_helper, start_link_loaded_hooks, []}]);
 
 init_per_testcase(revoked_token_is_not_valid, Config) ->
     mock_mongoose_metrics(),
     mock_tested_backend(),
-    Config1 = async_helper:start(Config, [{gen_hook, start_link, []}]),
+    Config1 = async_helper:start(Config, [{mongooseim_helper, start_link_loaded_hooks, []}]),
     mock_keystore(),
     Config1;
 

--- a/test/component_reg_SUITE.erl
+++ b/test/component_reg_SUITE.erl
@@ -18,13 +18,13 @@ init_per_suite(C) ->
     meck:expect(mongoose_domain_api, get_host_type,
                 fun(_) -> {error, not_found} end),
     application:ensure_all_started(exometer_core),
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     ejabberd_router:start_link(),
     C.
 
 init_per_testcase(_, C) ->
     mongoose_router:start(),
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     C.
 
 end_per_suite(_C) ->
@@ -48,7 +48,7 @@ registering(_C) ->
     ok.
 
 registering_with_local(_C) ->
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     Dom = <<"aaa.bbb.com">>,
     ThisNode = node(),
     AnotherNode = 'another@nohost',

--- a/test/event_pusher_sns_SUITE.erl
+++ b/test/event_pusher_sns_SUITE.erl
@@ -112,7 +112,7 @@ end_per_suite(_) ->
     ok.
 
 init_per_testcase(CaseName, Config) ->
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     meck:new(erlcloud_sns, [non_strict, passthrough]),
     meck:new([mongoose_wpool, mongoose_metrics], [stub_all]),
     meck:expect(erlcloud_sns, new, fun(_, _, _) -> mod_aws_sns_SUITE_erlcloud_sns_new end),

--- a/test/gen_hook_SUITE.erl
+++ b/test/gen_hook_SUITE.erl
@@ -33,7 +33,7 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(_, Config) ->
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     Config.
 
 end_per_testcase(_, Config) ->

--- a/test/gen_hook_SUITE.erl
+++ b/test/gen_hook_SUITE.erl
@@ -338,4 +338,4 @@ get_hook_handler(ModName, FunName, Fun) when is_function(Fun, 3) ->
     fun ModName:FunName/3.
 
 get_handlers_for_all_hooks() ->
-    ets:tab2list(gen_hook).
+    maps:to_list(persistent_term:get(gen_hook, #{})).

--- a/test/keystore_SUITE.erl
+++ b/test/keystore_SUITE.erl
@@ -27,7 +27,7 @@ end_per_suite(_C) ->
 
 init_per_testcase(_, Config) ->
     mock_mongoose_metrics(),
-    Config1 = async_helper:start(Config, gen_hook, start_link, []),
+    Config1 = async_helper:start(Config, mongooseim_helper, start_link_loaded_hooks, []),
     mongoose_config:set_opts(opts()),
     Config1.
 

--- a/test/mod_global_distrib_SUITE.erl
+++ b/test/mod_global_distrib_SUITE.erl
@@ -68,7 +68,7 @@ init_per_testcase(_CaseName, Config) ->
     mongoose_config:set_opts(opts()),
     mongoose_domain_sup:start_link(),
     mim_ct_sup:start_link(ejabberd_sup),
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     mongoose_modules:start(),
     Config.
 

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -82,7 +82,7 @@ end_per_group(_Group, Config) ->
 
 init_per_testcase(TestCase, Config) ->
     mim_ct_sup:start_link(ejabberd_sup),
-    {ok, _HooksServer} = gen_hook:start_link(),
+    {ok, _HooksServer} = mongooseim_helper:start_link_loaded_hooks(),
     {ok, _DomainSup} = mongoose_domain_sup:start_link(),
     setup_meck(meck_mods(TestCase)),
     start_component(TestCase),

--- a/test/mongoose_subdomain_core_SUITE.erl
+++ b/test/mongoose_subdomain_core_SUITE.erl
@@ -39,7 +39,7 @@ init_per_testcase(TestCase, Config) ->
     %%   - one "dynamic" host type with two configured domain names
     %% initial mongoose_subdomain_core conditions:
     %%   - no subdomains configured for any host type
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     mongoose_domain_sup:start_link(?STATIC_PAIRS, ?ALLOWED_HOST_TYPES),
     [mongoose_domain_core:insert(Domain, ?DYNAMIC_HOST_TYPE2, dummy_source)
      || Domain <- ?DYNAMIC_DOMAINS],

--- a/test/mongooseim_helper.erl
+++ b/test/mongooseim_helper.erl
@@ -1,0 +1,7 @@
+-module(mongooseim_helper).
+-compile([export_all, nowarn_export_all]).
+
+start_link_loaded_hooks() ->
+    Ret = gen_hook:start_link(),
+    gen_hook:reload_hooks(),
+    Ret.

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -38,7 +38,7 @@ init_per_suite(C) ->
     Sup = spawn(fun() ->
         mim_ct_sup:start_link(ejabberd_sup),
         Hooks = {gen_hook,
-                 {gen_hook, start_link, []},
+                 {mongooseim_helper, start_link_loaded_hooks, []},
                  permanent,
                  brutal_kill,
                  worker,

--- a/test/muc_light_SUITE.erl
+++ b/test/muc_light_SUITE.erl
@@ -56,7 +56,7 @@ init_per_testcase(codec_calls, Config) ->
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
     {ok, _} = application:ensure_all_started(exometer_core),
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     ejabberd_router:start_link(),
     mim_ct_sup:start_link(ejabberd_sup),
     mongoose_modules:start(),

--- a/test/privacy_SUITE.erl
+++ b/test/privacy_SUITE.erl
@@ -46,7 +46,7 @@ end_per_suite(_C) ->
     ok.
 
 init_per_testcase(_, C) ->
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     mongoose_config:set_opts(opts()),
     mongoose_modules:start(),
     C.

--- a/test/roster_SUITE.erl
+++ b/test/roster_SUITE.erl
@@ -48,7 +48,7 @@ end_per_suite(_C) ->
 
 init_per_testcase(_TC, C) ->
     init_ets(),
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     mongoose_modules:start(),
     C.
 

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -38,7 +38,7 @@ end_per_suite(_C) ->
 
 init_per_group(routing, Config) ->
     mongoose_config:set_opts(opts()),
-    gen_hook:start_link(),
+    mongooseim_helper:start_link_loaded_hooks(),
     ejabberd_router:start_link(),
     Config.
 


### PR DESCRIPTION
Optimising hooks, as every hook execution means copying a list of handler from the ets table, having them into persistent terms means faster access to super frequently used values: no copying, no GC, and keeping code hotter for memory caching.

`gen_hook` accumulates the handlers on an internal state, and does not dump into PT until explicitly requested (at the end of app startup). If any more handlers are added or removed afterwards, PT entry is updated immediately (this keeps tests easier).

Perhaps https://github.com/esl/MongooseIM/pull/4074 is preferred, needs to be discussed.