### PR TITLE
Add remove_domain for internal auth

### DIFF
--- a/big_tests/tests/muc_light_legacy_SUITE.erl
+++ b/big_tests/tests/muc_light_legacy_SUITE.erl
@@ -147,6 +147,7 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     clear_db(),
+    escalus_fresh:clean(),
     Config1 = escalus:delete_users(Config, escalus:get_users([alice, bob, kate, mike])),
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config1).

--- a/src/auth/ejabberd_auth_internal.erl
+++ b/src/auth/ejabberd_auth_internal.erl
@@ -40,6 +40,7 @@
          get_password_s/3,
          does_user_exist/3,
          remove_user/3,
+         remove_domain/2,
          supports_sasl_module/2,
          supported_features/0
         ]).
@@ -312,6 +313,19 @@ remove_user(_HostType, LUser, LServer) ->
                 mnesia:delete({passwd, US}),
                 mnesia:dirty_update_counter(reg_users_counter,
                                             LServer, -1)
+        end,
+    mnesia:transaction(F),
+    ok.
+
+-spec remove_domain(mongooseim:host_type(), jid:lserver()) -> ok.
+remove_domain(_HostType, LServer) ->
+    Users = get_users(LServer),
+    F = fun() ->
+                lists:foreach(fun(User) ->
+                    mnesia:delete({passwd, User}),
+                    mnesia:dirty_update_counter(reg_users_counter,
+                                                LServer, -1)
+                end, Users)
         end,
     mnesia:transaction(F),
     ok.


### PR DESCRIPTION
This PR adds a function for removing the domain for `auth.internal`. It also clears the users at the end of the `muc_light_legacy_SUITE` so that it doesn't finish dirty.