### PR TITLE
Restart execute in transactions

### DIFF
--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -95,7 +95,7 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_testcase(test_incremental_upsert, Config) ->
-    sql_query(Config, <<"TRUNCATE TABLE inbox">>),
+    erase_inbox(Config),
     escalus:init_per_testcase(test_incremental_upsert, Config);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
@@ -106,7 +106,7 @@ end_per_testcase(CaseName, Config)
     rpc(mim(), meck, unload, []),
     escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(test_incremental_upsert, Config) ->
-    sql_query(Config, <<"TRUNCATE TABLE inbox">>),
+    erase_inbox(Config),
     escalus:end_per_testcase(test_incremental_upsert, Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
@@ -568,11 +568,14 @@ decode_boolean(_Config, Value) ->
     escalus_ejabberd:rpc(mongoose_rdbms, to_bool, [Value]).
 
 erase_table(Config) ->
-    sql_query(Config, <<"TRUNCATE TABLE test_types">>).
+    {updated, _} = sql_query(Config, <<"DELETE FROM test_types">>).
 
 erase_users(Config) ->
-    sql_query(Config, <<"TRUNCATE TABLE users">>),
-    sql_query(Config, <<"TRUNCATE TABLE last">>).
+    {updated, _} = sql_query(Config, <<"DELETE FROM users">>),
+    {updated, _} = sql_query(Config, <<"DELETE FROM last">>).
+
+erase_inbox(Config) ->
+    {updated, _} = sql_query(Config, <<"DELETE FROM inbox">>).
 
 check_int32(Config, Value) ->
     check_generic_integer(Config, Value, <<"int32">>).

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -689,7 +689,7 @@ outer_op({sql_transaction, F}, State) ->
 outer_op({sql_dirty, F}, State) ->
     sql_dirty_internal(F, State);
 outer_op({sql_execute, Name, Params}, State) ->
-    sql_execute(Name, Params, State).
+    sql_execute(outer_op, Name, Params, State).
 
 %% @doc Called via sql_query/transaction/bloc from client code when inside a
 %% nested operation
@@ -703,7 +703,7 @@ nested_op({sql_transaction, F}, State) ->
     %% Transaction inside a transaction
     inner_transaction(F, State);
 nested_op({sql_execute, Name, Params}, State) ->
-    sql_execute(Name, Params, State).
+    sql_execute(nested_op, Name, Params, State).
 
 %% @doc Never retry nested transactions - only outer transactions
 -spec inner_transaction(fun(), state()) -> transaction_result() | {'EXIT', any()}.
@@ -792,8 +792,9 @@ sql_dirty_internal(F, State) ->
     end,
     {Result, erase_state()}.
 
--spec sql_execute(Name :: atom(), Params :: [term()], state()) -> {query_result(), state()}.
-sql_execute(Name, Params, State = #state{db_ref = DBRef, query_timeout = QueryTimeout}) ->
+-spec sql_execute(Type :: atom(), Name :: atom(), Params :: [term()], state()) ->
+    {query_result(), state()}.
+sql_execute(Type, Name, Params, State = #state{db_ref = DBRef, query_timeout = QueryTimeout}) ->
     {StatementRef, NewState} = prepare_statement(Name, State),
     Res = try mongoose_rdbms_backend:execute(DBRef, StatementRef, Params, QueryTimeout)
           catch Class:Reason:StackTrace ->
@@ -802,7 +803,26 @@ sql_execute(Name, Params, State = #state{db_ref = DBRef, query_timeout = QueryTi
                 stacktrace => StackTrace}),
             erlang:raise(Class, Reason, StackTrace)
           end,
+    check_execute_result(Type, Res, Name, Params),
     {Res, NewState}.
+
+%% Similar check as in sql_query_t
+check_execute_result(outer_op, _Res, _Name, _Params) ->
+    ok;
+check_execute_result(nested_op, Res, Name, Params) ->
+    case Res of
+        {error, Reason} ->
+            throw({aborted, #{reason => Reason, statement_name => Name, params => Params}});
+        _ when is_list(Res) ->
+            case lists:keysearch(error, 1, Res) of
+                {value, {error, Reason}} ->
+                    throw({aborted, #{reason => Reason, statement_name => Name, params => Params}});
+                _ ->
+                    ok
+            end;
+        _ ->
+            ok
+    end.
 
 -spec prepare_statement(Name :: atom(), state()) -> {Ref :: term(), state()}.
 prepare_statement(Name, State = #state{db_ref = DBRef, prepared = Prepared}) ->

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -795,7 +795,9 @@ sql_dirty_internal(F, State) ->
 -spec sql_execute(Type :: atom(), Name :: atom(), Params :: [term()], state()) ->
     {query_result(), state()}.
 sql_execute(Type, Name, Params, State = #state{db_ref = DBRef, query_timeout = QueryTimeout}) ->
+    %% Postgres allows to prepare statement only once, so we should take care that NewState is updated
     {StatementRef, NewState} = prepare_statement(Name, State),
+    put_state(NewState),
     Res = try mongoose_rdbms_backend:execute(DBRef, StatementRef, Params, QueryTimeout)
           catch Class:Reason:StackTrace ->
             ?LOG_ERROR(#{what => rdbms_sql_execute_failed, statement_name => Name,

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -812,17 +812,11 @@ sql_execute(Type, Name, Params, State = #state{db_ref = DBRef, query_timeout = Q
 check_execute_result(outer_op, _Res, _Name, _Params) ->
     ok;
 check_execute_result(nested_op, Res, Name, Params) ->
+    %% Res is not a list (i.e. executes are one query only and one result set only)
     case Res of
         {error, Reason} ->
             throw({aborted, #{reason => Reason, statement_name => Name, params => Params}});
-        _ when is_list(Res) ->
-            case lists:keysearch(error, 1, Res) of
-                {value, {error, Reason}} ->
-                    throw({aborted, #{reason => Reason, statement_name => Name, params => Params}});
-                _ ->
-                    ok
-            end;
-        _ ->
+        _ when is_tuple(Res) ->
             ok
     end.
 


### PR DESCRIPTION
This PR addresses MIM-1823

Proposed changes include:
* Restarts execute call in transactions


fixed :

Test works locally.
On CI we have:

`
4986 when=2023-02-26T18:43:52.383188+00:00 level=error what=rdbms_outer_transaction_failed reason="{badmatch,{error,{error,error,<<\"42P05\">>,duplicate_prepared_statement,<<\"prepared statement \\\"insert_int8\\\" already exists\">>,[{file,<<\"prepare.c\">>},{line,<<\"412\">>},{routine,<<\"StorePreparedStatement\">>},{severity,<<\"ERROR\">>}]}}}" pid=<0.1943.3> at=mongoose_rdbms:apply_transaction_function/1:770 stacktrace="mongoose_rdbms:prepare_statement/2:831 mongoose_rdbms:sql_execute/4:797 mongoose_rdbms:sql_call/2:345 mongoose_rdbms:apply_transaction_function/1:765 mongoose_rdbms:outer_transaction/4:728 mongoose_rdbms:handle_call/3:622 wpool_process:handle_call/3:225 gen_server:try_handle_call/4:721" 
`