### PR TITLE
Add github to known hosts to avoid the unknown host error

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -488,6 +488,7 @@ jobs:
             - run:
                 name: Build latest
                 command: |
+                  ssh-keyscan github.com >> ~/.ssh/known_hosts
                   git fetch git@github.com:esl/MongooseDocs.git gh-pages:gh-pages
                   pip3 install mike
                   mike deploy $DOCS_TAG --remote git@github.com:esl/MongooseDocs.git --branch gh-pages --push --rebase


### PR DESCRIPTION
The issue is present when the latest docs are deployed from 'master', because there is no 'checkout' step now (the workspace is restored instead), and push access is needed in git.

I tested it manually on CircleCI with SSH.