### PR TITLE
Refactored handlers to follow stop convention

### DIFF
--- a/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
+++ b/big_tests/tests/acc_e2e_SUITE_data/acc_test_helper.erl
@@ -16,18 +16,17 @@ test_save_acc(#{ stanza := #{ type := <<"chat">>} } = Acc, _, _) ->
     {ok, Acc2};
 test_save_acc(Acc, _, _) -> {ok, Acc}.
 
--spec test_check_acc(Acc, Params, Extra) -> {ok, Acc} when
-    Acc :: mongoose_hooks:filter_packet_acc() | drop,
+-spec test_check_acc(Acc, Params, Extra) -> {ok, Acc} | {stop, drop} when
+    Acc :: mongoose_hooks:filter_packet_acc(),
     Params :: map(),
     Extra :: map().
 test_check_acc({F, T, #{ stanza := #{ type := <<"chat">> } } = Acc, P}, _, _) ->
-    NewAcc = try
+    try
         check_acc(Acc),
-        {F, T, Acc, P}
+        {ok, {F, T, Acc, P}}
     catch error:{badmatch, _} ->
-        drop
-    end,
-    {ok, NewAcc};
+        {stop, drop}
+    end;
 test_check_acc(Acc, _, _) ->
     {ok, Acc}.
 

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -43,11 +43,10 @@ delete_hooks(HostType) ->
 %%--------------------------------------------------------------------
 %% Hook callbacks
 %%--------------------------------------------------------------------
--type routing_data() :: {jid:jid(), jid:jid(), mongoose_acc:t(), exml:element()}.
--spec filter_local_packet(drop, _, _) -> {ok, drop};
-                         (routing_data(), _, _) -> {ok, routing_data()}.
-filter_local_packet(drop, _, _) ->
-    {ok, drop};
+-spec filter_local_packet(Acc, Args, Extra) -> {ok, Acc} when
+      Acc :: mongoose_hooks:filter_packet_acc(),
+      Args :: map(),
+      Extra :: gen_hook:extra().
 filter_local_packet({From, To, Acc0, Packet}, _, _) ->
     Acc = case chat_type(Acc0) of
               false -> Acc0;

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -279,8 +279,7 @@ inbox_unread_count(Acc, #{user := User}, _) ->
     NewAcc = get_inbox_unread(Res, Acc, User),
     {ok, NewAcc}.
 
--spec filter_local_packet(drop, _, _) -> {ok, drop};
-                         (FPacketAcc, Params, Extra) -> {ok, FPacketAcc} when
+-spec filter_local_packet(FPacketAcc, Params, Extra) -> {ok, FPacketAcc} when
       FPacketAcc :: mongoose_hooks:filter_packet_acc(),
       Params :: map(),
       Extra :: gen_hook:extra().

--- a/src/mam/mod_mam_pm.erl
+++ b/src/mam/mod_mam_pm.erl
@@ -189,13 +189,10 @@ user_send_packet(Acc, _, _) ->
 %%
 %% Return drop to drop the packet, or the original input to let it through.
 %% From and To are jid records.
--spec filter_packet(drop, _, _) -> {ok, drop};
-                   (FPacketAcc, Params, Extra) -> {ok, FPacketAcc} when
+-spec filter_packet(FPacketAcc, Params, Extra) -> {ok, FPacketAcc} when
       FPacketAcc :: mongoose_hooks:filter_packet_acc(),
       Params :: map(),
       Extra :: gen_hook:extra().
-filter_packet(drop, _, _) ->
-    {ok, drop};
 filter_packet({From, To, Acc1, Packet}, _, _) ->
     ?LOG_DEBUG(#{what => mam_user_receive_packet, acc => Acc1}),
     HostType = mongoose_acc:host_type(Acc1),

--- a/src/smart_markers/mod_smart_markers.erl
+++ b/src/smart_markers/mod_smart_markers.erl
@@ -226,16 +226,15 @@ user_send_packet(Acc, From, To, Packet = #xmlel{name = <<"message">>}) ->
 user_send_packet(Acc, _From, _To, _Packet) ->
     Acc.
 
--spec filter_local_packet(Acc, Params, Extra) -> {ok, Acc} when
-      Acc :: mongoose_hooks:filter_packet_acc() | drop,
+-spec filter_local_packet(Acc, Params, Extra) -> {ok, Acc} | {stop, drop} when
+      Acc :: mongoose_hooks:filter_packet_acc(),
       Params :: map(),
       Extra :: gen_hook:extra().
 filter_local_packet(Filter = {_From, _To, _Acc, Msg = #xmlel{name = <<"message">>}}, _, _) ->
-    NewFilter = case mongoose_chat_markers:has_chat_markers(Msg) of
-        false -> Filter;
-        true -> drop
-    end,
-    {ok, NewFilter};
+    case mongoose_chat_markers:has_chat_markers(Msg) of
+        false -> {ok, Filter};
+        true -> {stop, drop}
+    end;
 filter_local_packet(Filter, _, _) ->
     {ok, Filter}.
 


### PR DESCRIPTION
All handlers use return value `{stop, Acc}` to interrupt further processing. In `filter_local_packet` I couldn't remove `drop` as a result Acc since code which launch this hook has logic depending on it.