### PR TITLE
Use more granular c2s hooks

### DIFF
--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -22,7 +22,7 @@
 
 -export([add_hooks/1, delete_hooks/1]).
 
--export([user_send_packet/3,
+-export([user_send_message/3,
          filter_local_packet/3,
          user_present/3,
          user_not_present/3,
@@ -54,9 +54,9 @@ filter_local_packet({From, To, Acc0, Packet}, _, _) ->
           end,
     {ok, {From, To, Acc, Packet}}.
 
--spec user_send_packet(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
+-spec user_send_message(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
     mongoose_c2s_hooks:result().
-user_send_packet(Acc, _, _) ->
+user_send_message(Acc, _, _) ->
     Packet = mongoose_acc:packet(Acc),
     ChatType = chat_type(Acc),
     ResultAcc = if
@@ -132,6 +132,6 @@ hooks(HostType) ->
         {filter_local_packet, HostType, fun ?MODULE:filter_local_packet/3, #{}, 80},
         {unset_presence_hook, HostType, fun ?MODULE:user_not_present/3, #{}, 90},
         {user_available_hook, HostType, fun ?MODULE:user_present/3, #{}, 90},
-        {user_send_packet, HostType, fun ?MODULE:user_send_packet/3, #{}, 90},
+        {user_send_message, HostType, fun ?MODULE:user_send_message/3, #{}, 90},
         {unacknowledged_message, HostType, fun ?MODULE:unacknowledged_message/3, #{}, 90}
     ].

--- a/src/mam/mod_mam_pm.erl
+++ b/src/mam/mod_mam_pm.erl
@@ -480,7 +480,7 @@ should_archive_if_groupchat(_, _) ->
 %% Only store messages sent to yourself in user_send_packet.
 should_archive_if_sent_to_yourself(LocJID, RemJID, incoming) ->
     not jid:are_bare_equal(LocJID, RemJID);
-should_archive_if_sent_to_yourself(LocJID, RemJID, _Dir) ->
+should_archive_if_sent_to_yourself(_LocJID, _RemJID, _Dir) ->
     true.
 
 -spec return_external_message_id_if_ok(ReturnMessID :: boolean(),

--- a/src/mam/mod_mam_pm.erl
+++ b/src/mam/mod_mam_pm.erl
@@ -47,7 +47,7 @@
 
 %% hook handlers
 -export([disco_local_features/3,
-         user_send_packet/3,
+         user_send_message/3,
          filter_packet/3,
          remove_user/3,
          determine_amp_strategy/3,
@@ -172,13 +172,13 @@ disco_local_features(Acc, _, _) ->
 %%
 %% Note: for outgoing messages, the server MUST use the value of the 'to'
 %%       attribute as the target JID.
--spec user_send_packet(Acc, Args, Extra) -> {ok, Acc} when
+-spec user_send_message(Acc, Args, Extra) -> {ok, Acc} when
        Acc :: mongoose_acc:t(),
        Args :: map(),
        Extra :: gen_hook:extra().
-user_send_packet(Acc, _, _) ->
+user_send_message(Acc, _, _) ->
     {From, To, Packet} = mongoose_acc:packet(Acc),
-    ?LOG_DEBUG(#{what => mam_user_send_packet, acc => Acc}),
+    ?LOG_DEBUG(#{what => mam_user_send_message, acc => Acc}),
     {_, Acc2} = handle_package(outgoing, true, From, To, From, Packet, Acc),
     {ok, Acc2}.
 
@@ -477,7 +477,7 @@ should_archive_if_groupchat(HostType, <<"groupchat">>) ->
 should_archive_if_groupchat(_, _) ->
     true.
 
-%% Only store messages sent to yourself in user_send_packet.
+%% Only store messages sent to yourself in user_send_message.
 should_archive_if_sent_to_yourself(LocJID, RemJID, incoming) ->
     not jid:are_bare_equal(LocJID, RemJID);
 should_archive_if_sent_to_yourself(_LocJID, _RemJID, _Dir) ->
@@ -670,7 +670,7 @@ is_archivable_message(HostType, Dir, Packet) ->
 hooks(HostType) ->
     [
         {disco_local_features, HostType, fun ?MODULE:disco_local_features/3, #{}, 99},
-        {user_send_packet, HostType, fun ?MODULE:user_send_packet/3, #{}, 60},
+        {user_send_message, HostType, fun ?MODULE:user_send_message/3, #{}, 60},
         {filter_local_packet, HostType, fun ?MODULE:filter_packet/3, #{}, 60},
         {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
         {anonymous_purge_hook, HostType, fun ?MODULE:remove_user/3, #{}, 50},


### PR DESCRIPTION
This PR changes the hooks used in the `mod_event_pusher` and `mod_mam` to more granular ones.