### PR TITLE
Add capability of measuring async sql execute requests

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -295,23 +295,24 @@ commands:
   restore_workspace:
     steps:
       - attach_workspace: {at: ~/project}
-  fetch_coverage_packages:
-    steps:
-      - run:
-          name: Install pip3 and codecov packages
-          command: |
-            tools/circle-install-packages.sh python3-pip && \
-            pip3 install codecov
-  run_coverage_analysis:
-    steps:
-      - fetch_coverage_packages
-      - run:
-          name: Coverage
-          when: on_success
-          command: |
-            echo "Success!"
-            $EXEC ./rebar3 codecov analyze
-            codecov --disable=gcov --env PRESET
+  # TODO migrate to a new codecov uploader, see - https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader
+  # fetch_coverage_packages:
+  #   steps:
+  #     - run:
+  #         name: Install pip3 and codecov packages
+  #         command: |
+  #           tools/circle-install-packages.sh python3-pip && \
+  #           pip3 install codecov
+  # run_coverage_analysis:
+  #   steps:
+  #     - fetch_coverage_packages
+  #     - run:
+  #         name: Coverage
+  #         when: on_success
+  #         command: |
+  #           echo "Success!"
+  #           $EXEC ./rebar3 codecov analyze
+  #           codecov --disable=gcov --env PRESET
   run_small_tests:
     steps:
       - restore_workspace
@@ -323,7 +324,7 @@ commands:
           name: Run Small Tests
           command: |
             $EXEC tools/test.sh -p small_tests -s true -e true
-      - run_coverage_analysis
+      # - run_coverage_analysis
       - upload_results_to_aws
       - publish_github_comment
   run_docker_smoke_test:
@@ -650,7 +651,7 @@ jobs:
             - store_test_results:
                 when: always
                 path: junit_report.xml
-      - run_coverage_analysis
+      # - run_coverage_analysis
       - run:
           name: Build Failed - Logs
           when: on_fail

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -708,7 +708,8 @@ outer_op({sql_execute_wrapped, Name, Params, Wrapper}, State) ->
         Wrapper(fun() -> sql_execute(outer_op, Name, Params, State) end)
     catch
         _Class:Error ->
-            ?LOG_ERROR(#{what => sql_execute_wrapped_failed, reason => Error}),
+            ?LOG_ERROR(#{what => sql_execute_wrapped_failed, reason => Error,
+                         statement_name => Name, wrapper_fun => Wrapper}),
             {{error, Error}, State}
     end.
 


### PR DESCRIPTION
This PR adds a new API to `mongoose_rdbms` allowing to inject some additional code (e.g. measure time and record a metric) to asynchronous sql execute calls. Interface is similar to basic `sql_execute_request` with additional argument `MeasureFun` which is a function that encapsulates `sql_execute` call and performs additional actions. Intended usage is shown in newly added test.
