### PR TITLE
Adding script building docker image from remote

### DIFF
--- a/tools/build-docker-from-remote.sh
+++ b/tools/build-docker-from-remote.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+# Setting COMMIT_HASH to the value of the first parameter or to local HEAD if it was not provided
+COMMIT_HASH=${1:-$(git rev-parse HEAD)}
+
+SRC_ROOT="$(dirname "${BASH_SOURCE}")"
+source $SRC_ROOT/circleci-prepare-mongooseim-docker.sh
+
+# Build a builder image (contains erlang and the build tools)
+docker build -f Dockerfile.builder -t mongooseim-builder .
+
+# Create a volume for the result tarballs
+docker volume create mongooseim-builds || echo "Probably already created volume"
+
+# Build MongooseIM release
+docker run --rm -v mongooseim-builds:/builds -e TARBALL_NAME=mongooseim mongooseim-builder /build.sh MongooseIM https://github.com/esl/MongooseIM ${COMMIT_HASH} 
+
+# Copy the latest build artifact
+CID=$(docker run --rm -d -v mongooseim-builds:/builds busybox sleep 1000)
+docker cp $CID:/builds/. ./member/
+docker rm -f $CID
+
+# Build a final image
+docker build -f Dockerfile.member -t mongooseim .
+
+cd ..
+rm -rf mongooseim-docker


### PR DESCRIPTION
Adding the script to build docker from remote MongooseIM.
It takes one argument, the commit hash or branch name based on which it builds the docker image. If it's not provided, the hash of current local commit is being used.

Example usage:
./tools/build-docker-from-remote.sh

./tools/build-docker-from-remote.sh master