### PR TITLE
C2S/csi

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -108,7 +108,7 @@
 {suites, "tests", vcard_SUITE}.
 {suites, "tests", vcard_simple_SUITE}.
 {suites, "tests", websockets_SUITE}.
-% {suites, "tests", xep_0352_csi_SUITE}.
+{suites, "tests", xep_0352_csi_SUITE}.
 {suites, "tests", service_domain_db_SUITE}.
 {skip_cases, "tests", service_domain_db_SUITE,
  [rest_delete_domain_cleans_data_from_mam], "this test tries to use presences"}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -155,7 +155,7 @@
 {suites, "tests", vcard_SUITE}.
 {suites, "tests", vcard_simple_SUITE}.
 {suites, "tests", websockets_SUITE}.
-% {suites, "tests", xep_0352_csi_SUITE}.
+{suites, "tests", xep_0352_csi_SUITE}.
 {suites, "tests", domain_removal_SUITE}.
 {suites, "tests", local_iq_SUITE}.
 % {suites, "tests", tcp_listener_SUITE}.

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -888,9 +888,11 @@ resume_session_with_wrong_h_does_not_leak_sessions(Config) ->
         Resumed = sm_helper:try_to_resume_stream(Alice, SMID, 30),
         escalus:assert(is_stream_error, [<<"undefined-condition">>, <<>>], Resumed),
         escalus_connection:wait_for_close(Alice, timer:seconds(5)),
-        [] = sm_helper:get_user_present_resources(Alice),
-        mongoose_helper:wait_until(fun() -> sm_helper:get_sid_by_stream_id(HostType, SMID) end,
-                                   {error, smid_not_found}, #{name => smid_is_cleaned})
+        Fun = fun() ->
+                      [] = sm_helper:get_user_present_resources(Alice),
+                      sm_helper:get_sid_by_stream_id(HostType, SMID)
+              end,
+        mongoose_helper:wait_until(Fun, {error, smid_not_found}, #{name => smid_is_cleaned})
     end).
 
 resume_session_with_wrong_sid_returns_item_not_found(Config) ->

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -40,6 +40,7 @@
 -define(LONG_TIMEOUT, 3600).
 -define(SHORT_TIMEOUT, 1).
 -define(SMALL_SM_BUFFER, 3).
+-define(EXT_C2S_STATE(S), {external_state, S}).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -508,7 +509,7 @@ preserve_order(Config) ->
     %% kill alice connection
     escalus_connection:kill(Alice),
     C2SPid = mongoose_helper:get_session_pid(Alice),
-    mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session),
+    wait_until_resume_session(C2SPid),
 
     escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"2">>)),
     escalus_connection:send(Bob, escalus_stanza:chat_to_short_jid(Alice, <<"3">>)),
@@ -575,7 +576,7 @@ resend_unacked_after_resume_timeout(Config) ->
 
     %% ensure there is no session
     C2SPid = mongoose_helper:get_session_pid(Alice),
-    mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session),
+    wait_until_resume_session(C2SPid),
 
     %% alice come back and receives unacked message
     NewAlice = connect_spec(AliceSpec, session),
@@ -640,7 +641,7 @@ resume_session_state_send_message_generic(Config, AckInitialPresence) ->
     %% kill alice connection
     C2SPid = mongoose_helper:get_session_pid(Alice),
     escalus_connection:kill(Alice),
-    mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session),
+    wait_until_resume_session(C2SPid),
     sm_helper:assert_alive_resources(Alice, 1),
 
     %% send some messages and check if c2s can handle it
@@ -688,7 +689,7 @@ resume_session_state_stop_c2s(Config) ->
     % session should be alive
     sm_helper:assert_alive_resources(Alice, 1),
     rpc(mim(), mongoose_c2s, stop, [C2SPid, normal]),
-    mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session),
+    wait_until_resume_session(C2SPid),
     %% suspend the process to ensure that Alice has enough time to reconnect,
     %% before resumption timeout occurs.
     ok = rpc(mim(), sys, suspend, [C2SPid]),
@@ -719,7 +720,7 @@ wait_for_resumption(Config) ->
     Bob = connect_fresh(Config, bob, session),
     Texts = three_texts(),
     {C2SPid, _} = buffer_unacked_messages_and_die(Config, AliceSpec, Bob, Texts),
-    mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session).
+    wait_until_resume_session(C2SPid).
 
 unacknowledged_message_hook_filter(Config) ->
     FilterText = <<"filter">>,
@@ -737,7 +738,7 @@ unacknowledged_message_hook_filter(Config) ->
     %% kill alice connection
     C2SPid = mongoose_helper:get_session_pid(Alice),
     escalus_connection:kill(Alice),
-    mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session),
+    wait_until_resume_session(C2SPid),
     sm_helper:assert_alive_resources(Alice, 1),
     %% ensure second C2S is registered so all the messages are bounced properly
     NewAlice = connect_spec([{resource, <<"2">>}| AliceSpec], sr_presence, manual),
@@ -825,7 +826,7 @@ unacknowledged_message_hook_common(RestartConnectionFN, Config) ->
     %% kill alice connection
     C2SPid = mongoose_helper:get_session_pid(Alice),
     escalus_connection:kill(Alice),
-    mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session),
+    wait_until_resume_session(C2SPid),
     sm_helper:assert_alive_resources(Alice, 1),
 
     escalus:assert(is_chat_message, [<<"msg-1">>], wait_for_unacked_msg_hook(0, Resource, 100)),
@@ -851,7 +852,7 @@ unacknowledged_message_hook_common(RestartConnectionFN, Config) ->
 
     NewC2SPid = mongoose_helper:get_session_pid(NewAlice),
     escalus_connection:kill(NewAlice),
-    mongoose_helper:wait_for_c2s_state_name(NewC2SPid, resume_session),
+    wait_until_resume_session(NewC2SPid),
 
     escalus:assert(is_chat_message, [<<"msg-1">>], wait_for_unacked_msg_hook(1, NewResource, 100)),
     escalus:assert(is_chat_message, [<<"msg-2">>], wait_for_unacked_msg_hook(1, NewResource, 100)),
@@ -929,7 +930,7 @@ resume_session_kills_old_C2S_gracefully(Config) ->
     escalus_client:kill_connection(Config, Alice),
 
     %% Ensure the c2s process is waiting for resumption.
-    mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session),
+    wait_until_resume_session(C2SPid),
 
     %% Resume the session.
     NewAlice = connect_resume(Alice, 1),
@@ -947,7 +948,7 @@ buffer_unacked_messages_and_die(Config, AliceSpec, Bob, Texts) ->
     sm_helper:wait_for_messages(Alice, Texts),
     %% Alice's connection is violently terminated.
     escalus_client:kill_connection(Config, Alice),
-    mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session),
+    wait_until_resume_session(C2SPid),
     SMID = sm_helper:client_to_smid(Alice),
     {C2SPid, SMID}.
 
@@ -1080,7 +1081,7 @@ messages_are_properly_flushed_during_resumption(Config) ->
         escalus_client:kill_connection(Config, Alice),
         %% The receiver process would stop now
         C2SPid = mongoose_helper:get_session_pid(Alice),
-        mongoose_helper:wait_for_c2s_state_name(C2SPid, resume_session),
+        wait_until_resume_session(C2SPid),
 
         sm_helper:wait_for_queue_length(C2SPid, 0),
         ok = rpc(mim(), sys, suspend, [C2SPid]),
@@ -1265,6 +1266,9 @@ wait_for_session(JID, Retries, SleepTime) ->
         _ ->
             ok
     end.
+
+wait_until_resume_session(C2SPid) ->
+    mongoose_helper:wait_for_c2s_state_name(C2SPid, ?EXT_C2S_STATE(resume_session)).
 
 maybe_ack_initial_presence(Alice, ack) ->
     ack_initial_presence(Alice);

--- a/big_tests/tests/xep_0352_csi_SUITE.erl
+++ b/big_tests/tests/xep_0352_csi_SUITE.erl
@@ -28,7 +28,8 @@ all_tests() ->
      alice_gets_buffered_messages_after_reconnection_with_sm,
      alice_gets_buffered_messages_after_stream_resumption,
      bob_gets_msgs_from_inactive_alice,
-     alice_is_inactive_but_sends_sm_req_and_recives_ack
+     alice_is_inactive_but_sends_sm_req_and_recives_ack,
+     invalid_csi_request_returns_error
     ].
 
 suite() ->
@@ -64,6 +65,13 @@ server_announces_csi(Config) ->
     Steps = [start_stream, stream_features, maybe_use_ssl, authenticate, bind, session],
     {ok, _Client, Features} = escalus_connection:start(Spec, Steps),
     true = proplists:get_value(client_state_indication, Features).
+
+invalid_csi_request_returns_error(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        escalus:send(Alice, csi_stanza(<<"invalid">>)),
+        Stanza = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_error, [<<"modify">>, <<"bad-request">>], Stanza)
+    end).
 
 alice_is_inactive_and_no_stanza_arrived(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->

--- a/big_tests/tests/xep_0352_csi_SUITE.erl
+++ b/big_tests/tests/xep_0352_csi_SUITE.erl
@@ -21,6 +21,7 @@ all_tests() ->
     [
      server_announces_csi,
      alice_is_inactive_and_no_stanza_arrived,
+     inactive_twice_does_not_reset_buffer,
      alice_gets_msgs_after_activate,
      alice_gets_msgs_after_activate_in_order,
      alice_gets_message_after_buffer_overflow,
@@ -81,6 +82,15 @@ alice_gets_msgs_after_activate(Config, N) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         given_client_is_inactive_and_no_messages_arrive(Alice),
         Msgs = given_messages_are_sent(Alice, Bob, N),
+        given_client_is_active(Alice),
+        then_client_receives_message(Alice, Msgs)
+    end).
+
+inactive_twice_does_not_reset_buffer(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        given_client_is_inactive_and_no_messages_arrive(Alice),
+        Msgs = given_messages_are_sent(Alice, Bob, 2),
+        given_client_is_inactive_and_no_messages_arrive(Alice),
         given_client_is_active(Alice),
         then_client_receives_message(Alice, Msgs)
     end).

--- a/doc/modules/mod_csi.md
+++ b/doc/modules/mod_csi.md
@@ -1,8 +1,6 @@
 ## Module Description
-Enables [XEP-0352: Client State Indication](http://xmpp.org/extensions/xep-0352.html) functionality.
-It is implemented mostly in `ejabberd_c2s`, this module is just a "starter", to advertise the `csi` stream feature.
 
-The Client State Indication functionality will be possible to use even without enabling this module, but the feature will not be present in the stream features list.
+Enables [XEP-0352: Client State Indication](http://xmpp.org/extensions/xep-0352.html) functionality.
 
 The XEP doesn't **require** any specific server behaviour in response to CSI stanzas, there are only some suggestions.
 The implementation in MongooseIM will simply buffer all packets (up to a configured limit) when the session is "inactive" and will flush the buffer when it becomes "active" again.

--- a/include/jlib.hrl
+++ b/include/jlib.hrl
@@ -36,5 +36,6 @@
 
 -define(STREAM_TRAILER, <<"</stream:stream>">>).
 -define(XML_STREAM_TRAILER, #xmlstreamend{name = <<"stream:stream">>}).
+-define(EXT_C2S_STATE(S), {external_state, S}).
 
 -endif.

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -707,8 +707,8 @@ handle_stanza_to_client(StateData = #c2s_data{host_type = HostType}, C2SState, A
             Res = process_stanza_to_client(StateData, HookParams, Acc2, StanzaName),
             Acc3 = maybe_deliver(StateData, Res),
             handle_state_after_packet(StateData, C2SState, Acc3);
-        {stop, _Acc1} ->
-            keep_state_and_data
+        {stop, Acc2} ->
+            handle_state_after_packet(StateData, C2SState, Acc2)
     end.
 
 %% @doc Process packets sent to the user (coming to user on c2s XMPP connection)

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -731,8 +731,13 @@ handle_state_after_packet(StateData, C2SState, Acc) ->
                           c2s_state(),
                           undefined | mongoose_acc:t(),
                           mongoose_c2s_acc:t()) -> fsm_res().
-handle_state_result(StateData, _, _, #{hard_stop := Reason}) when Reason =/= undefined ->
-    {stop, {shutdown, Reason}, StateData};
+handle_state_result(StateData0, _, _, #{c2s_data := MaybeNewFsmData, hard_stop := Reason})
+  when Reason =/= undefined ->
+    StateData1 = case MaybeNewFsmData of
+                     undefined -> StateData0;
+                     _ -> MaybeNewFsmData
+                 end,
+    {stop, {shutdown, Reason}, StateData1};
 handle_state_result(StateData0, C2SState, MaybeAcc,
                     #{state_mod := ModuleStates, actions := MaybeActions,
                       c2s_state := MaybeNewFsmState, c2s_data := MaybeNewFsmData,

--- a/src/c2s/mongoose_c2s_acc.erl
+++ b/src/c2s/mongoose_c2s_acc.erl
@@ -10,8 +10,8 @@
 %% - `c2s_data': a new state data is requested for the state machine.
 %% - `stop': an action of type `{cast, {stop, Reason}}' is to be triggered.
 %% - `hard_stop': no other request is allowed, the state machine is immediatly triggered to stop.
-%% - `route': mongoose_acc elements to trigger the whole `handle_stanza_to_client' pipeline.
-%% - `flush': mongoose_acc elements to flush on the socket to the user.
+%% - `route': mongoose_acc elements to trigger the whole `handle_route' pipeline.
+%% - `flush': mongoose_acc elements to trigger the `handle_flush` pipeline.
 %% - `socket_send': xml elements to send on the socket to the user.
 -module(mongoose_c2s_acc).
 
@@ -87,18 +87,18 @@ extract_stop(Params) ->
     Params.
 
 extract_flushes(Params = #{flush := Accs}) ->
-    WithoutStop = maps:remove(flush, Params),
+    WithoutFlush = maps:remove(flush, Params),
     NewAction = [{next_event, internal, {flush, Acc}} || Acc <- Accs ],
     Fun = fun(Actions) -> NewAction ++ Actions end,
-    maps:update_with(actions, Fun, NewAction, WithoutStop);
+    maps:update_with(actions, Fun, NewAction, WithoutFlush);
 extract_flushes(Params) ->
     Params.
 
 extract_routes(Params = #{route := Accs}) ->
-    WithoutStop = maps:remove(route, Params),
+    WithoutRoute = maps:remove(route, Params),
     NewAction = [{next_event, info, {route, Acc}} || Acc <- Accs ],
     Fun = fun(Actions) -> NewAction ++ Actions end,
-    maps:update_with(actions, Fun, NewAction, WithoutStop);
+    maps:update_with(actions, Fun, NewAction, WithoutRoute);
 extract_routes(Params) ->
     Params.
 

--- a/src/c2s/mongoose_c2s_hooks.erl
+++ b/src/c2s/mongoose_c2s_hooks.erl
@@ -2,11 +2,11 @@
 -module(mongoose_c2s_hooks).
 
 -type fn() :: fun((mongoose_acc:t(), params(), gen_hook:hook_extra()) -> result()).
--type params() :: #{c2s_data := mongoose_c2s:state(),
-                         c2s_state := mongoose_c2s:c2s_state(),
-                         event_type := undefined | gen_statem:event_type(),
-                         event_content := undefined | term(),
-                         reason := undefined | term()}.
+-type params() :: #{c2s_data := mongoose_c2s:c2s_data(),
+                    c2s_state := mongoose_c2s:c2s_state(),
+                    event_type := undefined | gen_statem:event_type(),
+                    event_content := undefined | term(),
+                    reason := undefined | term()}.
 -type result() :: gen_hook:hook_fn_ret(mongoose_acc:t()).
 -export_type([fn/0, params/0, result/0]).
 
@@ -20,7 +20,8 @@
          user_receive_message/3,
          user_receive_iq/3,
          user_receive_presence/3,
-         user_receive_xmlel/3
+         user_receive_xmlel/3,
+         xmpp_presend_element/3
         ]).
 
 %% General event handlers
@@ -129,6 +130,14 @@ user_receive_presence(HostType, Acc, Params) ->
     Result :: result().
 user_receive_xmlel(HostType, Acc, Params) ->
     gen_hook:run_fold(user_receive_xmlel, HostType, Acc, Params).
+
+-spec xmpp_presend_element(HostType, Acc, Params) -> Result when
+    HostType :: mongooseim:host_type(),
+    Acc :: mongoose_acc:t(),
+    Params :: params(),
+    Result :: result().
+xmpp_presend_element(HostType, Acc, Params) ->
+    gen_hook:run_fold(xmpp_presend_element, HostType, Acc, Params).
 
 %% @doc Triggered when the c2s statem process receives any event it is not defined to handle.
 %% These events should not by default stop the process, and they are expected to

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -667,9 +667,8 @@ do_route(Acc, From, To, El) ->
                     do_route_offline(Name, mongoose_acc:stanza_type(Acc),
                                      From, To, Acc, El);
                 Pid when is_pid(Pid) ->
-                    ?LOG_DEBUG(#{what => sm_route_to_pid,
-                                 session_pid => Pid, acc => Acc}),
-                    Pid ! {route, Acc},
+                    ?LOG_DEBUG(#{what => sm_route_to_pid, session_pid => Pid, acc => Acc}),
+                    mongoose_c2s:route(Pid, Acc),
                     Acc
             end
     end.
@@ -810,7 +809,7 @@ route_message(From, To, Acc, Packet) ->
               %% positive
               fun({Prio, Pid}) when Prio == Priority ->
                  %% we will lose message if PID is not alive
-                      Pid ! {route, Acc};
+                      mongoose_c2s:route(Pid, Acc);
                  %% Ignore other priority:
                  ({_Prio, _Pid}) ->
                       ok

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -147,7 +147,12 @@ reroute_unacked_messages(Acc, #{c2s_data := C2SData}, _) ->
 handle_csi_request(Acc, Params, #xmlel{name = <<"inactive">>}) ->
     handle_inactive_request(Acc, Params);
 handle_csi_request(Acc, Params, #xmlel{name = <<"active">>}) ->
-    handle_active_request(Acc, Params).
+    handle_active_request(Acc, Params);
+handle_csi_request(Acc, _, _) ->
+    {From, To, El} = mongoose_acc:packet(Acc),
+    Error = jlib:make_error_reply(El, mongoose_xmpp_errors:bad_request()),
+    ErrorAcc = mongoose_acc:update_stanza(#{from_jid => From, to_jid => To, element => Error }, Acc),
+    mongoose_c2s_acc:to_acc(Acc, route, ErrorAcc).
 
 -spec handle_inactive_request(mongoose_acc:t(), mongoose_c2s_hooks:params()) -> mongoose_acc:t().
 handle_inactive_request(Acc, #{c2s_data := C2SData} = _Params) ->

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -1,51 +1,56 @@
-%% @doc Client State Indication.
-%%
-%% Includes support for XEP-0352: Client State Indication.
-%%
 -module(mod_csi).
--xep([{xep, 352}, {version, "0.2"}]).
+
+-xep([{xep, 352}, {version, "1.0.0"}]).
+
+-include("mongoose_config_spec.hrl").
+-include("jlib.hrl").
+
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).
 
 %% gen_mod callbacks
--export([start/2,
-         stop/1,
-         config_spec/0,
-         supported_features/0]).
+-export([start/2, stop/1, config_spec/0, supported_features/0]).
 
 %% Hook handlers
--export([c2s_stream_features/3]).
+-export([c2s_stream_features/3,
+         xmpp_presend_element/3,
+         user_send_xmlel/3,
+         handle_user_stopping/3,
+         reroute_unacked_messages/3
+        ]).
 
--ignore_xref([c2s_stream_features/3]).
-
--include("jlib.hrl").
--include("mongoose_config_spec.hrl").
+-record(csi_state, {
+          state = active :: state(),
+          buffer = [] :: [mongoose_acc:t()],
+          buffer_max = 20 :: non_neg_integer()
+         }).
 
 -type state() :: active | inactive.
-
--export_type([state/0]).
+-type csi_state() :: #csi_state{}.
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, _Opts) ->
-    gen_hook:add_handlers(hooks(HostType)),
     ensure_metrics(HostType),
-    ok.
+    gen_hook:add_handlers(hooks(HostType)).
 
 -spec stop(mongooseim:host_type()) -> ok.
 stop(HostType) ->
-    gen_hook:delete_handlers(hooks(HostType)),
-    ok.
+    gen_hook:delete_handlers(hooks(HostType)).
 
 hooks(HostType) ->
-    [{c2s_stream_features, HostType, fun ?MODULE:c2s_stream_features/3, #{}, 60}].
+    [
+     {c2s_stream_features, HostType, fun ?MODULE:c2s_stream_features/3, #{}, 60},
+     {xmpp_presend_element, HostType, fun ?MODULE:xmpp_presend_element/3, #{}, 45}, %% just before stream management!
+     {user_send_xmlel, HostType, fun ?MODULE:user_send_xmlel/3, #{}, 60},
+     {user_stop_request, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
+     {user_socket_closed, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
+     {user_socket_error, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
+     {reroute_unacked_messages, HostType, fun ?MODULE:reroute_unacked_messages/3, #{}, 70}
+    ].
 
 ensure_metrics(HostType) ->
     mongoose_metrics:ensure_metric(HostType, [HostType, modCSIInactive], spiral),
-    mongoose_metrics:ensure_metric(HostType, [HostType, modCSIInactive], spiral).
-
-%%%
-%%% config_spec
-%%%
+    mongoose_metrics:ensure_metric(HostType, [HostType, modCSIActive], spiral).
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
@@ -59,17 +64,126 @@ config_spec() ->
 supported_features() ->
     [dynamic_domains].
 
-%%%
-%%% Hook handlers
-%%%
 
--spec c2s_stream_features(Acc, Params, Extra) -> {ok, Acc} when
-    Acc :: [exml:element()],
-    Params :: map(),
-    Extra :: map().
+%%% Hook handlers
+-spec c2s_stream_features(Acc, map(), gen_hook:extra()) -> {ok, Acc} when Acc :: [exml:element()].
 c2s_stream_features(Acc, _, _) ->
     {ok, lists:keystore(<<"csi">>, #xmlel.name, Acc, csi())}.
 
+%% The XEP doesn't require any specific server behaviour in response to CSI stanzas,
+%% there are only some suggestions. The implementation in MongooseIM will simply buffer
+%% all packets (up to a configured limit) when the session is "inactive" and will flush
+%% the buffer when it becomes "active" again.
+-spec xmpp_presend_element(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
+    mongoose_c2s_hooks:result().
+xmpp_presend_element(Acc, #{c2s_data := C2SData}, _Extra) ->
+    case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
+        {ok, Csi} ->
+            handle_presend_element(Acc, Csi);
+        _ ->
+            {ok, Acc}
+    end.
+
+-spec handle_presend_element(mongoose_acc:t(), csi_state()) -> mongoose_c2s_hooks:result().
+handle_presend_element(Acc, Csi = #csi_state{state = inactive, buffer = Buffer, buffer_max = BMax}) ->
+    case length(Buffer) + 1 > BMax of
+        true ->
+            NewBuffer = [mark_acc_as_buffered(Acc) | Buffer],
+            NewCsi = Csi#csi_state{buffer = []},
+            ToAcc = [{state_mod, {?MODULE, NewCsi}}, {flush, lists:reverse(NewBuffer)}],
+            {stop, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)};
+        _ ->
+            buffer_acc(Acc, Csi, is_acc_buffered(Acc))
+    end;
+handle_presend_element(Acc, _) ->
+    {ok, Acc}.
+
+-spec buffer_acc(mongoose_acc:t(), csi_state(), boolean()) -> mongoose_c2s_hooks:result().
+buffer_acc(Acc, Csi = #csi_state{buffer = Buffer}, false) ->
+    AccToBuffer = mark_acc_as_buffered(Acc),
+    NewCsi = Csi#csi_state{buffer = [AccToBuffer | Buffer]},
+    {stop, mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi})};
+buffer_acc(Acc, _, true) ->
+    {ok, Acc}.
+
+-spec user_send_xmlel(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
+    mongoose_c2s_hooks:result().
+user_send_xmlel(Acc, Params, _Extra) ->
+    El = mongoose_acc:element(Acc),
+    case exml_query:attr(El, <<"xmlns">>) of
+        ?NS_CSI ->
+            {stop, handle_csi_request(Acc, Params, El)};
+        _ ->
+            {ok, Acc}
+    end.
+
+%% here we ensure CSI is active and won't buffer anymore, and the current buffer is given to sm
+-spec handle_user_stopping(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
+     mongoose_c2s_hooks:result().
+handle_user_stopping(Acc, #{c2s_data := C2SData}, _) ->
+    case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
+        {ok, Csi = #csi_state{buffer = Buffer}} ->
+            NewCsi = Csi#csi_state{state = active, buffer = []},
+            ToAcc = [{state_mod, {?MODULE, NewCsi}}, {flush, lists:reverse(Buffer)}],
+            {ok, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)};
+        _ ->
+            {ok, Acc}
+    end.
+
+-spec reroute_unacked_messages(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
+    mongoose_c2s_hooks:result().
+reroute_unacked_messages(Acc, #{c2s_data := C2SData}, _) ->
+    case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
+        {ok, Csi = #csi_state{buffer = Buffer}} ->
+            mongoose_c2s:reroute_buffer(C2SData, Buffer),
+            NewCsi = Csi#csi_state{state = active, buffer = []},
+            {ok, mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi})};
+        _ ->
+            {ok, Acc}
+    end.
+
+-spec handle_csi_request(mongoose_acc:t(), mongoose_c2s_hooks:params(), exml:element()) ->
+    mongoose_acc:t().
+handle_csi_request(Acc, Params, #xmlel{name = <<"inactive">>}) ->
+    handle_inactive_request(Acc, Params);
+handle_csi_request(Acc, Params, #xmlel{name = <<"active">>}) ->
+    handle_active_request(Acc, Params).
+
+-spec handle_inactive_request(mongoose_acc:t(), mongoose_c2s_hooks:params()) -> mongoose_acc:t().
+handle_inactive_request(Acc, #{c2s_data := C2SData} = _Params) ->
+    HostType = mongoose_c2s:get_host_type(C2SData),
+    mongoose_metrics:update(HostType, modCSIInactive, 1),
+    case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
+        {error, not_found} ->
+            BMax = gen_mod:get_module_opt(HostType, ?MODULE, buffer_max),
+            Csi = #csi_state{state = inactive, buffer_max = BMax},
+            mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, Csi});
+        {ok, Csi = #csi_state{}} ->
+            NewCsi = Csi#csi_state{state = inactive},
+            mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi})
+    end.
+
+-spec handle_active_request(mongoose_acc:t(), mongoose_c2s_hooks:params()) -> mongoose_acc:t().
+handle_active_request(Acc, #{c2s_data := C2SData}) ->
+    HostType = mongoose_c2s:get_host_type(C2SData),
+    mongoose_metrics:update(HostType, modCSIActive, 1),
+    case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
+        {ok, Csi = #csi_state{state = inactive, buffer = Buffer}} ->
+            NewCsi = Csi#csi_state{state = active, buffer = []},
+            ToAcc = [{state_mod, {?MODULE, NewCsi}}, {flush, lists:reverse(Buffer)}],
+            mongoose_c2s_acc:to_acc_many(Acc, ToAcc);
+        _ ->
+            Acc
+    end.
+
+-spec csi() -> exml:element().
 csi() ->
-    #xmlel{name = <<"csi">>,
-           attrs = [{<<"xmlns">>, ?NS_CSI}]}.
+    #xmlel{name = <<"csi">>, attrs = [{<<"xmlns">>, ?NS_CSI}]}.
+
+-spec mark_acc_as_buffered(mongoose_acc:t()) -> mongoose_acc:t().
+mark_acc_as_buffered(Acc) ->
+    mongoose_acc:set(?MODULE, buffered, true, Acc).
+
+-spec is_acc_buffered(mongoose_acc:t()) -> boolean().
+is_acc_buffered(Acc) ->
+    mongoose_acc:get(?MODULE, buffered, false, Acc).

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -784,8 +784,6 @@ handle_resume_call(StateData, Acc, From) ->
 recover_messages(SmState) ->
     receive
         {route, Acc} ->
-            recover_messages(maybe_buffer_acc(SmState, Acc, is_message(mongoose_acc:stanza_name(Acc))));
-        {route, _From, _To, Acc} ->
             recover_messages(maybe_buffer_acc(SmState, Acc, is_message(mongoose_acc:stanza_name(Acc))))
     after 0 ->
               SmState

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -376,7 +376,7 @@ handle_user_terminate(#sm_state{counter_in = H} = SmState, StateData, HostType) 
     SmState#sm_state{buffer = [], buffer_size = 0}.
 
 reroute_buffer(StateData, #sm_state{buffer = Buffer, peer = {gen_statem, {Pid, _}}}) ->
-    mongoose_c2s:reroute_buffer_to_peer(StateData, Pid, Buffer);
+    mongoose_c2s:reroute_buffer_to_pid(StateData, Pid, Buffer);
 reroute_buffer(StateData, #sm_state{buffer = Buffer}) ->
     mongoose_c2s:reroute_buffer(StateData, Buffer).
 

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -47,10 +47,11 @@
           counter_out = 0 :: short(),
           buffer_max = 100 :: buffer_max(),
           ack_freq = 1 :: ack_freq(),
-          resumed_from :: undefined | ejabberd_sm:sid()
+          peer :: undefined | {gen_statem, gen_statem:from()} | {sid, ejabberd_sm:sid()}
          }).
 
 -type sm_state() :: #sm_state{}.
+-type maybe_sm_state() :: {error, not_found} | #sm_state{}.
 -type c2s_state() :: mongoose_c2s:c2s_state(resume_session).
 
 -type buffer_max() :: pos_integer() | infinity | no_buffer.
@@ -278,14 +279,16 @@ user_send_xmlel(Acc, Params, Extra) ->
       Params :: mongoose_c2s_hooks:params(),
       Extra :: gen_hook:extra(),
       Result :: mongoose_c2s_hooks:result().
-foreign_event(Acc, #{c2s_data := StateData, event_type := {call, From}, event_content := resume}, _Extra) ->
-    case handle_resume_call(StateData, Acc, From) of
-        {stop, bad_stream_management_request} ->
-            {stop, mongoose_c2s_acc:to_acc(Acc, hard_stop, bad_stream_management_request)};
-        {stop_and_reply, {shutdown, Reason}, ReplyAction, NewStateData} ->
-            gen_statem:reply(ReplyAction),
-            ToAcc = [{c2s_data, NewStateData}, {hard_stop, Reason}],
-            {stop, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)}
+foreign_event(Acc, #{c2s_data := StateData,
+                     event_type := {call, From},
+                     event_content := {stream_mgmt_resume, H}}, _Extra) ->
+    case handle_resume_call(StateData, Acc, From, H) of
+        {ok, SmState} ->
+            FlushedStateData = mongoose_c2s:merge_mod_state(StateData, #{?MODULE => SmState}),
+            ToAcc = [{c2s_data, FlushedStateData}, {hard_stop, {shutdown, resumed}}],
+            {stop, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)};
+        error ->
+            {stop, mongoose_c2s_acc:to_acc(Acc, hard_stop, bad_stream_management_request)}
     end;
 foreign_event(Acc, #{c2s_data := StateData, event_type := timeout, event_content := check_buffer_full}, _Extra) ->
     #sm_state{buffer_size = BufferSize, buffer_max = BufferMax} = get_mod_state(StateData),
@@ -351,7 +354,7 @@ user_terminate(Acc, _Params, _Extra) ->
     {ok, Acc}.
 
 -spec maybe_handle_stream_mgmt_reroute(
-        mongoose_acc:t(), mongoose_c2s:c2s_data(), mongooseim:host_type(), term(), sm_state()) ->
+        mongoose_acc:t(), mongoose_c2s:c2s_data(), mongooseim:host_type(), term(), maybe_sm_state()) ->
     mongoose_c2s_hooks:result().
 maybe_handle_stream_mgmt_reroute(Acc, StateData, HostType, Reason, #sm_state{counter_in = H} = SmState)
   when ?IS_STREAM_MGMT_STOP(Reason) ->
@@ -365,13 +368,17 @@ maybe_handle_stream_mgmt_reroute(Acc, StateData, HostType, _Reason, #sm_state{} 
 maybe_handle_stream_mgmt_reroute(Acc, _StateData, _HostType, _Reason, {error, not_found}) ->
     {ok, Acc}.
 
--spec handle_user_terminate(sm_state(), mongoose_c2s:c2s_data(), mongooseim:host_type()) ->
-    sm_state().
-handle_user_terminate(SmState = #sm_state{buffer = Buffer, counter_in = H}, StateData, HostType) ->
+-spec handle_user_terminate(sm_state(), mongoose_c2s:c2s_data(), mongooseim:host_type()) -> sm_state().
+handle_user_terminate(#sm_state{counter_in = H} = SmState, StateData, HostType) ->
     Sid = mongoose_c2s:get_sid(StateData),
     do_remove_smid(HostType, Sid, H),
-    mongoose_c2s:reroute_buffer(StateData, Buffer),
+    reroute_buffer(StateData, SmState),
     SmState#sm_state{buffer = [], buffer_size = 0}.
+
+reroute_buffer(StateData, #sm_state{buffer = Buffer, peer = {gen_statem, {Pid, _}}}) ->
+    mongoose_c2s:reroute_buffer_to_peer(StateData, Pid, Buffer);
+reroute_buffer(StateData, #sm_state{buffer = Buffer}) ->
+    mongoose_c2s:reroute_buffer(StateData, Buffer).
 
 -spec terminate(term(), c2s_state(), mongoose_c2s:c2s_data()) -> term().
 terminate(Reason, C2SState, StateData) ->
@@ -421,14 +428,22 @@ handle_a(Acc, #{c2s_data := StateData}, El) ->
             mongoose_c2s:c2s_stream_error(StateData, Stanza),
             {stop, mongoose_c2s_acc:to_acc(Acc, hard_stop, invalid_h_attribute)};
         {Handler, H} ->
-            do_handle_ack(Acc, StateData, Handler, H)
+            HandledAck = do_handle_ack(Handler, H),
+            finish_handle_a(StateData, Acc, HandledAck)
     end.
 
--spec do_handle_ack(mongoose_acc:t(), mongoose_c2s:c2s_data(), sm_state(), non_neg_integer()) ->
+-spec finish_handle_a(mongoose_c2s:c2s_data(), mongoose_acc:t(), sm_state() | {error, term()}) ->
     mongoose_c2s_hooks:result().
-do_handle_ack(Acc, StateData, SmState = #sm_state{counter_out = OldAcked,
-                                                    buffer_size = BufferSize,
-                                                    buffer = Buffer}, Acked) ->
+finish_handle_a(StateData, Acc, {error, ErrorStanza, Reason}) ->
+    mongoose_c2s:c2s_stream_error(StateData, ErrorStanza),
+    {stop, mongoose_c2s_acc:to_acc(Acc, stop, Reason)};
+finish_handle_a(_StateData, Acc, #sm_state{} = NewSmState) ->
+    {ok, mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewSmState})}.
+
+-spec do_handle_ack(sm_state(), non_neg_integer()) -> sm_state() | {error, exml:element(), term()}.
+do_handle_ack(#sm_state{counter_out = OldAcked,
+                        buffer_size = BufferSize,
+                        buffer = Buffer} = SmState, Acked) ->
     ToDrop = calc_to_drop(Acked, OldAcked),
     case BufferSize < ToDrop of
         true ->
@@ -437,13 +452,11 @@ do_handle_ack(Acc, StateData, SmState = #sm_state{counter_out = OldAcked,
                     ?MYLANG, <<"You acknowledged more stanzas that what has been sent">>),
             HandledCountField = sm_handled_count_too_high_stanza(Acked, OldAcked),
             ErrorStanza = ErrorStanza0#xmlel{children = [HandledCountField | Children]},
-            mongoose_c2s:c2s_stream_error(StateData, ErrorStanza),
-            {stop, mongoose_c2s_acc:to_acc(Acc, stop, {shutdown, sm_handled_count_too_high_stanza})};
+            {error, ErrorStanza, {shutdown, sm_handled_count_too_high_stanza}};
         false ->
             NewSize = BufferSize - ToDrop,
             {NewBuffer, _Dropped} = lists:split(NewSize, Buffer),
-            NewSmState = SmState#sm_state{counter_out = Acked, buffer_size = NewSize, buffer = NewBuffer},
-            {ok, mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewSmState})}
+            SmState#sm_state{counter_out = Acked, buffer_size = NewSize, buffer = NewBuffer}
     end.
 
 -spec incr_counter(short()) -> short().
@@ -513,23 +526,25 @@ handle_resume(Acc, #{c2s_state := C2SState, c2s_data := StateData}, El) ->
 -spec do_handle_resume(Acc, StateData, C2SState, SMID, H, FromSMID) -> HookResult when
       Acc :: mongoose_acc:t(),
       StateData :: mongoose_c2s:c2s_data(),
-      C2SState :: mongoose_c2s:c2s_state(),
+      C2SState :: c2s_state(),
       SMID :: smid(),
       H :: non_neg_integer(),
       FromSMID :: maybe_smid(),
       HookResult :: mongoose_c2s_hooks:result().
-do_handle_resume(Acc, StateData, _FsmState, SMID, H, {sid, {_TS, Pid}}) ->
-    case get_peer_state(Pid) of
+do_handle_resume(Acc, StateData, _C2SState, SMID, H, {sid, {_TS, Pid}}) ->
+    case get_peer_state(Pid, H) of
         {ok, OldStateData} ->
             NewState = mongoose_c2s:merge_states(OldStateData, StateData),
-            do_resume(Acc, NewState, SMID, H);
-        {C, R, S} ->
+            do_resume(Acc, NewState, SMID);
+        {error, ErrorStanza, Reason} ->
+            mongoose_c2s:c2s_stream_error(StateData, ErrorStanza),
+            {stop, mongoose_c2s_acc:to_acc(Acc, stop, Reason)};
+        {exception, {C, R, S}} ->
             ?LOG_WARNING(#{what => resumption_error,
                            text => <<"Resumption error because of invalid response">>,
-                           class => C, reason => R, stacktrace => S, c2s_state => StateData}),
+                           class => C, reason => R, stacktrace => S, pid => Pid, c2s_state => StateData}),
             Err = stream_mgmt_failed(<<"item-not-found">>),
             {stop, mongoose_c2s_acc:to_acc(Acc, socket_send, Err)}
-
     end;
 do_handle_resume(Acc, StateData, C2SState, SMID, _H, {stale_h, StaleH}) ->
     ?LOG_WARNING(#{what => resumption_error, reason => session_resumption_timed_out,
@@ -543,33 +558,28 @@ do_handle_resume(Acc, StateData, C2SState, SMID, _H, {error, smid_not_found}) ->
     stream_mgmt_error(Acc, StateData, C2SState, Err).
 
 %% This runs on the new process
--spec do_resume(Acc, StateData, SMID, H) -> HookResult when
+-spec do_resume(Acc, StateData, SMID) -> HookResult when
       Acc :: mongoose_acc:t(),
       StateData :: mongoose_c2s:c2s_data(),
       SMID :: smid(),
-      H :: non_neg_integer(),
       HookResult :: mongoose_c2s_hooks:result().
-do_resume(Acc0, StateData, SMID, H) ->
-    OldSmState = get_mod_state(StateData),
-    case do_handle_ack(Acc0, StateData, OldSmState, H) of
-        {ok, Acc1} ->
-            Sid = mongoose_c2s:get_sid(StateData),
-            Jid = mongoose_c2s:get_jid(StateData),
-            LServer = mongoose_c2s:get_lserver(StateData),
-            HostType = mongoose_c2s:get_host_type(StateData),
-            ejabberd_sm:open_session(HostType, Sid, Jid, 0, #{}),
-            ok = register_smid(HostType, SMID, Sid),
-            #{?MODULE := NewSmState} = mongoose_c2s_acc:from_mongoose_acc(Acc1, state_mod),
-            Stanzas = get_all_stanzas_to_forward(NewSmState, SMID, LServer),
-            ToAcc = [{c2s_state, session_established}, {c2s_data, StateData}, {socket_send, Stanzas}],
-            {ok, mongoose_c2s_acc:to_acc_many(Acc1, ToAcc)};
-        {stop, Acc} ->
-            {stop, Acc}
-    end.
+do_resume(Acc, StateData, SMID) ->
+    mongoose_c2s:open_session(StateData),
+    ok = register_smid(StateData, SMID),
+    Stanzas = get_all_stanzas_to_forward(StateData, SMID),
+    ToAcc = [{c2s_state, session_established}, {c2s_data, StateData}, {socket_send, Stanzas}],
+    {ok, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)}.
 
--spec get_all_stanzas_to_forward(sm_state(), smid(), jid:lserver()) -> [exml:element()].
-get_all_stanzas_to_forward(#sm_state{counter_in = Counter, buffer = Buffer}, SMID, LServer) ->
+register_smid(StateData, SMID) ->
+    Sid = mongoose_c2s:get_sid(StateData),
+    HostType = mongoose_c2s:get_host_type(StateData),
+    ok = register_smid(HostType, SMID, Sid).
+
+-spec get_all_stanzas_to_forward(mongoose_c2s:c2s_data(), smid()) -> [exml:element()].
+get_all_stanzas_to_forward(StateData, SMID) ->
+    #sm_state{counter_in = Counter, buffer = Buffer} = get_mod_state(StateData),
     Resumed = stream_mgmt_resumed(SMID, Counter),
+    LServer = mongoose_c2s:get_lserver(StateData),
     FromServer = jid:make_noprep(<<>>, LServer, <<>>),
     ToForward = [ begin
                       TS = mongoose_acc:timestamp(Acc),
@@ -614,16 +624,15 @@ is_conflict_incoming_acc(Acc, StateData) ->
             StateSid = mongoose_c2s:get_sid(StateData),
             SameSid = OriginSid =:= StateSid,
             % possible to receive response addressed to process which we resumed from - still valid!
-            OldSid = maybe_get_resumed_from(get_mod_state(StateData)),
+            OldSid = maybe_get_resumed_from_sid(get_mod_state(StateData)),
             SameOldSession = OriginSid =:= OldSid,
             SameJid andalso not (SameSid or SameOldSession)
     end.
 
--spec maybe_get_resumed_from(sm_state()) -> ejabberd_sm:sid();
-                            ({error, not_found}) -> undefined.
-maybe_get_resumed_from(#sm_state{resumed_from = ResumedFrom}) ->
+-spec maybe_get_resumed_from_sid(maybe_sm_state()) -> undefined | ejabberd_sm:sid().
+maybe_get_resumed_from_sid(#sm_state{peer = {sid, ResumedFrom}}) ->
     ResumedFrom;
-maybe_get_resumed_from(_) ->
+maybe_get_resumed_from_sid(_) ->
     undefined.
 
 -spec is_conflict_receiver_sid(mongoose_acc:t(), mongoose_c2s:c2s_data()) -> boolean().
@@ -645,21 +654,21 @@ stream_error(Acc, StateData) ->
     mongoose_c2s:c2s_stream_error(StateData, Err),
     {stop, mongoose_c2s_acc:to_acc(Acc, stop, {shutdown, stream_error})}.
 
--spec unexpected_sm_request(mongoose_acc:t(), mongoose_c2s:c2s_data(), mongoose_c2s:c2s_state()) ->
+-spec unexpected_sm_request(mongoose_acc:t(), mongoose_c2s:c2s_data(), c2s_state()) ->
     {stop, mongoose_acc:t()}.
 unexpected_sm_request(Acc, StateData, C2SState) ->
     Err = stream_mgmt_failed(<<"unexpected-request">>),
     stream_mgmt_error(Acc, StateData, C2SState, Err).
 
 -spec stream_mgmt_error(
-        mongoose_acc:t(), mongoose_c2s:c2s_data(), mongoose_c2s:c2s_state(), exml:element()) ->
+        mongoose_acc:t(), mongoose_c2s:c2s_data(), c2s_state(), exml:element()) ->
     {stop, mongoose_acc:t()}.
 stream_mgmt_error(Acc, _StateData, C2SState, Err) ->
     case mongoose_c2s:maybe_retry_state(C2SState) of
         {stop, {shutdown, retries}} ->
             {stop, mongoose_c2s_acc:to_acc(Acc, stop, {shutdown, retries})};
-        NewFsmState ->
-            ToAcc = [{c2s_state, NewFsmState}, {socket_send, Err}],
+        NewC2SState ->
+            ToAcc = [{c2s_state, NewC2SState}, {socket_send, Err}],
             {stop, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)}
     end.
 
@@ -669,19 +678,20 @@ build_sm_handler(HostType) ->
     AckFreq = get_ack_freq(HostType),
     #sm_state{buffer_max = BufferMax, ack_freq = AckFreq}.
 
--spec get_mod_state(mongoose_c2s:c2s_data()) -> sm_state() | {error, not_found}.
+-spec get_mod_state(mongoose_c2s:c2s_data()) -> maybe_sm_state().
 get_mod_state(StateData) ->
     case mongoose_c2s:get_mod_state(StateData, ?MODULE) of
         {ok, State} -> State;
         Error -> Error
     end.
 
--spec get_peer_state(pid()) -> {ok, mongoose_c2s:c2s_data()} | {_, _, _}.
-get_peer_state(Pid) ->
-    try gen_statem:call(Pid, resume, 5000) of
-        {ok, StateData} -> {ok, StateData}
+-spec get_peer_state(pid(), non_neg_integer()) ->
+    {ok, mongoose_c2s:c2s_data()} | {error, exml:element(), term()} | {exception, tuple()}.
+get_peer_state(Pid, H) ->
+    try
+        gen_statem:call(Pid, {stream_mgmt_resume, H}, 5000)
     catch
-        C:R:S -> {C, R, S}
+        C:R:S -> {exception, {C, R, S}}
     end.
 
 -spec stream_mgmt_parse_h(exml:element()) -> invalid_h_attribute | non_neg_integer().
@@ -740,42 +750,68 @@ do_remove_smid(HostType, Sid, H) ->
 callback_mode() ->
     handle_event_function.
 
--spec init(term()) -> gen_statem:init_result(mongoose_c2s:c2s_state(), mongoose_c2s:c2s_data()).
+-spec init(term()) -> gen_statem:init_result(c2s_state(), mongoose_c2s:c2s_data()).
 init(_) ->
     {stop, this_should_have_never_been_called}.
 
 -spec handle_event(gen_statem:event_type(), term(), c2s_state(), mongoose_c2s:c2s_data()) ->
     gen_statem:event_handler_result(c2s_state()).
-handle_event({call, From}, resume, ?EXT_C2S_STATE(resume_session), StateData) ->
+handle_event({call, From}, {stream_mgmt_resume, H}, ?EXT_C2S_STATE(resume_session), StateData) ->
     LServer = mongoose_c2s:get_lserver(StateData),
     HostType = mongoose_c2s:get_host_type(StateData),
     Acc = mongoose_acc:new(#{host_type => HostType, lserver => LServer, location => ?LOCATION}),
-    handle_resume_call(StateData, Acc, From);
+    case handle_resume_call(StateData, Acc, From, H) of
+        {ok, SmState} ->
+            NewStateData = mongoose_c2s:merge_mod_state(StateData, #{?MODULE => SmState}),
+            {stop, {shutdown, resumed}, NewStateData};
+        error ->
+            {stop, {shutdown, resumed}}
+    end;
 handle_event(timeout, resume_timeout, ?EXT_C2S_STATE(resume_session), StateData) ->
     {stop, {shutdown, ?MODULE}, StateData};
 handle_event(EventType, EventContent, C2SState, StateData) ->
     mongoose_c2s:handle_event(EventType, EventContent, C2SState, StateData).
 
 %% This runs on the old process
--spec handle_resume_call(mongoose_c2s:c2s_data(), mongoose_acc:t(), gen_statem:from()) ->
-    mongoose_c2s:fsm_res().
-handle_resume_call(StateData, Acc, From) ->
-    case get_mod_state(StateData) of
-        {error, not_found} ->
-            {stop, bad_stream_management_request};
-        #sm_state{} = SmState ->
-            Sid = mongoose_c2s:get_sid(StateData),
-            Jid = mongoose_c2s:get_jid(StateData),
-            ejabberd_sm:close_session(Acc, Sid, Jid, resumed),
-            mongoose_c2s:c2s_stream_error(StateData, mongoose_xmpp_errors:stream_conflict()),
-            WithResumedFrom = SmState#sm_state{resumed_from = Sid},
-            PassSmState = recover_messages(WithResumedFrom),
-            PassStateData = mongoose_c2s:merge_mod_state(StateData, #{?MODULE => PassSmState}),
-            ReplyAction = {reply, From, {ok, PassStateData}},
-            KeepSmState = SmState#sm_state{buffer = [], buffer_size = 0},
-            KeepStateData = mongoose_c2s:merge_mod_state(StateData, #{?MODULE => KeepSmState}),
-            {stop_and_reply, {shutdown, resumed}, ReplyAction, KeepStateData}
+-spec handle_resume_call(
+        mongoose_c2s:c2s_data(), mongoose_acc:t(), gen_statem:from(), non_neg_integer()) ->
+    {ok, sm_state()} | error.
+handle_resume_call(StateData, Acc, From, H) ->
+    case do_handle_ack(get_mod_state(StateData), H) of
+        #sm_state{} = SmState1 ->
+            KeepSmState = sm_state_to_keep(SmState1, From),
+            close_old_session(StateData, Acc),
+            PassSmState = pipeline_future_sm_state(StateData, SmState1),
+            pass_c2s_data_to_new_session(StateData, PassSmState, From),
+            {ok, KeepSmState};
+        HandledAck ->
+            ReplyAction = {reply, From, HandledAck},
+            gen_statem:reply(ReplyAction),
+            error
     end.
+
+-spec close_old_session(mongoose_c2s:c2s_data(), mongoose_acc:t()) -> term().
+close_old_session(StateData, Acc) ->
+    mongoose_c2s:close_session(StateData, Acc, resumed),
+    mongoose_c2s:c2s_stream_error(StateData, mongoose_xmpp_errors:stream_conflict()).
+
+-spec pipeline_future_sm_state(mongoose_c2s:c2s_data(), sm_state()) -> sm_state().
+pipeline_future_sm_state(StateData, SmState) ->
+    Sid = mongoose_c2s:get_sid(StateData),
+    WithResumedFrom = SmState#sm_state{peer = {sid, Sid}},
+    recover_messages(WithResumedFrom).
+
+-spec pass_c2s_data_to_new_session(mongoose_c2s:c2s_data(), sm_state(), gen_statem:from()) -> ok.
+pass_c2s_data_to_new_session(StateData, PassSmState, From) ->
+    FutureStateData = mongoose_c2s:merge_mod_state(StateData, #{?MODULE => PassSmState}),
+    ReplyAction = {reply, From, {ok, FutureStateData}},
+    gen_statem:reply(ReplyAction).
+
+%% The dying c2s will keep no buffer and will only know of the session that resumed him off,
+%% to reroute him messages later
+-spec sm_state_to_keep(sm_state(), gen_statem:from()) -> sm_state().
+sm_state_to_keep(SmState, From) ->
+    SmState#sm_state{buffer = [], buffer_size = 0, peer = {gen_statem, From}}.
 
 %%
 %% API for `mongoose_c2s'

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -369,10 +369,7 @@ maybe_handle_stream_mgmt_reroute(Acc, _StateData, _HostType, _Reason, {error, no
 handle_user_terminate(SmState = #sm_state{buffer = Buffer, counter_in = H}, StateData, HostType) ->
     Sid = mongoose_c2s:get_sid(StateData),
     do_remove_smid(HostType, Sid, H),
-    Jid = mongoose_c2s:get_jid(StateData),
-    OrderedBuffer = lists:reverse(Buffer),
-    FilteredBuffer = mongoose_hooks:filter_unacknowledged_messages(HostType, Jid, OrderedBuffer),
-    [mongoose_c2s:reroute(StateData, BufferedAcc) || BufferedAcc <- FilteredBuffer],
+    mongoose_c2s:reroute_buffer(StateData, Buffer),
     SmState#sm_state{buffer = [], buffer_size = 0}.
 
 -spec terminate(term(), c2s_state(), mongoose_c2s:c2s_data()) -> term().

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -203,7 +203,7 @@ user_receive_packet(Acc, _Params, _Extra) ->
     {ok, Acc}.
 
 -spec do_user_receive_packet(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
-    gen_hook:hook_fn_ret(mongoose_acc:t()).
+    mongoose_c2s_hooks:result().
 do_user_receive_packet(Acc, #{c2s_data := StateData, c2s_state := C2SState}, _Extra) ->
     case {get_mod_state(StateData), mongoose_acc:stanza_type(Acc)} of
         {{error, not_found}, _} ->
@@ -218,7 +218,7 @@ do_user_receive_packet(Acc, #{c2s_data := StateData, c2s_state := C2SState}, _Ex
     end.
 
 -spec handle_buffer_and_ack(mongoose_acc:t(), c2s_state(), jid:jid(), sm_state()) ->
-    gen_hook:hook_fn_ret(mongoose_acc:t()).
+    mongoose_c2s_hooks:result().
 handle_buffer_and_ack(Acc, C2SState, Jid, #sm_state{buffer = Buffer, buffer_max = BufferMax,
                                                     buffer_size = BufferSize} = SmState) ->
     NewBufferSize = BufferSize + 1,
@@ -247,7 +247,7 @@ is_buffer_full(_, _) ->
     true.
 
 -spec maybe_send_ack_request(mongoose_acc:t(), sm_state()) ->
-    gen_hook:hook_fn_ret(mongoose_acc:t()).
+    mongoose_c2s_hooks:result().
 maybe_send_ack_request(Acc, #sm_state{buffer_size = BufferSize,
                                       counter_out = Out,
                                       ack_freq = AckFreq} = SmState)
@@ -262,7 +262,7 @@ maybe_send_ack_request(Acc, SmState) ->
       Acc :: mongoose_acc:t(),
       Params :: mongoose_c2s_hooks:params(),
       Extra :: gen_hook:extra(),
-      Result :: gen_hook:hook_fn_ret(mongoose_acc:t()).
+      Result :: mongoose_c2s_hooks:result().
 user_send_xmlel(Acc, Params, Extra) ->
     El = mongoose_acc:element(Acc),
     case exml_query:attr(El, <<"xmlns">>) of
@@ -276,7 +276,7 @@ user_send_xmlel(Acc, Params, Extra) ->
       Acc :: mongoose_acc:t(),
       Params :: mongoose_c2s_hooks:params(),
       Extra :: gen_hook:extra(),
-      Result :: gen_hook:hook_fn_ret(mongoose_acc:t()).
+      Result :: mongoose_c2s_hooks:result().
 foreign_event(Acc, #{c2s_data := StateData, event_type := {call, From}, event_content := resume}, _Extra) ->
     case handle_resume_call(StateData, Acc, From) of
         {stop, bad_stream_management_request} ->
@@ -304,7 +304,7 @@ foreign_event(Acc, _Params, _Extra) ->
       Acc :: mongoose_acc:t(),
       Params :: mongoose_c2s_hooks:params(),
       Extra :: gen_hook:extra(),
-      Result :: gen_hook:hook_fn_ret(mongoose_acc:t()).
+      Result :: mongoose_c2s_hooks:result().
 handle_user_stopping(Acc, #{c2s_data := StateData}, #{host_type := HostType}) ->
     case get_mod_state(StateData) of
         {error, not_found} ->
@@ -337,13 +337,13 @@ notify_unacknowledged_msg(Acc, Jid) ->
     mongoose_acc:strip(NewAcc).
 
 -spec reroute_unacked_messages(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
-    gen_hook:hook_fn_ret(mongoose_acc:t()).
+    mongoose_c2s_hooks:result().
 reroute_unacked_messages(Acc, #{c2s_data := StateData, reason := Reason}, #{host_type := HostType}) ->
     MaybeSmState = get_mod_state(StateData),
     maybe_handle_stream_mgmt_reroute(Acc, StateData, HostType, Reason, MaybeSmState).
 
 -spec user_terminate(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
-    gen_hook:hook_fn_ret(mongoose_acc:t()).
+    mongoose_c2s_hooks:result().
 user_terminate(Acc, #{reason := Reason}, _Extra) when ?IS_STREAM_MGMT_STOP(Reason) ->
     {stop, Acc}; %% We stop here because this termination was triggered internally
 user_terminate(Acc, _Params, _Extra) ->
@@ -351,7 +351,7 @@ user_terminate(Acc, _Params, _Extra) ->
 
 -spec maybe_handle_stream_mgmt_reroute(
         mongoose_acc:t(), mongoose_c2s:c2s_data(), mongooseim:host_type(), term(), sm_state()) ->
-    gen_hook:hook_fn_ret(mongoose_acc:t()).
+    mongoose_c2s_hooks:result().
 maybe_handle_stream_mgmt_reroute(Acc, StateData, HostType, Reason, #sm_state{counter_in = H} = SmState)
   when ?IS_STREAM_MGMT_STOP(Reason) ->
     Sid = mongoose_c2s:get_sid(StateData),

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -496,9 +496,7 @@ do_handle_enable(Acc, StateData, true) ->
 -spec handle_resume(mongoose_acc:t(), mongoose_c2s_hooks:params(), exml:element()) ->
     mongoose_c2s_hooks:result().
 handle_resume(Acc, #{c2s_state := C2SState, c2s_data := StateData}, El) ->
-    case {exml_query:attr(El, <<"previd">>, undefined),
-          stream_mgmt_parse_h(El),
-          get_mod_state(StateData)} of
+    case {get_previd(El), stream_mgmt_parse_h(El), get_mod_state(StateData)} of
         {undefined, _, _} ->
             bad_request(Acc);
         {_, invalid_h_attribute, _} ->
@@ -692,6 +690,10 @@ stream_mgmt_parse_h(El) ->
         H when is_integer(H), H >= 0 -> H;
         _ -> invalid_h_attribute
     end.
+
+-spec get_previd(exml:element()) -> undefined | binary().
+get_previd(El) ->
+    exml_query:attr(El, <<"previd">>, undefined).
 
 -spec c2s_stream_features(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: [exml:element()],

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -480,7 +480,7 @@ do_handle_enable(Acc, StateData, false) ->
     HostType = mongoose_c2s:get_host_type(StateData),
     SmState = build_sm_handler(HostType),
     ToAcc = [{state_mod, {?MODULE, SmState}}, {socket_send, Stanza}],
-    {ok, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)};
+    {stop, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)};
 
 do_handle_enable(Acc, StateData, true) ->
     SMID = make_smid(),
@@ -490,7 +490,7 @@ do_handle_enable(Acc, StateData, true) ->
     Stanza = stream_mgmt_enabled([{<<"id">>, SMID}, {<<"resume">>, <<"true">>}]),
     SmState = build_sm_handler(HostType),
     ToAcc = [{state_mod, {?MODULE, SmState}}, {socket_send, Stanza}],
-    {ok, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)}.
+    {stop, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)}.
 
 -spec handle_resume(mongoose_acc:t(), mongoose_c2s_hooks:params(), exml:element()) ->
     mongoose_c2s_hooks:result().


### PR DESCRIPTION
Important in this PR took many changes to many modules, so some explanation below:

## c2s

### Route pipeline processing
In the old implementation, when receiving a packet through routing, c2s would, in strict order:
1. verify for `sid` conflicts
2. _if successful_, run the `user_receive_packet` hook
3. maybe buffer CSI
4. _if allowed_, maybe buffer stream management
5. send in the socket
6. run `xmpp_send_element` with the result of the send

So, steps 1, 3 and 4 are the ones that are not XMPP core related and need to be taken out of c2s. So now I've reordered as follows:
1. run the `user_receive_packet` hook (and the more granular `user_receive_*` ones) <- stream management is an early subscriber for the `sid` conflict verification.
2. _if allowed_, run a new `xmpp_presend_element` <- here CSI and stream_mgmt subscribe and can stop the actual socket delivery
3. _if allowed_, send in the socket
4. run `xmpp_send_element` with the result of the send

This, very importantly, solves a bug in the current implementation of stream_mgmt: if stream_mgmt subscribes to `user_receive_packet`, it will buffer stanzas that are made to be handled by the server and not delivered to the socket, like IQs addressed to a specific resource, for example those from `mod_last`.

Thus, we also introduce a new kind of internal event, `handle_flush`, which will run the received-packet logic _from_ step 2, skipping step one. This is necessary for CSI, when packets are being flushed, to not go through the `user_receive_*` handlers and have modules like inbox processing them twice. The event is internal to avoid third processes sending erlang messages that would run an incomplete pipeline.

### State machine states
Before, c2s states where defined with strict names, where other modules, like stream management (and in the future mod_websockets), can take over the state machine and inject their own states, but still reuse functionality available from `mongoose_c2s`. In that case, the types defined for the state machine wouldn't match anymore. So we add a new state to the `c2s_state()` type, called `{external_state, term()}`, to identify states defined by other modules, which will in turn know what to do with them, separately from c2s. This was a suggestion from @kamilwaz 😉 

## Stream management
So as described above, stream management now subscribes to `user_receive_packet` only for `sid` conflict verification. Then, it subscribes to `xmpp_presend_element` to do the buffering.

Another optimisation, is the fact that on resumption, rerouting lost messages is strictly meant to be delivered to the process that resumed the session, with no new filtering applied. So we can bypass the complex routing logic, and directly send the erlang messages to the resuming process. So `mongoose_c2s` implements a new `reroute_buffer_to_peer/3` helper, which takes a pid and sends all the messages.

Also a flaky test (`resume_session_with_wrong_h_does_not_leak_sessions`) was fixed by introducing a wait, as smids are removed by requesting so to mnesia, asynchonously, so again we can have a race condition between mnesia and the verification.

## CSI
First of all one more test was introduced and many other were fixed, for details redirect to commits 8743faf074931cbb4639ec2ff83c3383a52f4f55 and 8e21d5734b596f9264225bd5794f65bef1d7aba5. For the implementation, see 881d827c05ae8b886d3726b34070b0495113dada.