### PR TITLE
Update npm to work with the latest SpectaQL

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -435,7 +435,7 @@ jobs:
   docs_build_deploy:
     parallelism: 1
     docker:
-      - image: cimg/python:3.9.0-node
+      - image: cimg/python:3.11.0-node
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The `build_and_deploy_docs` job is failing because the old `npm` does not work with the latest `spectaql`

