### PR TITLE
Update GraphQL docs and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * [Developer's guide](https://esl.github.io/MongooseDocs/latest/developers-guide/Testing-MongooseIM/)
 * [Packages](https://www.erlang-solutions.com/resources/download.html)
 * Product page: [https://www.erlang-solutions.com/products/mongooseim.html](https://www.erlang-solutions.com/products/mongooseim.html)
-* Documentation: [https://esl.github.io/MongooseDocs/](https://esl.github.io/MongooseDocs/)
+* Documentation: [https://esl.github.io/MongooseDocs/](https://esl.github.io/MongooseDocs/latest/)
 
 ## Get to know MongooseIM
 MongooseIM is a robust, scalable and efficient XMPP server at the core of an Instant Messaging platform aimed at large installations.

--- a/doc/History.md
+++ b/doc/History.md
@@ -3,7 +3,7 @@
 ## 2022: GraphQL
 
 New GraphQL API allows to access MongooseIM using HTTP protocol to extract data and make changes in a flexible way.
-The command-line intrerface (CLI) has been reworked to match the GraphQL functionality.
+The command-line interface (CLI) has been reworked to match the GraphQL functionality.
 The configuration for the admin and the client API has been simplified.
 
 ## 2020-2021: Friendly, cloud-native and dynamic

--- a/doc/History.md
+++ b/doc/History.md
@@ -3,6 +3,8 @@
 ## 2022: GraphQL
 
 New GraphQL API allows to access MongooseIM using HTTP protocol to extract data and make changes in a flexible way.
+The command-line intrerface (CLI) has been reworked to match the GraphQL functionality.
+The configuration for the admin and the client API has been simplified.
 
 ## 2020-2021: Friendly, cloud-native and dynamic
 

--- a/doc/modules/mod_auth_token.md
+++ b/doc/modules/mod_auth_token.md
@@ -154,7 +154,7 @@ Refresh tokens issued by the server can be used to:
 An administrator may *revoke* a refresh token:
 
 ```sh
-mongooseimctl revoke_token owner@xmpphost
+mongooseimctl token revokeToken --user owner@xmpphost
 ```
 
 A client can no longer use a revoked token either for authentication or requesting new access tokens.


### PR DESCRIPTION


This PR addresses MIM-1711

Proposed changes include:
* Update revokeToken command
* Use a direct link to docss to avoid redirect
* Update history with Graphql and API info

