### PR TITLE
Fix announcing session establishment feature

### DIFF
--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -451,7 +451,7 @@ stream_start_features_before_auth(#c2s_data{host_type = HostType, lserver = LSer
 stream_start_features_after_auth(#c2s_data{host_type = HostType, lserver = LServer,
                                            lang = Lang, listener_opts = LOpts} = S) ->
     send_header(S, LServer, <<"1.0">>, Lang),
-    StreamFeatures = mongoose_c2s_stanzas:stream_features_after_auth(HostType, LServer),
+    StreamFeatures = mongoose_c2s_stanzas:stream_features_after_auth(HostType, LServer, LOpts),
     send_element_from_server_jid(S, StreamFeatures),
     {next_state, {wait_for_feature_after_auth, ?BIND_RETRIES}, S, state_timeout(LOpts)}.
 

--- a/src/c2s/mongoose_c2s_stanzas.erl
+++ b/src/c2s/mongoose_c2s_stanzas.erl
@@ -7,7 +7,7 @@
          stream_header/4,
          stream_features_before_auth/4,
          tls_proceed/0,
-         stream_features_after_auth/2,
+         stream_features_after_auth/3,
          sasl_success_stanza/1,
          sasl_failure_stanza/1,
          sasl_challenge_stanza/1,
@@ -87,9 +87,17 @@ tls_proceed() ->
     #xmlel{name = <<"proceed">>,
            attrs = [{<<"xmlns">>, ?NS_TLS}]}.
 
--spec stream_features_after_auth(mongooseim:host_type(), jid:lserver()) -> exml:element().
-stream_features_after_auth(HostType, LServer) ->
+-spec stream_features_after_auth(mongooseim:host_type(), jid:lserver(), mongoose_listener:options()) ->
+    exml:element().
+stream_features_after_auth(HostType, LServer, #{backwards_compatible_session := false}) ->
     Features = [#xmlel{name = <<"bind">>,
+                       attrs = [{<<"xmlns">>, ?NS_BIND}]}
+                | hook_enabled_features(HostType, LServer)],
+    stream_features(Features);
+stream_features_after_auth(HostType, LServer, #{backwards_compatible_session := true}) ->
+    Features = [#xmlel{name = <<"session">>,
+                       attrs = [{<<"xmlns">>, ?NS_SESSION}]},
+                #xmlel{name = <<"bind">>,
                        attrs = [{<<"xmlns">>, ?NS_BIND}]}
                 | hook_enabled_features(HostType, LServer)],
     stream_features(Features).


### PR DESCRIPTION
An XMPP client won't try the old session establishment step if it doesn't see it announced in the server features, even when the server is strictly waiting for it, so this would deadlock all connections.