### PR TITLE
Deprecating riak

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -224,11 +224,6 @@ executors:
       - image: *OTP25
       - *redis_container
       - *mssql_container
-  otp_24_riak_redis:
-    docker:
-      - image: *OTP24
-      - *redis_container
-      - *riak_container
   otp_25_elasticsearch_cassandra:
     docker:
       - image: *OTP25
@@ -350,15 +345,6 @@ commands:
           command: |
             if [[ "$DB" == *ldap* ]]; then
               sed -i "s/connection.port = 3636/connection.port = 636/g" big_tests/test.config
-            fi
-
-  maybe_wait_for_solr:
-    steps:
-      - run:
-          name: Maybe wait for Riak SOLR
-          command: |
-            if [[ "$DB" == *riak* ]]; then
-              tools/circle-wait-for-solr.sh
             fi
 
   maybe_setup_elasticsearch:
@@ -546,7 +532,7 @@ jobs:
       preset:
         type: enum
         enum: [internal_mnesia, mysql_redis, odbc_mssql_mnesia, ldap_mnesia,
-               elasticsearch_and_cassandra_mnesia, pgsql_mnesia, riak_mnesia]
+               elasticsearch_and_cassandra_mnesia, pgsql_mnesia]
         description: Preset to run
         default: internal_mnesia
       db:
@@ -577,7 +563,6 @@ jobs:
       - maybe_prepare_minio
       - maybe_prepare_odbc
       - maybe_prepare_ldap
-      - maybe_wait_for_solr
       - maybe_setup_elasticsearch
       - prepare_etc_hosts
       - run:
@@ -843,15 +828,6 @@ workflows:
             - otp_25_docker
           filters: *all_tags
       - big_tests_in_docker:
-          name: riak_mnesia_24
-          executor: otp_24_riak_redis
-          context: mongooseim-org
-          preset: riak_mnesia
-          db: "riak redis"
-          requires:
-            - otp_24_docker
-          filters: *all_tags
-      - big_tests_in_docker:
           name: ldap_mnesia_24
           executor: otp_24_ldap_redis
           context: mongooseim-org
@@ -887,7 +863,6 @@ workflows:
             - small_tests_24
             - ldap_mnesia_24
             - pgsql_mnesia_24
-            - riak_mnesia_24
             - dynamic_domains_pgsql_mnesia_24
             - dialyzer_24
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         preset: [internal_mnesia, pgsql_mnesia, mysql_redis, odbc_mssql_mnesia,
-                 ldap_mnesia, riak_mnesia, elasticsearch_and_cassandra_mnesia]
+                 ldap_mnesia, elasticsearch_and_cassandra_mnesia]
         otp: ['23.0.3', '24.0.2']
     runs-on: ubuntu-20.04
     env:

--- a/doc/authentication-methods/riak.md
+++ b/doc/authentication-methods/riak.md
@@ -1,3 +1,6 @@
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 ## Overview
 
 This authentication method stores user accounts in Riak.

--- a/doc/configuration/auth.md
+++ b/doc/configuration/auth.md
@@ -7,7 +7,9 @@ The following methods are supported:
 * [`anonymous`](../authentication-methods/anonymous.md) - allows anonymous connections,
 * [`ldap`](../authentication-methods/ldap.md) - checks the user credentials in LDAP,
 * [`jwt`](../authentication-methods/jwt.md) - authenticates the users with JSON Web Tokens,
-* [`riak`](../authentication-methods/riak.md) - stores the user accounts in a Riak database,
+* [`riak (deprecated)`](../authentication-methods/riak.md) - stores the user accounts in a Riak database,
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 * [`http`](../authentication-methods/http.md) - uses an external HTTP service to authenticate the user,
 * [`pki`](../authentication-methods/pki.md) - uses the certificate provided by the user to authenticate them,
 * [`dummy`](../authentication-methods/dummy.md) - no authentication, only for development and testing.
@@ -25,6 +27,9 @@ The options listed here affect more than one configuration method.
 * **Syntax:** array of strings. Allowed values: `"internal"`, `"rdbms"`, `"external"`, `"anonymous"`, `"ldap"`, `"jwt"`, `"riak"`, `"http"`, `"pki"`, `"dummy"`
 * **Default:** not set
 * **Example:** `methods = ["internal", "anonymous"]`
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 It is possible to enable more than one method - they are queried one by one in the alphabetical order until one of them succeeds or there are no more methods. You can change the default order by using this option. Make sure that all methods from the list have their corresponding sections included in the `auth` section, e.g.
 
@@ -57,18 +62,18 @@ Specifies the list of allowed SASL mechanisms, which are announced during stream
 
 The table below shows the supported SASL mechanisms (columns) for each authentication method (row).
 
-|           | plain | digest | scram_sha* | anonymous | external |
-|-----------|:-----:|:------:|:----------:|:---------:|:--------:|
-| internal  |   x   |   x    |     x      |           |          |
-| rdbms     |   x   |   x    |     x      |           |          |
-| external  |   x   |        |            |           |          |
-| anonymous |   x   |   x    |     x      |     x     |          |
-| ldap      |   x   |        |            |           |    x     |
-| jwt       |   x   |        |            |           |          |
-| riak      |   x   |   x    |     x      |           |          |
-| http      |   x   |   x    |     x      |           |          |
-| pki       |       |        |            |           |    x     |
-| dummy     |   x   |        |            |           |          |
+|                   | plain | digest | scram_sha* | anonymous | external |
+|-------------------|:-----:|:------:|:----------:|:---------:|:--------:|
+| internal          |   x   |   x    |     x      |           |          |
+| rdbms             |   x   |   x    |     x      |           |          |
+| external          |   x   |        |            |           |          |
+| anonymous         |   x   |   x    |     x      |     x     |          |
+| ldap              |   x   |        |            |           |    x     |
+| jwt               |   x   |        |            |           |          |
+| riak (deprecated) |   x   |   x    |     x      |           |          |
+| http              |   x   |   x    |     x      |           |          |
+| pki               |       |        |            |           |    x     |
+| dummy             |   x   |        |            |           |          |
 
 ### `auth.sasl_external`
 * **Syntax:** list of strings, allowed values: `"standard"`, `"common_name"`, `"auth_id"`
@@ -85,7 +90,7 @@ This option allows you to list the enabled ones in the order of preference (they
 
 ## Password-related options
 
-These options are common to the `http`, `rdbms`, `internal` and `riak` methods.
+These options are common to the `http`, `rdbms`, `internal` and `riak(deprecated)` methods.
 
 ### `auth.password.format`
 * **Syntax:** string, one of: `"plain"`, `"scram"`
@@ -156,5 +161,5 @@ See the links below for options related to the particular methods:
 * [External method options](../authentication-methods/external.md#configuration-options)
 * [LDAP method options](../authentication-methods/ldap.md#configuration-options)
 * [JWT method options](../authentication-methods/jwt.md#configuration-options)
-* [Riak method options](../authentication-methods/riak.md#configuration-options)
+* [Riak(deprecated) method options](../authentication-methods/riak.md#configuration-options)
 * [HTTP method options](../authentication-methods/http.md#configuration-options)

--- a/doc/configuration/auth.md
+++ b/doc/configuration/auth.md
@@ -8,11 +8,11 @@ The following methods are supported:
 * [`ldap`](../authentication-methods/ldap.md) - checks the user credentials in LDAP,
 * [`jwt`](../authentication-methods/jwt.md) - authenticates the users with JSON Web Tokens,
 * [`riak (deprecated)`](../authentication-methods/riak.md) - stores the user accounts in a Riak database,
-!!! warning
-    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 * [`http`](../authentication-methods/http.md) - uses an external HTTP service to authenticate the user,
 * [`pki`](../authentication-methods/pki.md) - uses the certificate provided by the user to authenticate them,
 * [`dummy`](../authentication-methods/dummy.md) - no authentication, only for development and testing.
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 To allow the users to connect, you need to choose the authentication method from the list above and enable it by adding a corresponding section. For example, the default configuration file has the `[auth.internal]` section, which enables the `internal` method, using the internal Mnesia database to store users and their passwords. However, for production systems other methods like `rdbms` are recommended, as using an external database offers easier maintenance, flexibility, scalability and configurability in a typical setup. Some methods have more complex setup procedures and have their own specific options - the method names above are links to their descriptions. There are some general authentication options as well, which are described below.
 
@@ -90,7 +90,7 @@ This option allows you to list the enabled ones in the order of preference (they
 
 ## Password-related options
 
-These options are common to the `http`, `rdbms`, `internal` and `riak(deprecated)` methods.
+These options are common to the `http`, `rdbms`, `internal` and `riak` (deprecated) methods.
 
 ### `auth.password.format`
 * **Syntax:** string, one of: `"plain"`, `"scram"`
@@ -161,5 +161,5 @@ See the links below for options related to the particular methods:
 * [External method options](../authentication-methods/external.md#configuration-options)
 * [LDAP method options](../authentication-methods/ldap.md#configuration-options)
 * [JWT method options](../authentication-methods/jwt.md#configuration-options)
-* [Riak(deprecated) method options](../authentication-methods/riak.md#configuration-options)
+* [Riak (deprecated) method options](../authentication-methods/riak.md#configuration-options)
 * [HTTP method options](../authentication-methods/http.md#configuration-options)

--- a/doc/configuration/database-backends-configuration.md
+++ b/doc/configuration/database-backends-configuration.md
@@ -25,7 +25,7 @@ Transient data:
  Being an Erlang-based database, it's the default persistence option for most modules in MongooseIM.
   
     !!! Warning
-        We **strongly recommend** keeping **persistent** data in an external DB (RDBMS or Riak) for production.
+        We **strongly recommend** keeping **persistent** data in an external DB (RDBMS) for production.
         Mnesia is not suitable for the volumes of **persistent** data which some modules may require.
         Sooner or later a migration will be needed which may be painful.
         It is possible to store all data in Mnesia, but only for testing purposes, not for any serious deployments.
@@ -43,10 +43,13 @@ Persistent Data:
  Never loose your data.
  Use MySQL, MariaDB, PostgreSQL, or MS SQL Server.
 
-* Riak KV - If you're planning to deploy a massive cluster, consider Riak KV as a potential storage backend solution.
+* Riak KV (deprecated) - If you're planning to deploy a massive cluster, consider Riak KV as a potential storage backend solution.
  It offers high availability and fault tolerance which is exactly what you need for your distributed MongooseIM architecture.
  Use Riak KV with `privacy lists`, `vcards`, `roster`, `private storage`, `last activity` and `message archive`.
- Erlang Solutions commercially supports Riak KV.
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 
 * Cassandra - Only for MAM (Message Archive Management).
 
@@ -232,7 +235,10 @@ Configure the `outgoing_pools.rdbms` section as follows:
 
 ## NoSQL
 
-### Riak KV
+### Riak KV (deprecated)
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 Riak KV, for Key-Value, is technically supported by MongooseIM for versions upper than Riak KV 2.0. Erlang Solutions commercially supports Riak KV.
 

--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -156,6 +156,9 @@ Enables backward-compatible session establishement IQs. See https://www.rfc-edit
 * **Default:** not set
 * **Example:** `allowed_auth_methods = ["internal"]`
 
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 A subset of enabled methods to login with for this listener.
 This option allows to enable only some backends.
 It is useful, if you want to have several listeners for different type of users (for example, some users use PKI while other users use LDAP auth).

--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -2,13 +2,16 @@ MongooseIM can be configured to talk to external services like databases or HTTP
 The interface for outgoing connections management is available via the `outgoing_pools` config option for the following types of connections:
 
 * `cassandra` - pool of connections to Cassandra cluster
-* `riak` - pool of connections to Riak cluster
+* `riak (deprecated)` - pool of connections to Riak cluster
 * `redis` - pool of connections to Redis server
 * `http` - pool of connections to an HTTP(S) server MongooseIM can talk to, for example HTTP authentication backend or HTTP notifications
 * `elastic` - pool of connections to ElasticSearch server
 * `rdbms` - pool of connections to an RDBMS database
 * `rabbit` - pool of connections to a RabbitMQ server
 * `ldap` - pool of connections to an LDAP server
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 * **Syntax:** Each pool is specified in a subsection starting with `[outgoing_pools.type.tag]`, where `type` is one of available connection types and `tag` is an arbitrary value uniquely identifying the pool within its type.
 This allows you to create multiple dedicated pools of the same type.
@@ -221,6 +224,9 @@ Logical database index (zero-based).
 * **Example:** `password = "topsecret"`
 
 ## Riak options
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 Currently, only one Riak connection pool can exist for each supported XMPP host (the default pool).
 

--- a/doc/developers-guide/Testing-MongooseIM.md
+++ b/doc/developers-guide/Testing-MongooseIM.md
@@ -288,6 +288,9 @@ Why would we want to ever repeat the tests?
 In order to test different backends of the same parts of the system.
 E.g. a message archive might store messages in MySQL/PostgreSQL or Riak KV - the glue code between the XMPP logic module and database is different in each case, therefore repeating the same tests with different databases is necessary to guarantee a truthful code coverage measurement.
 
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 ### Testing a feature in development / TDD
 
 The whole suite takes a significant amount of time to complete.

--- a/doc/developers-guide/mod_muc_light_developers_guide.md
+++ b/doc/developers-guide/mod_muc_light_developers_guide.md
@@ -156,8 +156,11 @@ Drawbacks are:
 ### Medium
 
   * Add optional per-room processes to avoid the need of DB transactions and ensure message ordering (maybe "hard"?).
-  * Riak backend
+  * Riak(deprecated) backend
   * Redis backend
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 ### Hard
 

--- a/doc/developers-guide/mod_muc_light_developers_guide.md
+++ b/doc/developers-guide/mod_muc_light_developers_guide.md
@@ -156,7 +156,7 @@ Drawbacks are:
 ### Medium
 
   * Add optional per-room processes to avoid the need of DB transactions and ensure message ordering (maybe "hard"?).
-  * Riak(deprecated) backend
+  * Riak (deprecated) backend
   * Redis backend
 
 !!! warning

--- a/doc/developers-guide/release_config.md
+++ b/doc/developers-guide/release_config.md
@@ -43,6 +43,9 @@ Options:
     user      System user to run the server as. Default:
 ```
 
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 This script is also accessible via the make `configure` target.
 
 ### Example

--- a/doc/modules/mod_last.md
+++ b/doc/modules/mod_last.md
@@ -20,6 +20,9 @@ Strategy to handle incoming stanzas. For details, please refer to
 
 Storage backend.
 
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 ### Riak-specific options
 
 #### `bucket_type`

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -54,7 +54,7 @@ If this happens, the client will receive only messages that contain words specif
 
 The exact behaviour, like whether word ordering matters, may depend on the storage backend in use.
 For now `rdbms` backend has very limited support for this feature, while `cassandra` does not support it at all.
-`riak(deprecated)` and `elasticsearch` backends, on the other hand, should provide you with the best results when it comes to text filtering.
+`riak` (deprecated) and `elasticsearch` backends, on the other hand, should provide you with the best results when it comes to text filtering.
 
 `mod_mam_rdbms_arch` returns all messages that contain all search words, order
 of words does not matter. Messages are sorted by timestamp (not by relevance).

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -10,9 +10,12 @@ MongooseIM is compatible with MAM 0.4-0.6.
 Configure MAM with different storage backends:
 
 * RDBMS (databases like MySQL, PostgreSQL, MS SQL Server)
-* Riak KV (NoSQL)
+* Riak KV (deprecated) (NoSQL)
 * Cassandra (NoSQL)
 * ElasticSearch (NoSQL)
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 `mod_mam` is a meta-module that ensures all relevant `mod_mam_*` modules are loaded and properly configured.
 
@@ -51,7 +54,7 @@ If this happens, the client will receive only messages that contain words specif
 
 The exact behaviour, like whether word ordering matters, may depend on the storage backend in use.
 For now `rdbms` backend has very limited support for this feature, while `cassandra` does not support it at all.
-`riak` and `elasticsearch` backends, on the other hand, should provide you with the best results when it comes to text filtering.
+`riak(deprecated)` and `elasticsearch` backends, on the other hand, should provide you with the best results when it comes to text filtering.
 
 `mod_mam_rdbms_arch` returns all messages that contain all search words, order
 of words does not matter. Messages are sorted by timestamp (not by relevance).
@@ -68,6 +71,9 @@ Also note that the default separator for the search query is `AND` (which roughl
 * **Syntax:** string, one of `"rdbms"`, `"riak"`, `"cassandra"` and `"elasticsearch"`
 * **Default:** `"rdbms"`
 * **Example:** `backend = "riak"`
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 Database backend to use.
 
@@ -276,7 +282,7 @@ The possible values are:
 * **Example:** `modules.mod_mam.full_text_search = false`
 
 Enables full text search in message archive (see *Full Text Search* paragraph).
-Please note that the full text search is currently only implemented for `"rdbms"` and `"riak"` backends.
+Please note that the full text search is currently only implemented for `"rdbms"` and `"riak(deprecated)"` backends.
 Also, full text search works only for messages archived while this option is enabled.
 
 #### <a id="is_archivable_message"></a>`is_archivable_message/3` callback
@@ -300,6 +306,9 @@ Archiving chat markers can be enabled by setting `archive_chat_markers` option t
 When performing full text search chat markers are treated as if they had empty message body.
 
 ### Riak backend
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 The Riak KV backend for MAM stores messages in weekly buckets so it's easier to remove old buckets.
 Archive querying is done using Riak KV 2.0 [search mechanism](http://docs.basho.com/riak/2.1.1/dev/using/search/) called Yokozuna.

--- a/doc/modules/mod_offline.md
+++ b/doc/modules/mod_offline.md
@@ -24,6 +24,9 @@ to disable this error message.
  * **Default:** `"mnesia"`
  * **Example:** `backend = "rdbms"`
 
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
  Storage backend.
 
 ### `modules.mod_offline.store_groupchat_messages`
@@ -36,6 +39,9 @@ to disable this error message.
     This option can work only with MUC-light and is not expected to work with MUC.
 
 ### Riak-specific options
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 #### `modules.mod_offline.riak.bucket_type`
  * **Syntax:** non-empty string

--- a/doc/modules/mod_privacy.md
+++ b/doc/modules/mod_privacy.md
@@ -10,6 +10,9 @@ This extension allows user to block IQs, messages, presences, or all, based on J
 * **Default:** `"mnesia"`
 * **Example:** `backend = "mnesia"`
 
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 ### Riak-specific options
 
 #### `modules.mod_privacy.riak.defaults_bucket_type`

--- a/doc/modules/mod_private.md
+++ b/doc/modules/mod_private.md
@@ -19,6 +19,9 @@ Strategy to handle incoming stanzas. For details, please refer to
 
 Database backend to use.
 
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 **CAUTION:**  Riak KV backend doesn't support transactions (rollbacks), so please avoid inserting
 more than one value in a single set request, otherwise you may end up with partially saved data.
 Backend returns the first error.

--- a/doc/modules/mod_roster.md
+++ b/doc/modules/mod_roster.md
@@ -33,6 +33,9 @@ Improves performance but should be disabled, when shared rosters are used.
 * **Default:** `"mnesia"`
 * **Example:** `backend = "mnesia"`
 
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 ### Riak-specific options
 
 #### `modules.mod_roster.riak.bucket_type`

--- a/doc/modules/mod_vcard.md
+++ b/doc/modules/mod_vcard.md
@@ -33,6 +33,9 @@ Enables/disables the domain set in the previous option. `false` makes searching 
 
 vCard storage backend.
 
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
+
 !!! Warning 
     LDAP backend is read-only.
 
@@ -91,6 +94,9 @@ A default operator used for search query items.
 An array of search fields, which values should be Base64-encoded by MongooseIM before sending to LDAP.
 
 ### Riak-specific options
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 #### `modules.mod_vcard.riak.bucket_type`
 * **Syntax:** string

--- a/doc/user-guide/Features.md
+++ b/doc/user-guide/Features.md
@@ -36,7 +36,7 @@ This modular architecture allows high customisability and easy access to the req
 
 MongooseIM enables authenticating users using external or internal [databases](../authentication-methods/rdbms.md) (Mnesia, RDBMS, NoSQL), [LDAP](../authentication-methods/ldap.md), [HTTP](../authentication-methods/http.md) or [external scripts](../authentication-methods/external.md). It also allows connecting [anonymous users](../authentication-methods/anonymous.md), when required.
 
-For storing persistent data, MongooseIM uses Mnesia (the distributed internal Erlang database), relational databases: MySQL, PostgreSQL or a NoSQL alternative: Riak KV.
+For storing persistent data, MongooseIM uses Mnesia (the distributed internal Erlang database), relational databases: MySQL, PostgreSQL or a NoSQL alternative: Riak KV (deprecated).
 Please take a look at [database backends configurations](../configuration/database-backends-configuration.md) to learn more.
 If necessary, MongooseIM can be customised to work with a different database.
 You can [contact us](https://www.erlang-solutions.com/contact/) to learn more.

--- a/doc/user-guide/Features.md
+++ b/doc/user-guide/Features.md
@@ -36,7 +36,7 @@ This modular architecture allows high customisability and easy access to the req
 
 MongooseIM enables authenticating users using external or internal [databases](../authentication-methods/rdbms.md) (Mnesia, RDBMS, NoSQL), [LDAP](../authentication-methods/ldap.md), [HTTP](../authentication-methods/http.md) or [external scripts](../authentication-methods/external.md). It also allows connecting [anonymous users](../authentication-methods/anonymous.md), when required.
 
-For storing persistent data, MongooseIM uses Mnesia (the distributed internal Erlang database), relational databases: MySQL, PostgreSQL or a NoSQL alternative: Riak KV (deprecated).
+For storing persistent data, MongooseIM uses Mnesia (the distributed internal Erlang database), relational databases: MySQL, PostgreSQL or NoSQL alternatives: Riak KV (deprecated) and Cassandra.
 Please take a look at [database backends configurations](../configuration/database-backends-configuration.md) to learn more.
 If necessary, MongooseIM can be customised to work with a different database.
 You can [contact us](https://www.erlang-solutions.com/contact/) to learn more.

--- a/doc/user-guide/High-level-Architecture.md
+++ b/doc/user-guide/High-level-Architecture.md
@@ -38,9 +38,12 @@ There is no need to set up any backups for transient data since it naturally reb
 
 #### Persistent databases
 
-Both RDBMS/SQL (MySQL/PostgreSQL) and NoSQL (Riak KV) databases are supported.
+Both RDBMS/SQL (MySQL/PostgreSQL) and NoSQL (Riak KV (deprecated)) databases are supported.
 
 Backups should be regular, and tested.
+
+!!! warning
+    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 #### LDAP directory
 

--- a/doc/user-guide/High-level-Architecture.md
+++ b/doc/user-guide/High-level-Architecture.md
@@ -38,12 +38,9 @@ There is no need to set up any backups for transient data since it naturally reb
 
 #### Persistent databases
 
-Both RDBMS/SQL (MySQL/PostgreSQL) and NoSQL (Riak KV (deprecated)) databases are supported.
+Both RDBMS/SQL (MySQL/PostgreSQL) and NoSQL (Cassandra) databases are supported.
 
 Backups should be regular, and tested.
-
-!!! warning
-    Riak is deprecated and its support will be withdrawn in future versions of MongooseIM.
 
 #### LDAP directory
 

--- a/doc/user-guide/Supported-standards.md
+++ b/doc/user-guide/Supported-standards.md
@@ -29,7 +29,7 @@
         * Redis
     * Persistent:
         * RDBMS: MySQL, PostgreSQL, generic ODBC
-        * NoSQL: Riak KV(deprecated), Cassandra
+        * NoSQL: Riak KV (deprecated), Cassandra
 * Integration with third-party services
     * [Amazon Simple Notification Service](../modules/mod_event_pusher_sns.md)
 

--- a/doc/user-guide/Supported-standards.md
+++ b/doc/user-guide/Supported-standards.md
@@ -29,7 +29,7 @@
         * Redis
     * Persistent:
         * RDBMS: MySQL, PostgreSQL, generic ODBC
-        * NoSQL: Riak KV, Cassandra
+        * NoSQL: Riak KV(deprecated), Cassandra
 * Integration with third-party services
     * [Amazon Simple Notification Service](../modules/mod_event_pusher_sns.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,7 @@ nav:
       - 'Anonymous': 'authentication-methods/anonymous.md'
       - 'LDAP': 'authentication-methods/ldap.md'
       - 'JWT': 'authentication-methods/jwt.md'
-      - 'Riak': 'authentication-methods/riak.md'
+      - 'Riak (deprecated)': 'authentication-methods/riak.md'
       - 'HTTP': 'authentication-methods/http.md'
       - 'PKI': 'authentication-methods/pki.md'
       - 'Dummy': 'authentication-methods/dummy.md'


### PR DESCRIPTION
Deleting presets requiring Riak from CricleCI.
Marking Riak as deprecated in the docs.