### PR TITLE
Fix type issues discovered by the extended dialyzer checks

### DIFF
--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -301,7 +301,7 @@ handle_socket_error(StateData = #c2s_data{host_type = HostType, lserver = LServe
 %% These conditions required that one and only one handler declared full control over it,
 %% by making the hook stop at that point. If so, the process remains alive,
 %% in control of the handler, otherwise, the condition is treated as terminal.
--spec stop_if_unhandled(data(), state(), gen_hook:hook_fn_res(mongoose_acc:t()), atom()) -> fsm_res().
+-spec stop_if_unhandled(data(), state(), gen_hook:hook_fn_ret(mongoose_acc:t()), atom()) -> fsm_res().
 stop_if_unhandled(StateData, C2SState, {stop, Acc}, _) ->
     handle_state_after_packet(StateData, C2SState, Acc);
 stop_if_unhandled(_, _, {ok, _Acc}, Reason) ->
@@ -678,7 +678,7 @@ handle_c2s_packet(StateData = #c2s_data{host_type = HostType}, C2SState, El) ->
     end.
 
 %% @doc Process packets sent by the user (coming from user on c2s XMPP connection)
--spec handle_stanza_from_client(data(), mongoose_c2s_hooks:hook_params(), mongoose_acc:t(), binary()) ->
+-spec handle_stanza_from_client(data(), mongoose_c2s_hooks:params(), mongoose_acc:t(), binary()) ->
     mongoose_acc:t().
 handle_stanza_from_client(#c2s_data{host_type = HostType}, HookParams, Acc, <<"message">>) ->
     TS0 = mongoose_acc:timestamp(Acc),
@@ -742,7 +742,7 @@ maybe_send_element(_, {stop, Acc}) ->
     Acc.
 
 %% @doc Process packets sent to the user (coming to user on c2s XMPP connection)
--spec process_stanza_to_client(data(), mongoose_c2s_hooks:hook_params(), mongoose_acc:t(), binary()) ->
+-spec process_stanza_to_client(data(), mongoose_c2s_hooks:params(), mongoose_acc:t(), binary()) ->
     mongoose_c2s_hooks:result().
 process_stanza_to_client(#c2s_data{host_type = HostType}, Params, Acc, <<"message">>) ->
     mongoose_c2s_hooks:user_receive_message(HostType, Acc, Params);
@@ -958,7 +958,7 @@ generate_random_resource() ->
     <<(mongoose_bin:gen_from_timestamp())/binary, "-", (mongoose_bin:gen_from_crypto())/binary>>.
 
 -spec hook_arg(data(), state(), terminate | gen_statem:event_type(), term(), term()) ->
-    mongoose_c2s_hooks:hook_params().
+    mongoose_c2s_hooks:params().
 hook_arg(StateData, C2SState, EventType, #{event_tag := EventTag,
                                            event_content := EventContent}, Reason) ->
     #{c2s_data => StateData, c2s_state => C2SState,

--- a/src/c2s/mongoose_c2s_hooks.erl
+++ b/src/c2s/mongoose_c2s_hooks.erl
@@ -1,7 +1,7 @@
 %% @doc This module builds an interface to c2s event handling
 -module(mongoose_c2s_hooks).
 
--type fn() :: fun((mongoose_acc:t(), params(), gen_hook:hook_extra()) -> result()).
+-type fn() :: fun((mongoose_acc:t(), params(), gen_hook:extra()) -> result()).
 -type params() :: #{c2s_data := mongoose_c2s:data(),
                     c2s_state := mongoose_c2s:state(),
                     event_type := undefined | gen_statem:event_type(),

--- a/src/gen_hook.erl
+++ b/src/gen_hook.erl
@@ -59,6 +59,7 @@
 
 -export_type([hook_fn/0,
               hook_list/0,
+              hook_list/1,
               hook_fn_ret/0,
               hook_fn_ret/1,
               hook_tuple/0,

--- a/src/metrics/mongoose_metrics_hooks.erl
+++ b/src/metrics/mongoose_metrics_hooks.erl
@@ -93,7 +93,7 @@ auth_failed(Acc, #{server := Server}, _) ->
     mongoose_metrics:update(HostType, sessionAuthFails, 1),
     {ok, Acc}.
 
--spec user_send_packet(mongoose_acc:t(), mongoose_c2s:hook_params(), map()) ->
+-spec user_send_packet(mongoose_acc:t(), mongoose_c2s_hooks:params(), map()) ->
     mongoose_c2s_hooks:result().
 user_send_packet(Acc, _Params, #{host_type := HostType}) ->
     mongoose_metrics:update(HostType, xmppStanzaSent, 1),
@@ -168,7 +168,7 @@ xmpp_send_element_type(HostType, #xmlel{name = <<"iq">>}) ->
 xmpp_send_element_type(HostType, #xmlel{name = <<"presence">>}) ->
     mongoose_metrics:update(HostType, xmppPresenceReceived, 1).
 
--spec user_open_session(mongoose_acc:t(), mongoose_c2s:hook_params(), map()) ->
+-spec user_open_session(mongoose_acc:t(), mongoose_c2s_hooks:params(), map()) ->
     mongoose_c2s_hooks:result().
 user_open_session(Acc, _Params, #{host_type := HostType}) ->
     mongoose_metrics:update(HostType, xmppStanzaSent, 1),

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -252,7 +252,7 @@ remove_domain(Acc, #{domain := Domain}, #{host_type := HostType}) ->
     mod_last_backend:remove_domain(HostType, Domain),
     {ok, Acc}.
 
--spec user_receive_iq(mongoose_acc:t(), mongoose_c2s:hook_params(), gen_hook:extra()) ->
+-spec user_receive_iq(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
     mongoose_c2s_hooks:result().
 user_receive_iq(Acc, _Params, _Extra) ->
     case mongoose_iq:info(Acc) of

--- a/src/privacy/mod_blocking.erl
+++ b/src/privacy/mod_blocking.erl
@@ -57,7 +57,7 @@ c2s_hooks(HostType) ->
      {foreign_event, HostType, fun ?MODULE:foreign_event/3, #{}, 50}
     ].
 
--spec user_send_iq(mongoose_acc:t(), mongoose_c2s:hook_params(), map()) ->
+-spec user_send_iq(mongoose_acc:t(), mongoose_c2s_hooks:params(), map()) ->
     mongoose_c2s_hooks:result().
 user_send_iq(Acc, #{c2s_data := StateData}, #{host_type := HostType}) ->
     case mongoose_iq:info(Acc) of

--- a/src/sasl/cyrsasl.erl
+++ b/src/sasl/cyrsasl.erl
@@ -55,7 +55,7 @@
                      | {continue, binary(), sasl_state()}
                      | error().
 
--export_type([sasl_module/0, mechanism/0, error/0, sasl_result/0]).
+-export_type([sasl_module/0, mechanism/0, error/0, sasl_result/0, sasl_state/0]).
 
 -callback mechanism() -> mechanism().
 


### PR DESCRIPTION
After merging feature/mongoose_c2s the new code was checked with the `{warnings, [unknown]}` option, and the check started failing.

The `gen_hook:extra` type should be used instead of `gen_hook:hook_extra`, because the handler function gets the extended `extra`.