### PR TITLE
 Fix typo in doc [iOS tutorial]

### DIFF
--- a/doc/tutorials/iOS_tutorial.md
+++ b/doc/tutorials/iOS_tutorial.md
@@ -120,7 +120,7 @@ Every time you want to send a message to someone (a JID), you will have to send 
 <message from='andres@erlang-solutions.com/iphone' to='juana@erlang-solutions.com' type='chat'>
     <body>Hey there!</body>
 </message>
- ```
+```
  
 ### `<iq/>`
 


### PR DESCRIPTION
There is incorrect markdown parsing issue in the iOS tutorial page https://esl.github.io/MongooseDocs/latest/tutorials/iOS_tutorial/. I deleted the space that can lead to the issue.

![изображение](https://user-images.githubusercontent.com/3222305/219848107-f6936c31-15b1-41c0-ae0a-fa81a529a9ef.png)
