### PR TITLE
Fix minor c2s issues

### DIFF
--- a/big_tests/tests/presence_SUITE.erl
+++ b/big_tests/tests/presence_SUITE.erl
@@ -17,6 +17,7 @@
 -module(presence_SUITE).
 -compile([export_all, nowarn_export_all]).
 
+-include_lib("exml/include/exml.hrl").
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("common_test/include/ct.hrl").
 
@@ -41,6 +42,7 @@ all() ->
 
 groups() ->
     [{presence, [parallel], [available,
+                             explicit_available,
                              available_direct,
                              available_direct_then_unavailable,
                              available_direct_then_disconnect,
@@ -125,12 +127,18 @@ end_rosters_remove(Config) ->
 %%--------------------------------------------------------------------
 
 available(Config) ->
+    Presence = escalus_stanza:presence(<<"available">>),
+    run_send_available_presence(Config, Presence).
+
+explicit_available(Config) ->
+    Presence = #xmlel{name = <<"presence">>, attrs = [{<<"type">>, <<"available">>}]},
+    run_send_available_presence(Config, Presence).
+
+run_send_available_presence(Config, Presence) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-
-        escalus:send(Alice, escalus_stanza:presence(<<"available">>)),
+        escalus:send(Alice, Presence),
         escalus:assert(is_presence, escalus:wait_for_stanza(Alice))
-
-        end).
+    end).
 
 available_direct(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->

--- a/src/logger/mongoose_log_filter.erl
+++ b/src/logger/mongoose_log_filter.erl
@@ -28,10 +28,10 @@ fill_metadata_filter(Event=#{msg := {report, Msg}, meta := Meta}, Fields) ->
 fill_metadata_filter(Event, _) ->
     Event.
 
-format_c2s_state_filter(Event=#{msg := {report, Msg=#{c2s_state := State}}}, _) ->
-    StateMap = filter_undefined(c2s_state_to_map(State)),
+format_c2s_state_filter(Event=#{msg := {report, Msg=#{c2s_data := State}}}, _) ->
+    StateMap = filter_undefined(c2s_data_to_map(State)),
     %% C2S fields have lower priority, if the field is already present in msg.
-    Msg2 = maps:merge(StateMap, maps:remove(c2s_state, Msg)),
+    Msg2 = maps:merge(StateMap, maps:remove(c2s_data, Msg)),
     Event#{msg => {report, Msg2}};
 format_c2s_state_filter(Event, _) ->
     Event.
@@ -103,7 +103,7 @@ remove_fields_filter(Event, _) ->
     Event.
 
 
-c2s_state_to_map(State) ->
+c2s_data_to_map(State) ->
     SocketMap = format_socket(mongoose_c2s:get_socket(State)),
     Jid = mongoose_c2s:get_jid(State),
     SocketMap#{

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -348,7 +348,8 @@ handle_received_available(Acc, Presences) ->
 -spec presence_update(
         mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:data(), undefined | binary()) ->
     mongoose_acc:t().
-presence_update(Acc, FromJid, ToJid, Packet, StateData, undefined) ->
+presence_update(Acc, FromJid, ToJid, Packet, StateData, Available)
+  when Available =:= undefined; Available =:= <<"available">> ->
     Presences = maybe_get_handler(StateData),
     presence_update_to_available(Acc, FromJid, ToJid, Packet, StateData, Presences);
 presence_update(Acc, FromJid, ToJid, Packet, StateData, <<"unavailable">>) ->


### PR DESCRIPTION
Accept presence of type 'available', even if this doesn't seem correct from the RFC perspective, I have seen client code sending such presence.

Also fix the key c2s_state->c2s_data in the logger filters.