### PR TITLE
Fix push_integration_SUITE

### DIFF
--- a/big_tests/tests/push_helper.erl
+++ b/big_tests/tests/push_helper.erl
@@ -75,6 +75,7 @@ become_available(Client, NumberOfUnreadMessages) ->
     become_available(Client, NumberOfUnreadMessages, 5000).
 
 become_available(Client, NumberOfUnreadMessages, Timeout) ->
+    mongoose_helper:wait_for_n_offline_messages(Client, NumberOfUnreadMessages),
     escalus:send(Client, escalus_stanza:presence(<<"available">>)),
     Preds = [ is_presence | lists:duplicate(NumberOfUnreadMessages, is_message) ],
     Stanzas = escalus:wait_for_stanzas(Client, NumberOfUnreadMessages + 1, Timeout),


### PR DESCRIPTION
There was a race condition which sometimes occurred in push_integration_SUITE:pubsub_less:pm_notifications_with_inbox:inbox_msg_reset_unread_count_fcm.
It looked like this:
- Bob sends presence „unavailable”
- Alice sends first message
- Alice sends second message
- First message is saved in mod_offline
- Bob sends presence „available” -> this triggers mod_pressence:resend_offline_messages/2
- Second message is saved in mod_offline -> this one is not resent
- We check for incoming messages and expect two of them
- Second message does not come -> timeout