### PR TITLE
Refactored hook handlers in ejabberd_ctl

### DIFF
--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -49,7 +49,6 @@ start(normal, _Args) ->
     mongoose_graphql:init(),
     translate:start(),
     ejabberd_node_id:start(),
-    ejabberd_ctl:init(),
     ejabberd_commands:init(),
     mongoose_graphql_commands:start(),
     mongoose_config:start(),

--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -38,7 +38,7 @@
 
 -ignore_xref([add/4, delete/4, error_running_hook/3, start_link/0,
     % temporary until the module is deleted
-    add/1, delete/1]).
+    add/1, delete/1, add/5, delete/5]).
 
 -include("mongoose.hrl").
 

--- a/src/gen_hook.erl
+++ b/src/gen_hook.erl
@@ -55,7 +55,11 @@
 
 -type hook_list() :: [hook_tuple()].
 
--export_type([hook_fn/0, hook_list/0, hook_fn_ret/0, hook_fn_ret/1]).
+-export_type([hook_fn/0,
+              hook_list/0,
+              hook_fn_ret/0,
+              hook_fn_ret/1,
+              extra/0]).
 
 -record(hook_handler, {prio :: pos_integer(),
                        hook_fn :: hook_fn(),

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -340,7 +340,7 @@ get_user_roster(Acc, #{jid := #jid{luser = LUser, lserver = LServer}}, #{host_ty
 -spec get_user_roster(mongoose_acc:t(),
                       jid:luser(),
                       jid:lserver(),
-                      mongooseim:host_type()) ->mongoose_acc:t().
+                      mongooseim:host_type()) -> mongoose_acc:t().
 get_user_roster(Acc, LUser, LServer, HostType) ->
     case mongoose_acc:get(roster, show_full_roster, false, Acc) of
         true ->

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -334,7 +334,15 @@ create_sub_el(Items, Version) ->
     Params :: #{jid := jid:jid()},
     Extra :: gen_hook:extra().
 get_user_roster(Acc, #{jid := #jid{luser = LUser, lserver = LServer}}, #{host_type := HostType}) ->
-    NewAcc = case mongoose_acc:get(roster, show_full_roster, false, Acc) of
+    NewAcc = get_user_roster(Acc, LUser, LServer, HostType),
+    {ok, NewAcc}.
+
+-spec get_user_roster(mongoose_acc:t(),
+                      jid:luser(),
+                      jid:lserver(),
+                      mongooseim:host_type()) ->mongoose_acc:t().
+get_user_roster(Acc, LUser, LServer, HostType) ->
+    case mongoose_acc:get(roster, show_full_roster, false, Acc) of
         true ->
             Roster = get_roster(HostType, LUser, LServer),
             mongoose_acc:append(roster, items, Roster, Acc);
@@ -345,8 +353,7 @@ get_user_roster(Acc, #{jid := #jid{luser = LUser, lserver = LServer}}, #{host_ty
                                           true
                                   end, get_roster(HostType, LUser, LServer)),
             mongoose_acc:append(roster, items, Roster, Acc)
-    end,
-    {ok, NewAcc}.
+    end.
 
 item_to_xml(Item) ->
     Attrs1 = [{<<"jid">>,
@@ -826,7 +833,8 @@ try_send_unsubscription_to_rosteritems(Acc, JID) ->
 %% Both or To, send a "unsubscribe" presence stanza.
 -spec send_unsubscription_to_rosteritems(mongoose_acc:t(), jid:jid()) -> mongoose_acc:t().
 send_unsubscription_to_rosteritems(Acc, JID) ->
-    {ok, Acc1} = get_user_roster(Acc, #{jid => JID}, #{host_type => mongoose_acc:host_type(Acc)}),
+    #jid{luser = LUser, lserver = LServer} = JID,
+    Acc1 = get_user_roster(Acc, LUser, LServer, mongoose_acc:host_type(Acc)),
     RosterItems = mongoose_acc:get(roster, items, [], Acc1),
     lists:foreach(fun(RosterItem) ->
                           send_unsubscribing_presence(JID, RosterItem)

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -14,7 +14,6 @@
          anonymous_purge_hook/3,
          auth_failed/3,
          does_user_exist/3,
-         ejabberd_ctl_process/2,
          failed_to_store_message/1,
          filter_local_packet/1,
          filter_packet/1,
@@ -259,13 +258,6 @@ node_cleanup(Node) ->
     Args = [Node],
     ParamsWithLegacyArgs = ejabberd_hooks:add_args(Params, Args),
     run_global_hook(node_cleanup, #{}, ParamsWithLegacyArgs).
-
--spec ejabberd_ctl_process(Acc, Args) -> Result when
-    Acc :: any(),
-    Args :: [string()],
-    Result :: any().
-ejabberd_ctl_process(Acc, Args) ->
-    run_global_hook(ejabberd_ctl_process, Acc, [Args]).
 
 -spec failed_to_store_message(Acc) -> Result when
     Acc :: mongoose_acc:t(),

--- a/src/vcard/mod_vcard.erl
+++ b/src/vcard/mod_vcard.erl
@@ -390,7 +390,7 @@ process_local_iq(Acc, _From, _To, IQ = #iq{type = get}, _Extra) ->
                     From :: jid:jid(),
                     To :: jid:jid(),
                     IQ :: jlib:iq(),
-                    Extra :: gen_hook:extra()) ->
+                    Extra :: map()) ->
      {stop, mongoose_acc:t()} | {mongoose_acc:t(), jlib:iq()}.
 process_sm_iq(Acc, From, To, IQ = #iq{type = set, sub_el = VCARD}, _Extra) ->
     HostType = mongoose_acc:host_type(Acc),


### PR DESCRIPTION
This PR changes all hook handlers in `ejabberd_ctl` to `gen_hook` format.
