### PR TITLE
Build docker image for arm64

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 references:
-  - &OTP24 chrzaszcz/cimg-erlang:24.3.4
-  - &OTP25 chrzaszcz/cimg-erlang:25.2
+  - &OTP24 mongooseim/cimg-erlang:24.3.4.9
+  - &OTP25 mongooseim/cimg-erlang:25.2.3
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -236,16 +236,18 @@ executors:
       - *elasticsearch_container
       - *cassandra_container
       - *cassandra_proxy_container
+  arm64:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: arm.medium
 commands:
   fetch_build_packages:
     steps:
       - run:
           name: Install packages necessary for building
           command: |
-            sudo pkill -9 apt-get || true && \
-            echo "Acquire::ForceIPv4 'true';" | sudo tee -a /etc/apt/apt.conf.d/99force-ipv4 && \
-            sudo ./tools/retry.sh apt-get update && \
-            sudo ./tools/retry.sh apt-get install libssl-dev unixodbc-dev unixodbc tdsodbc rsync zlib1g-dev -y
+            $EXEC tools/circle-install-packages.sh \
+            'libssl-dev unixodbc-dev unixodbc tdsodbc rsync zlib1g-dev'
   maybe_build_deps_and_cache:
     steps:
       - restore_cache:
@@ -266,18 +268,27 @@ commands:
           paths:
             - ~/project/_build/default/
             - ~/project/big_tests/_build/default/
-  build_and_cache_prod_build:
+  cache_prod_build:
+    parameters:
+      arch:
+        type: string
     steps:
       - run:
-          name: Generate prod release
+          name: Create prod tarball
           command: |
-            echo $ERLANG_VERSION > otp_version
-            make rel
+            export BUILD_PATH=_build/prod/rel/mongooseim
+            tar czh --transform="s,${BUILD_PATH},mongooseim,S" \
+              -f mongooseim-<<parameters.arch>>.tar.gz ${BUILD_PATH}
       - save_cache:
           key: *BUILD_CACHE_KEY
-          paths: ~/project/_build/prod/rel/mongooseim
+          paths: ~/project/mongooseim-<<parameters.arch>>.tar.gz
   restore_prod_build:
+    parameters:
+      arch:
+        type: string
     steps:
+      - run:
+          echo $OTP_VERSION-<<parameters.arch>> > otp_version
       - restore_cache:
           key: *BUILD_CACHE_KEY
   persist_workspace:
@@ -294,10 +305,7 @@ commands:
       - run:
           name: Install pip3 and codecov packages
           command: |
-            sudo pkill -9 apt-get || true && \
-            echo "Acquire::ForceIPv4 'true';" | sudo tee -a /etc/apt/apt.conf.d/99force-ipv4 && \
-            sudo ./tools/retry.sh apt-get update && \
-            sudo ./tools/retry.sh apt-get install python3-pip -y && \
+            tools/circle-install-packages.sh python3-pip && \
             pip3 install codecov && codecov
   run_coverage_analysis:
     steps:
@@ -406,7 +414,7 @@ commands:
     steps:
       - run:
           name: Prepare for cache
-          command: echo $ERLANG_VERSION > otp_version
+          command: $EXEC bash -c 'echo $OTP_VERSION-$ARCH > otp_version'
 
 jobs:
   # #########################
@@ -419,15 +427,15 @@ jobs:
         type: executor
     steps:
       - checkout
-      - prepare_for_cache
       - setup_remote_docker
-      - restore_prod_build
+      - restore_prod_build: {arch: amd64}
+      - restore_prod_build: {arch: arm64}
       - run:
           name: Execute Docker image build and upload
           command: tools/circle-build-and-push-docker.sh
       - run:
           name: Smoke testing
-          command: mongooseim-docker/smoke_test.sh
+          command: IMAGE_TAG=`cat image_tag` mongooseim-docker/smoke_test.sh
 
   docs_build_deploy:
     parallelism: 1
@@ -479,6 +487,21 @@ jobs:
                   pip3 install mike
                   mike deploy $DOCS_TAG --remote git@github.com:esl/MongooseDocs.git --branch gh-pages --push --rebase
 
+  build_in_docker_arm64:
+    executor: arm64
+    environment:
+      DOCKER_IMAGE: *OTP25
+      EXEC: docker exec main
+    steps:
+      - run: docker run -dit --name main --rm -v `pwd`:`pwd` $DOCKER_IMAGE
+      - checkout
+      - prepare_for_cache
+      - restore_certs
+      - fetch_build_packages
+      - run: $EXEC tools/configure with-all
+      - run: $EXEC make rel
+      - cache_prod_build: {arch: arm64}
+
   build_in_docker:
     executor: << parameters.executor >>
     parameters:
@@ -505,7 +528,9 @@ jobs:
           command: ./tools/build-releases.sh
       - when:
           condition: << parameters.build_prod >>
-          steps: [ build_and_cache_prod_build ]
+          steps:
+            - run: make rel
+            - cache_prod_build: {arch: amd64}
       - run:
           name: Build Big Tests
           command: tools/build-tests.sh
@@ -715,6 +740,9 @@ workflows:
           executor: otp_24
           context: mongooseim-org
           build_prod: false
+      - build_in_docker_arm64:
+          name: otp_25_docker_arm64
+          context: mongooseim-org
       # ============= DIALYZER =============
       - dialyzer:
           name: dialyzer_24
@@ -884,6 +912,7 @@ workflows:
           executor: otp_25
           context: mongooseim-org
           requires:
+
             - small_tests_24
             - ldap_mnesia_24
             - pgsql_mnesia_24
@@ -905,4 +934,6 @@ workflows:
 
             - xref
             - edoc
+
+            - otp_25_docker_arm64
           filters: *all_tags

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -1,16 +1,8 @@
 #!/bin/bash
 
 set -e
-# From https://github.com/esl/mongooseim-docker/pull/47
-MIM_DOCKER_VERSION=fe6d9d31a720a254ea0150c44138e5f3955bf77b
-
-MONGOOSE_TGZ=mongooseim.tar.gz
-
-BUILD_PATH=_build/prod/rel/mongooseim
-
-tar czh --transform="s,${BUILD_PATH},mongooseim,S" -f $MONGOOSE_TGZ ${BUILD_PATH}
-
-export BUILDS=`pwd`
+# From https://github.com/esl/mongooseim-docker/pull/49
+MIM_DOCKER_VERSION=6b62e9cf26c523e35fe78c57cbae2e8832f555d2
 
 # We use output of generate_vsn, because it does not contain illegal characters, returns
 # git tag when building from tag itself, and is unique in any other case
@@ -29,8 +21,6 @@ elif [ ${CIRCLE_BRANCH} == 'master' ]; then
     DOCKERHUB_TAG="latest";
 fi
 
-# TODO: Add DOCKERHUB=${VERSION} when CircleCI handles weekly builds as well
-
 echo "Tag: ${DOCKERHUB_TAG}"
 
 IMAGE_TAG=${DOCKERHUB_REPO}/mongooseim:${DOCKERHUB_TAG}
@@ -39,15 +29,18 @@ git clone https://github.com/esl/mongooseim-docker.git
 cd mongooseim-docker
 git checkout $MIM_DOCKER_VERSION
 
-cp ../${MONGOOSE_TGZ} member
+cp ../mongooseim-*.tar.gz member
 
-docker build -f Dockerfile.member -t mongooseim -t ${IMAGE_TAG} \
+docker run --privileged --rm tonistiigi/binfmt --install all
+docker buildx create --name builder --driver docker-container --bootstrap --use
+docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
+
+docker buildx build --platform linux/amd64,linux/arm64 \
+             -f Dockerfile.member -t ${IMAGE_TAG} --push --progress=plain \
              --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 	     --build-arg VCS_REF=${GIT_REF} \
 	     --build-arg VCS_REF_DESC="${GIT_COMMIT_MSG}" \
 	     --build-arg VERSION=${VERSION} \
 	     .
 
-docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
-
-docker push ${IMAGE_TAG}
+echo $IMAGE_TAG > ../image_tag

--- a/tools/circle-install-packages.sh
+++ b/tools/circle-install-packages.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+sudo pkill -9 apt-get || true
+echo "Acquire::ForceIPv4 'true';" | sudo tee -a /etc/apt/apt.conf.d/99force-ipv4
+sudo ./tools/retry.sh apt-get update
+sudo ./tools/retry.sh apt-get install $1 -y


### PR DESCRIPTION
The goal is to build and push Docker images for both `amd64` and `arm64` architectures.

1. New multi-platform [Erlang/OTP images](https://hub.docker.com/r/mongooseim/cimg-erlang) are used.
2. A job is added to compile MongooseIM on `arm64`, and pack the results to a separate tarball.
3. The `docker_build_and_ship` job uses `docker buildx` to build a multi-platform image, combining the tarballs for both architectures.

**Notes:**
- Machine executor is used for `arm64`, because CircleCI has no Docker one (yet). Docker is used on that machine to make use of the OTP docker image, and to make build environments for both architectures more consistent.
- There are no tests for `arm64` yet, because they would complicate this PR. There is a plan to add some tests soon. The resulting [images](https://hub.docker.com/r/mongooseim/mongooseim/tags?page=1&name=PR-3979) start correctly on both `amd64` and `arm64` machines.

Related pull requests to other repositories:
- https://github.com/esl/cimg-erlang/pull/2
- https://github.com/esl/mongooseim-docker/pull/49