### PR TITLE
Added optional max limit configuration option for quering inbox

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -701,7 +701,7 @@ jobs:
         type: executor
       platform:
         type: enum
-        enum: [centos_7, debian_stretch]
+        enum: [centos_7, debian_bullseye]
         description: Platform type
       otp_package:
         type: string
@@ -742,9 +742,9 @@ workflows:
           otp_package: "25.0.1-1"
           filters: *all_tags
       - package:
-          name: debian_stretch
+          name: debian_bullseye
           executor: otp_25
-          platform: debian_stretch
+          platform: debian_bullseye
           context: mongooseim-org
           otp_package: "25.0.1-1"
           filters: *all_tags

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -100,6 +100,15 @@ If true, the inbox conversation is removed for a user when they are removed from
 Strategy to handle incoming stanzas. For details, please refer to
 [IQ processing policies](../configuration/Modules.md#iq-processing-policies).
 
+#### `modules.mod_inbox.max_result_limit`
+* **Syntax:** the string `"infinity"` or a positive integer
+* **Default:** `"infinity"`
+* **Example:** `modules.mod_inbox.max_result_limit = 100`
+
+This option sets the maximum size of returned results when quering inbox.
+It works in the same manner as [setting a limit in iq stanza](../open-extensions/inbox.md#limiting-the-query).
+The special value `infinity` means no limit.
+
 ## Note about supported RDBMS
 
 `mod_inbox` executes upsert queries, which have different syntax in every supported RDBMS.

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -543,18 +543,7 @@ all_modules() ->
             max_http_connections => 100,
             pool_name => mongoose_push_http},
       mod_roster => mod_config(mod_roster, #{store_current_id => true, versioning => true}),
-      mod_inbox =>
-          #{backend => rdbms,
-            async_writer => #{pool_size => 2 * erlang:system_info(schedulers_online)},
-            boxes => [<<"inbox">>, <<"archive">>, <<"bin">>],
-            bin_ttl => 30,
-            bin_clean_after => timer:hours(1),
-            iqdisc => no_queue,
-            aff_changes => true,
-            delete_domain_limit => infinity,
-            groupchat => [muclight],
-            remove_on_kicked => true,
-            reset_markers => [<<"displayed">>]},
+      mod_inbox => default_mod_config(mod_inbox),
       mod_mam =>
           mod_config(mod_mam,
                      #{archive_chat_markers => true,
@@ -876,7 +865,8 @@ default_mod_config(mod_inbox) ->
       delete_domain_limit => infinity,
       remove_on_kicked => true,
       reset_markers => [<<"displayed">>],
-      iqdisc => no_queue};
+      iqdisc => no_queue,
+      max_result_limit => infinity};
 default_mod_config(mod_jingle_sip) ->
     #{proxy_host => "localhost", proxy_port => 5060, listen_port => 5600, local_host => "localhost",
       sdp_origin => "127.0.0.1", transport => "udp", username_to_phone => []};

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1556,6 +1556,8 @@ mod_inbox(_Config) ->
     ?cfgh(P ++ [aff_changes], true, T(#{<<"aff_changes">> => true})),
     ?cfgh(P ++ [delete_domain_limit], 1000, T(#{<<"delete_domain_limit">> => 1000})),
     ?cfgh(P ++ [remove_on_kicked], false, T(#{<<"remove_on_kicked">> => false})),
+    ?cfgh(P ++ [max_result_limit], infinity, T(#{<<"max_result_limit">> => <<"infinity">>})),
+    ?cfgh(P ++ [max_result_limit], 100, T(#{<<"max_result_limit">> => 100})),
     ?errh(T(#{<<"backend">> => <<"nodejs">>})),
     ?errh(T(#{<<"pool_size">> => -1})),
     ?errh(T(#{<<"reset_markers">> => 1})),
@@ -1568,7 +1570,9 @@ mod_inbox(_Config) ->
     ?errh(T(#{<<"bin_clean_after">> => -1})),
     ?errh(T(#{<<"aff_changes">> => 1})),
     ?errh(T(#{<<"delete_domain_limit">> => []})),
-    ?errh(T(#{<<"remove_on_kicked">> => 1})).
+    ?errh(T(#{<<"remove_on_kicked">> => 1})),
+    ?errh(T(#{<<"max_result_limit">> => 0})),
+    ?errh(T(#{<<"max_result_limit">> => -1})).
 
 mod_global_distrib(_Config) ->
     P = [modules, mod_global_distrib],


### PR DESCRIPTION
This PR adds a new configuration option which allows to set a limit on a page size for queries to inbox. The default option is set to infinity, i.e. not setting such option would not change anything compared to what we have now.