### PR TITLE
C2s/Do not route broadcast tuples

### DIFF
--- a/src/c2s/mongoose_c2s_hooks.erl
+++ b/src/c2s/mongoose_c2s_hooks.erl
@@ -5,6 +5,7 @@
 -type params() :: #{c2s_data := mongoose_c2s:data(),
                     c2s_state := mongoose_c2s:state(),
                     event_type := undefined | gen_statem:event_type(),
+                    event_tag => atom(),
                     event_content := undefined | term(),
                     reason := undefined | term()}.
 -type result() :: gen_hook:hook_fn_ret(mongoose_acc:t()).

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -51,7 +51,6 @@
          get_full_session_list/0,
          register_iq_handler/3,
          unregister_iq_handler/2,
-         force_update_presence/2,
          user_resources/2,
          get_session_pid/1,
          get_session/1,
@@ -81,7 +80,7 @@
 -export([do_filter/3]).
 -export([do_route/4]).
 
--ignore_xref([do_filter/3, do_route/4, force_update_presence/2, get_unique_sessions_number/0,
+-ignore_xref([do_filter/3, do_route/4, get_unique_sessions_number/0,
               get_user_present_pids/2, start_link/0, user_resources/2, sm_backend/0]).
 
 -include("mongoose.hrl").
@@ -950,14 +949,6 @@ process_iq(#iq{xmlns = XMLNS} = IQ, From, To, Acc, Packet) ->
 process_iq(_, From, To, Acc, Packet) ->
     {Acc1, Err} = jlib:make_error_reply(Acc, Packet, mongoose_xmpp_errors:bad_request()),
    ejabberd_router:route(To, From, Acc1, Err).
-
-
--spec force_update_presence(mongooseim:host_type(), {jid:luser(), jid:lserver()}) -> 'ok'.
-force_update_presence(_HostType, {LUser, LServer}) ->
-    Ss = ejabberd_sm_backend:get_sessions(LUser, LServer),
-    lists:foreach(fun(#session{sid = {_, Pid}}) ->
-                          Pid ! {force_update_presence, LUser}
-                  end, Ss).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% ejabberd commands

--- a/src/metrics/mongoose_metrics_hooks.erl
+++ b/src/metrics/mongoose_metrics_hooks.erl
@@ -58,7 +58,7 @@ get_hooks(HostType) ->
       {privacy_iq_get, HostType, fun ?MODULE:privacy_iq_get/3, #{}, 1},
       {privacy_iq_set, HostType, fun ?MODULE:privacy_iq_set/3, #{}, 1},
       {privacy_check_packet, HostType, fun ?MODULE:privacy_check_packet/3, #{}, 55},
-      {sm_broadcast, HostType, fun ?MODULE:privacy_list_push/3, #{}, 1}
+      {privacy_list_push, HostType, fun ?MODULE:privacy_list_push/3, #{}, 1}
       | c2s_hooks(HostType)].
 
 -spec c2s_hooks(mongooseim:host_type()) -> gen_hook:hook_list(mongoose_c2s_hooks:fn()).
@@ -265,7 +265,7 @@ privacy_iq_set(Acc, #{iq := #iq{sub_el = SubEl}}, #{host_type := HostType}) ->
     {ok, Acc}.
 
 -spec privacy_list_push(Acc, Params, Extra) -> {ok, Acc} when
-      Acc :: mongoose_acc:t(),
+      Acc :: any(),
       Params :: #{session_count := non_neg_integer()},
       Extra :: #{host_type := mongooseim:host_type()}.
 privacy_list_push(Acc, #{session_count := SessionCount}, #{host_type := HostType}) ->

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -521,9 +521,9 @@ push_item(HostType, JID, From, Item) ->
 
 -spec broadcast_item(jid:jid(), jid:simple_jid(), subscription_state()) -> ok.
 broadcast_item(#jid{luser = LUser, lserver = LServer}, ContactJid, Subscription) ->
-    Broadcast = {broadcast, {item, ContactJid, Subscription}},
+    Item = {item, ContactJid, Subscription},
     UserPids = ejabberd_sm:get_user_present_pids(LUser, LServer),
-    lists:foreach(fun({_, Pid}) -> Pid ! Broadcast end, UserPids).
+    lists:foreach(fun({_, Pid}) -> mongoose_c2s:cast(Pid, ?MODULE, Item) end, UserPids).
 
 push_item_without_version(HostType, JID, Resource, From, Item) ->
     mongoose_hooks:roster_push(HostType, From, Item),

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -50,7 +50,8 @@
          set_items/3,
          set_roster_entry/5,
          remove_from_roster/3,
-         item_to_xml/1
+         item_to_xml/1,
+         broadcast_item/3
         ]).
 
 % Hook handlers
@@ -507,8 +508,7 @@ process_item_els(Item, [{xmlcdata, _} | Els]) ->
 process_item_els(Item, []) -> Item.
 
 push_item(HostType, JID, From, Item) ->
-    ejabberd_sm:route(jid:make_noprep(<<>>, <<>>, <<>>), JID,
-                      {broadcast, {item, Item#roster.jid, Item#roster.subscription}}),
+    broadcast_item(JID, Item#roster.jid, Item#roster.subscription),
     case roster_versioning_enabled(HostType) of
         true ->
             push_item_version(JID, From, Item, roster_version(HostType, JID));
@@ -518,6 +518,12 @@ push_item(HostType, JID, From, Item) ->
                           end,
                           ejabberd_sm:get_user_resources(JID))
     end.
+
+-spec broadcast_item(jid:jid(), jid:simple_jid(), subscription_state()) -> ok.
+broadcast_item(#jid{luser = LUser, lserver = LServer}, ContactJid, Subscription) ->
+    Broadcast = {broadcast, {item, ContactJid, Subscription}},
+    UserPids = ejabberd_sm:get_user_present_pids(LUser, LServer),
+    lists:foreach(fun({_, Pid}) -> Pid ! Broadcast end, UserPids).
 
 push_item_without_version(HostType, JID, Resource, From, Item) ->
     mongoose_hooks:roster_push(HostType, From, Item),

--- a/src/mongoose_hooks.erl
+++ b/src/mongoose_hooks.erl
@@ -48,12 +48,12 @@
          privacy_get_user_list/2,
          privacy_iq_get/6,
          privacy_iq_set/5,
-         privacy_updated_list/3]).
+         privacy_updated_list/3,
+         privacy_list_push/5]).
 
 -export([offline_groupchat_message_hook/4,
          offline_message_hook/4,
          set_presence_hook/3,
-         sm_broadcast/5,
          sm_filter_offline_message/4,
          sm_register_connection_hook/4,
          sm_remove_connection_hook/5,
@@ -564,6 +564,17 @@ privacy_updated_list(HostType, OldList, NewList) ->
     Params = #{old_list => OldList, new_list => NewList},
     run_hook_for_host_type(privacy_updated_list, HostType, false, Params).
 
+-spec privacy_list_push(HostType, LUser, LServer, Item, SessionCount) -> Result when
+    HostType :: mongooseim:host_type(),
+    LUser :: jid:luser(),
+    LServer :: jid:lserver(),
+    Item :: term(),
+    SessionCount :: non_neg_integer(),
+    Result :: any().
+privacy_list_push(HostType, LUser, LServer, Item, SessionCount) ->
+    Params = #{luse => LUser, lserver => LServer, item => Item, session_count => SessionCount},
+    run_hook_for_host_type(privacy_list_push, HostType, ok, Params).
+
 %% Session management related hooks
 
 -spec offline_groupchat_message_hook(Acc, From, To, Packet) -> Result when
@@ -597,18 +608,6 @@ set_presence_hook(Acc, JID, Presence) ->
     Params = #{jid => JID, presence => Presence},
     HostType = mongoose_acc:host_type(Acc),
     run_hook_for_host_type(set_presence_hook, HostType, Acc, Params).
-
--spec sm_broadcast(Acc, From, To, Broadcast, SessionCount) -> Result when
-    Acc :: mongoose_acc:t(),
-    From :: jid:jid(),
-    To :: jid:jid(),
-    Broadcast :: ejabberd_c2s:broadcast(),
-    SessionCount :: non_neg_integer(),
-    Result :: mongoose_acc:t().
-sm_broadcast(Acc, From, To, Broadcast, SessionCount) ->
-    Params = #{from => From, to => To, broadcast => Broadcast, session_count => SessionCount},
-    HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(sm_broadcast, HostType, Acc, Params).
 
 -spec sm_filter_offline_message(HostType, From, To, Packet) -> Result when
     HostType :: mongooseim:host_type(),

--- a/src/privacy/mod_blocking.erl
+++ b/src/privacy/mod_blocking.erl
@@ -221,9 +221,9 @@ complete_iq_set(blocking_command, Acc, _, _, {error, Reason}) ->
 complete_iq_set(blocking_command, Acc, LUser, LServer, {ok, Changed, List, Type}) ->
     UserList = #userlist{name = <<"blocking">>, list = List, needdb = false},
     % send the list to all users c2s processes (resources) to make it effective immediately
-    Acc1 = broadcast_blocking_command(Acc, LUser, LServer, UserList, Changed, Type),
+    broadcast_blocking_command(Acc, LUser, LServer, UserList, Changed, Type),
     % return a response here so that c2s sets the list in its state
-    {Acc1, {result, [], UserList}}.
+    {Acc, {result, [], UserList}}.
 %%complete_iq_set(blocking_command, _, _, _) ->
 %%    {result, []}.
 
@@ -297,9 +297,11 @@ make_blocking_list_entry(J) ->
 broadcast_blocking_command(Acc, LUser, LServer, UserList, _Changed, unblock_all) ->
     broadcast_blocking_command(Acc, LUser, LServer, UserList, [], unblock);
 broadcast_blocking_command(Acc, LUser, LServer, UserList, Changed, Type) ->
-    UserJID = jid:make_noprep(LUser, LServer, <<>>),
-    Bcast = {blocking, UserList, Type, Changed},
-    ejabberd_sm:route(UserJID, UserJID, Acc, {broadcast, Bcast}).
+    Item = {blocking, UserList, Type, Changed},
+    UserPids = ejabberd_sm:get_user_present_pids(LUser, LServer),
+    HostType = mongoose_acc:host_type(Acc),
+    mongoose_hooks:privacy_list_push(HostType, LUser, LServer, Item, length(UserPids)),
+    lists:foreach(fun({_, Pid}) -> Pid ! {broadcast, Item} end, UserPids).
 
 -spec blocking_query_response([mod_privacy:list_name()]) -> exml:element().
 blocking_query_response(Lst) ->


### PR DESCRIPTION
The special `{broadcast, _}` tuples were routed in `ejabberd_sm`, as if they were XMPP stanzas. This introduced confusion and made the code awkward, while not providing clear benefits. Some arguments, like `From`, were made up to fit the `route` function signature. Additionally, the `sm_broadcast` hook was misused by `mongoose_metrics` - it triggered update of a metric that was presence-specific.

Additionally, to avoid more and more expressions like `C2SPid ! SomeTuple` and `gen_statem:call(C2sPid, SomeTuple)`, API functions for `call` and `cast` are added to `mongoose_c2s`.

The API function have `EventTag :: atom()` as the second argument. The tag is then passed to the `foreign_event` handler. This is to encourage and unify consistent naming of foreign events. The tag is a not mandatory hook arg, because some other events (e.g. timeouts) have their own naming (e.g. `{timeout, ?MODULE}`).
