### PR TITLE
removing incorrect CORS headers

### DIFF
--- a/src/mongoose_admin_api/mongoose_admin_api.erl
+++ b/src/mongoose_admin_api/mongoose_admin_api.erl
@@ -73,15 +73,7 @@ api_paths_for_handler(Handler, State) ->
 
 -spec init(req(), state()) -> {cowboy_rest, req(), state()}.
 init(Req, State) ->
-    {cowboy_rest, set_cors_headers(Req), State}.
-
-set_cors_headers(Req) ->
-    Req1 = cowboy_req:set_resp_header(<<"Access-Control-Allow-Methods">>,
-                                      <<"GET, OPTIONS, PUT, POST, DELETE">>, Req),
-    Req2 = cowboy_req:set_resp_header(<<"Access-Control-Allow-Origin">>,
-                                      <<"*">>, Req1),
-    cowboy_req:set_resp_header(<<"Access-Control-Allow-Headers">>,
-                               <<"Content-Type">>, Req2).
+    {cowboy_rest, Req, State}.
 
 -spec is_authorized(req(), state()) -> {true | {false, iodata()}, req(), state()}.
 is_authorized(Req, State) ->


### PR DESCRIPTION
There are multiple things that are wrong with that admin API `Access-Control-Allow-*` headers, also we do not support it for GraphQL nor client REST API.

Removing them for now, if we want to add CORS support in the future it must be done properly and for GraphQL and  
client REST API as well admin REST API.

Issue can be easily demonstrated with curl, below is the corresponding part of the config:
```
[[listen.http]]
  port = 8088
  transport.num_acceptors = 10
  transport.max_connections = 1024
  tls.verify_mode = "none"
  tls.certfile = "priv/ssl/fake_cert.pem"
  tls.keyfile = "priv/ssl/fake_key.pem"
  
  [[listen.http.handlers.mongoose_admin_api]]
    host = "_"
    path = "/api"
```

and here are 2 curl commands:
* HTTP1.1 request: `curl -v --http1.1  --insecure -X OPTIONS  https://localhost:8088/api/users/localhost`
* HTTP2 request: `curl -v --http2  --insecure -X OPTIONS  https://localhost:8088/api/users/localhost`

Notice that HTTP2 query fails with existing CORS headers.
