### PR TITLE
Add retry logic into mongooseim task aggregator

### DIFF
--- a/src/async_pools/mongoose_aggregator_worker.erl
+++ b/src/async_pools/mongoose_aggregator_worker.erl
@@ -104,9 +104,9 @@ handle_info(Msg, #state{async_request = {AsyncRequest, ReqTask}} = State) ->
     case check_response(Msg, AsyncRequest, ReqTask, State) of
         ignore ->
             {noreply, State};
-         next ->
+        next ->
             {noreply, maybe_request_next(State)};
-         retry ->
+        retry ->
             {noreply, maybe_request_retry(ReqTask, State)}
      end.
 

--- a/src/async_pools/mongoose_aggregator_worker.erl
+++ b/src/async_pools/mongoose_aggregator_worker.erl
@@ -121,7 +121,7 @@ maybe_request_retry(ReqTask, State = #state{retries_left = Left}) ->
             State2
     end.
 
-cancel_request_retry(State = #state{total_retries = Retries}) ->
+cancel_request_retry(State) ->
     maybe_request_next(State#state{async_request = no_request_pending}).
 
 check_response(Msg, AsyncRequest, ReqTask, State) ->

--- a/src/inbox/mod_inbox_rdbms_async.erl
+++ b/src/inbox/mod_inbox_rdbms_async.erl
@@ -97,13 +97,14 @@ request_one(HostType, {remove_inbox_row, {LUser, LServer, LToBareJid}}) ->
 aggregate(Current, NewTask, _Extra) ->
     {ok, aggregate(Current, NewTask)}.
 
--spec verify(term(), task(), mongoose_async_pools:pool_extra()) -> ok.
+-spec verify(term(), task(), mongoose_async_pools:pool_extra()) -> ok | {error, term()}.
 verify(Answer, InboxTask, _Extra) ->
     case mod_inbox_rdbms:check_result(Answer) of
         {error, Reason} ->
             {LU, LS, LRem} = element(2, InboxTask),
             ?LOG_WARNING(#{what => inbox_process_message_failed, reason => Reason,
-                           from_jid => jid:to_binary({LU, LS}), to_jid => LRem});
+                           from_jid => jid:to_binary({LU, LS}), to_jid => LRem}),
+            {error, Reason};
         _ -> ok
     end.
 


### PR DESCRIPTION
This PR addresses "Failing inbox tests on mssql". A part of MIM-1823 ticket.

Proposed changes include:
*  Retry logic and a test