### PR TITLE
Enable codecov with the new uploader

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -295,24 +295,15 @@ commands:
   restore_workspace:
     steps:
       - attach_workspace: {at: ~/project}
-  # TODO migrate to a new codecov uploader, see - https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader
-  # fetch_coverage_packages:
-  #   steps:
-  #     - run:
-  #         name: Install pip3 and codecov packages
-  #         command: |
-  #           tools/circle-install-packages.sh python3-pip && \
-  #           pip3 install codecov
-  # run_coverage_analysis:
-  #   steps:
-  #     - fetch_coverage_packages
-  #     - run:
-  #         name: Coverage
-  #         when: on_success
-  #         command: |
-  #           echo "Success!"
-  #           $EXEC ./rebar3 codecov analyze
-  #           codecov --disable=gcov --env PRESET
+  run_coverage_analysis:
+    steps:
+      - run:
+          name: Coverage
+          when: on_success
+          command: |
+            echo "Success!"
+            $EXEC ./rebar3 codecov analyze
+            tools/circle-upload-codecov.sh
   run_small_tests:
     steps:
       - restore_workspace
@@ -324,9 +315,6 @@ commands:
           name: Run Small Tests
           command: |
             $EXEC tools/test.sh -p small_tests -s true -e true
-      # - run_coverage_analysis
-      - upload_results_to_aws
-      - publish_github_comment
   run_docker_smoke_test:
     steps:
       - checkout
@@ -566,6 +554,9 @@ jobs:
       SKIP_AUTO_COMPILE: true
     steps:
       - run_small_tests
+      - run_coverage_analysis
+      - upload_results_to_aws
+      - publish_github_comment
 
   small_tests_in_docker_arm64:
     executor: arm64
@@ -585,6 +576,8 @@ jobs:
           command: |
             docker run -dit --name redis --network host --rm redis:__REDIS_VERSION__
       - run_small_tests
+      - upload_results_to_aws
+      - publish_github_comment
 
   big_tests_in_docker:
     executor: << parameters.executor >>
@@ -651,7 +644,7 @@ jobs:
             - store_test_results:
                 when: always
                 path: junit_report.xml
-      # - run_coverage_analysis
+      - run_coverage_analysis
       - run:
           name: Build Failed - Logs
           when: on_fail

--- a/tools/circle-upload-codecov.sh
+++ b/tools/circle-upload-codecov.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Source: https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader
+curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl -Os https://uploader.codecov.io/latest/linux/codecov
+curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+shasum -a 256 -c codecov.SHA256SUM
+
+chmod +x codecov
+./codecov -t ${CODECOV_TOKEN} -e PRESET


### PR DESCRIPTION
The python uploader is now [phased out](https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader).

The new uploader is a binary executable for x86-64 (amd64), so there is no simple way of running it for arm64. However, the arm64 build for small tests shouldn't affect coverage anyway (the tests are exactly the same as for amd64), so it is just
skipped for now until the uploader supports this arch, see codecov/uploader#523

`CODECOV_TOKEN` needs to be used now because of [a known issue](https://community.codecov.com/t/commit-sha-does-not-match-circle-build/4266).