### PR TITLE
Refactored hook handlers in mod_stream_management

### DIFF
--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -36,7 +36,9 @@
 
 -export([gen_hook_fn_wrapper/3]).
 
--ignore_xref([add/4, delete/4, error_running_hook/3, start_link/0]).
+-ignore_xref([add/4, delete/4, error_running_hook/3, start_link/0,
+    % temporary until the module is deleted
+    add/1, delete/1]).
 
 -include("mongoose.hrl").
 


### PR DESCRIPTION
This PR changes all hook handlers in `mod_stream_management` module to `gen_hook` format.