### PR TITLE
Inbox/extend messages

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -1419,7 +1419,7 @@ rpc_stop_hook_handler(HookExtra, HostType) ->
     gen_hook:delete_handler(does_user_exist, HostType, fun ?MODULE:hook_handler_fn/3, HookExtra, 1).
 
 hook_handler_fn(Acc,
-                #{args := [_HostType, User, _Stored]} = _Params,
+                #{jid := User} = _Params,
                 #{test_case_pid := Pid} = _Extra) ->
     Pid ! {input, User#jid.luser},
     {ok, Acc}.

--- a/include/mod_inbox.hrl
+++ b/include/mod_inbox.hrl
@@ -8,8 +8,11 @@
                        timestamp := integer(),
                        muted_until := integer(),
                        unread_count := integer(),
-                       box := binary()}.
+                       box := binary(),
+                       extra := [exml:element()]}.
 
 -type entry_properties() :: #{muted_until := integer(),
                               unread_count := integer(),
-                              box := binary()} | inbox_res().
+                              box := binary(),
+                              extra := [exml:element()]}
+                            | inbox_res().

--- a/src/inbox/mod_inbox_rdbms.erl
+++ b/src/inbox/mod_inbox_rdbms.erl
@@ -507,7 +507,8 @@ decode_row(HostType, {RemBareJID, MsgId, Box, Content, Timestamp, MutedUntil, Co
       msg => Parsed,
       timestamp => NumericTimestamp,
       muted_until => NumericMutedUntil,
-      unread_count => BCount}.
+      unread_count => BCount,
+      extra => []}.
 
 -spec decode_properties({_, _, _}) -> entry_properties().
 decode_properties({Box, BMutedUntil, BCount}) ->
@@ -515,7 +516,8 @@ decode_properties({Box, BMutedUntil, BCount}) ->
     MutedUntil = mongoose_rdbms:result_to_integer(BMutedUntil),
     #{box => Box,
       unread_count => Count,
-      muted_until => MutedUntil}.
+      muted_until => MutedUntil,
+      extra => []}.
 
 -spec check_result_is_expected(_, list()) -> mod_inbox:write_res().
 check_result_is_expected({updated, Val}, ValList) when is_list(ValList) ->

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -5,7 +5,6 @@
 %%% make sure they pass the expected arguments.
 -module(mongoose_hooks).
 
--include("jlib.hrl").
 -include("mod_privacy.hrl").
 -include("mongoose.hrl").
 
@@ -18,7 +17,7 @@
          filter_local_packet/1,
          filter_packet/1,
          inbox_unread_count/3,
-         extend_inbox_message/3,
+         extend_inbox_result/3,
          get_key/2,
          packet_to_component/3,
          presence_probe_hook/5,
@@ -280,12 +279,12 @@ inbox_unread_count(LServer, Acc, User) ->
     Params = #{user => User},
     run_hook_for_host_type(inbox_unread_count, LServer, Acc, Params).
 
--spec extend_inbox_message(mongoose_acc:t(), mod_inbox:inbox_res(), jlib:iq()) ->
-    [exml:element()].
-extend_inbox_message(MongooseAcc, InboxRes, IQ) ->
+-spec extend_inbox_result(mongoose_acc:t(), [mod_inbox:inbox_res()], jlib:iq()) ->
+    [mod_inbox:inbox_res()].
+extend_inbox_result(MongooseAcc, InboxResults, IQ) ->
     HostType = mongoose_acc:host_type(MongooseAcc),
-    HookParams = #{mongoose_acc => MongooseAcc, inbox_res => InboxRes, iq => IQ},
-    run_hook_for_host_type(extend_inbox_message, HostType, [], HookParams).
+    HookParams = #{mongoose_acc => MongooseAcc, iq => IQ},
+    run_hook_for_host_type(extend_inbox_result, HostType, InboxResults, HookParams).
 
 %%% @doc The `get_key' hook is called to extract a key from `mod_keystore'.
 -spec get_key(HostType, KeyName) -> Result when


### PR DESCRIPTION
It happens that handler to extend inbox entries want to fetch extra data for each entry, so if the
hook is ran per message, the handler will have to make an extra query for each message, potentially
incurring into way too many round trips to the DB. Instead, we can pass the whole buffer to the
handler, so that the handler is able to aggregate as best as possible all the entries.