### PR TITLE
Enable global_distrib, muc, and fix stream_mgmt timeouts

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -74,7 +74,7 @@
 {suites, "tests", mongoose_cassandra_SUITE}.
 {suites, "tests", mongoose_elasticsearch_SUITE}.
 {suites, "tests", mongooseimctl_SUITE}.
-% {suites, "tests", muc_SUITE}.
+{suites, "tests", muc_SUITE}.
 {suites, "tests", muc_http_api_SUITE}.
 {suites, "tests", muc_light_SUITE}.
 {suites, "tests", muc_light_http_api_SUITE}.

--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -110,11 +110,9 @@
 {suites, "tests", websockets_SUITE}.
 {suites, "tests", xep_0352_csi_SUITE}.
 {suites, "tests", service_domain_db_SUITE}.
-{skip_cases, "tests", service_domain_db_SUITE,
- [rest_delete_domain_cleans_data_from_mam], "this test tries to use presences"}.
 {suites, "tests", domain_isolation_SUITE}.
 {suites, "tests", domain_removal_SUITE}.
-% {suites, "tests", dynamic_domains_SUITE}.
+{suites, "tests", dynamic_domains_SUITE}.
 {suites, "tests", local_iq_SUITE}.
 % {suites, "tests", tcp_listener_SUITE}.
 

--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -66,7 +66,7 @@
 {suites, "tests", mod_event_pusher_http_SUITE}.
 {suites, "tests", mod_event_pusher_rabbit_SUITE}.
 {suites, "tests", mod_event_pusher_sns_SUITE}.
-% {suites, "tests", mod_global_distrib_SUITE}.
+{suites, "tests", mod_global_distrib_SUITE}.
 {suites, "tests", mod_http_upload_SUITE}.
 {suites, "tests", mod_ping_SUITE}.
 {suites, "tests", mod_time_SUITE}.

--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -102,7 +102,7 @@
 {suites, "tests", sasl_external_SUITE}.
 {suites, "tests", service_mongoose_system_metrics_SUITE}.
 % {suites, "tests", shared_roster_SUITE}.
-% {suites, "tests", sic_SUITE}.
+{suites, "tests", sic_SUITE}.
 {suites, "tests", smart_markers_SUITE}.
 {suites, "tests", sm_SUITE}.
 {suites, "tests", vcard_SUITE}.

--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -101,7 +101,7 @@
 {suites, "tests", sasl_SUITE}.
 {suites, "tests", sasl_external_SUITE}.
 {suites, "tests", service_mongoose_system_metrics_SUITE}.
-% {suites, "tests", shared_roster_SUITE}.
+{suites, "tests", shared_roster_SUITE}.
 {suites, "tests", sic_SUITE}.
 {suites, "tests", smart_markers_SUITE}.
 {suites, "tests", sm_SUITE}.

--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -18,7 +18,7 @@
 {suites, "tests", accounts_SUITE}.
 {suites, "tests", adhoc_SUITE}.
 {suites, "tests", amp_big_SUITE}.
-% {suites, "tests", anonymous_SUITE}.
+{suites, "tests", anonymous_SUITE}.
 {suites, "tests", auth_methods_for_c2s_SUITE}.
 {suites, "tests", bosh_SUITE}.
 {suites, "tests", carboncopy_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -100,11 +100,11 @@
 
 {suites, "tests", mongooseimctl_SUITE}.
 
-% {suites, "tests", muc_SUITE}.
-% {skip_groups, "tests", muc_SUITE,
-%  [register_over_s2s],
-%  "at the moment S2S doesn't support dynamic domains "
-%  "(requires mod_register creating CT users)"}.
+{suites, "tests", muc_SUITE}.
+{skip_groups, "tests", muc_SUITE,
+ [register_over_s2s],
+ "at the moment S2S doesn't support dynamic domains "
+ "(requires mod_register creating CT users)"}.
 
 {suites, "tests", muc_http_api_SUITE}.
 

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -19,7 +19,7 @@
 
 {suites, "tests", amp_big_SUITE}.
 
-% {suites, "tests", anonymous_SUITE}.
+{suites, "tests", anonymous_SUITE}.
 
 {suites, "tests", auth_methods_for_c2s_SUITE}.
 

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -35,7 +35,7 @@
 
 {suites, "tests", domain_isolation_SUITE}.
 
-% {suites, "tests", dynamic_domains_SUITE}.
+{suites, "tests", dynamic_domains_SUITE}.
 
 {suites, "tests", extdisco_SUITE}.
 
@@ -140,8 +140,6 @@
 {suites, "tests", sasl_external_SUITE}.
 
 {suites, "tests", service_domain_db_SUITE}.
-{skip_cases, "tests", service_domain_db_SUITE,
- [rest_delete_domain_cleans_data_from_mam], "this test tries to use presences"}.
 
 {suites, "tests", service_mongoose_system_metrics_SUITE}.
 {skip_cases, "tests", service_mongoose_system_metrics_SUITE,

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -146,7 +146,7 @@
  [xmpp_components_are_reported],
  "at the moment external components doesn't support dynamic domains"}.
 
-% {suites, "tests", sic_SUITE}.
+{suites, "tests", sic_SUITE}.
 
 {suites, "tests", smart_markers_SUITE}.
 {suites, "tests", sm_SUITE}.

--- a/big_tests/tests/mim_c2s_SUITE.erl
+++ b/big_tests/tests/mim_c2s_SUITE.erl
@@ -35,6 +35,7 @@ init_per_suite(Config) ->
                         {start_ready_clients, fun ?MODULE:escalus_start/2}],
     Config1 = save_c2s_listener(Config),
     Config2 = dynamic_modules:save_modules(HostType, Config1),
+    dynamic_modules:ensure_stopped(HostType, [mod_presence]),
     Config3 = escalus_users:update_userspec(Config2, alice, connection_steps, Steps),
     Config4 = escalus_users:update_userspec(Config3, bob, connection_steps, Steps),
     configure_c2s_listener(Config4, #{backwards_compatible_session => false, max_stanza_size => 1024}),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -749,7 +749,6 @@ do_test_pm_with_ungraceful_reconnection_to_different_server(Config0, BeforeResum
 
               %% Trigger rerouting
               ok = rpc(asia_node, sys, resume, [C2sPid]),
-              C2sPid ! resume_timeout,
 
               %% Let C2sPid to process the message and reroute (and die finally, poor little thing)
               mongoose_helper:wait_for_pid_to_die(C2sPid),

--- a/big_tests/tests/presence_SUITE.erl
+++ b/big_tests/tests/presence_SUITE.erl
@@ -729,7 +729,9 @@ remove_roster(Config, UserSpec) ->
     case lists:member(mod_roster, Mods) of
         true ->
             Acc = mongoose_helper:new_mongoose_acc(Server),
-            rpc(mim(), mod_roster, remove_user, [Acc, Username, Server]);
+            Extra = #{host_type => host_type()},
+            Params = #{jid => jid:make_bare(Username, Server)},
+            rpc(mim(), mod_roster, remove_user, [Acc, Params, Extra]);
         false ->
             case lists:member(mod_roster_rdbms, Mods) of
                 true ->

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -32,7 +32,7 @@
 
 [[host_config]]
   host_type = \"anonymous\"
-  modules = { }
+  [host_config.modules.mod_presence]
 
   [host_config.auth.anonymous]
     allow_multiple_connections = true

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -40,7 +40,7 @@
 
 [[host_config]]
   host_type = \"dummy auth\"
-  modules = { }
+  [host_config.modules.mod_presence]
 
   [host_config.auth.dummy]
     base_time = 1

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -53,8 +53,8 @@
 {host_config,
   "[[host_config]]
   host_type = \"dummy auth\"
-  modules = { }
-  auth.dummy = { }"}.
+  [host_config.modules.mod_presence]
+  [host_config.auth.dummy]"}.
 
 %% Include common vars shared by all profiles
 "./vars-toml.config".

--- a/src/global_distrib/mod_global_distrib_receiver.erl
+++ b/src/global_distrib/mod_global_distrib_receiver.erl
@@ -204,7 +204,9 @@ start_listeners() ->
                      RetriesLeft :: non_neg_integer()) -> any().
 start_listener({Addr, Port} = Ref, RetriesLeft) ->
     ?LOG_INFO(#{what => gd_start_listener, address => Addr, port => Port}),
-    case ranch:start_listener(Ref, ranch_tcp, #{num_acceptors => 10, ip => Addr, port => Port}, ?MODULE, []) of
+    SocketOpts = [{ip, Addr}, {port, Port}],
+    RanchOpts = #{max_connections => infinity, num_acceptors => 10, socket_opts => SocketOpts},
+    case ranch:start_listener(Ref, ranch_tcp, RanchOpts, ?MODULE, []) of
         {ok, _} -> ok;
         {error, eaddrinuse} when RetriesLeft > 0 ->
             ?LOG_ERROR(#{what => gd_start_listener_failed, address => Addr, port => Port,

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -436,7 +436,7 @@ presence_track(Acc, FromJid, ToJid, Packet, _, <<"error">>) ->
     ejabberd_router:route(FromJid, ToJid, Acc, Packet),
     Acc;
 presence_track(Acc, FromJid, ToJid, Packet, _, <<"probe">>) ->
-    ejabberd_router:route(ToJid, FromJid, Acc, Packet),
+    ejabberd_router:route(FromJid, ToJid, Acc, Packet),
     Acc.
 
 process_presence_track_available(Acc, FromJid, ToJid, Packet, Presences) ->

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -433,7 +433,7 @@ presence_track(Acc, FromJid, ToJid, Packet, _, <<"unsubscribe">>) ->
 presence_track(Acc, FromJid, ToJid, Packet, _, <<"unsubscribed">>) ->
     process_presence_track_subscription_and_route(Acc, FromJid, ToJid, Packet, unsubscribed);
 presence_track(Acc, FromJid, ToJid, Packet, _, <<"error">>) ->
-    ejabberd_router:route(ToJid, FromJid, Acc, Packet),
+    ejabberd_router:route(FromJid, ToJid, Acc, Packet),
     Acc;
 presence_track(Acc, FromJid, ToJid, Packet, _, <<"probe">>) ->
     ejabberd_router:route(ToJid, FromJid, Acc, Packet),


### PR DESCRIPTION
Fixing global distribution, muc presence error, and stream management.

Also enable other unrelated suites that can now pass successfully.

Note that for `gen_statem`, timeouts of the type `{timeout, Time, Msg}` are considered event timeouts, and are canceled upon any event delivered before them, so they can get lost for example upon the process receiving any other routed message. So we need to name them, `{{timeout, ?MODULE}, Time, Msg}`.
