### PR TITLE
C2S/fix muc_light_legacy tests

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -78,7 +78,7 @@
 {suites, "tests", muc_http_api_SUITE}.
 {suites, "tests", muc_light_SUITE}.
 {suites, "tests", muc_light_http_api_SUITE}.
-% {suites, "tests", muc_light_legacy_SUITE}.
+{suites, "tests", muc_light_legacy_SUITE}.
 {suites, "tests", oauth_SUITE}.
 {suites, "tests", offline_SUITE}.
 {suites, "tests", offline_stub_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -110,7 +110,7 @@
 
 {suites, "tests", muc_light_SUITE}.
 
-% {suites, "tests", muc_light_legacy_SUITE}.
+{suites, "tests", muc_light_legacy_SUITE}.
 
 {suites, "tests", muc_light_http_api_SUITE}.
 

--- a/big_tests/tests/muc_light_legacy_SUITE.erl
+++ b/big_tests/tests/muc_light_legacy_SUITE.erl
@@ -92,7 +92,7 @@ all() ->
     ].
 
 groups() ->
-    G = [
+    [
          {entity, [sequence], [
                                disco_service,
                                disco_features,
@@ -131,8 +131,7 @@ groups() ->
                                  block_user,
                                  blocking_disabled
                                 ]}
-        ],
-    ct_helper:repeat_all_until_all_ok(G).
+    ].
 
 suite() ->
     escalus:suite().
@@ -603,7 +602,8 @@ user_leave(User, RemainingOccupants) ->
 
 -spec stanza_blocking_get() -> xmlel().
 stanza_blocking_get() ->
-    escalus_stanza:privacy_get_lists([?NS_MUC_LIGHT]).
+    escalus_stanza:to(
+      escalus_stanza:privacy_get_lists([?NS_MUC_LIGHT]), ?MUCHOST).
 
 -spec stanza_config_get(Room :: binary()) -> xmlel().
 stanza_config_get(Room) ->
@@ -622,7 +622,8 @@ stanza_aff_get(Room) ->
 -spec stanza_blocking_set(BlocklistChanges :: [ct_block_item()]) -> xmlel().
 stanza_blocking_set(BlocklistChanges) ->
     Items = [ encode_privacy_item(What, Action, Who) || {What, Action, Who} <- BlocklistChanges ],
-    escalus_stanza:privacy_set_list(escalus_stanza:privacy_list(?NS_MUC_LIGHT, Items)).
+    Stanza = escalus_stanza:privacy_set_list(escalus_stanza:privacy_list(?NS_MUC_LIGHT, Items)),
+    escalus_stanza:to(Stanza, ?MUCHOST).
 
 encode_privacy_item(What, Action, Who) ->
     Value = case What of

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -285,9 +285,9 @@ encode_meta({set, #affiliations{} = Affs, OldAffUsers, NewAffUsers},
     bcast_aff_messages(RoomJID, OldAffUsers, NewAffUsers, SenderJID,
                        Affs#affiliations.aff_users, HandleFun),
     {iq_reply, Affs#affiliations.id};
-encode_meta({get, #blocking{} = Blocking}, SenderBareJID, _SenderJID, _HandleFun, Acc) ->
+encode_meta({get, #blocking{} = Blocking}, RoomJID, _SenderJID, _HandleFun, Acc) ->
     HostType = mod_muc_light_utils:acc_to_host_type(Acc),
-    ServerHost = SenderBareJID#jid.lserver,
+    ServerHost = mod_muc_light_utils:room_jid_to_server_host(RoomJID),
     MUCHost = mongoose_subdomain_utils:get_fqdn(mod_muc_light:subdomain_pattern(HostType), ServerHost),
     BlockingEls = [ blocking_to_el(BlockingItem, MUCHost)
                     || BlockingItem <- Blocking#blocking.items ],


### PR DESCRIPTION
The goal is to make `muc_light_legacy_SUITE` pass with the new `mongoose_c2s`.

The new c2s implementation requires proper addressing of the stanzas, so the tests are amended according to https://esl.github.io/MongooseDocs/latest/open-extensions/muc_light/#451-requesting-a-blocking-list

There is also a small fix in the code.

