### PR TITLE
Rename c2s types as the module name already contains c2s

### DIFF
--- a/src/c2s/mongoose_c2s_acc.erl
+++ b/src/c2s/mongoose_c2s_acc.erl
@@ -25,8 +25,8 @@
 -type pairs() :: [pair()].
 -type pair() :: {state_mod, {module(), term()}}
               | {actions, gen_statem:action()}
-              | {c2s_state, mongoose_c2s:c2s_state()}
-              | {c2s_data, mongoose_c2s:c2s_data()}
+              | {c2s_state, mongoose_c2s:state()}
+              | {c2s_data, mongoose_c2s:data()}
               | {stop, term() | {shutdown, atom()}}
               | {hard_stop, term() | {shutdown, atom()}}
               | {route, mongoose_acc:t()}
@@ -36,8 +36,8 @@
 -type t() :: #{
         state_mod := #{module() => term()},
         actions := [gen_statem:action()],
-        c2s_state := undefined | mongoose_c2s:c2s_state(),
-        c2s_data := undefined | mongoose_c2s:c2s_data(),
+        c2s_state := undefined | mongoose_c2s:state(),
+        c2s_data := undefined | mongoose_c2s:data(),
         hard_stop := undefined | Reason :: term(),
         socket_send := [exml:element()]
        }.
@@ -45,8 +45,8 @@
 -type params() :: #{
         state_mod => #{module() => term()},
         actions => [gen_statem:action()],
-        c2s_state => mongoose_c2s:c2s_state(),
-        c2s_data => mongoose_c2s:c2s_data(),
+        c2s_state => mongoose_c2s:state(),
+        c2s_data => mongoose_c2s:data(),
         stop => Reason :: term(),
         hard_stop => Reason :: term(),
         route => [mongoose_acc:t()],
@@ -116,8 +116,8 @@ from_mongoose_acc(Acc, Key) ->
 
 -spec to_acc(mongoose_acc:t(), state_mod, {module(), term()}) -> mongoose_acc:t();
             (mongoose_acc:t(), actions, gen_statem:action() | [gen_statem:action()]) -> mongoose_acc:t();
-            (mongoose_acc:t(), c2s_state, term()) -> mongoose_acc:t();
-            (mongoose_acc:t(), c2s_data, mongoose_c2s:c2s_data()) -> mongoose_acc:t();
+            (mongoose_acc:t(), c2s_state, mongoose_c2s:state()) -> mongoose_acc:t();
+            (mongoose_acc:t(), c2s_data, mongoose_c2s:data()) -> mongoose_acc:t();
             (mongoose_acc:t(), hard_stop, atom()) -> mongoose_acc:t();
             (mongoose_acc:t(), stop, atom() | {shutdown, atom()}) -> mongoose_acc:t();
             (mongoose_acc:t(), route, mongoose_acc:t()) -> mongoose_acc:t();

--- a/src/c2s/mongoose_c2s_hooks.erl
+++ b/src/c2s/mongoose_c2s_hooks.erl
@@ -2,8 +2,8 @@
 -module(mongoose_c2s_hooks).
 
 -type fn() :: fun((mongoose_acc:t(), params(), gen_hook:hook_extra()) -> result()).
--type params() :: #{c2s_data := mongoose_c2s:c2s_data(),
-                    c2s_state := mongoose_c2s:c2s_state(),
+-type params() :: #{c2s_data := mongoose_c2s:data(),
+                    c2s_state := mongoose_c2s:state(),
                     event_type := undefined | gen_statem:event_type(),
                     event_content := undefined | term(),
                     reason := undefined | term()}.

--- a/src/c2s/mongoose_c2s_stanzas.erl
+++ b/src/c2s/mongoose_c2s_stanzas.erl
@@ -37,7 +37,7 @@ stream_features(Features) ->
     #xmlel{name = <<"stream:features">>, children = Features}.
 
 -spec stream_features_before_auth(
-        mongooseim:host_type(), jid:lserver(), mongoose_listener:options(), mongoose_c2s:c2s_data()) ->
+        mongooseim:host_type(), jid:lserver(), mongoose_listener:options(), mongoose_c2s:data()) ->
     exml:element().
 stream_features_before_auth(HostType, LServer, LOpts, StateData) ->
     IsSSL = mongoose_c2s_socket:is_ssl(mongoose_c2s:get_socket(StateData)),

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -324,7 +324,7 @@ upsert_caps(LFrom, Caps, Rs) ->
 
 -spec c2s_broadcast_recipients(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: [jid:simple_jid()],
-    Params :: #{c2s_data := mongoose_c2s:c2s_data(), type := {atom(), binary()}},
+    Params :: #{c2s_data := mongoose_c2s:data(), type := {atom(), binary()}},
     Extra :: map().
 c2s_broadcast_recipients(InAcc, #{c2s_data := C2SData, type := {pep_message, Feature}}, _) ->
     HostType = mongoose_c2s:get_host_type(C2SData),

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -149,7 +149,7 @@ user_send_packet(Acc, _Params, #{host_type := HostType}) ->
     Action = {{timeout, ping}, Interval, fun ping_c2s_handler/2},
     {ok, mongoose_c2s_acc:to_acc(Acc, actions, Action)}.
 
--spec ping_c2s_handler(atom(), mongoose_c2s:state()) -> mongoose_c2s_acc:t().
+-spec ping_c2s_handler(atom(), mongoose_c2s:data()) -> mongoose_c2s_acc:t().
 ping_c2s_handler(ping, StateData) ->
     HostType = mongoose_c2s:get_host_type(StateData),
     Interval = gen_mod:get_module_opt(HostType, ?MODULE, ping_req_timeout),

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -112,7 +112,7 @@ user_terminate(Acc, #{c2s_data := StateData, reason := Reason}, _Extra) ->
         Presences -> handle_user_terminate(Acc, StateData, Presences, Reason)
     end.
 
--spec handle_user_terminate(mongoose_acc:t(), mongoose_c2s:c2s_data(), presences_state(), term()) ->
+-spec handle_user_terminate(mongoose_acc:t(), mongoose_c2s:data(), presences_state(), term()) ->
     gen_hook:hook_fn_ret(mongoose_acc:t()).
 handle_user_terminate(Acc, StateData, Presences, Reason) ->
     Jid = mongoose_c2s:get_jid(StateData),
@@ -179,7 +179,7 @@ get_statustag(Presence) ->
     xml:get_path_s(Presence, [{elem, <<"status">>}, cdata]).
 
 -spec handle_subscription_change(
-        mongoose_acc:t(), mongoose_c2s:c2s_data(), term(), term(), presences_state()) ->
+        mongoose_acc:t(), mongoose_c2s:data(), term(), term(), presences_state()) ->
     mongoose_acc:t().
 handle_subscription_change(Acc, StateData, IJID, ISubscription, Presences) ->
     To = jid:make(IJID),
@@ -327,7 +327,7 @@ handle_received_available(Acc, Presences) ->
 
 %% @doc User updates his presence (non-directed presence packet)
 -spec presence_update(
-        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:c2s_data(), undefined | binary()) ->
+        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:data(), undefined | binary()) ->
     mongoose_acc:t().
 presence_update(Acc, FromJid, ToJid, Packet, StateData, undefined) ->
     Presences = maybe_get_handler(StateData),
@@ -346,7 +346,7 @@ presence_update(Acc, _, _, _, _, <<"unsubscribe">>) -> Acc;
 presence_update(Acc, _, _, _, _, <<"unsubscribed">>) -> Acc.
 
 -spec presence_update_to_available(
-        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:c2s_data(), presences_state()) ->
+        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:data(), presences_state()) ->
     mongoose_acc:t().
 presence_update_to_available(Acc0, FromJid, ToJid, Packet, StateData, Presences) ->
     Jid = mongoose_c2s:get_jid(StateData),
@@ -375,7 +375,7 @@ presence_update_to_available(Acc0, FromJid, ToJid, Packet, StateData, Presences)
       OldPriority, NewPriority, FromUnavail).
 
 -spec presence_update_to_unavailable(
-        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:c2s_data(), presences_state()) ->
+        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:data(), presences_state()) ->
     mongoose_acc:t().
 presence_update_to_unavailable(Acc, _FromJid, _ToJid, Packet, StateData, Presences) ->
     Status = exml_query:path(Packet, [{element, <<"status">>}, cdata], <<>>),
@@ -392,7 +392,7 @@ presence_update_to_unavailable(Acc, _FromJid, _ToJid, Packet, StateData, Presenc
     mongoose_c2s_acc:to_acc(Acc1, state_mod, {?MODULE, NewPresences}).
 
 -spec presence_update_to_invisible(
-        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:c2s_data(), presences_state()) ->
+        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:data(), presences_state()) ->
     mongoose_acc:t().
 presence_update_to_invisible(Acc, FromJid, _ToJid, Packet, StateData, Presences) ->
     NewPriority = get_priority_from_presence(Packet),
@@ -413,7 +413,7 @@ presence_update_to_invisible(Acc, FromJid, _ToJid, Packet, StateData, Presences)
 
 %% @doc User sends a directed presence packet
 -spec presence_track(
-        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:c2s_data(), undefined | binary()) ->
+        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:data(), undefined | binary()) ->
     mongoose_acc:t().
 presence_track(Acc, FromJid, ToJid, Packet, StateData, undefined) ->
     Presences = maybe_get_handler(StateData),
@@ -473,7 +473,7 @@ presence_broadcast(Acc, JIDSet) ->
                  end, Acc, JIDSet).
 
 -spec presence_update_to_available(
-        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:c2s_data(),
+        mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:data(),
         presences_state(), list(), priority(), priority(), boolean()) ->
     mongoose_acc:t().
 presence_update_to_available(Acc, FromJid, _ToJid, Packet, StateData, Presences, SocketSend,
@@ -514,7 +514,7 @@ presence_broadcast_to_trusted(Acc, FromJid, T, A, Packet) ->
               end
       end, Acc, A).
 
--spec resend_offline_messages(mongoose_acc:t(), mongoose_c2s:c2s_data()) -> mongoose_acc:t().
+-spec resend_offline_messages(mongoose_acc:t(), mongoose_c2s:data()) -> mongoose_acc:t().
 resend_offline_messages(Acc, StateData) ->
     ?LOG_DEBUG(#{what => resend_offline_messages, acc => Acc, c2s_state => StateData}),
     Jid = mongoose_c2s:get_jid(StateData),
@@ -602,14 +602,14 @@ close_session_status({shutdown, Reason}) when is_binary(Reason) ->
 close_session_status(_) ->
     <<"Unknown condition">>.
 
--spec maybe_get_handler(mongoose_c2s:c2s_data()) -> presences_state().
+-spec maybe_get_handler(mongoose_c2s:data()) -> presences_state().
 maybe_get_handler(StateData) ->
     case mongoose_c2s:get_mod_state(StateData, ?MODULE) of
         {ok, #presences_state{} = Presences} -> Presences;
         {error, not_found} -> #presences_state{}
     end.
 
--spec get_mod_state(mongoose_c2s:c2s_data()) -> presences_state() | {error, not_found}.
+-spec get_mod_state(mongoose_c2s:data()) -> presences_state() | {error, not_found}.
 get_mod_state(StateData) ->
     case mongoose_c2s:get_mod_state(StateData, ?MODULE) of
         {ok, Presence} -> Presence;
@@ -634,7 +634,7 @@ get_old_priority(Presences) ->
 -spec update_priority(Acc :: mongoose_acc:t(),
                       Priority :: integer(),
                       Packet :: exml:element(),
-                      StateData :: mongoose_c2s:c2s_data()) -> mongoose_acc:t().
+                      StateData :: mongoose_c2s:data()) -> mongoose_acc:t().
 update_priority(Acc, Priority, Packet, StateData) ->
     Sid = mongoose_c2s:get_sid(StateData),
     Jid = mongoose_c2s:get_jid(StateData),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -456,7 +456,7 @@ xmpp_stanza_dropped(Acc, From, To, Packet) ->
 %% C2S related hooks
 
 -spec c2s_broadcast_recipients(State, Type, From, Packet) -> Result when
-    State :: mongoose_c2s:state(),
+    State :: mongoose_c2s:data(),
     Type :: {atom(), any()},
     From :: jid:jid(),
     Packet :: exml:element(),

--- a/src/privacy/mod_blocking.erl
+++ b/src/privacy/mod_blocking.erl
@@ -82,7 +82,7 @@ handle_new_blocking_command(Acc, StateData, UserList, Action, JIDs) ->
     ToAcc = [{state_mod, {mod_privacy, UserList}}],
     mongoose_c2s_acc:to_acc_many(Acc, ToAcc).
 
--spec blocking_push_to_resources(blocking_type(), [binary()], mongoose_c2s:c2s_data()) -> ok.
+-spec blocking_push_to_resources(blocking_type(), [binary()], mongoose_c2s:data()) -> ok.
 blocking_push_to_resources(Action, JIDs, StateData) ->
     SubEl = case Action of
                 block -> blocking_stanza(JIDs, <<"block">>);
@@ -95,7 +95,7 @@ blocking_push_to_resources(Action, JIDs, StateData) ->
     ejabberd_router:route(F, T, PrivPushEl),
     ok.
 
--spec blocking_presence_to_contacts(blocking_type(), [binary()], mongoose_c2s:c2s_data()) -> ok.
+-spec blocking_presence_to_contacts(blocking_type(), [binary()], mongoose_c2s:data()) -> ok.
 blocking_presence_to_contacts(_Action, [], _StateData) -> ok;
 blocking_presence_to_contacts(Action, [Jid | JIDs], StateData) ->
     Presences = mod_presence:maybe_get_handler(StateData),

--- a/src/privacy/mod_privacy.erl
+++ b/src/privacy/mod_privacy.erl
@@ -201,7 +201,7 @@ foreign_event(Acc, #{c2s_data := StateData,
 foreign_event(Acc, _Params, _Extra) ->
     {ok, Acc}.
 
--spec do_privacy_check_send(mongoose_acc:t(), mongoose_c2s:c2s_data()) ->
+-spec do_privacy_check_send(mongoose_acc:t(), mongoose_c2s:data()) ->
     mongoose_c2s_hooks:result().
 do_privacy_check_send(Acc, StateData) ->
     case s_privacy_check_packet(Acc, StateData, out) of
@@ -213,7 +213,7 @@ do_privacy_check_send(Acc, StateData) ->
             {stop, send_back_error(Acc1, not_acceptable_cancel, send)}
     end.
 
--spec do_privacy_check_receive(mongoose_acc:t(), mongoose_c2s:c2s_data(), maybe_send()) ->
+-spec do_privacy_check_receive(mongoose_acc:t(), mongoose_c2s:data(), maybe_send()) ->
     mongoose_c2s_hooks:result().
 do_privacy_check_receive(Acc, StateData, MaybeSendError) ->
     case s_privacy_check_packet(Acc, StateData, in) of
@@ -223,7 +223,7 @@ do_privacy_check_receive(Acc, StateData, MaybeSendError) ->
             {stop, send_back_error(Acc1, service_unavailable, MaybeSendError)}
     end.
 
--spec do_user_send_iq(mongoose_acc:t(), mongoose_c2s:c2s_data(), mongooseim:host_type(), jlib:iq()) ->
+-spec do_user_send_iq(mongoose_acc:t(), mongoose_c2s:data(), mongooseim:host_type(), jlib:iq()) ->
     mongoose_c2s_hooks:result().
 do_user_send_iq(Acc1, StateData, HostType, #iq{type = Type, sub_el = SubEl} = IQ) ->
     FromJid = mongoose_acc:from_jid(Acc1),
@@ -245,7 +245,7 @@ do_user_send_iq(Acc1, StateData, HostType, #iq{type = Type, sub_el = SubEl} = IQ
     {stop, Acc2}.
 
 -spec handle_new_privacy_list(
-        mongoose_acc:t(), mongoose_c2s:c2s_data(), mongooseim:host_type(), term(), term()) ->
+        mongoose_acc:t(), mongoose_c2s:data(), mongooseim:host_type(), term(), term()) ->
     mongoose_acc:t().
 handle_new_privacy_list(Acc, StateData, HostType, PrivList, PrivListName) ->
     OldPrivList = get_handler(StateData),
@@ -268,7 +268,7 @@ handle_new_privacy_list(Acc, StateData, HostType, PrivList, PrivListName) ->
                          mongooseim:host_type(),
                          Type :: get | set,
                          ToJid :: jid:jid(),
-                         StateData :: mongoose_c2s:c2s_data()) -> mongoose_acc:t().
+                         StateData :: mongoose_c2s:data()) -> mongoose_acc:t().
 process_privacy_iq(Acc, HostType, get, ToJid, StateData) ->
     PrivacyList = get_handler(StateData),
     From = mongoose_acc:from_jid(Acc),
@@ -319,7 +319,7 @@ do_send_unavail_if_newly_blocked(Acc, _, _, _, _, _) ->
                            To :: jid:jid(),
                            Dir :: mongoose_privacy:direction(),
                            PrivList :: mongoose_privacy:userlist(),
-                           StateData :: mongoose_c2s:c2s_data()) ->
+                           StateData :: mongoose_c2s:data()) ->
     {mongoose_privacy:decision(), mongoose_acc:t()}.
 p_privacy_check_packet(#xmlel{} = Packet, From, To, Dir, PrivList, StateData) ->
     LServer = mongoose_c2s:get_lserver(StateData),
@@ -328,7 +328,7 @@ p_privacy_check_packet(#xmlel{} = Packet, From, To, Dir, PrivList, StateData) ->
                              from_jid => From, to_jid => To, element => Packet}),
     mongoose_privacy:privacy_check_packet(Acc, From, PrivList, To, Dir).
 
--spec s_privacy_check_packet(mongoose_acc:t(), mongoose_c2s:c2s_data(), mongoose_privacy:direction()) ->
+-spec s_privacy_check_packet(mongoose_acc:t(), mongoose_c2s:data(), mongoose_privacy:direction()) ->
     {mongoose_privacy:decision(), mongoose_acc:t()}.
 s_privacy_check_packet(Acc, StateData, Dir) ->
     To = mongoose_acc:to_jid(Acc),
@@ -348,14 +348,14 @@ send_back_error(Acc1, ErrorType, send) ->
 send_back_error(Acc, _, _) ->
     Acc.
 
--spec get_handler(mongoose_c2s:c2s_data()) -> mongoose_privacy:userlist() | {error, not_found}.
+-spec get_handler(mongoose_c2s:data()) -> mongoose_privacy:userlist() | {error, not_found}.
 get_handler(StateData) ->
     case mongoose_c2s:get_mod_state(StateData, ?MODULE) of
         {error, not_found} -> get_privacy_list(StateData);
         {ok, Handler} -> Handler
     end.
 
--spec get_privacy_list(mongoose_c2s:c2s_data()) -> mongoose_privacy:userlist().
+-spec get_privacy_list(mongoose_c2s:data()) -> mongoose_privacy:userlist().
 get_privacy_list(StateData) ->
     Jid = mongoose_c2s:get_jid(StateData),
     HostType = mongoose_c2s:get_host_type(StateData),


### PR DESCRIPTION
Simply rename the types, `mongoose_c2s:c2s_state()` contains duplicated information, we already know the type refers to c2s by its module name.