### PR TITLE
Pass SID into store_info

### DIFF
--- a/big_tests/tests/carboncopy_SUITE.erl
+++ b/big_tests/tests/carboncopy_SUITE.erl
@@ -150,7 +150,7 @@ unavailable_resources_dont_get_carbons(Config) ->
           Body2 = <<"carbonated">>,
           escalus_client:send(Bob, escalus_stanza:chat_to(Alice2, Body2)),
           wait_for_message_with_body(Alice2, Body2),
-          wait_for_carbon_with_body(Alice1, Body2, #{from => Bob, to => Alice2})
+          carboncopy_helper:wait_for_carbon_with_body(Alice1, Body2, #{from => Bob, to => Alice2})
       end).
 
 dropped_client_doesnt_create_duplicate_carbons(Config) ->
@@ -287,9 +287,3 @@ run_prop(PropName, Property) ->
 wait_for_message_with_body(Alice, Body) ->
     AliceReceived = escalus_client:wait_for_stanza(Alice),
     escalus:assert(is_chat_message, [Body], AliceReceived).
-
-wait_for_carbon_with_body(Alice, Body, #{from := From, to := To}) ->
-    escalus:assert(
-      is_forwarded_received_message,
-      [escalus_client:full_jid(From), escalus_client:full_jid(To), Body],
-      escalus_client:wait_for_stanza(Alice)).

--- a/big_tests/tests/carboncopy_helper.erl
+++ b/big_tests/tests/carboncopy_helper.erl
@@ -1,0 +1,8 @@
+-module(carboncopy_helper).
+-export([wait_for_carbon_with_body/3]).
+
+wait_for_carbon_with_body(Client, Body, #{from := From, to := To}) ->
+    escalus:assert(
+      is_forwarded_received_message,
+      [escalus_client:full_jid(From), escalus_client:full_jid(To), Body],
+      escalus_client:wait_for_stanza(Client)).

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -367,9 +367,8 @@ wait_until(Fun, ExpectedValue, Opts) ->
 do_wait_until(_Fun, #{expected_value := ExpectedValue,
                       time_left := TimeLeft,
                       history := History,
-                      name := Name}) when TimeLeft =< 0 ->
-    error({Name, ExpectedValue, simplify_history(lists:reverse(History), 1)});
-
+                      name := Name} = Opts) when TimeLeft =< 0 ->
+    error({Name, ExpectedValue, simplify_history(lists:reverse(History), 1), on_error(Opts)});
 do_wait_until(Fun, #{validator := Validator} = Opts) ->
     try Fun() of
         Value -> case Validator(Value) of
@@ -379,6 +378,11 @@ do_wait_until(Fun, #{validator := Validator} = Opts) ->
     catch Error:Reason:Stacktrace ->
               wait_and_continue(Fun, {Error, Reason, Stacktrace}, Opts)
     end.
+
+on_error(#{on_error := F}) ->
+    F();
+on_error(_Opts) ->
+    ok.
 
 simplify_history([H|[H|_]=T], Times) ->
     simplify_history(T, Times + 1);

--- a/big_tests/tests/presence_SUITE.erl
+++ b/big_tests/tests/presence_SUITE.erl
@@ -45,6 +45,7 @@ groups() ->
                              explicit_available,
                              available_direct,
                              available_direct_then_unavailable,
+                             become_unavailable,
                              available_direct_then_disconnect,
                              additions,
                              invisible_presence]},
@@ -167,6 +168,11 @@ available_direct_then_unavailable(Config) ->
         escalus:assert(is_presence, Received2),
         escalus_assert:is_stanza_from(Alice, Received2)
         end).
+
+become_unavailable(Config) ->
+    %% We test that after sending presence unavailable, priority is set to undefined in the SM table,
+    %% so the session is not on a list of active sessions
+    escalus:story(Config, [{alice, 1}], fun(Alice) -> push_helper:become_unavailable(Alice) end).
 
 available_direct_then_disconnect(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->

--- a/big_tests/tests/push_SUITE.erl
+++ b/big_tests/tests/push_SUITE.erl
@@ -431,6 +431,7 @@ pm_no_msg_notifications_if_user_online(Config) ->
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)),
 
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
+            escalus:assert(is_message, escalus:wait_for_stanza(Bob)),
 
             ?assert(not truly(received_push())),
             ok

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -273,23 +273,6 @@ get_session(JID) ->
             lists:max(Ss)
     end.
 
--spec get_session_by_sid(JID, SID) -> offline | session() when
-      JID :: jid:jid(),
-      SID :: sid().
-get_session_by_sid(JID, SID) ->
-    #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
-    case ejabberd_sm_backend:get_sessions(LUser, LServer, LResource) of
-        [] ->
-            offline;
-        Ss ->
-            case lists:keyfind(SID, #session.sid, Ss) of
-                false ->
-                    offline;
-                S ->
-                    S
-            end
-    end.
-
 -spec get_raw_sessions(jid:jid()) -> [session()].
 get_raw_sessions(#jid{luser = LUser, lserver = LServer}) ->
     clean_session_list(
@@ -581,23 +564,7 @@ set_session(SID, JID, Priority, Info) ->
                        us = US,
                        priority = Priority,
                        info = Info},
-    ejabberd_sm_backend:create_session(LUser, LServer, LResource, Session).
-
--spec update_session(SID, JID, Prio, Info) -> ok | {error, any()} when
-      SID :: sid() | 'undefined',
-      JID :: jid:jid(),
-      Prio :: priority(),
-      Info :: info().
-update_session(SID, JID, Priority, Info) ->
-    #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
-    US = {LUser, LServer},
-    USR = {LUser, LServer, LResource},
-    Session = #session{sid = SID,
-                       usr = USR,
-                       us = US,
-                       priority = Priority,
-                       info = Info},
-    ejabberd_sm_backend:update_session(LUser, LServer, LResource, Session).
+    ejabberd_sm_backend:set_session(LUser, LServer, LResource, Session).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -36,7 +36,7 @@
          route/4,
          make_new_sid/0,
          open_session/5,
-         close_session/4,
+         close_session/5,
          store_info/4,
          get_info/2,
          remove_info/3,
@@ -194,20 +194,15 @@ open_session(HostType, SID, JID, Priority, Info) ->
     mongoose_hooks:sm_register_connection_hook(HostType, SID, JID, Info),
     ReplacedPIDs.
 
--spec close_session(Acc, SID, JID, Reason) -> Acc1 when
+-spec close_session(Acc, SID, JID, Reason, Info) -> Acc1 when
       Acc :: mongoose_acc:t(),
       SID :: 'undefined' | sid(),
       JID :: jid:jid(),
       Reason :: close_reason(),
+      Info :: info(),
       Acc1 :: mongoose_acc:t().
-close_session(Acc, SID, JID, Reason) ->
+close_session(Acc, SID, JID, Reason, Info) ->
     #jid{luser = LUser, lserver = LServer, lresource = LResource} = JID,
-    Info = case ejabberd_sm_backend:get_sessions(LUser, LServer, LResource) of
-               [Session] ->
-                   Session#session.info;
-               _ ->
-                   []
-           end,
     ejabberd_sm_backend:delete_session(SID, LUser, LServer, LResource),
     mongoose_hooks:sm_remove_connection_hook(Acc, SID, JID, Info, Reason).
 

--- a/src/ejabberd_sm_backend.erl
+++ b/src/ejabberd_sm_backend.erl
@@ -11,15 +11,10 @@
     [ejabberd_sm:session()].
 -callback get_sessions(jid:user(), jid:server(), jid:resource()) ->
     [ejabberd_sm:session()].
--callback create_session(jid:luser(),
-                         jid:lserver(),
-                         jid:lresource(),
-                         ejabberd_sm:session()) ->
-    ok | {error, term()}.
--callback update_session(jid:luser(),
-                         jid:lserver(),
-                         jid:lresource(),
-                         ejabberd_sm:session()) ->
+-callback set_session(jid:luser(),
+                      jid:lserver(),
+                      jid:lresource(),
+                      ejabberd_sm:session()) ->
     ok | {error, term()}.
 -callback delete_session(ejabberd_sm:sid(),
                          jid:user(),
@@ -31,7 +26,7 @@
 
 -export([init/1,
          get_sessions/0, get_sessions/1, get_sessions/2, get_sessions/3,
-         create_session/4, update_session/4, delete_session/4, cleanup/1,
+         set_session/4, delete_session/4, cleanup/1,
          total_count/0, unique_count/0]).
 
 -ignore_xref([cleanup/1, behaviour_info/1]).
@@ -67,19 +62,11 @@ get_sessions(User, Server, Resource) ->
     Args = [User, Server, Resource],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec create_session(User :: jid:user(),
-                     Server :: jid:server(),
-                     Resource :: jid:resource(),
-                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-create_session(User, Server, Resource, Session) ->
-    Args = [User, Server, Resource, Session],
-    mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
-
--spec update_session(User :: jid:luser(),
-                     Server :: jid:lserver(),
-                     Resource :: jid:lresource(),
-                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-update_session(User, Server, Resource, Session) ->
+-spec set_session(User :: jid:user(),
+                  Server :: jid:server(),
+                  Resource :: jid:resource(),
+                  Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+set_session(User, Server, Resource, Session) ->
     Args = [User, Server, Resource, Session],
     mongoose_backend:call(global, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -63,17 +63,8 @@ get_sessions(User, Server, Resource) ->
                      _Server :: jid:lserver(),
                      _Resource :: jid:lresource(),
                      Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-create_session(User, Server, Resource, Session) ->
-    case get_sessions(User, Server, Resource) of
-        [] -> mnesia:sync_dirty(fun() -> mnesia:write(Session) end);
-        Sessions when is_list(Sessions) ->
-            %% Fix potential race condition during XMPP bind, where
-            %% multiple calls (> 2) to ejabberd_sm:open_session
-            %% have been made, resulting in >1 sessions for this resource
-            MergedSession = mongoose_session:merge_info
-                              (Session, hd(lists:sort(Sessions))),
-            mnesia:sync_dirty(fun() -> mnesia:write(MergedSession) end)
-    end.
+create_session(_User, _Server, _Resource, Session) ->
+    mnesia:sync_dirty(fun() -> mnesia:write(Session) end).
 
 -spec update_session(_User :: jid:luser(),
                      _Server :: jid:lserver(),

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -18,8 +18,7 @@
          get_sessions/1,
          get_sessions/2,
          get_sessions/3,
-         create_session/4,
-         update_session/4,
+         set_session/4,
          delete_session/4,
          cleanup/1,
          total_count/0,
@@ -59,18 +58,11 @@ get_sessions(User, Server) ->
 get_sessions(User, Server, Resource) ->
     mnesia:dirty_index_read(session, {User, Server, Resource}, #session.usr).
 
--spec create_session(_User :: jid:luser(),
-                     _Server :: jid:lserver(),
-                     _Resource :: jid:lresource(),
-                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-create_session(_User, _Server, _Resource, Session) ->
-    mnesia:sync_dirty(fun() -> mnesia:write(Session) end).
-
--spec update_session(_User :: jid:luser(),
-                     _Server :: jid:lserver(),
-                     _Resource :: jid:lresource(),
-                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-update_session(_User, _Server, _Resource, Session) ->
+-spec set_session(_User :: jid:luser(),
+                  _Server :: jid:lserver(),
+                  _Resource :: jid:lresource(),
+                  Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+set_session(_User, _Server, _Resource, Session) ->
     mnesia:sync_dirty(fun() -> mnesia:write(Session) end).
 
 -spec delete_session(ejabberd_sm:sid(),

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -70,9 +70,7 @@ set_session(_User, _Server, _Resource, Session) ->
                      _Server :: jid:lserver(),
                      _Resource :: jid:lresource()) -> ok.
 delete_session(SID, _User, _Server, _Resource) ->
-    mnesia:sync_dirty(fun() ->
-                              mnesia:delete({session, SID})
-                      end).
+    mnesia:sync_dirty(fun() -> mnesia:delete({session, SID}) end).
 
 -spec cleanup(atom()) -> any().
 cleanup(Node) ->

--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -17,8 +17,7 @@
          get_sessions/1,
          get_sessions/2,
          get_sessions/3,
-         create_session/4,
-         update_session/4,
+         set_session/4,
          delete_session/4,
          cleanup/1,
          maybe_initial_cleanup/2,
@@ -71,33 +70,11 @@ get_sessions(User, Server, Resource) ->
 
     lists:map(fun(S) -> binary_to_term(S) end, Sessions).
 
--spec create_session(User :: jid:luser(),
-                     Server :: jid:lserver(),
-                     Resource :: jid:lresource(),
-                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-create_session(User, Server, Resource, Session) ->
-    OldSessions = get_sessions(User, Server, Resource),
-    case lists:keysearch(Session#session.sid, #session.sid, OldSessions) of
-        {value, OldSession} ->
-            BOldSession = term_to_binary(OldSession),
-            BSession = term_to_binary(Session),
-            mongoose_redis:cmds([["SADD", n(node()), hash(User, Server, Resource, Session#session.sid)],
-                                 ["SREM", hash(User, Server), BOldSession],
-                                 ["SREM", hash(User, Server, Resource), BOldSession],
-                                 ["SADD", hash(User, Server), BSession],
-                                 ["SADD", hash(User, Server, Resource), BSession]]);
-        false ->
-            BSession = term_to_binary(Session),
-            mongoose_redis:cmds([["SADD", n(node()), hash(User, Server, Resource, Session#session.sid)],
-                                 ["SADD", hash(User, Server), BSession],
-                                 ["SADD", hash(User, Server, Resource), BSession]])
-    end.
-
--spec update_session(User :: jid:luser(),
-                     Server :: jid:lserver(),
-                     Resource :: jid:lresource(),
-                     Session :: ejabberd_sm:session()) -> ok | {error, term()}.
-update_session(User, Server, Resource, Session) ->
+-spec set_session(User :: jid:luser(),
+                  Server :: jid:lserver(),
+                  Resource :: jid:lresource(),
+                  Session :: ejabberd_sm:session()) -> ok | {error, term()}.
+set_session(User, Server, Resource, Session) ->
     OldSessions = get_sessions(User, Server, Resource),
     case lists:keysearch(Session#session.sid, #session.sid, OldSessions) of
         {value, OldSession} ->

--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -79,9 +79,8 @@ create_session(User, Server, Resource, Session) ->
     OldSessions = get_sessions(User, Server, Resource),
     case lists:keysearch(Session#session.sid, #session.sid, OldSessions) of
         {value, OldSession} ->
-            MergedInfoSession = mongoose_session:merge_info(Session, OldSession),
             BOldSession = term_to_binary(OldSession),
-            BSession = term_to_binary(MergedInfoSession),
+            BSession = term_to_binary(Session),
             mongoose_redis:cmds([["SADD", n(node()), hash(User, Server, Resource, Session#session.sid)],
                                  ["SREM", hash(User, Server), BOldSession],
                                  ["SREM", hash(User, Server, Resource), BOldSession],

--- a/src/jingle_sip/jingle_sip_callbacks.erl
+++ b/src/jingle_sip/jingle_sip_callbacks.erl
@@ -47,6 +47,9 @@
 -ignore_xref([sip_bye/2, sip_cancel/3, sip_dialog_update/3, sip_info/2,
               sip_invite/2, sip_reinvite/2]).
 
+%% nksip specs do not fully cover case when they return a parsing error
+-dialyzer({nowarn_function, [assert_sdp_record/2]}).
+
 sip_invite(Req, Call) ->
     try
         sip_invite_unsafe(Req, Call)

--- a/src/jingle_sip/jingle_sip_callbacks.erl
+++ b/src/jingle_sip/jingle_sip_callbacks.erl
@@ -91,6 +91,7 @@ translate_and_deliver_invite(Req, FromJID, FromBinary, ToJID, ToBinary) ->
     {ok, ReqID} = nksip_request:get_handle(Req),
 
     {CodecMap, SDP} = nksip_sdp_util:extract_codec_map(Body),
+    assert_sdp_record(Body, SDP),
 
     OtherEls = sip_to_jingle:parse_sdp_attributes(SDP#sdp.attributes),
 
@@ -123,6 +124,7 @@ sip_reinvite_unsafe(Req, _Call) ->
     Body = nksip_sipmsg:meta(body, Req),
 
     {CodecMap, SDP} = nksip_sdp_util:extract_codec_map(Body),
+    assert_sdp_record(Body, SDP),
     RemainingAttrs = SDP#sdp.attributes,
     OtherEls = sip_to_jingle:parse_sdp_attributes(RemainingAttrs),
 
@@ -229,6 +231,7 @@ invite_resp_callback({resp, 200, SIPMsg, _Call}) ->
     Body = nksip_sipmsg:meta(body, SIPMsg),
     CallID = nksip_sipmsg:header(<<"call-id">>, SIPMsg),
     {CodecMap, SDP} = nksip_sdp_util:extract_codec_map(Body),
+    assert_sdp_record(Body, SDP),
     OtherEls = sip_to_jingle:parse_sdp_attributes(SDP#sdp.attributes),
 
 
@@ -342,3 +345,8 @@ maybe_route_to_all_sessions(From, To, Acc, Packet) ->
               ejabberd_router:route(From, jid:replace_resource(To, R), Acc, Packet)
       end, PResources).
 
+
+assert_sdp_record(_Body, #sdp{}) ->
+    ok;
+assert_sdp_record(Body, SDP) ->
+    error({assert_sdp_record, Body, SDP}).

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -8,6 +8,7 @@
 
 -type jid_set() :: gb_sets:set(jid:jid()).
 -type priority() :: -128..128.
+-type maybe_priority() :: priority() | undefined.
 -record(presences_state, {
           %% We have _subscription to_ these users' presence status;
           %% i.e. they send us presence updates.
@@ -496,7 +497,7 @@ presence_broadcast(Acc, JIDSet) ->
 
 -spec presence_update_to_available(
         mongoose_acc:t(), jid:jid(), jid:jid(), exml:element(), mongoose_c2s:data(),
-        presences_state(), list(), priority(), priority(), boolean()) ->
+        presences_state(), list(), maybe_priority(), priority(), boolean()) ->
     mongoose_acc:t().
 presence_update_to_available(Acc, FromJid, _ToJid, Packet, StateData, Presences, SocketSend,
                              _OldPriority, NewPriority, true) ->
@@ -512,7 +513,7 @@ presence_update_to_available(Acc, FromJid, _ToJid, Packet, StateData, Presences,
                              OldPriority, NewPriority, false) ->
     presence_broadcast_to_trusted(
              Acc, FromJid, Presences#presences_state.pres_f, Presences#presences_state.pres_a, Packet),
-    Acc1 = case OldPriority < 0 andalso NewPriority >= 0 of
+    Acc1 = case (OldPriority < 0 orelse OldPriority =:= undefined) andalso NewPriority >= 0 of
                true ->
                    resend_offline_messages(Acc, StateData);
                false ->
@@ -646,10 +647,10 @@ get_priority_from_presence(PresencePacket) ->
         _ -> 0
     end.
 
--spec get_old_priority(presences_state()) -> priority().
+-spec get_old_priority(presences_state()) -> maybe_priority().
 get_old_priority(Presences) ->
     case Presences#presences_state.pres_last of
-        undefined -> 0;
+        undefined -> undefined;
         OldPresence -> get_priority_from_presence(OldPresence)
     end.
 

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -47,7 +47,8 @@
          get_presence/1,
          get_subscribed/1,
          set_presence/2,
-         maybe_get_handler/1
+         maybe_get_handler/1,
+         get_old_priority/1
         ]).
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -401,7 +401,8 @@ presence_update_to_unavailable(Acc, _FromJid, _ToJid, Packet, StateData, Presenc
     Status = exml_query:path(Packet, [{element, <<"status">>}, cdata], <<>>),
     Sid = mongoose_c2s:get_sid(StateData),
     Jid = mongoose_c2s:get_jid(StateData),
-    Acc1 = ejabberd_sm:unset_presence(Acc, Sid, Jid, Status, #{}),
+    Info = mongoose_c2s:get_info(StateData),
+    Acc1 = ejabberd_sm:unset_presence(Acc, Sid, Jid, Status, Info),
     presence_broadcast(Acc1, Presences#presences_state.pres_a),
     presence_broadcast(Acc1, Presences#presences_state.pres_i),
     NewPresences = Presences#presences_state{pres_last = undefined,
@@ -658,7 +659,8 @@ get_old_priority(Presences) ->
 update_priority(Acc, Priority, Packet, StateData) ->
     Sid = mongoose_c2s:get_sid(StateData),
     Jid = mongoose_c2s:get_jid(StateData),
-    ejabberd_sm:set_presence(Acc, Sid, Jid, Priority, Packet, #{}).
+    Info = mongoose_c2s:get_info(StateData),
+    ejabberd_sm:set_presence(Acc, Sid, Jid, Priority, Packet, Info).
 
 am_i_subscribed_to_presence(LJID, LBareJID, S) ->
     gb_sets:is_element(LJID, S#presences_state.pres_t)

--- a/src/mongoose_session.erl
+++ b/src/mongoose_session.erl
@@ -1,6 +1,5 @@
 -module(mongoose_session).
 
--export([merge_info/2]).
 -export([get_info/1]).
 -export([get_info/3]).
 -export([set_info/3]).
@@ -9,10 +8,6 @@
 -ignore_xref([get_info/1, set_info/3]).
 
 -include("session.hrl").
-
--spec merge_info(ejabberd_sm:session(), ejabberd_sm:session()) -> ejabberd_sm:session().
-merge_info(New = #session{info = NewInfo}, #session{info = OldInfo}) ->
-    New#session{info = maps:merge(OldInfo, NewInfo)}.
 
 -spec get_info(ejabberd_sm:session()) -> ejabberd_sm:info().
 get_info(#session{info = Info}) ->

--- a/src/mongoose_stanza_api.erl
+++ b/src/mongoose_stanza_api.erl
@@ -63,7 +63,7 @@ close_session(#{jid := Jid = #jid{lserver = S}, sid := Sid, host_type := HostTyp
               lserver => S,
               host_type => HostType,
               element => undefined}),
-    ejabberd_sm:close_session(Acc, Sid, Jid, normal),
+    ejabberd_sm:close_session(Acc, Sid, Jid, normal, #{}),
     {ok, closed}.
 
 %% Steps

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -284,6 +284,7 @@ foreign_event(Acc, #{c2s_data := StateData,
                      event_type := {call, From},
                      event_tag := ?MODULE,
                      event_content := {resume, H}}, _Extra) ->
+    %% XXX Do we deregister from SM correctly?
     case handle_resume_call(StateData, From, H) of
         {ok, SmState} ->
             FlushedStateData = mongoose_c2s:merge_mod_state(StateData, #{?MODULE => SmState}),
@@ -566,10 +567,10 @@ do_handle_resume(Acc, StateData, C2SState, SMID, _H, {error, smid_not_found}) ->
       SMID :: smid(),
       HookResult :: mongoose_c2s_hooks:result().
 do_resume(Acc, StateData, SMID) ->
-    mongoose_c2s:open_session(StateData),
-    ok = register_smid(StateData, SMID),
-    Stanzas = get_all_stanzas_to_forward(StateData, SMID),
-    ToAcc = [{c2s_state, session_established}, {c2s_data, StateData}, {socket_send, Stanzas}],
+    {_ReplacedPids, StateData2} = mongoose_c2s:open_session(StateData),
+    ok = register_smid(StateData2, SMID),
+    Stanzas = get_all_stanzas_to_forward(StateData2, SMID),
+    ToAcc = [{c2s_state, session_established}, {c2s_data, StateData2}, {socket_send, Stanzas}],
     {ok, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)}.
 
 register_smid(StateData, SMID) ->

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -284,7 +284,6 @@ foreign_event(Acc, #{c2s_data := StateData,
                      event_type := {call, From},
                      event_tag := ?MODULE,
                      event_content := {resume, H}}, _Extra) ->
-    %% XXX Do we deregister from SM correctly?
     case handle_resume_call(StateData, From, H) of
         {ok, SmState} ->
             FlushedStateData = mongoose_c2s:merge_mod_state(StateData, #{?MODULE => SmState}),

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -269,7 +269,7 @@ store_info_sends_message_to_the_session_owner(C) ->
     R = <<"res1">>,
     Session = #session{sid = SID, usr = {U, S, R}, us = {U, S}, priority = 1, info = #{}},
     %% Create session in one process
-    ?B(C):create_session(U, S, R, Session),
+    ?B(C):set_session(U, S, R, Session),
     %% but call store_info from another process
     JID = jid:make_noprep(U, S, R),
     spawn_link(fun() -> ejabberd_sm:store_info(JID, SID, cc, undefined) end),
@@ -297,7 +297,7 @@ remove_info_sends_message_to_the_session_owner(C) ->
     R = <<"res1">>,
     Session = #session{sid = SID, usr = {U, S, R}, us = {U, S}, priority = 1, info = #{}},
     %% Create session in one process
-    ?B(C):create_session(U, S, R, Session),
+    ?B(C):set_session(U, S, R, Session),
     %% but call remove_info from another process
     JID = jid:make_noprep(U, S, R),
     spawn_link(fun() -> ejabberd_sm:remove_info(JID, SID, cc) end),


### PR DESCRIPTION
This PR addresses MIM-1875 mongoose_session:merge_info merges data from different sessions

Proposed changes include:
* Pass SID into store_info
* Tweaking tests
* Remove merge_info function