### PR TITLE
Fixing errors in mod_private

### DIFF
--- a/big_tests/tests/graphql_private_SUITE.erl
+++ b/big_tests/tests/graphql_private_SUITE.erl
@@ -132,7 +132,7 @@ user_set_private(Config, Alice) ->
     ElemStr = exml:to_binary(private_input()),
     ResultSet = user_set_private(Alice, ElemStr, Config),
     ParsedResultSet = get_ok_value([data, private, setPrivate], ResultSet),
-    ?assertEqual(<<"[]">>, ParsedResultSet),
+    ?assertEqual(<<"<my_element xmlns='alice:private:ns'>DATA</my_element>">>, ParsedResultSet),
     ResultGet = user_get_private(Alice, <<"my_element">>, <<"alice:private:ns">>, Config),
     ParsedResultGet = get_ok_value([data, private, getPrivate], ResultGet),
     ?assertEqual(ElemStr, ParsedResultGet).
@@ -194,7 +194,7 @@ admin_set_private(Config, Alice) ->
     ElemStr = exml:to_binary(private_input()),
     ResultSet = admin_set_private(AliceBin, ElemStr, Config),
     ParsedResultSet = get_ok_value([data, private, setPrivate], ResultSet),
-    ?assertEqual(<<"[]">>, ParsedResultSet),
+    ?assertEqual(<<"<my_element xmlns='alice:private:ns'>DATA</my_element>">>, ParsedResultSet),
     ResultGet = admin_get_private(AliceBin, <<"my_element">>, <<"alice:private:ns">>, Config),
     ParsedResultGet = get_ok_value([data, private, getPrivate], ResultGet),
     ?assertEqual(ElemStr, ParsedResultGet).

--- a/big_tests/tests/graphql_stanza_SUITE.erl
+++ b/big_tests/tests/graphql_stanza_SUITE.erl
@@ -392,7 +392,7 @@ user_send_stanza_with_spoofed_from_story(Config, Alice, Bob) ->
 
 admin_send_unparsable_stanza(Config) ->
     Res = send_stanza(<<"<test">>, Config),
-    ?assertEqual(<<"Input coercion failed for type Stanza with value <<\"<test\">>. "
+    ?assertEqual(<<"Input coercion failed for type XmlElement with value <<\"<test\">>. "
                    "The reason it failed is: \"expected >\"">>,
                  get_coercion_err_msg(Res)).
 

--- a/priv/graphql/schemas/admin/private.gql
+++ b/priv/graphql/schemas/admin/private.gql
@@ -3,7 +3,7 @@ Allow admin to set the user's private data
 """
 type PrivateAdminMutation @protected @use(modules: ["mod_private"]){
     "Set the user's private data"
-    setPrivate(user: JID!, elementString: String!): String
+    setPrivate(user: JID!, elementString: XmlElement): String
       @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
 }
 
@@ -12,6 +12,6 @@ Allow admin to get the user's private data
 """
 type PrivateAdminQuery @protected @use(modules: ["mod_private"]){
     "Get the user's private data"
-    getPrivate(user: JID!, element: String!, nameSpace: String!): String
+    getPrivate(user: JID!, element: String!, nameSpace: NonEmptyString!): XmlElement
       @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
 }

--- a/priv/graphql/schemas/admin/private.gql
+++ b/priv/graphql/schemas/admin/private.gql
@@ -3,7 +3,7 @@ Allow admin to set the user's private data
 """
 type PrivateAdminMutation @protected @use(modules: ["mod_private"]){
     "Set the user's private data"
-    setPrivate(user: JID!, elementString: XmlElement): String
+    setPrivate(user: JID!, elementString: XmlElement!): XmlElement
       @protected(type: DOMAIN, args: ["user"]) @use(arg: "user")
 }
 

--- a/priv/graphql/schemas/admin/stanza.gql
+++ b/priv/graphql/schemas/admin/stanza.gql
@@ -16,7 +16,7 @@ type StanzaAdminMutation @protected{
   sendMessageHeadLine(from: JID!, to: JID!, subject: String, body: String): SendStanzaPayload
     @protected(type: DOMAIN, args: ["from"])
   "Send an arbitrary stanza. Only for global admin"
-  sendStanza(stanza: Stanza): SendStanzaPayload
+  sendStanza(stanza: XmlElement): SendStanzaPayload
     @protected(type: GLOBAL)
 }
 

--- a/priv/graphql/schemas/global/scalar_types.gql
+++ b/priv/graphql/schemas/global/scalar_types.gql
@@ -1,7 +1,7 @@
 "Date and time represented using **YYYY-MM-DDTHH:mm:ssZ** format"
 scalar DateTime
-"Body of a data structure exchanged by XMPP entities in XML streams"
-scalar Stanza @spectaql(options: [{ key: "example", value: "Hi!" }])
+"String containing the XML document"
+scalar XmlElement @spectaql(options: [{ key: "example", value: "<message to='bob@localhost' type='chat' from='alice@localhost'><body>Hi!</body></message>" }])
 "Unique XMPP identifier in the form of **node@domain** or **node@domain/resource"
 scalar JID @spectaql(options: [{ key: "example", value: "alice@localhost" }])
 "JID without a resource"

--- a/priv/graphql/schemas/global/stanza.gql
+++ b/priv/graphql/schemas/global/stanza.gql
@@ -15,7 +15,7 @@ type StanzaMap{
   "ID of the stanza"
   stanza_id: String
   "Stanza's data"
-  stanza: Stanza
+  stanza: XmlElement
 }
 
 "Send stanza payload"

--- a/priv/graphql/schemas/user/private.gql
+++ b/priv/graphql/schemas/user/private.gql
@@ -3,7 +3,7 @@ Allow user to set own private
 """
 type PrivateUserMutation @protected @use(modules: ["mod_private"]){
     "Set user's own private"
-    setPrivate(elementString: String!): String @use
+setPrivate(elementString: XmlElement!): String @use
 }
 
 """
@@ -11,5 +11,5 @@ Allow user to get own private
 """
 type PrivateUserQuery @protected @use(modules: ["mod_private"]){
     "Get user's own private"
-    getPrivate(element: String!, nameSpace: String!): String @use
+    getPrivate(element: String!, nameSpace: NonEmptyString!): XmlElement @use
 }

--- a/priv/graphql/schemas/user/private.gql
+++ b/priv/graphql/schemas/user/private.gql
@@ -3,7 +3,7 @@ Allow user to set own private
 """
 type PrivateUserMutation @protected @use(modules: ["mod_private"]){
     "Set user's own private"
-setPrivate(elementString: XmlElement!): String @use
+setPrivate(elementString: XmlElement!): XmlElement @use
 }
 
 """

--- a/priv/graphql/schemas/user/stanza.gql
+++ b/priv/graphql/schemas/user/stanza.gql
@@ -16,7 +16,7 @@ type StanzaUserMutation @protected{
   "Send a headline message to a local or remote bare or full JID"
   sendMessageHeadLine(from: JID, to: JID!, subject: String, body: String): SendStanzaPayload
   "Send an arbitrary stanza"
-  sendStanza(stanza: Stanza): SendStanzaPayload
+  sendStanza(stanza: XmlElement): SendStanzaPayload
 }
 
 type StanzaUserSubscription @protected{

--- a/src/admin_extra/service_admin_extra_private.erl
+++ b/src/admin_extra/service_admin_extra_private.erl
@@ -80,7 +80,7 @@ private_get(Username, Host, Element, Ns) ->
 
 -spec private_set(jid:user(), jid:server(),
                   ElementString :: binary()) -> {Res, string()} when
-    Res :: ok | not_found | not_loaded | parse_error.
+    Res :: ok | not_found | parse_error.
 private_set(Username, Host, ElementString) ->
     case exml:parse(ElementString) of
         {error, Error} ->
@@ -89,5 +89,8 @@ private_set(Username, Host, ElementString) ->
             {parse_error, String};
         {ok, Xml} ->
             JID = jid:make(Username, Host, <<>>),
-            mod_private_api:private_set(JID, Xml)
+            case mod_private_api:private_set(JID, Xml) of
+                {ok, _} -> {ok, ""};
+                Error -> Error
+            end
     end.

--- a/src/admin_extra/service_admin_extra_private.erl
+++ b/src/admin_extra/service_admin_extra_private.erl
@@ -84,7 +84,7 @@ private_get(Username, Host, Element, Ns) ->
 private_set(Username, Host, ElementString) ->
     case exml:parse(ElementString) of
         {error, Error} ->
-            String = io_lib:format("Error found parsing the element: '~s' Error: ~s",
+            String = io_lib:format("Error found parsing the element: '~ts' Error: ~ts",
                       [ElementString, Error]),
             {parse_error, String};
         {ok, Xml} ->

--- a/src/graphql/admin/mongoose_graphql_private_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_private_admin_mutation.erl
@@ -13,5 +13,6 @@ execute(_Ctx, _Obj, <<"setPrivate">>, #{<<"user">> := CallerJID,
         <<"elementString">> := Element}) ->
     case mod_private_api:private_set(CallerJID, Element) of
         {ok, _} = Result -> Result;
-        Error -> make_error(Error, #{user => jid:to_binary(CallerJID), element => Element})
+        Error -> make_error(Error, #{user => jid:to_binary(CallerJID),
+                                     element => exml:to_binary(Element)})
     end.

--- a/src/graphql/admin/mongoose_graphql_private_admin_mutation.erl
+++ b/src/graphql/admin/mongoose_graphql_private_admin_mutation.erl
@@ -13,5 +13,5 @@ execute(_Ctx, _Obj, <<"setPrivate">>, #{<<"user">> := CallerJID,
         <<"elementString">> := Element}) ->
     case mod_private_api:private_set(CallerJID, Element) of
         {ok, _} = Result -> Result;
-        Error -> make_error(Error, #{user => CallerJID, element => Element})
+        Error -> make_error(Error, #{user => jid:to_binary(CallerJID), element => Element})
     end.

--- a/src/graphql/admin/mongoose_graphql_private_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_private_admin_query.erl
@@ -14,5 +14,6 @@ execute(_Ctx, _Obj, <<"getPrivate">>, #{<<"user">> := CallerJID,
     case mod_private_api:private_get(CallerJID, Element, SubElement) of
         {ok, _} = Result -> Result;
         Error ->
-            make_error(Error, #{user => CallerJID, element => Element, subElement => SubElement})
+            make_error(Error, #{user => jid:to_binary(CallerJID), element => Element,
+                                subElement => SubElement})
     end.

--- a/src/graphql/mongoose_graphql_scalar.erl
+++ b/src/graphql/mongoose_graphql_scalar.erl
@@ -11,7 +11,7 @@
     Coerced :: any(),
     Reason :: term().
 input(<<"DateTime">>, DT) -> binary_to_microseconds(DT);
-input(<<"Stanza">>, Value) -> exml:parse(Value);
+input(<<"XmlElement">>, Value) -> exml:parse(Value);
 input(<<"JID">>, Jid) -> jid_from_binary(Jid);
 input(<<"BareJID">>, Jid) -> bare_jid_from_binary(Jid);
 input(<<"FullJID">>, Jid) -> full_jid_from_binary(Jid);
@@ -33,7 +33,7 @@ input(Ty, V) ->
     Coerced :: any(),
     Reason :: term().
 output(<<"DateTime">>, DT) -> {ok, microseconds_to_binary(DT)};
-output(<<"Stanza">>, Elem) -> {ok, exml:to_binary(Elem)};
+output(<<"XmlElement">>, Elem) -> {ok, exml:to_binary(Elem)};
 output(<<"JID">>, Jid) -> {ok, jid:to_binary(Jid)};
 output(<<"UserName">>, User) -> {ok, User};
 output(<<"DomainName">>, Domain) -> {ok, Domain};

--- a/src/graphql/user/mongoose_graphql_private_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_private_user_mutation.erl
@@ -12,5 +12,5 @@
 execute(#{user := CallerJID}, _Obj, <<"setPrivate">>, #{<<"elementString">> := Element}) ->
     case mod_private_api:private_set(CallerJID, Element) of
         {ok, _} = Result -> Result;
-        Error -> make_error(Error, #{user => CallerJID, element => Element})
+        Error -> make_error(Error, #{user => jid:to_binary(CallerJID), element => Element})
     end.

--- a/src/graphql/user/mongoose_graphql_private_user_mutation.erl
+++ b/src/graphql/user/mongoose_graphql_private_user_mutation.erl
@@ -12,5 +12,6 @@
 execute(#{user := CallerJID}, _Obj, <<"setPrivate">>, #{<<"elementString">> := Element}) ->
     case mod_private_api:private_set(CallerJID, Element) of
         {ok, _} = Result -> Result;
-        Error -> make_error(Error, #{user => jid:to_binary(CallerJID), element => Element})
+        Error -> make_error(Error, #{user => jid:to_binary(CallerJID),
+                                     element => exml:to_binary(Element)})
     end.

--- a/src/graphql/user/mongoose_graphql_private_user_query.erl
+++ b/src/graphql/user/mongoose_graphql_private_user_query.erl
@@ -14,5 +14,6 @@ execute(#{user := CallerJID}, _Obj, <<"getPrivate">>,
     case mod_private_api:private_get(CallerJID, Element, SubElement) of
         {ok, _} = Result -> Result;
         Error ->
-            make_error(Error, #{user => CallerJID, element => Element, subElement => SubElement})
+            make_error(Error, #{user => jid:to_binary(CallerJID), element => Element,
+                                subElement => SubElement})
     end.

--- a/src/mod_private_api.erl
+++ b/src/mod_private_api.erl
@@ -18,14 +18,14 @@ private_get(JID, Element, Ns) ->
             {not_found, io_lib:format("User ~s does not exist", [jid:to_binary(JID)])}
     end.
 
--spec private_set(jid:jid(), exml:element()) -> {Res, iolist()} when
-    Res :: ok | not_found.
+-spec private_set(jid:jid(), exml:element()) ->
+    {ok, exml:element()} | {not_found, iolist()}.
 private_set(#jid{lserver = Domain} = JID, Xml) ->
     case ejabberd_auth:does_user_exist(JID) of
         true ->
             {ok, HostType} = mongoose_domain_api:get_domain_host_type(Domain),
             send_iq(set, Xml, JID, HostType),
-            {ok, ""};
+            {ok, Xml};
         false ->
             {not_found, io_lib:format("User ~s does not exist", [jid:to_binary(JID)])}
     end.
@@ -35,8 +35,8 @@ do_private_get(JID, Element, Ns) ->
     Xml = #xmlel{ name = Element, attrs = [{<<"xmlns">>, Ns}]},
     {_, ResIq} = send_iq(get, Xml, JID, HostType),
     [#xmlel{ name = <<"query">>,
-     attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
-     children = [SubEl] }] = ResIq#iq.sub_el,
+             attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
+             children = [SubEl] }] = ResIq#iq.sub_el,
     {ok, SubEl}.
 
 send_iq(Method, Xml, From = To = _JID, HostType) ->

--- a/src/mod_private_api.erl
+++ b/src/mod_private_api.erl
@@ -15,7 +15,7 @@ private_get(JID, Element, Ns) ->
         true ->
             do_private_get(JID, Element, Ns);
         false ->
-            {not_found, io_lib:format("User ~s does not exist", [jid:to_binary(JID)])}
+            {not_found, io_lib:format("User ~ts does not exist", [jid:to_binary(JID)])}
     end.
 
 -spec private_set(jid:jid(), exml:element()) ->
@@ -27,7 +27,7 @@ private_set(#jid{lserver = Domain} = JID, Xml) ->
             send_iq(set, Xml, JID, HostType),
             {ok, Xml};
         false ->
-            {not_found, io_lib:format("User ~s does not exist", [jid:to_binary(JID)])}
+            {not_found, io_lib:format("User ~ts does not exist", [jid:to_binary(JID)])}
     end.
 
 do_private_get(JID, Element, Ns) ->
@@ -40,7 +40,7 @@ do_private_get(JID, Element, Ns) ->
     {ok, SubEl}.
 
 send_iq(Method, Xml, From = To = _JID, HostType) ->
-    IQ = {iq, <<"">>, Method, ?NS_PRIVATE, <<"">>,
+    IQ = {iq, <<>>, Method, ?NS_PRIVATE, <<>>,
           #xmlel{ name = <<"query">>,
                   attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
                   children = [Xml] } },

--- a/src/mod_private_api.erl
+++ b/src/mod_private_api.erl
@@ -9,7 +9,7 @@
 -export([private_get/3, private_set/2]).
 
 -spec private_get(jid:jid(), binary(), binary()) -> {ok, exml:element()} | {Error, string()} when
-    Error :: not_found | parsing_error | element_does_not_exist_error.
+    Error :: not_found.
 private_get(JID, Element, Ns) ->
     case ejabberd_auth:does_user_exist(JID) of
         true ->

--- a/src/mod_private_api.erl
+++ b/src/mod_private_api.erl
@@ -8,38 +8,19 @@
 
 -export([private_get/3, private_set/2]).
 
--spec private_get(jid:jid(), binary(), binary()) -> {Res, iodata()} when
-    Res :: ok | not_found.
+-spec private_get(jid:jid(), binary(), binary()) -> {ok, exml:element()} | {Error, string()} when
+    Error :: not_found | parsing_error | element_does_not_exist_error.
 private_get(JID, Element, Ns) ->
     case ejabberd_auth:does_user_exist(JID) of
         true ->
-            {ok, do_private_get(JID, Element, Ns)};
+            do_private_get(JID, Element, Ns);
         false ->
             {not_found, io_lib:format("User ~s does not exist", [jid:to_binary(JID)])}
     end.
 
--spec private_set(jid:jid(), ElementString :: binary()) -> {Res, iolist()} when
-    Res :: ok | not_found | parse_error.
-private_set(JID, ElementString) ->
-    case exml:parse(ElementString) of
-        {error, Error} ->
-            String = io_lib:format("Error found parsing the element:~n  ~p~nError: ~p~n",
-                      [ElementString, Error]),
-            {parse_error, String};
-        {ok, Xml} ->
-            do_private_set(JID, Xml)
-    end.
-
-do_private_get(JID, Element, Ns) ->
-    {ok, HostType} = mongoose_domain_api:get_domain_host_type(JID#jid.lserver),
-    Xml = #xmlel{ name = Element, attrs = [{<<"xmlns">>, Ns}]},
-    {_, ResIq} = send_iq(get, Xml, JID, HostType),
-    [#xmlel{ name = <<"query">>,
-             attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
-             children = [SubEl] }] = ResIq#iq.sub_el,
-    exml:to_binary(SubEl).
-
-do_private_set(#jid{lserver = Domain} = JID, Xml) ->
+-spec private_set(jid:jid(), exml:element()) -> {Res, iolist()} when
+    Res :: ok | not_found.
+private_set(#jid{lserver = Domain} = JID, Xml) ->
     case ejabberd_auth:does_user_exist(JID) of
         true ->
             {ok, HostType} = mongoose_domain_api:get_domain_host_type(Domain),
@@ -48,6 +29,15 @@ do_private_set(#jid{lserver = Domain} = JID, Xml) ->
         false ->
             {not_found, io_lib:format("User ~s does not exist", [jid:to_binary(JID)])}
     end.
+
+do_private_get(JID, Element, Ns) ->
+    {ok, HostType} = mongoose_domain_api:get_domain_host_type(JID#jid.lserver),
+    Xml = #xmlel{ name = Element, attrs = [{<<"xmlns">>, Ns}]},
+    {_, ResIq} = send_iq(get, Xml, JID, HostType),
+    [#xmlel{ name = <<"query">>,
+     attrs = [{<<"xmlns">>, ?NS_PRIVATE}],
+     children = [SubEl] }] = ResIq#iq.sub_el,
+    {ok, SubEl}.
 
 send_iq(Method, Xml, From = To = _JID, HostType) ->
     IQ = {iq, <<"">>, Method, ?NS_PRIVATE, <<"">>,


### PR DESCRIPTION
Improving error handling in mod_private.
1. Changing the name, example, and description of the Stanza type. Now its name is XmlElement, which is used by graphql_stanza and graphql_private.
2. Adding validation to private_get to check if the given user exists
3. Changing the type of nameSpace variable in get_private to disallow empty strings
4. Changing the way the user JID is being returned in an error. Now the binary instead of JID is being returned.