### PR TITLE
Simplify filter_room_packet

### DIFF
--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -151,9 +151,9 @@ disco_muc_features(Acc, _Params, _Extra) ->
 %% @doc Handle public MUC-message.
 -spec filter_room_packet(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: exml:element(),
-    Params :: map(),
+    Params :: mod_muc:room_event_data(),
     Extra :: gen_hook:extra().
-filter_room_packet(Packet, #{event_data := #{} = EventData}, #{host_type := HostType}) ->
+filter_room_packet(Packet, EventData, #{host_type := HostType}) ->
     ?LOG_DEBUG(#{what => mam_room_packet, text => <<"Incoming room packet">>,
                  packet => Packet, event_data => EventData}),
     IsArchivable = is_archivable_message(HostType, incoming, Packet),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -1390,8 +1390,7 @@ amp_verify_support(HostType, Rules) ->
     EventData :: mod_muc:room_event_data(),
     Result :: exml:element().
 filter_room_packet(HostType, Packet, EventData) ->
-    Params = #{packet => Packet, event_data => EventData},
-    run_hook_for_host_type(filter_room_packet, HostType, Packet, Params).
+    run_hook_for_host_type(filter_room_packet, HostType, Packet, EventData).
 
 %%% @doc The `forget_room' hook is called when a room is removed from the database.
 -spec forget_room(HostType, MucHost, Room) -> Result when


### PR DESCRIPTION
This handler is (in open-source) used only by `mod_mam_muc`, which only looks at the `event_data` key, so we can instead pass such event data as the hook params, it is a map that already contains all that is needed.