### PR TITLE
Revert history order

### DIFF
--- a/doc/History.md
+++ b/doc/History.md
@@ -1,64 +1,8 @@
 # MongooseIM history
 
-## 2011: Fork of ejabberd
+## 2022: GraphQL
 
-MongooseIM's birthplace is a private Erlang Solutions' branch of ProcessOne's ejabberd - an XMPP/Jabber server written in Erlang.
-What would later become a leading, highly customisable and scalable XMPP platform, originated in a strong idea - storing all internal strings in binaries instead of lists, among other significant improvements.
-
-The change was introduced in 0.1.0 proto-MongooseIM release and 3.0.0-alpha-X series of ejabberd.
-This opened the door for achieving higher performance, lower latency and introducing other subsequent improvements building up to a platform we are truly proud of.
-
-### Initial differences from the parent project
-
-This project began its life as a fork of ejabberd v.2.1.8, and later underwent major cleanup, refactoring and optimization:
-
-*   Bringing the project source tree to compliance with OTP project structure recommendations
-*   Swapping `autotools` for the Erlang community-standard build tool `rebar`
-*   Removal of obsolete and/or rarely used modules to reduce maintenance burden
-*   Reduction of runtime memory consumption by refactoring the code
-    to use Erlang's binary data type for string manipulation and storage
-    instead of operating on linked lists of characters
-*   Functional test coverage of the system according to corresponding
-    RFCs and XEPs
-
-## 2012-2015: Fully independent project growing fast
-
-The next steps were achieving full OTP and `rebar` compliance, removal of obsolete and/or rarely used modules, reduction of the runtime memory consumption and functional test coverage. 
-[MongooseIM 1.0.0](https://github.com/esl/MongooseIM/releases/tag/1.0.0) was released on July 10th of 2012.
-
-MongooseIM XMPP server fully independently went through multiple versions, following its own path with its own resources: [1.1.x](https://github.com/esl/MongooseIM/releases/tag/1.1.0) in 2012, [1.2.x](https://github.com/esl/MongooseIM/releases/tag/1.2.0) in 2013, [1.3.x](https://github.com/esl/MongooseIM/releases/tag/1.3.0), [1.4.x](https://github.com/esl/MongooseIM/releases/tag/1.4.0),  [1.5.x](https://github.com/esl/MongooseIM/releases/tag/1.5.0) in 2014, and [1.6.x](https://github.com/esl/MongooseIM/releases/tag/1.6.0) in 2015.
-
-## 2016: Pivot to fullstack messaging platform
-
-MongooseIM Platform appeared in 2016, with the release of [MongooseIM XMPP server 2.0.0](https://github.com/esl/MongooseIM/releases/tag/2.0.0).
-
-The MongooseIM platform components were:
-
-* MongooseIM XMPP server, featuring a unique REST API for client developers and MUC light
-* [WombatOAM](https://www.erlang-solutions.com/capabilities/wombatoam/), for monitoring and operations
-* [escalus](https://github.com/esl/escalus), an Erlang XMPP client for test automation
-* [amoc](https://github.com/esl/amoc), for load generation
-* [Smack](https://github.com/igniterealtime/Smack) for Android in Java (third party)
-* [XMPPFramework](https://github.com/robbiehanson/XMPPFramework) for iOS in Objective-C (third party)
-* [Retrofit](https://square.github.io/retrofit/) by Square for Android in Java (third party)
-* [Jayme](https://github.com/inaka/Jayme) by Inaka for iOS in Swift
-
-## 2017: Platform expansion and strengthening
-
-We also introduced some MongooseIM platform components that are independent of the XMPP server.
-So far the list includes:
-
-* [Mangosta iOS](https://github.com/esl/mangosta-ios)
-* [Mangosta Android](https://github.com/esl/mangosta-android)
-* [MongoosePush](https://github.com/esl/mongoosepush)
-* [MongooseICE](https://github.com/esl/MongooseICE)
-
-## 2018-2019: Global distribution ready
-
-The next step on our journey with the MongooseIM platform was to enable building global scale architectures.
-This was necessary to welcome the massive influx of users that come with a full stack IoT and chatbot solution.
-
-Erlang Solution's goal is to utilise XMPP features suited for chatbots, and build open standards for the completeness of our solution.
+New GraphQL API allows to access MongooseIM using HTTP protocol to extract data and make changes in a flexible way.
 
 ## 2020-2021: Friendly, cloud-native and dynamic
 
@@ -67,3 +11,85 @@ This goes hand in hand with the prioritisation of solutions that enable Mongoose
 
 Whether in the cloud or on-premise, it is now possible to have a multi-tenant setup, powered by the new dynamic XMPP domains feature.
 It means thousands of domains can be simply set up, managed, and removed dynamically, without a noticeable performance overhead.
+
+Releases:
+
+* [MongooseIM 5.1.0](https://github.com/esl/MongooseIM/releases/tag/5.1.0) in June 2022.
+* [MongooseIM 5.0.0](https://github.com/esl/MongooseIM/releases/tag/5.0.0) in October 2021.
+* [MongooseIM 4.2.0](https://github.com/esl/MongooseIM/releases/tag/4.2.0) in April 2021.
+* [MongooseIM 4.1.0](https://github.com/esl/MongooseIM/releases/tag/4.1.0) in February 2021.
+* [MongooseIM 4.0.0](https://github.com/esl/MongooseIM/releases/tag/4.0.0) in September 2020.
+* [MongooseIM 3.7.0](https://github.com/esl/MongooseIM/releases/tag/3.7.0) in May 2020.
+* [MongooseIM 3.6.0](https://github.com/esl/MongooseIM/releases/tag/3.6.0) in January 2020.
+
+## 2018-2019: Global distribution ready
+
+* Focus on global scale architecture.
+* Chat bot integrations.
+* Optimizations for IoT clients.
+* GDPR compliance.
+* New XML parser [exml](https://github.com/esl/exml).
+
+Releases:
+
+* [MongooseIM 3.5.0](https://github.com/esl/MongooseIM/releases/tag/3.5.0) in October 2019.
+* [MongooseIM 3.4.0](https://github.com/esl/MongooseIM/releases/tag/3.4.0) in June 2019.
+* [MongooseIM 3.3.0](https://github.com/esl/MongooseIM/releases/tag/3.3.0) in March 2019.
+* [MongooseIM 3.2.0](https://github.com/esl/MongooseIM/releases/tag/3.2.0) in November 2018.
+* [MongooseIM 3.1.1](https://github.com/esl/MongooseIM/releases/tag/3.1.1) in July 2018.
+* [MongooseIM 3.0.1](https://github.com/esl/MongooseIM/releases/tag/3.0.1) in May 2018.
+* [MongooseIM 2.2.2](https://github.com/esl/MongooseIM/releases/tag/2.2.2) in April 2018.
+* [MongooseIM 2.1.1](https://github.com/esl/MongooseIM/releases/tag/2.1.1) in January 2018.
+
+## 2017: Platform expansion and strengthening
+
+[MongooseIM 2.1.0](https://github.com/esl/MongooseIM/releases/tag/2.1.0) in October 2017.
+
+New components were added to the MongooseIM platform:
+
+* [MongoosePush](https://github.com/esl/mongoosepush), push notifications server
+* [MongooseICE](https://github.com/esl/MongooseICE), ICE server to help with voice calls functionality
+* [Mangosta iOS](https://github.com/esl/mangosta-ios), demo XMPP client application for iOS
+* [Mangosta Android](https://github.com/esl/mangosta-android), demo XMPP client application for Android
+
+## 2016: Pivot to fullstack messaging platform
+
+MongooseIM Platform was created, that included a list of components:
+
+* [MongooseIM XMPP server 2.0.0](https://github.com/esl/MongooseIM/releases/tag/2.0.0), featuring a unique REST API for client developers and MUC light
+* [WombatOAM](https://www.erlang-solutions.com/capabilities/wombatoam/), for monitoring and operations
+* [escalus](https://github.com/esl/escalus), an Erlang XMPP client for test automation
+* [amoc](https://github.com/esl/amoc), for load generation
+* [Smack](https://github.com/igniterealtime/Smack) for Android in Java (third party)
+* [XMPPFramework](https://github.com/robbiehanson/XMPPFramework) for iOS in Objective-C (third party)
+* [Retrofit](https://square.github.io/retrofit/) by Square for Android in Java (third party)
+* [Jayme](https://github.com/inaka/Jayme) by Inaka for iOS in Swift
+
+## 2012-2015: Fully independent project growing fast
+
+* Full OTP and `rebar` compliance.
+* Removal of obsolete and/or rarely used modules.
+* Reduction of the runtime memory consumption and functional test coverage.
+* Added Message Archive Management support (XEP-0313).
+
+Releases:
+
+* [MongooseIM 1.6.x](https://github.com/esl/MongooseIM/releases/tag/1.6.0) in October 2015.
+* [MongooseIM 1.5.x](https://github.com/esl/MongooseIM/releases/tag/1.5.0) in December 2014.
+* [MongooseIM 1.4.x](https://github.com/esl/MongooseIM/releases/tag/1.4.0) in May 2014.
+* [MongooseIM 1.3.x](https://github.com/esl/MongooseIM/releases/tag/1.3.0) in January 2014.
+* [MongooseIM 1.2.x](https://github.com/esl/MongooseIM/releases/tag/1.2.0) in May 2013.
+* [MongooseIM 1.1.x](https://github.com/esl/MongooseIM/releases/tag/1.1.0) in December 2012.
+* [MongooseIM 1.0.0](https://github.com/esl/MongooseIM/releases/tag/1.0.0) in July 2012.
+
+## 2011: Fork of ejabberd
+
+This project began its life as a fork of ejabberd v.2.1.8.
+
+Version 0.1.0 included:
+
+* Replaced strings with binaries to significantly reduce memory consumption.
+* Refactored directory structure of the project to be OTP complient.
+* Replaced `autotools` with the `rebar` build tool.
+* Removed obsolete and/or rarely used modules to reduce maintenance burden.
+* Added functional tests based on RFCs and XEPs.


### PR DESCRIPTION
This PR addresses MIM-1711

Proposed changes include:
* Also added links to the releases (to be consistent).
* Bullet points are more easy to read.
* Added more info, for example, for years 2018-2019. 
* Removed Next, Next, Next sentences, because the order is in reverse.

Still could be refactored a bit, because 2011 and 2012-2015 blocks have a lot of common items (could be even merged).
Probably could add inbox introduction.