### PR TITLE
Replace 'egrep' with 'grep -E'

### DIFF
--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -37,7 +37,7 @@ mkdir -p "$RUNNER_LOG_DIR"
 export ERL_CRASH_DUMP="${RUNNER_LOG_DIR}/erl_crash.dump"
 
 # Extract the target node name from node.args
-NAME_ARG=`egrep -e '^-s?name' "$RUNNER_ETC_DIR"/vm.args`
+NAME_ARG=`grep -E '^-s?name' "$RUNNER_ETC_DIR"/vm.args`
 if [ -z "$NAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -35,13 +35,13 @@ SCRIPTS_DIR="$MIM_DIR"/scripts
 EJABBERD_STATUS_PATH="{{mongooseim_status_dir}}/status"
 export EJABBERD_STATUS_PATH="$EJABBERD_STATUS_PATH"
 
-COOKIE_ARG=`grep -e '^-setcookie' "$EJABBERD_VMARGS_PATH"`
+COOKIE_ARG=`grep '^-setcookie' "$EJABBERD_VMARGS_PATH"`
 if [ -z "$COOKIE_ARG" ]; then
     echo "vm.args needs to have a -setcookie parameter."
     exit 1
 fi
 
-NODENAME_ARG=`egrep -e '^-s?name' "$EJABBERD_VMARGS_PATH"`
+NODENAME_ARG=`grep -E '^-s?name' "$EJABBERD_VMARGS_PATH"`
 if [ -z "$NODENAME_ARG" ]; then
     echo "vm.args needs to have either -name or -sname parameter."
     exit 1

--- a/tools/gh-actions-configure-preset.sh
+++ b/tools/gh-actions-configure-preset.sh
@@ -22,5 +22,5 @@ case "$1" in
 esac
 
 if [ ! -z "$GITHUB_ENV" ]; then
-  env | egrep "^(DB|REL_CONFIG|TLS_DIST|TESTSPEC)=" >> $GITHUB_ENV
+  env | grep -E "^(DB|REL_CONFIG|TLS_DIST|TESTSPEC)=" >> $GITHUB_ENV
 fi


### PR DESCRIPTION
GNU grep 3.8 prints the following warning when you call `egrep`:

```
egrep: warning: egrep is obsolescent; using grep -E
```

That warning would be visible every time you use `mongooseimctl` - checked on a Linux machine

