### PR TITLE
Update version of XEP-0030: Service Discovery

### DIFF
--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -25,7 +25,7 @@
 
 -module(mod_disco).
 -author('alexey@process-one.net').
--xep([{xep, 30}, {version, "2.4"}]).
+-xep([{xep, 30}, {version, "2.5rc3"}]).
 -xep([{xep, 157}, {version, "1.0"}]).
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).


### PR DESCRIPTION
This PR changes version of XEP-0016: Privacy Lists from 2.4 to 2.5rc3.

The changes between these versions included clarifications of the existing conditions, fixing some examples, and the removal of the order restriction in the XML schema used to validate XMPP traffic.

These changes did not require any modification of the existing implementation, so only the version number has changed.

https://xmpp.org/extensions/xep-0030.html#appendix-revs