### PR TITLE
Add port and ip in the listener opts for websockets and bosh

### DIFF
--- a/include/mod_bosh.hrl
+++ b/include/mod_bosh.hrl
@@ -5,5 +5,5 @@
 
 -record(bosh_socket, {sid   :: mod_bosh:sid(),
                       pid   :: pid(),
-                      peer  :: {inet:ip_address(), inet:port_number()},
+                      peer  :: mongoose_transport:peer(),
                       peercert :: undefined | binary()}).

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -56,6 +56,9 @@
                            max_stanza_size := non_neg_integer(),
                            backwards_compatible_session := boolean(),
                            c2s_state_timeout := non_neg_integer(),
+                           port := inet:port_number(),
+                           ip_tuple := inet:ip_address(),
+                           proto := tcp,
                            term() => term()}.
 
 -export_type([packet/0, data/0, state/0, state/1, listener_opts/0]).

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -150,8 +150,9 @@ start_cowboy(Ref, Opts, Retries, SleepTime) ->
 
 -spec do_start_cowboy(atom(), listener_options()) -> {ok, pid()} | {error, any()}.
 do_start_cowboy(Ref, Opts) ->
-    #{ip_tuple := IPTuple, port := Port, handlers := Handlers,
+    #{ip_tuple := IPTuple, port := Port, handlers := Handlers0,
       transport := TransportOpts0, protocol := ProtocolOpts0} = Opts,
+    Handlers = [ Handler#{ip_tuple => IPTuple, port => Port, proto => tcp} || Handler <- Handlers0 ],
     Routes = mongoose_http_handler:get_routes(Handlers),
     Dispatch = cowboy_router:compile(Routes),
     ProtocolOpts = ProtocolOpts0#{env => #{dispatch => Dispatch}},

--- a/src/mod_bosh_socket.erl
+++ b/src/mod_bosh_socket.erl
@@ -4,8 +4,8 @@
 -behaviour(mongoose_c2s_socket).
 
 %% API
--export([start/4,
-         start_link/4,
+-export([start/5,
+         start_link/5,
          start_supervisor/0,
          is_supervisor_started/0,
          handle_request/2,
@@ -49,7 +49,7 @@
               closing/3, compress/1, compress/3, get_cached_responses/1,
               get_client_acks/1, get_handlers/1, get_peer_certificate/1,
               get_pending/1, get_pending/1, get_sockmod/1, normal/2, normal/3,
-              pause/2, send/2, set_client_acks/2, start_link/4]).
+              pause/2, send/2, set_client_acks/2, start_link/5]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
@@ -101,16 +101,16 @@
 %%--------------------------------------------------------------------
 
 -spec start(mongooseim:host_type(), mod_bosh:sid(), mongoose_transport:peer(),
-            binary() | undefined) ->
+            binary() | undefined, map()) ->
     {'error', _} | {'ok', 'undefined' | pid()} | {'ok', 'undefined' | pid(), _}.
-start(HostType, Sid, Peer, PeerCert) ->
-    supervisor:start_child(?BOSH_SOCKET_SUP, [HostType, Sid, Peer, PeerCert]).
+start(HostType, Sid, Peer, PeerCert, Opts) ->
+    supervisor:start_child(?BOSH_SOCKET_SUP, [HostType, Sid, Peer, PeerCert, Opts]).
 
 -spec start_link(mongooseim:host_type(), mod_bosh:sid(), mongoose_transport:peer(),
-                 binary() | undefined) ->
+                 binary() | undefined, map()) ->
     'ignore' | {'error', _} | {'ok', pid()}.
-start_link(HostType, Sid, Peer, PeerCert) ->
-    gen_fsm_compat:start_link(?MODULE, [{HostType, Sid, Peer, PeerCert}], []).
+start_link(HostType, Sid, Peer, PeerCert, Opts) ->
+    gen_fsm_compat:start_link(?MODULE, [{HostType, Sid, Peer, PeerCert, Opts}], []).
 
 -spec start_supervisor() -> {ok, pid()} | {error, any()}.
 start_supervisor() ->
@@ -192,18 +192,19 @@ get_cached_responses(Pid) ->
 %%                     {stop, StopReason}
 %% @end
 %%--------------------------------------------------------------------
--spec init([{mongooseim:host_type(), mod_bosh:sid(), mongoose_transport:peer(), undefined | binary()}]) ->
+-spec init([{mongooseim:host_type(), mod_bosh:sid(), mongoose_transport:peer(), undefined |
+             binary(), map()}]) ->
     {ok, accumulate, state()}.
-init([{HostType, Sid, Peer = {IPTuple, Port}, PeerCert}]) ->
+init([{HostType, Sid, Peer, PeerCert, ListenerOpts}]) ->
     BoshSocket = #bosh_socket{sid = Sid, pid = self(), peer = Peer, peercert = PeerCert},
-    C2SOpts = #{access => all,
-                shaper => none,
-                xml_socket => true,
-                max_stanza_size => 0,
-                hibernate_after => 0,
-                c2s_state_timeout => 5000,
-                backwards_compatible_session => true,
-                port => Port, ip_tuple => IPTuple, proto => tcp},
+    C2SOpts = ListenerOpts#{access => all,
+                            shaper => none,
+                            xml_socket => true,
+                            max_stanza_size => 0,
+                            hibernate_after => 0,
+                            c2s_state_timeout => 5000,
+                            backwards_compatible_session => true,
+                            proto => tcp},
     {ok, C2SPid} = mongoose_c2s:start({?MODULE, BoshSocket, C2SOpts}, []),
     Opts = gen_mod:get_loaded_module_opts(HostType, mod_bosh),
     State = new_state(Sid, C2SPid, Opts),

--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -245,7 +245,8 @@ maybe_start_fsm([#xmlstreamstart{ name = <<"stream", _/binary>>, attrs = Attrs}
     end;
 maybe_start_fsm([#xmlel{ name = <<"open">> }],
                 #ws_state{fsm_pid = undefined,
-                          opts = #{c2s_state_timeout := StateTimeout,
+                          opts = #{ip_tuple := IPTuple, port := Port,
+                                   c2s_state_timeout := StateTimeout,
                                    backwards_compatible_session := BackwardsCompatible}} = State) ->
     Opts = #{
         access => all,
@@ -254,7 +255,8 @@ maybe_start_fsm([#xmlel{ name = <<"open">> }],
         xml_socket => true,
         hibernate_after => 0,
         c2s_state_timeout => StateTimeout,
-        backwards_compatible_session => BackwardsCompatible},
+        backwards_compatible_session => BackwardsCompatible,
+        port => Port, ip_tuple => IPTuple, proto => tcp},
     do_start_fsm(mongoose_c2s, Opts, State);
 maybe_start_fsm(_Els, State) ->
     {ok, State}.


### PR DESCRIPTION
This adds missing elements to the listener_opts for websockets and bosh and enforces that in dialyzer.