### PR TITLE
executing add_ssh_keys unconditionally for docs_build_deploy job

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -459,6 +459,7 @@ jobs:
       - image: cimg/python:3.11.0-node
     steps:
       - checkout
+      - add_ssh_keys
       - run:
           name: Build GraphQL static docs
           command: |
@@ -477,7 +478,6 @@ jobs:
               - equal: [ master, << pipeline.git.branch >> ]
               - << pipeline.git.tag >>
           steps:
-            - add_ssh_keys
             - run:
                 name: Configure Git
                 command: |


### PR DESCRIPTION
it's required for manual docs redeployment from release branches w/o moving release tag.
Redeployment can be done using "Rerun job with SSH" option for build_and_deploy_docs job.

