### PR TITLE
Check push form fields

### DIFF
--- a/big_tests/tests/push_SUITE.erl
+++ b/big_tests/tests/push_SUITE.erl
@@ -263,6 +263,12 @@ enable_should_fail_with_invalid_attributes(Config) ->
             escalus:send(Bob, enable_stanza(PubsubJID, <<>>)),
             escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
                            escalus:wait_for_stanza(Bob)),
+
+            %% Missing value
+            escalus:send(Bob, enable_stanza(PubsubJID, <<"nodeId">>,
+                                            [{<<"secret1">>, undefined}])),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
+                           escalus:wait_for_stanza(Bob)),
             ok
         end).
 

--- a/big_tests/tests/push_helper.erl
+++ b/big_tests/tests/push_helper.erl
@@ -60,6 +60,8 @@ make_form(Fields) ->
     #xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, ?NS_XDATA}, {<<"type">>, <<"submit">>}],
            children = [make_form_field(Name, Value) || {Name, Value} <- Fields]}.
 
+make_form_field(Name, undefined) ->
+    #xmlel{name = <<"field">>, attrs = [{<<"var">>, Name}]};
 make_form_field(Name, Value) ->
     #xmlel{name = <<"field">>,
            attrs = [{<<"var">>, Name}],


### PR DESCRIPTION
When the push notification node is enabled with an invalid form (especially with missing keys or values), it could still be saved to the DB. Afterwards, sending a push notification either resulted in `undefined` values being sent (RDBMS) or the a crash (Mnesia). This PR fixes this issue by more strict checking of the form values and rejecting invalid forms.

This PR resolves the most likely cause of https://github.com/esl/MongooseIM/issues/3806