### PR TITLE
GraphQL error handling in MUC Light

### DIFF
--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -270,7 +270,7 @@ maybe_enable_mam() ->
         Backend ->
             MAMOpts = mam_helper:config_opts(
                         #{backend => Backend,
-                          muc => #{host => subhost_pattern(muc_light_helper:muc_host_pattern())},
+                          muc => #{host => subhost_pattern(muc_helper:muc_host_pattern())},
                           async_writer => #{enabled => false}}),
             dynamic_modules:ensure_modules(domain_helper:host_type(), [{mod_mam, MAMOpts}]),
             true

--- a/big_tests/tests/muc_light_http_api_SUITE.erl
+++ b/big_tests/tests/muc_light_http_api_SUITE.erl
@@ -208,6 +208,8 @@ create_room_errors(Config) ->
         post(admin, Path, maps:remove(subject, Body)),
     {{<<"400">>, _}, <<"Invalid owner JID">>} =
         post(admin, Path, Body#{owner := <<"@invalid">>}),
+    {{<<"400">>, _}, <<"Given user does not exist">>} =
+        post(admin, Path, Body#{owner := <<"baduser@", (domain())/binary>>}),
     {{<<"404">>, _}, <<"MUC Light server not found">>} =
         post(admin, path([domain_helper:domain()]), Body).
 
@@ -228,6 +230,8 @@ create_identifiable_room_errors(Config) ->
         putt(admin, Path, maps:remove(subject, Body)),
     {{<<"400">>, _}, <<"Invalid owner JID">>} =
         putt(admin, Path, Body#{owner := <<"@invalid">>}),
+    {{<<"400">>, _}, <<"Given user does not exist">>} =
+        post(admin, Path, Body#{owner := <<"baduser@", (domain())/binary>>}),
     {{<<"403">>, _}, <<"Room already exists">>} =
         putt(admin, Path, Body#{id := <<"ID1">>, name := <<"NameB">>}),
     {{<<"404">>, _}, <<"MUC Light server not found">>} =
@@ -249,8 +253,12 @@ invite_to_room_errors(Config) ->
         rest_helper:post(admin, Path, Body#{recipient := <<"@invalid">>}),
     {{<<"400">>, _}, <<"Invalid sender JID">>} =
         rest_helper:post(admin, Path, Body#{sender := <<"@invalid">>}),
+    {{<<"400">>, _}, <<"Given user does not exist">>} =
+        rest_helper:post(admin, Path, Body#{sender := <<"baduser@", (domain())/binary>>}),
     {{<<"403">>, _}, <<"Given user does not occupy this room">>} =
         rest_helper:post(admin, Path, Body#{sender := BobJid, recipient := AliceJid}),
+    {{<<"404">>, _}, <<"Room not found">>} =
+        rest_helper:post(admin, path([muc_light_domain(), "badroom", "participants"]), Body),
     {{<<"404">>, _}, <<"MUC Light server not found">>} =
         rest_helper:post(admin, path([domain(), Name, "participants"]), Body).
 
@@ -270,9 +278,11 @@ send_message_errors(Config) ->
         rest_helper:post(admin, Path, maps:remove(from, Body)),
     {{<<"400">>, _}, <<"Invalid sender JID">>} =
         rest_helper:post(admin, Path, Body#{from := <<"@invalid">>}),
+    {{<<"400">>, _}, <<"Given user does not exist">>} =
+        rest_helper:post(admin, Path, Body#{from := <<"baduser@", (domain())/binary>>}),
     {{<<"403">>, _}, <<"Given user does not occupy this room">>} =
         rest_helper:post(admin, Path, Body#{from := BobJid}),
-    {{<<"403">>, _}, <<"Given user does not occupy this room">>} =
+    {{<<"404">>, _}, <<"Room not found">>} =
         rest_helper:post(admin, path([muc_light_domain(), "badroom", "messages"]), Body),
     {{<<"404">>, _}, <<"MUC Light server not found">>} =
         rest_helper:post(admin, path([domain(), Name, "messages"]), Body).
@@ -284,7 +294,7 @@ delete_room_errors(_Config) ->
         delete(admin, path([muc_light_domain()])),
     {{<<"404">>, _}, _} =
         delete(admin, path([muc_light_domain(), "badroom"])),
-    {{<<"404">>, _}, <<"Cannot remove not existing room">>} =
+    {{<<"404">>, _}, <<"Room not found">>} =
         delete(admin, path([muc_light_domain(), "badroom", "management"])),
     {{<<"404">>, _}, <<"MUC Light server not found">>} =
         delete(admin, path([domain(), "badroom", "management"])),

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -3,23 +3,24 @@ Allow admin to manage Multi-User Chat Light rooms.
 """
 type MUCLightAdminMutation @use(modules: ["mod_muc_light"]) @protected{
   "Create a MUC light room under the given XMPP hostname"
-  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createRoom(mucDomain: DomainName!, name: String!, owner: JID!, subject: String!, id: RoomName, options: [RoomConfigDictEntryInput!]): Room
-    @protected(type: DOMAIN, args: ["owner"])
+  createRoom(mucDomain: DomainName!, name: String, owner: JID!, subject: String, id: RoomName,
+             options: [RoomConfigDictEntryInput!]): Room
+    @protected(type: DOMAIN, args: ["mucDomain", "owner"]) @use(arg: "mucDomain")
   "Change configuration of a MUC Light room"
-  changeRoomConfiguration(room: JID!, owner: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room
+  changeRoomConfiguration(room: BareJID!, owner: JID!, name: String, subject: String,
+                          options: [RoomConfigDictEntryInput!]): Room
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Invite a user to a MUC Light room"
-  inviteUser(room: JID!, sender: JID!, recipient: JID!): String
+  inviteUser(room: BareJID!, sender: JID!, recipient: JID!): String
     @protected(type: DOMAIN, args: ["sender"]) @use(arg: "room")
   "Remove a MUC Light room"
-  deleteRoom(room: JID!): String
+  deleteRoom(room: BareJID!): String
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Kick a user from a MUC Light room"
-  kickUser(room: JID!, user: JID!): String
+  kickUser(room: BareJID!, user: JID!): String
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Send a message to a MUC Light room"
-  sendMessageToRoom(room: JID!, from: JID!, body: String!): String
+  sendMessageToRoom(room: BareJID!, from: JID!, body: String!): String
     @protected(type: DOMAIN, args: ["from"]) @use(arg: "room")
   "Set the user's list of blocked entities"
   setBlockingList(user: JID!, items: [BlockingInput!]!): String
@@ -31,13 +32,13 @@ Allow admin to get information about Multi-User Chat Light rooms.
 """
 type MUCLightAdminQuery @protected @use(modules: ["mod_muc_light"]){
   "Get the MUC Light room archived messages"
-  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload
-    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
+  getRoomMessages(room: BareJID!, pageSize: PosInt, before: DateTime): StanzasPayload
+    @protected(type: DOMAIN, args: ["room"]) @use(arg: "room", modules: ["mod_mam_muc"])
   "Get configuration of the MUC Light room"
-  getRoomConfig(room: JID!): Room
+  getRoomConfig(room: BareJID!): Room
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get users list of given MUC Light room"
-  listRoomUsers(room: JID!): [RoomUser!]
+  listRoomUsers(room: BareJID!): [RoomUser!]
     @protected(type: DOMAIN, args: ["room"]) @use(arg: "room")
   "Get the list of MUC Light rooms that the user participates in"
   listUserRooms(user: JID!): [JID!]

--- a/priv/graphql/schemas/global/muc_light.gql
+++ b/priv/graphql/schemas/global/muc_light.gql
@@ -61,11 +61,11 @@ type RoomConfigDictEntry{
 "Room data"
 type Room{
   "Room's JId"
-  jid: JID!
+  jid: BareJID!
   "Name of the room"
-  name: String!
+  name: String
   "Subject of the room"
-  subject: String!
+  subject: String
   "List of participants"
   participants: [RoomUser!]!
   "Configuration options"

--- a/priv/graphql/schemas/user/muc_light.gql
+++ b/priv/graphql/schemas/user/muc_light.gql
@@ -3,20 +3,25 @@ Allow user to manage Multi-User Chat Light rooms.
 """
 type MUCLightUserMutation @protected @use(modules: ["mod_muc_light"]){
   "Create a MUC light room under the given XMPP hostname"
-  #There is no @use directive because it is currently impossible to get HostType from mucDomain in directive code
-  createRoom(mucDomain: DomainName!, name: String!, subject: String!, id: RoomName, options: [RoomConfigDictEntryInput!]): Room
+  createRoom(mucDomain: DomainName!, name: String, subject: String, id: RoomName, options: [RoomConfigDictEntryInput!]): Room
+    @use(arg: "mucDomain")
   "Change configuration of a MUC Light room"
-  changeRoomConfiguration(room: JID!, name: String!, subject: String!, options: [RoomConfigDictEntryInput!]): Room @use(arg: "room")
+  changeRoomConfiguration(room: BareJID!, name: String, subject: String, options: [RoomConfigDictEntryInput!]): Room @use(arg: "room")
   "Invite a user to a MUC Light room"
-  inviteUser(room: JID!, recipient: JID!): String @use(arg: "room")
+  inviteUser(room: BareJID!, recipient: JID!): String
+    @use(arg: "room")
   "Remove a MUC Light room"
-  deleteRoom(room: JID!): String @use(arg: "room")
+  deleteRoom(room: BareJID!): String
+    @use(arg: "room")
   "Kick a user from a MUC Light room"
-  kickUser(room: JID!, user: JID): String @use(arg: "room")
+  kickUser(room: BareJID!, user: JID): String
+    @use(arg: "room")
   "Send a message to a MUC Light room"
-  sendMessageToRoom(room: JID!, body: String!): String @use(arg: "room")
+  sendMessageToRoom(room: BareJID!, body: String!): String
+    @use(arg: "room")
   "Set the user blocking list"
-  setBlockingList(items: [BlockingInput!]!): String @use
+  setBlockingList(items: [BlockingInput!]!): String
+    @use
 }
 
 """
@@ -24,13 +29,18 @@ Allow user to get information about Multi-User Chat Light rooms.
 """
 type MUCLightUserQuery @protected @use(modules: ["mod_muc_light"]){
   "Get the MUC Light room archived messages"
-  getRoomMessages(room: JID!, pageSize: Int, before: DateTime): StanzasPayload @use(arg: "room")
+  getRoomMessages(room: BareJID!, pageSize: PosInt, before: DateTime): StanzasPayload
+    @use(arg: "room", modules: ["mod_mam_muc"])
   "Get configuration of the MUC Light room"
-  getRoomConfig(room: JID!): Room @use(arg: "room")
+  getRoomConfig(room: BareJID!): Room
+    @use(arg: "room")
   "Get users list of given MUC Light room"
-  listRoomUsers(room: JID!): [RoomUser!] @use(arg: "room")
+  listRoomUsers(room: BareJID!): [RoomUser!]
+    @use(arg: "room")
   "Get the list of MUC Light rooms that the user participates in"
-  listRooms: [JID!] @use
+  listRooms: [JID!]
+    @use
   "Get the user blocking list"
-  getBlockingList: [BlockingItem!] @use
+  getBlockingList: [BlockingItem!]
+    @use
 }

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
@@ -29,7 +29,7 @@ list_user_rooms(#{<<"user">> := UserJID}) ->
         {ok, Rooms} ->
             {ok, [{ok, R} || R <- Rooms]};
         Err ->
-            make_error(Err, #{user => UserJID})
+            make_error(Err, #{user => jid:to_binary(UserJID)})
     end.
 
 -spec list_room_users(map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
@@ -38,7 +38,7 @@ list_room_users(#{<<"room">> := RoomJID}) ->
         {ok, Affs} ->
             {ok, [make_ok_user(A) || A <- Affs]};
         Err ->
-            make_error(Err, #{room => RoomJID})
+            make_error(Err, #{room => jid:to_binary(RoomJID)})
     end.
 
 -spec get_room_config(map()) -> {ok, map()} | {error, resolver_error()}.
@@ -47,7 +47,7 @@ get_room_config(#{<<"room">> := RoomJID}) ->
         {ok, Room} ->
             {ok, make_room(Room)};
         Err ->
-            make_error(Err, #{room => RoomJID})
+            make_error(Err, #{room => jid:to_binary(RoomJID)})
     end.
 
 -spec get_room_messages(map()) -> {ok, map()} | {error, resolver_error()}.
@@ -60,7 +60,7 @@ get_room_messages(#{<<"room">> := RoomJID, <<"pageSize">> := PageSize,
             Maps = lists:map(fun mongoose_graphql_stanza_helper:row_to_map/1, Rows),
             {ok, #{<<"stanzas">> => Maps, <<"limit">> => PageSize2}};
         Err ->
-            make_error(Err, #{room => RoomJID})
+            make_error(Err, #{room => jid:to_binary(RoomJID)})
     end.
 
 -spec get_blocking_list(map()) -> {ok, [{ok, map()}]} | {error, resolver_error()}.
@@ -70,5 +70,5 @@ get_blocking_list(#{<<"user">> := UserJID}) ->
             Items2 = lists:map(fun mongoose_graphql_muc_light_helper:blocking_item_to_map/1, Items),
             {ok, Items2};
         Err ->
-            make_error(Err, #{user => UserJID})
+            make_error(Err, #{user => jid:to_binary(UserJID)})
     end.

--- a/src/graphql/user/mongoose_graphql_muc_light_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_muc_light_user_query.erl
@@ -35,7 +35,7 @@ list_room_users(#{user := UserJID}, #{<<"room">> := RoomJID}) ->
         {ok, Affs} ->
             {ok, [make_ok_user(A) || A <- Affs]};
         Err ->
-            make_error(Err, #{room => RoomJID})
+            make_error(Err, #{room => jid:to_binary(RoomJID)})
     end.
 
 -spec get_room_config(map(), map()) -> {ok, map()} | {error, resolver_error()}.
@@ -44,7 +44,7 @@ get_room_config(#{user := UserJID}, #{<<"room">> := RoomJID}) ->
         {ok, Room} ->
             {ok, make_room(Room)};
         Err ->
-            make_error(Err, #{room => RoomJID})
+            make_error(Err, #{room => jid:to_binary(RoomJID)})
     end.
 
 -spec get_room_messages(map(), map()) -> {ok, map()} | {error, resolver_error()}.
@@ -57,7 +57,7 @@ get_room_messages(#{user := UserJID}, #{<<"room">> := RoomJID, <<"pageSize">> :=
             Maps = lists:map(fun mongoose_graphql_stanza_helper:row_to_map/1, Rows),
             {ok, #{<<"stanzas">> => Maps, <<"limit">> => PageSize2}};
         Err ->
-            make_error(Err, #{room => RoomJID})
+            make_error(Err, #{room => jid:to_binary(RoomJID)})
     end.
 
 -spec get_blocking_list(map(), map()) -> {ok, [{ok, map()}]}.

--- a/src/mongoose_client_api/mongoose_client_api_rooms_messages.erl
+++ b/src/mongoose_client_api/mongoose_client_api_rooms_messages.erl
@@ -76,6 +76,8 @@ handle_get(Req, State = #{jid := UserJid}) ->
         {ok, Msgs} ->
             JSONData = [make_json_item(Msg) || Msg <- Msgs],
             {jiffy:encode(JSONData), Req, State};
+        {room_not_found, Msg} ->
+            throw_error(not_found, Msg);
         {not_room_member, Msg} ->
             throw_error(denied, Msg)
     end.
@@ -92,6 +94,8 @@ handle_post(Req, State = #{jid := UserJid}) ->
             Resp = #{id => UUID},
             Req3 = cowboy_req:set_resp_body(jiffy:encode(Resp), Req),
             {true, Req3, State};
+        {room_not_found, Msg} ->
+            throw_error(not_found, Msg);
         {not_room_member, Msg} ->
             throw_error(denied, Msg)
     end.

--- a/src/muc_light/mod_muc_light_api.erl
+++ b/src/muc_light/mod_muc_light_api.erl
@@ -1,13 +1,11 @@
 %% @doc Provide an interface for frontends (like graphql or ctl) to manage MUC Light rooms.
 -module(mod_muc_light_api).
 
--export([create_room/4,
-         create_room/5,
-         create_room/6,
+-export([create_room/3,
+         create_room/4,
          invite_to_room/3,
          change_room_config/3,
          change_affiliation/4,
-         remove_user_from_room/3,
          send_message/3,
          send_message/4,
          delete_room/2,
@@ -20,7 +18,6 @@
          get_room_info/2,
          get_room_aff/1,
          get_room_aff/2,
-         get_room_user_aff/3,
          get_blocking_list/1,
          set_blocking/2
         ]).
@@ -30,12 +27,7 @@
 -include("jlib.hrl").
 -include("mongoose_rsm.hrl").
 
--type create_room_result() :: {ok, room()} | {already_exists | max_occupants_reached |
-                                              validation_error | muc_server_not_found, iolist()}.
-
 -type room() :: #{jid := jid:jid(),
-                  name := binary(),
-                  subject := binary(),
                   aff_users := aff_users(),
                   options := map()}.
 
@@ -44,181 +36,252 @@
 -define(ROOM_DELETED_SUCC_RESULT, {ok, "Room deleted successfully"}).
 -define(USER_NOT_ROOM_MEMBER_RESULT, {not_room_member, "Given user does not occupy this room"}).
 -define(ROOM_NOT_FOUND_RESULT, {room_not_found, "Room not found"}).
--define(DELETE_NOT_EXISTING_ROOM_RESULT, {room_not_found, "Cannot remove not existing room"}).
 -define(MUC_SERVER_NOT_FOUND_RESULT, {muc_server_not_found, "MUC Light server not found"}).
 -define(VALIDATION_ERROR_RESULT(Key, Reason),
-        {validation_error, io_lib:format("Validation failed for key: ~p with reason ~p",
+        {validation_error, io_lib:format("Validation failed for key: ~ts with reason ~p",
                                          [Key, Reason])}).
 
--spec create_room(jid:lserver(), jid:jid(), binary(), binary()) -> create_room_result().
-create_room(MUCLightDomain, CreatorJID, RoomTitle, Subject) ->
-    create_room(MUCLightDomain, <<>>, CreatorJID, RoomTitle, Subject).
+-spec create_room(jid:lserver(), jid:jid(), map()) ->
+          {ok, room()} | {user_not_found | muc_server_not_found |
+                          max_occupants_reached | validation_error, iolist()}.
+create_room(MUCLightDomain, CreatorJID, Config) ->
+    M = #{user => CreatorJID, room => jid:make_bare(<<>>, MUCLightDomain), options => Config},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun create_room_raw/1]).
 
--spec create_room(jid:lserver(), jid:luser(), jid:jid(), binary(), binary()) ->
-    create_room_result().
-create_room(MUCLightDomain, RoomID, CreatorJID, RoomTitle, Subject) ->
-    create_room(MUCLightDomain, RoomID, CreatorJID, RoomTitle, Subject, #{}).
-
-create_room(MUCLightDomain, RoomID, CreatorJID, RoomTitle, Subject, Options) ->
-    RoomJID = jid:make_bare(RoomID, MUCLightDomain),
-    Options1 = Options#{<<"roomname">> => RoomTitle, <<"subject">> => Subject},
-    create_room_raw(RoomJID, CreatorJID, Options1).
+-spec create_room(jid:lserver(), jid:luser(), jid:jid(), map()) ->
+          {ok, room()} | {user_not_found | muc_server_not_found | already_exists |
+                          max_occupants_reached | validation_error, iolist()}.
+create_room(MUCLightDomain, RoomID, CreatorJID, Config) ->
+    M = #{user => CreatorJID, room => jid:make_bare(RoomID, MUCLightDomain), options => Config},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun create_room_raw/1]).
 
 -spec invite_to_room(jid:jid(), jid:jid(), jid:jid()) ->
-    {ok | not_room_member | muc_server_not_found, iolist()}.
-invite_to_room(#jid{lserver = MUCServer} = RoomJID, SenderJID, RecipientJID) ->
-    case mongoose_domain_api:get_subdomain_host_type(MUCServer) of
-        {ok, HostType} ->
-            RecipientBin = jid:to_binary(jid:to_bare(RecipientJID)),
-            case is_user_room_member(HostType, jid:to_lus(SenderJID), jid:to_lus(RoomJID)) of
-                true ->
-                    S = jid:to_bare(SenderJID),
-                    R = jid:to_bare(RoomJID),
-                    Changes = query(?NS_MUC_LIGHT_AFFILIATIONS,
-                                    [affiliate(RecipientBin, <<"member">>)]),
-                    ejabberd_router:route(S, R, iq(jid:to_binary(S), jid:to_binary(R),
-                                                   <<"set">>, [Changes])),
-                    {ok, "User invited successfully"};
-                false ->
-                   ?USER_NOT_ROOM_MEMBER_RESULT
-            end;
-        {error, not_found} ->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
-
+    {ok | user_not_found | muc_server_not_found | room_not_found | not_room_member, iolist()}.
+invite_to_room(RoomJID, SenderJID, RecipientJID) ->
+    M = #{user => SenderJID, room => RoomJID, recipient => RecipientJID},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun get_user_aff/1,
+             fun do_invite_to_room/1]).
 
 -spec change_room_config(jid:jid(), jid:jid(), map()) ->
-    {ok, room()} | {not_room_member | not_allowed | room_not_found |
-                    validation_error | muc_server_not_found, iolist()}.
-change_room_config(#jid{luser = RoomID, lserver = MUCServer} = RoomJID,
-                   UserJID, Config) ->
-    case mongoose_domain_api:get_subdomain_info(MUCServer) of
-        {ok, #{host_type := HostType, parent_domain := LServer}} ->
-            UserUS = jid:to_bare(UserJID),
-            ConfigReq = #config{ raw_config = maps:to_list(Config) },
-            Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => LServer,
-                                     host_type => HostType}),
-            case mod_muc_light:change_room_config(UserUS, RoomID, MUCServer, ConfigReq, Acc) of
-                {ok, RoomJID, KV}  ->
-                    {ok, make_room(RoomJID, KV, [])};
-                {error, item_not_found} ->
-                    ?USER_NOT_ROOM_MEMBER_RESULT;
-                {error, not_allowed} ->
-                    {not_allowed, "Given user does not have permission to change config"};
-                {error, not_exists} ->
-                    ?ROOM_NOT_FOUND_RESULT;
-                {error, {Key, Reason}} ->
-                    ?VALIDATION_ERROR_RESULT(Key, Reason)
-            end;
-        {error, not_found} ->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
+    {ok, room()} | {user_not_found | muc_server_not_found | room_not_found | not_room_member |
+                    not_allowed | validation_error, iolist()}.
+change_room_config(RoomJID, UserJID, Config) ->
+    M = #{user => UserJID, room => RoomJID, config => Config},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun do_change_room_config/1]).
 
--spec change_affiliation(jid:jid(), jid:jid(), jid:jid(), binary()) -> ok.
-change_affiliation(RoomJID, SenderJID, RecipientJID, Affiliation) ->
-    RecipientBare = jid:to_bare(RecipientJID),
-    S = jid:to_bare(SenderJID),
-    Changes = query(?NS_MUC_LIGHT_AFFILIATIONS,
-                    [affiliate(jid:to_binary(RecipientBare), Affiliation)]),
-    ejabberd_router:route(S, RoomJID, iq(jid:to_binary(S), jid:to_binary(RoomJID),
-                                         <<"set">>, [Changes])),
-    ok.
-
--spec remove_user_from_room(jid:jid(), jid:jid(), jid:jid()) ->
-    {ok, iolist()}.
-remove_user_from_room(RoomJID, SenderJID, RecipientJID) ->
-    ok = change_affiliation(RoomJID, SenderJID, RecipientJID, <<"none">>),
-    {ok, io_lib:format("Stanza kicking user ~s sent successfully", [jid:to_binary(RecipientJID)])}.
+-spec change_affiliation(jid:jid(), jid:jid(), jid:jid(), add | remove) ->
+          {ok | user_not_found | muc_server_not_found | room_not_found | not_room_member |
+           not_allowed, iolist()}.
+change_affiliation(RoomJID, SenderJID, RecipientJID, Op) ->
+    M = #{user => SenderJID, room => RoomJID, recipient => RecipientJID, op => Op},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun get_user_aff/1,
+             fun check_aff_permission/1, fun do_change_affiliation/1]).
 
 -spec send_message(jid:jid(), jid:jid(), binary()) ->
-    {ok | not_room_member | muc_server_not_found, iolist()}.
+    {ok | user_not_found | muc_server_not_found | room_not_found | not_room_member, iolist()}.
 send_message(RoomJID, SenderJID, Text) when is_binary(Text) ->
     Body = #xmlel{name = <<"body">>, children = [#xmlcdata{content = Text}]},
     send_message(RoomJID, SenderJID, [Body], []).
 
 -spec send_message(jid:jid(), jid:jid(), [exml:element()], [exml:attr()]) ->
-    {ok | not_room_member | muc_server_not_found, iolist()}.
-send_message(#jid{lserver = MUCServer} = RoomJID, SenderJID, Children, ExtraAttrs) ->
-    case mongoose_domain_api:get_subdomain_host_type(MUCServer) of
-        {ok, HostType} ->
-            SenderBare = jid:to_bare(SenderJID),
-            RoomBare = jid:to_bare(RoomJID),
-            Stanza = #xmlel{name = <<"message">>,
-                            attrs = [{<<"type">>, <<"groupchat">>} | ExtraAttrs],
-                            children = Children
-                           },
-            case is_user_room_member(HostType, jid:to_lus(SenderBare), jid:to_lus(RoomJID)) of
-                true ->
-                    ejabberd_router:route(SenderBare, RoomBare, Stanza),
-                    {ok, "Message sent successfully"};
-                false ->
-                    ?USER_NOT_ROOM_MEMBER_RESULT
-            end;
-        {error, not_found}->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
+    {ok | user_not_found | muc_server_not_found | room_not_found | not_room_member, iolist()}.
+send_message(RoomJID, SenderJID, Children, ExtraAttrs) ->
+    M = #{user => SenderJID, room => RoomJID, children => Children, attrs => ExtraAttrs},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun get_user_aff/1, fun do_send_message/1]).
 
 -spec delete_room(jid:jid(), jid:jid()) ->
-    {ok | not_allowed | room_not_found | muc_server_not_found , iolist()}.
-delete_room(#jid{lserver = MUCServer} = RoomJID, UserJID) ->
-    case mongoose_domain_api:get_subdomain_host_type(MUCServer) of
-        {ok, HostType} ->
-            case get_room_user_aff(HostType, RoomJID, UserJID) of
-                {ok, owner} ->
-                    ok = mod_muc_light_db_backend:destroy_room(HostType, jid:to_lus(RoomJID)),
-                    ?ROOM_DELETED_SUCC_RESULT;
-                {ok, none} ->
-                    ?USER_NOT_ROOM_MEMBER_RESULT;
-                {ok, member} ->
-                    {not_allowed, "Given user cannot delete this room"};
-                {error, room_not_found} ->
-                    ?DELETE_NOT_EXISTING_ROOM_RESULT
-            end;
-        {error, not_found}->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
+    {ok | not_allowed | room_not_found | not_room_member | muc_server_not_found , iolist()}.
+delete_room(RoomJID, UserJID) ->
+    M = #{user => UserJID, room => RoomJID},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun get_user_aff/1,
+             fun check_delete_permission/1, fun do_delete_room/1]).
 
--spec delete_room(jid:jid()) -> {ok | room_not_found | muc_server_not_found, iolist()}.
+-spec delete_room(jid:jid()) -> {ok | muc_server_not_found | room_not_found, iolist()}.
 delete_room(RoomJID) ->
-    try mod_muc_light:delete_room(jid:to_lus(RoomJID)) of
-        ok ->
-            ?ROOM_DELETED_SUCC_RESULT;
-        {error, not_exists} ->
-            ?DELETE_NOT_EXISTING_ROOM_RESULT
-    catch
-        error:{muc_host_to_host_type_failed, _, _} ->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
+    M = #{room => RoomJID},
+    fold(M, [fun check_muc_domain/1, fun do_delete_room/1]).
+
 -spec get_room_messages(jid:jid(), jid:jid(), integer() | undefined,
                         mod_mam:unix_timestamp() | undefined) ->
-    {ok, list()} | {muc_server_not_found | internal | not_room_member, iolist()}.
+    {ok, list()} | {user_not_found | muc_server_not_found | room_not_found | not_room_member |
+                    internal, iolist()}.
 get_room_messages(RoomJID, UserJID, PageSize, Before) ->
-    case mongoose_domain_api:get_subdomain_host_type(RoomJID#jid.lserver) of
-        {ok, HostType} ->
-            case is_user_room_member(HostType, jid:to_lus(UserJID), jid:to_lus(RoomJID)) of
-                true ->
-                    get_room_messages(HostType, RoomJID, UserJID, PageSize, Before);
-                false ->
-                    ?USER_NOT_ROOM_MEMBER_RESULT
-            end;
-        {error, not_found} ->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
+    M = #{user => UserJID, room => RoomJID, page_size => PageSize, before => Before},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun get_user_aff/1,
+             fun do_get_room_messages/1]).
 
 -spec get_room_messages(jid:jid(), integer() | undefined,
                         mod_mam:unix_timestamp() | undefined) ->
-    {ok, [mod_mam:message_row()]} | {muc_server_not_found | internal, iolist()}.
+    {ok, [mod_mam:message_row()]} | {muc_server_not_found | room_not_found | internal, iolist()}.
 get_room_messages(RoomJID, PageSize, Before) ->
-    case mongoose_domain_api:get_subdomain_host_type(RoomJID#jid.lserver) of
+    M = #{user => undefined, room => RoomJID, page_size => PageSize, before => Before},
+    fold(M, [fun check_muc_domain/1, fun check_room/1, fun do_get_room_messages/1]).
+
+-spec get_room_info(jid:jid(), jid:jid()) ->
+    {ok, room()} | {user_not_found | muc_server_not_found | room_not_found | not_room_member,
+                    iolist()}.
+get_room_info(RoomJID, UserJID) ->
+    M = #{user => UserJID, room => RoomJID},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun do_get_room_info/1,
+             fun check_room_member/1, fun return_info/1]).
+
+-spec get_room_info(jid:jid()) -> {ok, room()} | {muc_server_not_found | room_not_found, iolist()}.
+get_room_info(RoomJID) ->
+    M = #{room => RoomJID},
+    fold(M, [fun check_muc_domain/1, fun do_get_room_info/1, fun return_info/1]).
+
+-spec get_room_aff(jid:jid(), jid:jid()) ->
+    {ok, aff_users()} | {user_not_found | muc_server_not_found | room_not_found | not_room_member,
+                         iolist()}.
+get_room_aff(RoomJID, UserJID) ->
+    M = #{user => UserJID, room => RoomJID},
+    fold(M, [fun check_user/1, fun check_muc_domain/1, fun do_get_room_aff/1,
+             fun check_room_member/1, fun return_aff/1]).
+
+-spec get_room_aff(jid:jid()) ->
+          {ok, aff_users()} | {muc_server_not_found | room_not_found, iolist()}.
+get_room_aff(RoomJID) ->
+    M = #{room => RoomJID},
+    fold(M, [fun check_muc_domain/1, fun do_get_room_aff/1, fun return_aff/1]).
+
+-spec get_user_rooms(jid:jid()) ->
+          {ok, [RoomUS :: jid:simple_bare_jid()]} | {user_not_found, iolist()}.
+get_user_rooms(UserJID) ->
+    fold(#{user => UserJID}, [fun check_user/1, fun do_get_user_rooms/1]).
+
+-spec get_blocking_list(jid:jid()) -> {ok, [blocking_item()]} | {user_not_found, iolist()}.
+get_blocking_list(UserJID) ->
+    fold(#{user => UserJID}, [fun check_user/1, fun do_get_blocking_list/1]).
+
+-spec set_blocking(jid:jid(), [blocking_item()]) -> {ok | user_not_found, iolist()}.
+set_blocking(UserJID, Items) ->
+    fold(#{user => UserJID, items => Items}, [fun check_user/1, fun do_set_blocking_list/1]).
+
+%% Internal: steps used in fold/2
+
+check_user(M = #{user := UserJID = #jid{lserver = LServer}}) ->
+    case mongoose_domain_api:get_domain_host_type(LServer) of
         {ok, HostType} ->
-            get_room_messages(HostType, RoomJID, undefined, PageSize, Before);
+            case ejabberd_auth:does_user_exist(HostType, UserJID, stored) of
+                true -> M#{user_host_type => HostType};
+                false -> {user_not_found, "Given user does not exist"}
+            end;
+        {error, not_found} ->
+            {user_not_found, "User's domain does not exist"}
+    end.
+
+check_muc_domain(M = #{room := #jid{lserver = LServer}}) ->
+    case mongoose_domain_api:get_subdomain_host_type(LServer) of
+        {ok, HostType} ->
+            M#{muc_host_type => HostType};
         {error, not_found} ->
             ?MUC_SERVER_NOT_FOUND_RESULT
     end.
 
--spec get_room_messages(mongooseim:host_type(), jid:jid(), jid:jid() | undefined,
-                        integer() | undefined, mod_mam:unix_timestamp() | undefined) ->
-    {ok, list()} | {internal, iolist()}.
+check_room_member(M = #{user := UserJID, aff_users := AffUsers}) ->
+    case get_aff(jid:to_lus(UserJID), AffUsers) of
+        none ->
+            ?USER_NOT_ROOM_MEMBER_RESULT;
+        _ ->
+            M
+    end.
+
+create_room_raw(#{room := InRoomJID, user := CreatorJID, options := Options}) ->
+    Config = make_room_config(Options),
+    case mod_muc_light:try_to_create_room(CreatorJID, InRoomJID, Config) of
+        {ok, RoomJID, #create{aff_users = AffUsers, raw_config = Conf}} ->
+            {ok, make_room(RoomJID, Conf, AffUsers)};
+        {error, exists} ->
+            {already_exists, "Room already exists"};
+        {error, max_occupants_reached} ->
+            {max_occupants_reached, "Max occupants number reached"};
+        {error, {Key, Reason}} ->
+            ?VALIDATION_ERROR_RESULT(Key, Reason)
+    end.
+
+do_invite_to_room(#{user := SenderJID, room := RoomJID, recipient := RecipientJID}) ->
+    S = jid:to_bare(SenderJID),
+    R = jid:to_bare(RoomJID),
+    RecipientBin = jid:to_binary(jid:to_bare(RecipientJID)),
+    Changes = query(?NS_MUC_LIGHT_AFFILIATIONS, [affiliate(RecipientBin, <<"member">>)]),
+    ejabberd_router:route(S, R, iq(jid:to_binary(S), jid:to_binary(R), <<"set">>, [Changes])),
+    {ok, "User invited successfully"}.
+
+do_change_room_config(#{user := UserJID, room := RoomJID, config := Config,
+                        muc_host_type := HostType}) ->
+    UserUS = jid:to_bare(UserJID),
+    ConfigReq = #config{ raw_config = maps:to_list(Config) },
+    #jid{lserver = LServer} = UserJID,
+    #jid{luser = RoomID, lserver = MUCServer} = RoomJID,
+    Acc = mongoose_acc:new(#{location => ?LOCATION, lserver => LServer, host_type => HostType}),
+    case mod_muc_light:change_room_config(UserUS, RoomID, MUCServer, ConfigReq, Acc) of
+        {ok, RoomJID, KV}  ->
+            {ok, make_room(RoomJID, KV, [])};
+        {error, item_not_found} ->
+            ?USER_NOT_ROOM_MEMBER_RESULT;
+        {error, not_allowed} ->
+            {not_allowed, "Given user does not have permission to change config"};
+        {error, not_exists} ->
+            ?ROOM_NOT_FOUND_RESULT;
+        {error, {Key, Reason}} ->
+            ?VALIDATION_ERROR_RESULT(Key, Reason)
+    end.
+
+check_aff_permission(M = #{user := UserJID, recipient := RecipientJID, aff := Aff, op := Op}) ->
+    case {Aff, Op} of
+        {member, remove} when RecipientJID =:= UserJID ->
+            M;
+        {owner, _} ->
+            M;
+        _ -> {not_allowed, "Given user does not have permission to change affiliations"}
+    end.
+
+check_delete_permission(M = #{aff := owner}) -> M;
+check_delete_permission(#{}) -> {not_allowed, "Given user cannot delete this room"}.
+
+get_user_aff(M = #{muc_host_type := HostType, user := UserJID, room := RoomJID}) ->
+    case get_room_user_aff(HostType, RoomJID, UserJID) of
+        {ok, owner} ->
+            M#{aff => owner};
+        {ok, member} ->
+            M#{aff => member};
+        {ok, none} ->
+            ?USER_NOT_ROOM_MEMBER_RESULT;
+        {error, room_not_found} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+do_change_affiliation(#{user := SenderJID, room := RoomJID, recipient := RecipientJID, op := Op}) ->
+    RecipientBare = jid:to_bare(RecipientJID),
+    S = jid:to_bare(SenderJID),
+    Changes = query(?NS_MUC_LIGHT_AFFILIATIONS,
+                    [affiliate(jid:to_binary(RecipientBare), op_to_aff(Op))]),
+    ejabberd_router:route(S, RoomJID, iq(jid:to_binary(S), jid:to_binary(RoomJID),
+                                         <<"set">>, [Changes])),
+    {ok, "Affiliation change request sent successfully"}.
+
+do_send_message(#{user := SenderJID, room := RoomJID, children := Children, attrs := ExtraAttrs}) ->
+    SenderBare = jid:to_bare(SenderJID),
+    RoomBare = jid:to_bare(RoomJID),
+    Stanza = #xmlel{name = <<"message">>,
+                    attrs = [{<<"type">>, <<"groupchat">>} | ExtraAttrs],
+                    children = Children},
+    ejabberd_router:route(SenderBare, RoomBare, Stanza),
+    {ok, "Message sent successfully"}.
+
+do_delete_room(#{room := RoomJID}) ->
+    case mod_muc_light:delete_room(jid:to_lus(RoomJID)) of
+        ok ->
+            ?ROOM_DELETED_SUCC_RESULT;
+        {error, not_exists} ->
+            ?ROOM_NOT_FOUND_RESULT
+    end.
+
+do_get_room_messages(#{user := CallerJID, room := RoomJID, page_size := PageSize, before := Before,
+                       muc_host_type := HostType}) ->
+   get_room_messages(HostType, RoomJID, CallerJID, PageSize, Before).
+
+%% Exported for mod_muc_api
 get_room_messages(HostType, RoomJID, CallerJID, PageSize, Before) ->
     ArchiveID = mod_mam_muc:archive_id_int(HostType, RoomJID),
     Now = os:system_time(microsecond),
@@ -244,118 +307,52 @@ get_room_messages(HostType, RoomJID, CallerJID, PageSize, Before) ->
             {internal, io_lib:format("Internal error occured ~p", [Term])}
     end.
 
--spec get_room_info(jid:jid(), jid:jid()) ->
-    {ok, room()} | {muc_server_not_found | room_not_found | not_room_member, iolist()}.
-get_room_info(RoomJID, UserJID) ->
-    case get_room_info(RoomJID) of
-        {ok, #{aff_users := Affs} = Room} ->
-            case get_aff(jid:to_lus(UserJID), Affs) of
-                none ->
-                    ?USER_NOT_ROOM_MEMBER_RESULT;
-                _ ->
-                    {ok, Room}
-            end;
-        Error ->
-            Error
+do_get_room_info(M = #{room := RoomJID, muc_host_type := HostType}) ->
+    case mod_muc_light_db_backend:get_info(HostType, jid:to_lus(RoomJID)) of
+        {ok, Config, AffUsers, _Version} ->
+            M#{aff_users => AffUsers, options => Config};
+        {error, not_exists} ->
+            ?ROOM_NOT_FOUND_RESULT
     end.
 
--spec get_room_info(jid:jid()) -> {ok, room()} | {muc_server_not_found | room_not_found, iolist()}.
-get_room_info(#jid{lserver = MUCServer} = RoomJID) ->
-    case mongoose_domain_api:get_subdomain_host_type(MUCServer) of
-        {ok, HostType} ->
-            case mod_muc_light_db_backend:get_info(HostType, jid:to_lus(RoomJID)) of
-                {ok, Conf, AffUsers, _Version} ->
-                    {ok, make_room(jid:to_binary(RoomJID), Conf, AffUsers)};
-                {error, not_exists} ->
-                    ?ROOM_NOT_FOUND_RESULT
-            end;
-        {error, not_found}->
-            ?MUC_SERVER_NOT_FOUND_RESULT
+return_info(#{room := RoomJID, aff_users := AffUsers, options := Config}) ->
+    {ok, make_room(jid:to_binary(RoomJID), Config, AffUsers)}.
+
+do_get_room_aff(M = #{room := RoomJID, muc_host_type := HostType}) ->
+    case mod_muc_light_db_backend:get_aff_users(HostType, jid:to_lus(RoomJID)) of
+        {ok, AffUsers, _Version} ->
+            M#{aff_users => AffUsers};
+        {error, not_exists} ->
+            ?ROOM_NOT_FOUND_RESULT
     end.
 
--spec get_room_aff(jid:jid(), jid:jid()) ->
-    {ok, aff_users()} | {muc_server_not_found | room_not_found, iolist()}.
-get_room_aff(RoomJID, UserJID) ->
-    case get_room_aff(RoomJID) of
-        {ok, Affs} ->
-            case get_aff(jid:to_lus(UserJID), Affs) of
-                none ->
-                    ?USER_NOT_ROOM_MEMBER_RESULT;
-                _ ->
-                    {ok, Affs}
-            end;
-        Error ->
-            Error
+return_aff(#{aff_users := AffUsers}) ->
+    {ok, AffUsers}.
+
+check_room(M = #{room := RoomJID, muc_host_type := HostType}) ->
+    case mod_muc_light_db_backend:room_exists(HostType, jid:to_lus(RoomJID)) of
+        true ->
+            M;
+        false ->
+            ?ROOM_NOT_FOUND_RESULT
     end.
 
--spec get_room_aff(jid:jid()) ->
-    {ok, aff_users()} | {muc_server_not_found | room_not_found, iolist()}.
-get_room_aff(#jid{lserver = MUCServer} = RoomJID) ->
-    case mongoose_domain_api:get_subdomain_host_type(MUCServer) of
-        {ok, HostType} ->
-            case mod_muc_light_db_backend:get_aff_users(HostType, jid:to_lus(RoomJID)) of
-                {ok, AffUsers, _Version} ->
-                    {ok, AffUsers};
-                {error, not_exists} ->
-                    ?ROOM_NOT_FOUND_RESULT
-            end;
-        {error, not_found}->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
+do_get_user_rooms(#{user := UserJID, user_host_type := HostType}) ->
+    MUCServer = mod_muc_light_utils:server_host_to_muc_host(HostType, UserJID#jid.lserver),
+    {ok, mod_muc_light_db_backend:get_user_rooms(HostType, jid:to_lus(UserJID), MUCServer)}.
 
--spec get_user_rooms(jid:jid()) -> {ok, [RoomUS :: jid:simple_bare_jid()]} |
-                                   {muc_server_not_found, iolist()}.
-get_user_rooms(#jid{lserver = LServer} = UserJID) ->
-    case mongoose_domain_api:get_domain_host_type(LServer) of
-        {ok, HostType} ->
-            UserUS = jid:to_lus(UserJID),
-            MUCServer = mod_muc_light_utils:server_host_to_muc_host(HostType, LServer),
-            {ok, mod_muc_light_db_backend:get_user_rooms(HostType, UserUS, MUCServer)};
-        {error, not_found} ->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
+do_get_blocking_list(#{user := UserJID, user_host_type := HostType}) ->
+    MUCServer = mod_muc_light_utils:server_host_to_muc_host(HostType, UserJID#jid.lserver),
+    {ok, mod_muc_light_db_backend:get_blocking(HostType, jid:to_lus(UserJID), MUCServer)}.
 
--spec get_blocking_list(jid:jid()) -> {ok, [blocking_item()]} | {muc_server_not_found, iolist()}.
-get_blocking_list(#jid{lserver = LServer} = User) ->
-    case mongoose_domain_api:get_domain_host_type(LServer) of
-        {ok, HostType} ->
-            MUCServer = mod_muc_light_utils:server_host_to_muc_host(HostType, LServer),
-            {ok, mod_muc_light_db_backend:get_blocking(HostType, jid:to_lus(User), MUCServer)};
-        {error, not_found} ->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
+do_set_blocking_list(#{user := UserJID, user_host_type := HostType, items := Items}) ->
+    MUCServer = mod_muc_light_utils:server_host_to_muc_host(HostType, UserJID#jid.lserver),
+    Q = query(?NS_MUC_LIGHT_BLOCKING, [blocking_item(I) || I <- Items]),
+    Iq = iq(jid:to_binary(UserJID), MUCServer, <<"set">>, [Q]),
+    ejabberd_router:route(UserJID, jid:from_binary(MUCServer), Iq),
+    {ok, "User blocking list updated successfully"}.
 
--spec set_blocking(jid:jid(), [blocking_item()]) -> {ok | muc_server_not_found, iolist()}.
-set_blocking(#jid{lserver = LServer} = User, Items) ->
-     case mongoose_domain_api:get_domain_host_type(LServer) of
-        {ok, HostType} ->
-            MUCServer = mod_muc_light_utils:server_host_to_muc_host(HostType, LServer),
-            Q = query(?NS_MUC_LIGHT_BLOCKING, [blocking_item(I) || I <- Items]),
-            Iq = iq(jid:to_binary(User), MUCServer, <<"set">>, [Q]),
-            ejabberd_router:route(User, jid:from_binary(MUCServer), Iq),
-            {ok, "User blocking list updated successfully"};
-        {error, not_found} ->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
-
- %% Internal
-
--spec create_room_raw(jid:jid(), jid:jid(), map()) -> create_room_result().
-create_room_raw(InRoomJID, CreatorJID, Options) ->
-    Config = make_room_config(Options),
-    try mod_muc_light:try_to_create_room(CreatorJID, InRoomJID, Config) of
-        {ok, RoomJID, #create{aff_users = AffUsers, raw_config = Conf}} ->
-            {ok, make_room(RoomJID, Conf, AffUsers)};
-        {error, exists} ->
-            {already_exists, "Room already exists"};
-        {error, max_occupants_reached} ->
-            {max_occupants_reached, "Max occupants number reached"};
-        {error, {Key, Reason}} ->
-            ?VALIDATION_ERROR_RESULT(Key, Reason)
-    catch
-        error:{muc_host_to_host_type_failed, _, _} ->
-            ?MUC_SERVER_NOT_FOUND_RESULT
-    end.
+%% Internal: helpers
 
 -spec blocking_item(blocking_item()) -> exml:element().
 blocking_item({What, Action, Who}) ->
@@ -387,24 +384,12 @@ get_aff(UserUS, Affs) ->
         false -> none
     end.
 
--spec is_user_room_member(mongooseim:host_type(), jid:simple_bare_jid(),
-                          jid:simple_bare_jid()) -> boolean().
-is_user_room_member(HostType, UserUS, {_, MUCServer} = RoomLUS) ->
-    case mod_muc_light_db_backend:get_user_rooms(HostType, UserUS, MUCServer) of
-        [] ->
-            false;
-        RoomJIDs when is_list(RoomJIDs) ->
-            lists:any(fun(LUS) -> LUS =:= RoomLUS end, RoomJIDs)
-    end.
-
-
 make_room(JID, #config{ raw_config = Options}, AffUsers) ->
     make_room(JID, Options, AffUsers);
 make_room(JID, Options, AffUsers) when is_list(Options) ->
     make_room(JID, maps:from_list(ensure_keys_are_binaries(Options)), AffUsers);
 make_room(JID, Options, AffUsers) when is_map(Options) ->
-    #{<<"roomname">> := Name, <<"subject">> := Subject} = Options,
-    #{jid => JID, name => Name, subject => Subject, aff_users => AffUsers, options => Options}.
+    #{jid => JID, aff_users => AffUsers, options => Options}.
 
 ensure_keys_are_binaries([{K, _}|_] = Conf) when is_binary(K) ->
     Conf;
@@ -442,3 +427,11 @@ maybe_caller_jid(undefined, Params) ->
     Params;
 maybe_caller_jid(CallerJID, Params) ->
     Params#{caller_jid => CallerJID}.
+
+op_to_aff(add) -> <<"member">>;
+op_to_aff(remove) -> <<"none">>.
+
+fold({_, _} = Result, _) ->
+    Result;
+fold(M, [Step | Rest]) when is_map(M) ->
+    fold(Step(M), Rest).


### PR DESCRIPTION
The main goal is to handle the error cases:
- Non-existent users shouldn't be room owners or message senders, and they shouldn't be able to have blocking lists.
- 'Room not found' should be returned if the room does not exist.
    
Other functional changes:
 - Name and subject are not required, because they shouldn't be. They have defaults, and they can be removed by the used in a custom room config schema.
 - Only room owner should be able to kick room members.
 - Room JID is always bare in the schema. User JID's are not required to be bare if this doesn't break anything. The resources are mostly ignored.
 - Update required modules and protected domains in the schema.
    
Operations are broken into reusable steps, and a fold operation is used to iterate over them.


