### PR TITLE
C2S/Enable pep_SUITE

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -82,7 +82,7 @@
 {suites, "tests", oauth_SUITE}.
 {suites, "tests", offline_SUITE}.
 {suites, "tests", offline_stub_SUITE}.
-% {suites, "tests", pep_SUITE}.
+{suites, "tests", pep_SUITE}.
 {suites, "tests", persistent_cluster_id_SUITE}.
 {suites, "tests", presence_SUITE}.
 {suites, "tests", privacy_SUITE}.

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -325,9 +325,9 @@ upsert_caps(LFrom, Caps, Rs) ->
 
 -spec get_pep_recipients(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: [jid:simple_jid()],
-    Params :: #{c2s_data := mongoose_c2s:data(), type := {atom(), binary()}},
+    Params :: #{c2s_data := mongoose_c2s:data(), feature := binary()},
     Extra :: map().
-get_pep_recipients(InAcc, #{state := C2SData, feature := Feature}, _) ->
+get_pep_recipients(InAcc, #{c2s_data := C2SData, feature := Feature}, _) ->
     HostType = mongoose_c2s:get_host_type(C2SData),
     NewAcc = case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
                  {ok, Rs} ->
@@ -350,9 +350,9 @@ filter_recipients_by_caps(HostType, InAcc, Feature, Rs) ->
 
 -spec filter_pep_recipient(Acc, Params, Extra) -> {ok | stop, Acc} when
       Acc :: boolean(),
-      Params :: #{state := ejabberd_c2s:state(), feature := binary(), to := jid:jid()},
+      Params :: #{c2s_data := mongoose_c2s:data(), feature := binary(), to := jid:jid()},
       Extra :: gen_hook:extra().
-filter_pep_recipient(InAcc, #{state := C2SData, feature := Feature, to := To}, _) ->
+filter_pep_recipient(InAcc, #{c2s_data := C2SData, feature := Feature, to := To}, _) ->
     case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
         {ok, Rs} ->
             ?LOG_DEBUG(#{what => caps_lookup, text => <<"Look for CAPS for To jid">>,
@@ -367,8 +367,7 @@ filter_pep_recipient(InAcc, #{state := C2SData, feature := Feature, to := To}, _
                     {stop, true}
             end;
         _ -> {ok, InAcc}
-    end;
-filter_pep_recipient(Acc, _, _) -> {ok, Acc}.
+    end.
 
 init_db(mnesia) ->
     case catch mnesia:table_info(caps_features, storage_type) of

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -456,23 +456,23 @@ xmpp_stanza_dropped(Acc, From, To, Packet) ->
 
 %% C2S related hooks
 
--spec get_pep_recipients(State, Feature) -> Result when
-    State :: mongoose_c2s:data(),
+-spec get_pep_recipients(C2SData, Feature) -> Result when
+    C2SData :: mongoose_c2s:data(),
     Feature :: binary(),
     Result :: [jid:simple_jid()].
-get_pep_recipients(State, Feature) ->
-    Params = #{state => State, feature => Feature},
-    HostType = mongoose_c2s:get_host_type(State),
+get_pep_recipients(C2SData, Feature) ->
+    Params = #{c2s_data => C2SData, feature => Feature},
+    HostType = mongoose_c2s:get_host_type(C2SData),
     run_hook_for_host_type(get_pep_recipients, HostType, [], Params).
 
--spec filter_pep_recipient(State, Feature, To) -> Result when
-    State :: ejabberd_c2s:state(),
+-spec filter_pep_recipient(C2SData, Feature, To) -> Result when
+    C2SData :: mongoose_c2s:data(),
     Feature :: binary(),
     To :: jid:jid(),
     Result :: boolean().
-filter_pep_recipient(State, Feature, To) ->
-    Params = #{state => State, feature => Feature, to => To},
-    HostType = mongoose_c2s:get_host_type(State),
+filter_pep_recipient(C2SData, Feature, To) ->
+    Params = #{c2s_data => C2SData, feature => Feature, to => To},
+    HostType = mongoose_c2s:get_host_type(C2SData),
     run_hook_for_host_type(filter_pep_recipient, HostType, true, Params).
 
 -spec c2s_stream_features(HostType, LServer) -> Result when

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -37,7 +37,8 @@
          xmpp_send_element/3,
          xmpp_stanza_dropped/4]).
 
--export([c2s_broadcast_recipients/4,
+-export([get_pep_recipients/2,
+         filter_pep_recipient/3,
          c2s_stream_features/2,
          check_bl_c2s/1,
          forbidden_session_hook/3,
@@ -455,16 +456,24 @@ xmpp_stanza_dropped(Acc, From, To, Packet) ->
 
 %% C2S related hooks
 
--spec c2s_broadcast_recipients(State, Type, From, Packet) -> Result when
+-spec get_pep_recipients(State, Feature) -> Result when
     State :: mongoose_c2s:data(),
-    Type :: {atom(), any()},
-    From :: jid:jid(),
-    Packet :: exml:element(),
+    Feature :: binary(),
     Result :: [jid:simple_jid()].
-c2s_broadcast_recipients(State, Type, From, Packet) ->
-    Params = #{state => State, type => Type, from => From, packet => Packet},
+get_pep_recipients(State, Feature) ->
+    Params = #{state => State, feature => Feature},
     HostType = mongoose_c2s:get_host_type(State),
-    run_hook_for_host_type(c2s_broadcast_recipients, HostType, [], Params).
+    run_hook_for_host_type(get_pep_recipients, HostType, [], Params).
+
+-spec filter_pep_recipient(State, Feature, To) -> Result when
+    State :: ejabberd_c2s:state(),
+    Feature :: binary(),
+    To :: jid:jid(),
+    Result :: boolean().
+filter_pep_recipient(State, Feature, To) ->
+    Params = #{state => State, feature => Feature, to => To},
+    HostType = mongoose_c2s:get_host_type(State),
+    run_hook_for_host_type(filter_pep_recipient, HostType, true, Params).
 
 -spec c2s_stream_features(HostType, LServer) -> Result when
     HostType :: mongooseim:host_type(),

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -77,7 +77,7 @@
          disco_sm_features/3,
          disco_sm_items/3,
          handle_pep_authorization_response/3,
-         handle_remote_hook/3]).
+         foreign_event/3]).
 
 %% exported iq handlers
 -export([iq_sm/4]).
@@ -471,7 +471,7 @@ pep_hooks(ServerHost) ->
      {disco_sm_features, ServerHost, fun ?MODULE:disco_sm_features/3, #{}, 75},
      {disco_sm_items, ServerHost, fun ?MODULE:disco_sm_items/3, #{}, 75},
      {filter_local_packet, ServerHost, fun ?MODULE:handle_pep_authorization_response/3, #{}, 1},
-     {c2s_remote_hook, ServerHost, fun ?MODULE:handle_remote_hook/3, #{}, 100}
+     {foreign_event, ServerHost, fun ?MODULE:foreign_event/3, #{}, 100}
     ].
 
 add_pep_iq_handlers(ServerHost, #{iqdisc := IQDisc}) ->
@@ -541,8 +541,8 @@ notify_worker(HostType, HashKey, Request) ->
 
 handle_msg({send_last_pubsub_items, Host, Recipient, Plugins}) ->
     send_last_pubsub_items(Host, Recipient, Plugins);
-handle_msg({send_last_pep_items, Host, IgnorePepFromOffline, RecipientJID, RecipientPid}) ->
-    send_last_pep_items(Host, IgnorePepFromOffline, RecipientJID, RecipientPid);
+handle_msg({send_last_pep_items, Host, IgnorePepFromOffline, RecipientJID, RecipientPid, Features}) ->
+    send_last_pep_items(Host, IgnorePepFromOffline, RecipientJID, RecipientPid, Features);
 handle_msg({send_last_items_from_owner, Host, NodeOwner, RecipientInfo}) ->
     send_last_items_from_owner(Host, NodeOwner, RecipientInfo).
 
@@ -559,28 +559,39 @@ send_last_pubsub_items_for_plugin(Host, PluginType, Recipient) ->
       end,
       lists:usort(Subs)).
 
-send_last_pep_items(Host, IgnorePepFromOffline, RecipientJID, RecipientPid) ->
+send_last_pep_items(Host, IgnorePepFromOffline, RecipientJID, RecipientPid, Features) ->
     RecipientLJID = jid:to_lower(RecipientJID),
-    [send_last_item_to_jid(NodeOwnerJID, Node, RecipientLJID) ||
+    [send_last_item_to_jid(NodeOwnerJID, NodeRec, RecipientLJID) ||
         NodeOwnerJID <- get_contacts_for_sending_last_item(RecipientPid, IgnorePepFromOffline),
-        Node <- get_nodes_for_sending_last_item(Host, NodeOwnerJID)],
+        NodeRec = #pubsub_node{nodeid = {_, Node}} <- get_nodes_for_sending_last_item(Host, NodeOwnerJID),
+        lists:member(<<Node/binary, "+notify">>, Features)],
     ok.
 
 get_contacts_for_sending_last_item(RecipientPid, IgnorePepFromOffline) ->
-    case catch ejabberd_c2s:get_subscribed(RecipientPid) of
+    case catch mod_presence:get_subscribed(RecipientPid) of
         Contacts when is_list(Contacts) ->
-            [jid:make(Contact) ||
-                Contact = {U, S, _R} <- Contacts,
-                user_resources(U, S) /= [] orelse not IgnorePepFromOffline];
+            [Contact || Contact = #jid{luser = U, lserver = S} <- Contacts,
+                        user_resources(U, S) /= [] orelse not IgnorePepFromOffline];
         _ ->
             []
     end.
 
 send_last_items_from_owner(Host, NodeOwner, _Recipient = {U, S, Resources}) ->
-    [send_last_item_to_jid(NodeOwner, Node, {U, S, R}) ||
-        Node <- get_nodes_for_sending_last_item(Host, NodeOwner),
-        R <- Resources],
+    [send_last_item_to_jid(NodeOwner, NodeRec, {U, S, R}) ||
+        NodeRec = #pubsub_node{nodeid = {_, Node}} <- get_nodes_for_sending_last_item(Host, NodeOwner),
+        R <- Resources,
+        not should_drop_pep_message(Node, jid:make(U, S, R))
+    ],
     ok.
+
+should_drop_pep_message(Node, RecipientJid) ->
+    case ejabberd_sm:get_session_pid(RecipientJid) of
+        none -> true;
+        Pid ->
+            try gen_statem:call(Pid, {filter_pep_recipient, RecipientJid, <<Node/binary, "+notify">>}, 5000)
+            catch exit:timeout -> true
+            end
+    end.
 
 get_nodes_for_sending_last_item(Host, NodeOwnerJID) ->
     lists:filter(fun(#pubsub_node{options = Options}) ->
@@ -793,23 +804,24 @@ handle_pep_authorization_response(_, _, From, To, Acc, Packet) ->
     {From, To, Acc, Packet}.
 
 %% -------
-%% callback for remote hook calls, to distribute pep messages from the node owner c2s process
+%% callback for foreign_event calls, to distribute pep messages from the node owner c2s process
 %%
--spec handle_remote_hook(Acc, Params, Extra) -> {ok, Acc} when
-    Acc :: term(),
-    Params :: #{tag := atom(), hook_args := term(), c2s_state := ejabberd_c2s:state()},
-    Extra :: gen_hook:extra().
-handle_remote_hook(HandlerState,
-                   #{tag := pep_message, hook_args := {Feature, From, Packet}, c2s_state := C2SState},
-                   _) ->
-    Recipients = mongoose_hooks:c2s_broadcast_recipients(C2SState,
-                                                         {pep_message, Feature},
-                                                         From, Packet),
-    lists:foreach(fun(USR) -> ejabberd_router:route(From, jid:make(USR), Packet) end,
-                  lists:usort(Recipients)),
-    {ok, HandlerState};
-handle_remote_hook(HandlerState, _, _) ->
-    {ok, HandlerState}.
+-spec foreign_event(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
+      mongoose_c2s_hooks:result().
+foreign_event(Acc, #{c2s_data := StateData,
+                     event_type := {call, From},
+                     event_content := {get_pep_recipients, Feature}}, _Extra) ->
+    Reply = mongoose_hooks:get_pep_recipients(StateData, Feature),
+    Acc1 = mongoose_c2s_acc:to_acc(Acc, actions, [{reply, From, Reply}]),
+    {stop, Acc1};
+foreign_event(Acc, #{c2s_data := StateData,
+                     event_type := {call, From},
+                     event_content := {filter_pep_recipient, To, Feature}}, _Extra) ->
+    Reply = mongoose_hooks:filter_pep_recipient(StateData, Feature, To),
+    Acc1 = mongoose_c2s_acc:to_acc(Acc, actions, [{reply, From, Reply}]),
+    {stop, Acc1};
+foreign_event(Acc, _Params, _Extra) ->
+    {ok, Acc}.
 
 %% -------
 %% presence hooks handling functions
@@ -817,12 +829,12 @@ handle_remote_hook(HandlerState, _, _) ->
 
 -spec caps_recognised(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_acc:t(),
-    Params :: #{from := jid:jid(), pid := pid()},
+    Params :: #{from := jid:jid(), pid := pid(), features := [binary()]},
     Extra :: gen_hook:extra().
-caps_recognised(Acc, #{from := #jid{ luser = U, lserver = S } = JID, pid := Pid}, _) ->
+caps_recognised(Acc, #{from := #jid{ luser = U, lserver = S } = JID, pid := Pid, features := Features}, _) ->
     Host = host(S, S),
     IgnorePepFromOffline = gen_mod:get_module_opt(S, ?MODULE, ignore_pep_from_offline),
-    notify_worker(S, U, {send_last_pep_items, Host, IgnorePepFromOffline, JID, Pid}),
+    notify_worker(S, U, {send_last_pep_items, Host, IgnorePepFromOffline, JID, Pid, Features}),
     {ok, Acc}.
 
 -spec presence_probe(Acc, Params, Extra) -> {ok, Acc} when
@@ -858,7 +870,8 @@ out_subscription(Acc,
                      _ -> [PResource]
                  end,
     Host = host(LServer, LServer),
-    notify_worker(LServer, LUser, {send_last_items_from_owner, Host, FromJID, {PUser, PServer, PResources}}),
+    notify_worker(LServer, LUser, {send_last_items_from_owner, Host, FromJID,
+                                   {PUser, PServer, PResources}}),
     {ok, Acc};
 out_subscription(Acc, _, _) ->
     {ok, Acc}.
@@ -883,7 +896,8 @@ unsubscribe_user(Entity, Owner) ->
                                             false -> Acc
                                         end
                                 end, [], [Entity#jid.lserver, Owner#jid.lserver])),
-    spawn(fun() -> [unsubscribe_user(ServerHost, Entity, Owner) || ServerHost <- ServerHosts] end).
+    [unsubscribe_user(ServerHost, Entity, Owner) || ServerHost <- ServerHosts],
+    ok.
 
 unsubscribe_user(Host, Entity, Owner) ->
     BJID = jid:to_lower(jid:to_bare(Owner)),
@@ -2698,36 +2712,26 @@ send_items(Host, Node, Nidx, Type, Options, LJID, last) ->
             ok;
         LastItem ->
             Stanza = items_event_stanza(Node, [LastItem]),
-            dispatch_items(Host, LJID, Node, Options, Stanza)
+            dispatch_items(Host, LJID, Options, Stanza)
     end;
 send_items(Host, Node, Nidx, Type, Options, LJID, Number) when Number > 0 ->
     Stanza = items_event_stanza(Node, get_last_items(Host, Type, Nidx, Number, LJID)),
-    dispatch_items(Host, LJID, Node, Options, Stanza);
+    dispatch_items(Host, LJID, Options, Stanza);
 send_items(Host, Node, _Nidx, _Type, Options, LJID, _) ->
     Stanza = items_event_stanza(Node, []),
-    dispatch_items(Host, LJID, Node, Options, Stanza).
+    dispatch_items(Host, LJID, Options, Stanza).
 
-dispatch_items({FromU, FromS, FromR} = From, {ToU, ToS, ToR} = To, Node,
-               Options, Stanza) ->
-    C2SPid = case ejabberd_sm:get_session_pid(jid:make(ToU, ToS, ToR)) of
-                 ToPid when is_pid(ToPid) -> ToPid;
-                 _ ->
-                     R = user_resource(FromU, FromS, FromR),
-                     case ejabberd_sm:get_session_pid(jid:make(FromU, FromS, R)) of
-                         FromPid when is_pid(FromPid) -> FromPid;
-                         _ -> undefined
-                     end
-             end,
-    case C2SPid of
-        undefined ->
-            ok;
-        _ ->
-            NotificationType = get_option(Options, notification_type, headline),
-            Message = add_message_type(Stanza, NotificationType),
-            ejabberd_c2s:send_filtered(C2SPid, {pep_message, <<Node/binary, "+notify">>},
-                                       service_jid(From), jid:make(To), Message)
-    end;
-dispatch_items(From, To, _Node, Options, Stanza) ->
+dispatch_items({_, FromS, _} = From, To, Options, Stanza) ->
+    NotificationType = get_option(Options, notification_type, headline),
+    Message = add_message_type(Stanza, NotificationType),
+    {ok, HostType} = mongoose_domain_api:get_domain_host_type(FromS),
+    FromJid = jid:make(From),
+    ToJid = jid:make(To),
+    AccParams = #{host_type => HostType, lserver => FromS, location => ?LOCATION,
+                  element => Message, from_jid => FromJid, to_jid => ToJid},
+    Acc = mongoose_acc:new(AccParams),
+    ejabberd_router:route(FromJid, ToJid, Acc);
+dispatch_items(From, To, Options, Stanza) ->
     NotificationType = get_option(Options, notification_type, headline),
     Message = add_message_type(Stanza, NotificationType),
     ejabberd_router:route(service_jid(From), jid:make(To), Message).
@@ -3365,7 +3369,7 @@ get_resource_state({U, S, R}, ShowValues, JIDs) ->
             %% If no PID, item can be delivered
             lists:append([{U, S, R}], JIDs);
         Pid ->
-            Show = case ejabberd_c2s:get_presence(Pid) of
+            Show = case mod_presence:get_presence(Pid) of
                        {_, _, <<"available">>, _} -> <<"online">>;
                        {_, _, State, _} -> State
                    end,
@@ -3644,13 +3648,13 @@ broadcast_stanza({LUser, LServer, LResource}, Publisher, Node, Nidx, Type, NodeO
             %% Also, add "replyto" if entity has presence subscription to the account owner
             %% See XEP-0163 1.1 section 4.3.1
             ReplyTo = extended_headers([jid:to_binary(Publisher)]),
-            ejabberd_c2s:run_remote_hook(C2SPid,
-                                         pep_message,
-                                         {<<((Node))/binary, "+notify">>,
-                                           jid:make_bare(LUser, LServer),
-                                           add_extended_headers(Stanza, ReplyTo)});
+            Feature = <<((Node))/binary, "+notify">>,
+            Recipients = gen_statem:call(C2SPid, {get_pep_recipients, Feature}, 5000),
+            Packet = add_extended_headers(Stanza, ReplyTo),
+            From = jid:make_bare(LUser, LServer),
+            lists:foreach(fun(USR) -> ejabberd_router:route(From, jid:make(USR), Packet) end,
+                          lists:usort(Recipients));
         _ ->
-
             ?LOG_DEBUG(#{what => pubsub_no_session,
                 text => <<"User has no session; cannot deliver stanza to contacts">>,
                 user => LUser, server => LServer, exml_packet => BaseStanza})


### PR DESCRIPTION
The goal is to enable PEP tests for `mongoose_c2s`. This required implementing missing parts of pubsub and caps, that were present directly in the legacy `c2s` implementation.

Functional changes:
- PubSub is now using `foreign_event` and `gen_statem:call` to call the functionality that requires c2s state data. The PEP-related function are still implemented as hooks, because `mod_caps` shouldn't be called directly from another module. As little as possible is delegated to the c2s processes.
- Added timeouts to `gen_statem` calls, because they were deadlock traps.

Test changes:
- PEP Tests don't use `timer:sleep` and shouldn't fail randomly anymore. Some functionality is fixed, and remaining race conditions are handled explicitly.
- Tests were performed with a repetition of 100 times to make sure that they are not flaky anymore.

Left for the future - out of scope for now:
- Adding an API to `mongoose_c2s` to prevent calling `gen_statem` with infinite timeout.
- Elimination of `gen_statem` calls in favor of requests. Alternatively, `mod_caps` could use mnesia table, even the session one, because the cached caps are propagated with presences, which makes them often inconsistent, and causes race conditions and unexpected behaviour (described in tests).
- Possible usage of presence subscriptions in conjunction with filtering in the recipient's process to avoid checking the caps entirely.
- Further optimizations of event sending to prevent the risk of duplication.

Follow-up stories can be groomed.


