### PR TITLE
Disable provenance to make the docker manifest backwards-compatible

### DIFF
--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -11,7 +11,7 @@ docker buildx create --name builder --driver docker-container --bootstrap --use
 docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASS}
 
 docker buildx build --platform linux/amd64,linux/arm64 \
-             -f Dockerfile.member -t ${IMAGE_TAG} --push --progress=plain \
+             -f Dockerfile.member -t ${IMAGE_TAG} --push --provenance=false --progress=plain \
              --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 	     --build-arg VCS_REF=${GIT_REF} \
 	     --build-arg VCS_REF_DESC="${GIT_COMMIT_MSG}" \


### PR DESCRIPTION
By default buildx creates OCI manifests, which cause a bug when you try to:
- Inspect the docker manifest - even in the latest docker version
- Pull the docker image in older docker - reproduced in 17.x

See docker/buildx#1509 for details.

Tested with latest docker:
```bash
root@ip-10-2-0-4:/home/ubuntu# docker manifest inspect mongooseim/mongooseim:PR-4008
no such manifest: docker.io/mongooseim/mongooseim:PR-4008
root@ip-10-2-0-4:/home/ubuntu# docker manifest inspect mongooseim/mongooseim:PR-4009
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1491,
         "digest": "sha256:a419ed034140ccd982fc704f9df433b723aba17c50353ff0093d184144b26693",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1491,
         "digest": "sha256:ee5bcade3181fd7c0b0c33ec1deff1564623c113b6539815ae321e6e835244d0",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```

`docker pull` also works for `PR-4009` in Docker 17.x