### PR TITLE
Fix indicators links to point to the latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ env:
   # required for run_common_test.erl
   KEEP_COVER_RUNNING: '1'
   SKIP_AUTO_COMPILE: 'true'
+  # required for tools/gh-upload-to-s3.sh script
+  AWS_DEFAULT_REGION: "${{ secrets.AWS_DEFAULT_REGION }}"
+  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
 
 jobs:
   small_tests:
@@ -42,6 +46,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: small_tests on OTP ${{matrix.otp}}
           path-to-lcov: ./lcov.info
+      - name: upload common test results on failure
+        if: ${{ failure() }}
+        run: tools/gh-upload-to-s3.sh _build/test/logs test_logs
 
   big_tests:
     name: ${{matrix.preset}} on OTP ${{matrix.otp}}
@@ -70,6 +77,9 @@ jobs:
           preset: ${{matrix.preset}}
           gh-token: ${{secrets.GITHUB_TOKEN}}
           test-spec: ${{matrix.test-spec}}
+      - name: upload common test results on failure
+        if: ${{ failure() }}
+        run: tools/gh-upload-to-s3.sh big_tests/ct_report
 
   dynamic_domains_big_tests:
     name: dynamic domains ${{matrix.preset}} on OTP ${{matrix.otp}}
@@ -92,6 +102,9 @@ jobs:
           preset: ${{matrix.preset}}
           gh-token: ${{secrets.GITHUB_TOKEN}}
           test-spec: ${{matrix.test-spec}}
+      - name: upload common test results on failure
+        if: ${{ failure() }}
+        run: tools/gh-upload-to-s3.sh big_tests/ct_report
 
   coveralls_webhook:
     needs: [big_tests, small_tests, dynamic_domains_big_tests]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # MongooseIM platform
 
-[![GitHub Actions](https://github.com/esl/MongooseIM/workflows/CI/badge.svg?branch=master)](https://github.com/esl/MongooseIM/actions?query=workflow%3ACI+branch%3Amaster)
-[![CircleCI](https://circleci.com/gh/esl/MongooseIM.svg?style=shield&circle-token=53cdda11cfb95bd7a7044c509c89cb73d3fdeb5a)](https://app.circleci.com/pipelines/github/esl/MongooseIM)
-[![Codecov](https://codecov.io/gh/esl/MongooseIM/branch/master/graph/badge.svg)](https://codecov.io/gh/esl/MongooseIM)
-[![Coveralls](https://coveralls.io/repos/github/DenysGonchar/MongooseIM/badge.svg?branch=master)](https://coveralls.io/github/DenysGonchar/MongooseIM?branch=master)
 [![GitHub release](https://img.shields.io/github/release/esl/MongooseIM.svg)](https://github.com/esl/MongooseIM/releases)
+[![GitHub Actions](https://github.com/esl/MongooseIM/workflows/CI/badge.svg?branch=rel-6.0)](https://github.com/esl/MongooseIM/actions?query=workflow%3ACI+branch%3Arel-6.0)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/esl/MongooseIM/tree/rel-6.0.svg?style=shield)](https://app.circleci.com/pipelines/github/esl/MongooseIM?branch=rel-6.0)
+[![Codecov](https://codecov.io/gh/esl/MongooseIM/branch/rel-6.0/graph/badge.svg)](https://app.codecov.io/gh/esl/MongooseIM/tree/rel-6.0)
+[![Coveralls](https://coveralls.io/repos/github/esl/MongooseIM/badge.svg?branch=rel-6.0)](https://coveralls.io/github/esl/MongooseIM?branch=rel-6.0)
 
 * [Getting started](https://esl.github.io/MongooseDocs/latest/getting-started/Installation/)
 * [Developer's guide](https://esl.github.io/MongooseDocs/latest/developers-guide/Testing-MongooseIM/)

--- a/tools/gh-actions-configure-preset.sh
+++ b/tools/gh-actions-configure-preset.sh
@@ -45,5 +45,6 @@ case "$PRESET" in
 esac
 
 if [ ! -z "$GITHUB_ENV" ]; then
+  ## $PRESET is required for gh-upload-to-s3.sh script
   env | grep -E "^(DB|REL_CONFIG|TLS_DIST|PRESET)=" >> $GITHUB_ENV
 fi

--- a/tools/gh-upload-to-s3.sh
+++ b/tools/gh-upload-to-s3.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+dir="$1"
+
+[ -d "$dir" ] || { echo "ERROR: directory '${dir}' does not exist"; exit 1; }
+
+dest_dir="${2:-$(basename "$dir")}"
+
+[ -z "$AWS_ACCESS_KEY_ID" ] && { echo "ERROR: AWS_ACCESS_KEY_ID env is not set"; exit 1; }
+[ -z "$AWS_SECRET_ACCESS_KEY" ] && { echo "ERROR: AWS_SECRET_ACCESS_KEY env is not set"; exit 1; }
+[ -z "$AWS_DEFAULT_REGION" ] && { echo "ERROR: AWS_DEFAULT_REGION env is not set"; exit 1; }
+
+[ -z "$GITHUB_RUN_ID" ] && { echo "ERROR: GITHUB_RUN_ID env is not set"; exit 1; }
+[ -z "$GITHUB_RUN_ATTEMPT" ] && { echo "ERROR: GITHUB_RUN_ATTEMPT env is not set"; exit 1; }
+
+which aws || { echo "aws tool is missing"; exit 1; }
+
+aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
+aws configure set default.region "$AWS_DEFAULT_REGION"
+aws configure set default.s3.max_concurrent_requests 64
+
+file_count=$(find "$dir" -type f | wc -l)
+echo "Uploading ${file_count} files"
+
+## $PRESET is not unique, so we have to add $RANDOM to avoid collisions
+prefix="GH/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${PRESET}.${RANDOM}/${dest_dir}"
+
+echo "directory '${dir}' is uploaded here:"
+echo "   https://esl.github.io/circleci-mim-results/s3_reports.html?prefix=${prefix}"
+
+time aws s3 cp "$dir" s3://circleci-mim-results/"${prefix}" --acl public-read --recursive --quiet


### PR DESCRIPTION
All status badges now point to the `rel-6.0` branch. They can be previewed here https://github.com/esl/MongooseIM/tree/fix-readme-project-status.

DG: 
added 2 minor updates:
* checrry-picked c48e2ef8f
* added missing `app.` to codecov url