### PR TITLE
Simplify the GraphQL handler name

### DIFF
--- a/big_tests/tests/graphql_helper.erl
+++ b/big_tests/tests/graphql_helper.erl
@@ -293,7 +293,7 @@ get_value([Field | Fields], Data) ->
     get_value(Fields, Data2).
 
 is_graphql_config(#{module := ejabberd_cowboy, handlers := Handlers}, ExpEpName) ->
-    lists:any(fun(#{module := mongoose_graphql_cowboy_handler, schema_endpoint := EpName}) ->
+    lists:any(fun(#{module := mongoose_graphql_handler, schema_endpoint := EpName}) ->
                       ExpEpName =:= EpName;
                  (_) -> false
               end, Handlers);

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -267,7 +267,7 @@ inject_creds_to_opts(Handler, _Creds) ->
 % @doc Checks whether a config for a port is an admin, client or GraphQL one.
 % This is determined based on handler modules used.
 is_roles_config(#{module := ejabberd_cowboy, handlers := Handlers}, {graphql, SchemaEndpoint}) ->
-    lists:any(fun(#{module := mongoose_graphql_cowboy_handler, schema_endpoint := Ep}) ->
+    lists:any(fun(#{module := mongoose_graphql_handler, schema_endpoint := Ep}) ->
                       SchemaEndpoint =:= Ep;
                  (_) ->
                       false

--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -410,7 +410,7 @@ There are the following options for each of the HTTP listeners:
 
     * `mod_bosh` - for [BOSH](https://xmpp.org/extensions/xep-0124.html) connections,
     * `mod_websockets` - for [WebSocket](https://tools.ietf.org/html/rfc6455) connections,
-    * `mongoose_graphql_cowboy_handler` - for GraphQL API,
+    * `mongoose_graphql_handler` - for GraphQL API,
     * `mongoose_admin_api`, `mongoose_client_api` - for REST API.
 
     These types are described below in more detail.
@@ -493,12 +493,12 @@ Maximum allowed incoming stanza size.
 This subsection enables external component connections over WebSockets.
 See the [service](#xmpp-components-listenservice) listener section for details.
 
-### Handler types: GraphQL API - `mongoose_graphql_cowboy_handler`
+### Handler types: GraphQL API - `mongoose_graphql_handler`
 
 For more information about the API, see the [Admin interface](../graphql-api/Admin-GraphQL.md) and [User interface](../graphql-api/User-GraphQL.md) documentation.
 The following options are supported for this handler:
 
-#### `listen.http.handlers.mongoose_graphql_cowboy_handler.schema_endpoint`
+#### `listen.http.handlers.mongoose_graphql_handler.schema_endpoint`
 * **Syntax:** string, one of `"admin"`, `"domain_admin"`, `"user"`
 * **Default:** no default, this option is mandatory
 * **Example:** `schema_endpoint = "admin"`
@@ -509,19 +509,19 @@ Specifies the schema endpoint:
 * `domain_admin` - Endpoint with the admin commands. A domain admin has permission to execute only commands with the owned domain. See the recommended configuration - [Example 3](#example-3-domain-admin-graphql-api).
 * `user` - Endpoint with the user commands. Used to manage the authorized user. See the recommended configuration - [Example 4](#example-4-user-graphql-api).
 
-#### `listen.http.handlers.mongoose_graphql_cowboy_handler.username` - only for `admin`
+#### `listen.http.handlers.mongoose_graphql_handler.username` - only for `admin`
 * **Syntax:** string
 * **Default:** not set
 * **Example:** `username = "admin"`
 
 When set, enables authentication for the admin API, otherwise it is disabled. Requires setting `password`.
 
-#### `listen.http.handlers.mongoose_graphql_cowboy_handler.password` - only for `admin`
+#### `listen.http.handlers.mongoose_graphql_handler.password` - only for `admin`
 * **Syntax:** string
 * **Default:** not set
 * **Example:** `password = "secret"`
 
-#### `listen.http.handlers.mongoose_graphql_cowboy_handler.allowed_categories`
+#### `listen.http.handlers.mongoose_graphql_handler.allowed_categories`
 * **Syntax:** non-empty array of strings. Allowed values: `"checkAuth", "account", "domain", "last", "muc", "muc_light", "session", "stanza", "roster", "vcard", "private", "metric", "stat", "gdpr", "mnesia", "server", "inbox", "http_upload", "offline", "token"`
 * **Default:** all GraphQL categories enabled
 * **Example:** `allowed_categories = ["domain", "last"]`
@@ -653,7 +653,7 @@ GraphQL API for administration, the listener is bound to 127.0.0.1 for increased
   transport.num_acceptors = 5
   transport.max_connections = 10
 
-  [[listen.http.handlers.mongoose_graphql_cowboy_handler]]
+  [[listen.http.handlers.mongoose_graphql_handler]]
     host = "localhost"
     path = "/api/graphql"
     schema_endpoint = "admin"
@@ -673,7 +673,7 @@ GraphQL API for the domain admin.
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
-  [[listen.http.handlers.mongoose_graphql_cowboy_handler]]
+  [[listen.http.handlers.mongoose_graphql_handler]]
     host = "_"
     path = "/api/graphql"
     schema_endpoint = "domain_admin"
@@ -690,7 +690,7 @@ GraphQL API for the user.
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
-  [[listen.http.handlers.mongoose_graphql_cowboy_handler]]
+  [[listen.http.handlers.mongoose_graphql_handler]]
     host = "_"
     path = "/api/graphql"
     schema_endpoint = "user"

--- a/doc/graphql-api/Admin-GraphQL.md
+++ b/doc/graphql-api/Admin-GraphQL.md
@@ -2,7 +2,7 @@
 
 The new GraphQL admin API contains all the commands available through the REST API, and the vast majority of the CLI (`mongooseimctl`) commands. Only commands that wouldn't have worked well with GraphQL style have been omitted.
 
-We can distinguish two levels of the administration. A global admin (has access to all commands), and the admin per domain (has access only to the own domain). Each of them is handled by a different endpoint. Please see the configuration [Listen](../../configuration/listen/#handler-types-graphql-api-mongoose_graphql_cowboy_handler) section for more details.
+We can distinguish two levels of the administration. A global admin (has access to all commands), and the admin per domain (has access only to the own domain). Each of them is handled by a different endpoint. Please see the configuration [Listen](../../configuration/listen/#handler-types-graphql-api-mongoose_graphql_handler) section for more details.
 
 There is only one schema for both admin types. Admin per domain simply has no permissions to execute global commands or commands with not owned domain. The API documentation clearly says which commands are global.
 
@@ -27,7 +27,7 @@ with the word `Basic` followed by a space and a base64-encoded string.
 
 ### Global admin endpoint
 
-The authentication for global admin is optional because this endpoint shouldn't be exposed outside. The credentials set in the handler section in the config enables the authentication. Please see the [GraphQL handler](../configuration/listen.md#handler-types-graphql-api-mongoose_graphql_cowboy_handler) section for more details.
+The authentication for global admin is optional because this endpoint shouldn't be exposed outside. The credentials set in the handler section in the config enables the authentication. Please see the [GraphQL handler](../configuration/listen.md#handler-types-graphql-api-mongoose_graphql_handler) section for more details.
 
 The base64-encoded string should have the form
 `LOGIN:PASSWORD`, where:

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -86,7 +86,7 @@
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
-  [[listen.http.handlers.mongoose_graphql_cowboy_handler]]
+  [[listen.http.handlers.mongoose_graphql_handler]]
     host = "localhost"
     path = "/api/graphql"
     schema_endpoint = "admin"
@@ -100,7 +100,7 @@
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
-  [[listen.http.handlers.mongoose_graphql_cowboy_handler]]
+  [[listen.http.handlers.mongoose_graphql_handler]]
     host = "_"
     path = "/api/graphql"
     schema_endpoint = "domain_admin"
@@ -112,7 +112,7 @@
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
-  [[listen.http.handlers.mongoose_graphql_cowboy_handler]]
+  [[listen.http.handlers.mongoose_graphql_handler]]
     host = "_"
     path = "/api/graphql"
     schema_endpoint = "user"

--- a/src/graphql/mongoose_graphql_handler.erl
+++ b/src/graphql/mongoose_graphql_handler.erl
@@ -4,7 +4,7 @@
 %%
 %% The graphql request is authorized, processed and then passed for execution.
 %% @end
--module(mongoose_graphql_cowboy_handler).
+-module(mongoose_graphql_handler).
 
 -behaviour(mongoose_http_handler).
 -behavior(cowboy_rest).

--- a/src/graphql/mongoose_graphql_sse_handler.erl
+++ b/src/graphql/mongoose_graphql_sse_handler.erl
@@ -28,9 +28,9 @@ init(State, _LastEvtId, Req) ->
     process_flag(trap_exit, true), % needed for 'terminate' to be called
     case cowboy_req:method(Req) of
         <<"GET">> ->
-            case mongoose_graphql_cowboy_handler:check_auth_header(Req, State) of
+            case mongoose_graphql_handler:check_auth_header(Req, State) of
                 {ok, State2} ->
-                    case mongoose_graphql_cowboy_handler:gather(Req) of
+                    case mongoose_graphql_handler:gather(Req) of
                         {ok, Req2, Decoded} ->
                             run_request(Decoded, Req2, State2);
                         {error, Reason} ->

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -84,4 +84,4 @@ configurable_handler_modules() ->
     [mod_websockets,
      mongoose_client_api,
      mongoose_admin_api,
-     mongoose_graphql_cowboy_handler].
+     mongoose_graphql_handler].

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -1084,8 +1084,8 @@ default_config([listen, http, handlers, mongoose_client_api]) ->
     #{handlers => [sse, messages, contacts, rooms, rooms_config, rooms_users, rooms_messages],
       docs => true,
       module => mongoose_client_api};
-default_config([listen, http, handlers, mongoose_graphql_cowboy_handler]) ->
-    #{module => mongoose_graphql_cowboy_handler,
+default_config([listen, http, handlers, mongoose_graphql_handler]) ->
+    #{module => mongoose_graphql_handler,
       schema_endpoint => admin};
 default_config([listen, http, handlers, Module]) ->
     #{module => Module};

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -610,13 +610,13 @@ listen_http_handlers_admin_api(_Config) ->
 
 listen_http_handlers_graphql(_Config) ->
     T = fun graphql_handler_raw/1,
-    {P, _} = test_listen_http_handler(mongoose_graphql_cowboy_handler, T),
+    {P, _} = test_listen_http_handler(mongoose_graphql_handler, T),
     test_listen_http_handler_creds(P, T),
     ?cfg(P ++ [allowed_categories], [<<"muc">>, <<"inbox">>],
          T(#{<<"allowed_categories">> => [<<"muc">>, <<"inbox">>]})),
     ?err(T(#{<<"allowed_categories">> => [<<"invalid">>]})),
     ?err(T(#{<<"schema_endpoint">> => <<"wrong_endpoint">>})),
-    ?err(http_handler_raw(mongoose_graphql_cowboy_handler, #{})).
+    ?err(http_handler_raw(mongoose_graphql_handler, #{})).
 
 test_listen_http_handler_creds(P, T) ->
     CredsRaw = #{<<"username">> => <<"user">>, <<"password">> => <<"pass">>},
@@ -2979,7 +2979,7 @@ listener(Type, Opts) ->
     config([listen, Type], Opts).
 
 graphql_handler_raw(Opts) ->
-    http_handler_raw(mongoose_graphql_cowboy_handler,
+    http_handler_raw(mongoose_graphql_handler,
                      maps:merge(#{<<"schema_endpoint">> => <<"admin">>}, Opts)).
 
 http_handler_raw(Type, Opts) ->

--- a/test/mongoose_graphql_SUITE.erl
+++ b/test/mongoose_graphql_SUITE.erl
@@ -1090,7 +1090,7 @@ init_ep_listener(Port, EpName, ListenerOpts, Config) ->
 -spec start_listener(atom(), integer(), listener_opts()) -> ok.
 start_listener(Ref, Port, Opts) ->
     Dispatch = cowboy_router:compile([
-        {'_', [{"/graphql", mongoose_graphql_cowboy_handler, Opts}]}
+        {'_', [{"/graphql", mongoose_graphql_handler, Opts}]}
     ]),
     {ok, _} = cowboy:start_clear(Ref,
                                  [{port, Port}],


### PR DESCRIPTION
None of the remaining HTTP handlers have 'cowboy' in their names, and there is no reason why the user would have to know that currently we are using Cowboy. This is an implementation detail that might change anyway.

