### PR TITLE
Define more granular overriding between inbox form and rms

### DIFF
--- a/doc/open-extensions/inbox.md
+++ b/doc/open-extensions/inbox.md
@@ -148,7 +148,10 @@ It can happen that the amount of inbox entries is too big for a given user, even
 ```
 where `Max` is a non-negative integer.
 
-Inbox also has partial support for pagination as described in [XEP-0059](https://xmpp.org/extensions/xep-0059.html). If specifying `before` or `after`, the `start` and `end` form fields will be overridden. However, inbox pagination does not support total count nor indexes as described in [XEP-0059: #2.6 Retrieving a Page Out of Order](https://xmpp.org/extensions/xep-0059.html#jump).
+Inbox also has partial support for pagination as described in [XEP-0059](https://xmpp.org/extensions/xep-0059.html). Note that therefore there are two ways to denote pages, the standard RSM mechanism and the custom inbox form. If both are used, the RSM marker will override the respective inbox form, as in, `before` will override `start`, and `after` will override `end`.
+
+!!! Note
+    Inbox pagination does not support total count nor indexes as described in [XEP-0059: #2.6 Retrieving a Page Out of Order](https://xmpp.org/extensions/xep-0059.html#jump).
 
 ## Properties of an entry
 Given an entry, certain properties are defined for such an entry:

--- a/src/inbox/mod_inbox.erl
+++ b/src/inbox/mod_inbox.erl
@@ -478,14 +478,13 @@ build_params(Params, none) ->
     Params;
 build_params(Params, #rsm_in{max = Max, id = undefined}) when Max =/= undefined ->
     Params#{limit => Max};
-build_params(Params0, Rsm) ->
-    Params = maps:without([start, 'end'], Params0),
+build_params(Params, Rsm) ->
     build_params_with_rsm(Params#{rsm => Rsm}, Rsm).
 
 build_params_with_rsm(Params, #rsm_in{max = Max, id = <<>>, direction = before}) ->
     Params#{limit => Max, order => asc, start => 0};
 build_params_with_rsm(Params, #rsm_in{max = Max, id = <<>>, direction = aft}) ->
-    Params#{limit => Max};
+    maps:remove('end', Params#{limit => Max});
 build_params_with_rsm(Params, #rsm_in{max = Max, id = Id, direction = Dir}) when is_binary(Id) ->
     case {mod_inbox_utils:decode_rsm_id(Id), Dir} of
         {error, _} ->


### PR DESCRIPTION
It happens that, if a user wants to paginate through inbox but only through what has changed since a given timestamp, once the second page is requested using the given `<after>` returned on the first page, the pagination would overrun any limit timestamp given and would therefore continue returning the entire inbox set.

Example:
```xml
<!-- We ask for all changes since the given `start` date -->
<iq type="set" id="8D07E14F-9A2D-442A-A996-81F4E47E6CC6">
    <inbox xmlns="erlang-solutions.com:xmpp:inbox:0">
        <x xmlns="jabber:x:data" type="form">
            <field var="box" type="list-single"><value>inbox</value></field>
            <field var="start"><value>2023-02-28T15:27:31.481Z</value></field>
        </x>
        <set xmlns="http://jabber.org/protocol/rsm">
            <max>30</max>
        </set>
    </inbox>
</iq>

<!-- we get all the 30 entries, and then the iq-result with the given page details -->
<iq xmlns="jabber:client" from="alice@localhost" to="alice@localhost/res1" id="8D07E14F-9A2D-442A-A996-81F4E47E6CC6" type="result">
    <fin xmlns="erlang-solutions.com:xmpp:inbox:0">
        <set xmlns="http://jabber.org/protocol/rsm">
            <first>1673349807109070/oaeusnth</first>
            <last>1673349791932211/qjkzlvwm</last>
        </set>
        <active-conversations>0</active-conversations>
        <count>30</count>
        <unread-messages>0</unread-messages>
    </fin>
</iq>

<!-- We decide to continue fetching from the previously given end of page, -->
<!-- but we still want to end on the same timestamp -->
<iq type="set" id="F2DF7FCE-4802-43E9-9C0B-6D0A333D7E8A">
    <inbox xmlns="erlang-solutions.com:xmpp:inbox:0">
        <x xmlns="jabber:x:data" type="form">
            <field var="box" type="list-single"><value>inbox</value></field>
            <field var="start"><value>2023-02-28T15:27:31.481Z</value></field>
        </x>
        <set xmlns="http://jabber.org/protocol/rsm">
            <max>30</max>
            <after>1673349791932211/qjkzlvwm</after>
        </set>
    </inbox>
</iq>
```

The old implementation would overrun the `start` part of the form and not limit the page size. The new implementation takes care of that, by instead of having RSM overriding the entire form, having `after` override _only_ `end`, and `before` override _only_ `start`.