### PR TITLE
Updating mysql schema

### DIFF
--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -367,7 +367,7 @@ CREATE TABLE muc_rooms(
 );
 
 CREATE TABLE muc_room_aff(
-    room_id BIGINT          NOT NULL REFERENCES muc_rooms(id),
+    room_id BIGINT UNSIGNED NOT NULL REFERENCES muc_rooms(id),
     luser VARCHAR(250)      NOT NULL,
     lserver VARCHAR(250)    NOT NULL,
     resource VARCHAR(250)   NOT NULL,


### PR DESCRIPTION
Adding UNSIGNED to the type of a room_id in muc_room_aff table to match the type in muc_rooms table. It is required in MariaDB version 10.5 to ensure the proper creation of a database.