### PR TITLE
Update version of XEP-0016: Privacy Lists

### DIFF
--- a/src/privacy/mod_privacy.erl
+++ b/src/privacy/mod_privacy.erl
@@ -25,7 +25,7 @@
 
 -module(mod_privacy).
 -author('alexey@process-one.net').
--xep([{xep, 16}, {version, "1.6"}]).
+-xep([{xep, 16}, {version, "1.7"}]).
 -xep([{xep, 126}, {version, "1.1"}]).
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).


### PR DESCRIPTION
This PR changes version of XEP-0016: Privacy Lists from 1.6 to 1.7. There were no changes in the code required as the only thing thing that's changed between the versions is the deprecation by the vote of the council.

https://xmpp.org/extensions/xep-0016.html#revision-history-v1.7
