### PR TITLE
Disable parallel test in inbox_extensions_SUITE

### DIFF
--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -102,7 +102,7 @@ groups() ->
         timestamp_is_not_reset_with_setting_properties,
         {group, pagination}
       ]},
-     {pagination, [parallel], [
+     {pagination, [], [
         pagination_error_conditions,
         pagination_overrides_form,
         can_paginate_forwards,

--- a/big_tests/tests/smart_markers_SUITE.erl
+++ b/big_tests/tests/smart_markers_SUITE.erl
@@ -28,8 +28,11 @@ all_cases() ->
     ].
 
 groups() ->
+    inbox_helper:maybe_run_in_parallel(groups1()) ++ groups2().
+
+groups1() ->
     [
-     {one2one, [parallel],
+     {one2one, [],
       [
        error_set_iq,
        error_bad_peer,
@@ -43,18 +46,22 @@ groups() ->
        remove_markers_when_removed_user,
        repeated_markers_produce_no_warnings
       ]},
-     {muclight, [parallel],
+     {muclight, [],
       [
        marker_is_stored_for_room,
        marker_can_be_fetched_for_room,
        marker_is_removed_when_user_leaves_room,
        markers_are_removed_when_room_is_removed
       ]},
-     {keep_private, [parallel],
+     {keep_private, [],
       [
        marker_is_not_routed_nor_fetchable,
        fetching_room_answers_only_own_marker
-      ]},
+      ]}
+    ].
+
+groups2() ->
+    [
      {regular, [],
       [
        {group, one2one},


### PR DESCRIPTION
**Disable parallel test in inbox_extensions_SUITE** to avoid eodbc timeouts. For ODBC preset. It **does not** change settings of other presents.

It disables parallel for this group, idk why it was not parallel.

Be aware, there is this call `inbox_helper:maybe_run_in_parallel` ANYWAY, so all tests are running in parallel on mysql/pgsql.

ODBC layer is just too slow to handle the load, and it was known before.

Same with smart_markers_SUITE, because we have [timeouts](https://circleci-mim-results.s3.eu-central-1.amazonaws.com/PR/3964/166348/odbc_mssql_mnesia.25.2/big/ct_run.test%40ee67b42a4a3e.2023-02-17_13.16.50/big_tests.tests.smart_markers_SUITE.logs/run.2023-02-17_13.31.13/smart_markers_suite.repeated_markers_produce_no_warnings.133251.html)