### PR TITLE
Add hook_helper to monitor hook activity

### DIFF
--- a/big_tests/tests/hook_helper.erl
+++ b/big_tests/tests/hook_helper.erl
@@ -1,0 +1,74 @@
+-module(hook_helper).
+%% API
+-export([start/4,
+         receive_all/0]).
+
+-export([handle_hook/3]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+%% Register hook on a node.
+%% Sends messages to the caller proceess.
+%% Hook is automatically unregistered if the caller dies.
+%% Example:
+%% hook_helper:start(distributed_helper:mim(), filter_packet, global, 60).
+%% Sends:
+%% {hook_called, #{hook_name := HookName, acc := Acc, params := Params}}
+start(Node, HookName, HostType, Priority) ->
+    ensure_server_started(),
+    gen_server:call(?MODULE, {register_hook, Node, HookName, HostType, Priority}).
+
+receive_all() ->
+    receive
+        {hook_called, Map} ->
+            [Map | receive_all()]
+    after 0 ->
+        []
+    end.
+
+handle_register_hook(Node, HookName, HostType, Priority, {ClientPid, _} = _From, State = #{mons := Mons}) ->
+    HookExtra = #{dest_pid => ClientPid, hook_name => HookName},
+    H = {HookName, HostType, fun ?MODULE:handle_hook/3, HookExtra, Priority},
+    ok = distributed_helper:rpc(Node, gen_hook, add_handlers, [[H]]),
+    MonRef = erlang:monitor(process, ClientPid),
+    {reply, ok, State#{mons => maps:put(MonRef, {Node, H}, Mons)}}.
+
+handle_hook(Acc, Params, #{hook_name := HookName, dest_pid := DestPid} = _Extra) ->
+    DestPid ! {hook_called, #{hook_name => HookName, acc => Acc, params => Params}},
+    {ok, Acc}.
+
+%% We need a server to serialize all register/unregister calls to
+%% avoid the race conditions.
+%% The server also monitors the caller pid.
+ensure_server_started() ->
+    %% Will start only one server.
+    gen_server:start({local, ?MODULE}, ?MODULE, [], []).
+
+init([]) ->
+    mongoose_helper:inject_module(?MODULE),
+    {ok, #{mons => #{}}}.
+
+handle_call({register_hook, Node, HookName, HostType, Priority}, From, State) ->
+    handle_register_hook(Node, HookName, HostType, Priority, From, State).
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', MonRef, _Type, _Pid, _Info}, State = #{mons := Mons}) ->
+    case maps:get(MonRef, Mons, unknown) of
+        unknown ->
+            ok;
+        {Node, H} ->
+            ok = distributed_helper:rpc(Node, gen_hook, delete_handlers, [[H]])
+    end,
+    {noreply, State#{mons => maps:delete(MonRef, Mons)}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -42,7 +42,7 @@
          remove_info/3,
          get_user_resources/1,
          set_presence/6,
-         unset_presence/5,
+         unset_presence/6,
          get_unique_sessions_number/0,
          get_total_sessions_number/0,
          get_node_sessions_number/0,
@@ -286,16 +286,17 @@ set_presence(Acc, SID, JID, Priority, Presence, Info) ->
     mongoose_hooks:set_presence_hook(Acc, JID, Presence).
 
 
--spec unset_presence(Acc, SID, JID, Status, Info) -> Acc1 when
+-spec unset_presence(Acc, SID, JID, Status, Info, Reason) -> Acc1 when
       Acc :: mongoose_acc:t(),
       Acc1 :: mongoose_acc:t(),
       SID :: 'undefined' | sid(),
       JID :: jid:jid(),
       Status :: binary(),
-      Info :: info().
-unset_presence(Acc, SID, JID, Status, Info) ->
+      Info :: info(),
+      Reason :: term().
+unset_presence(Acc, SID, JID, Status, Info, Reason) ->
     set_session(SID, JID, undefined, Info),
-    mongoose_hooks:unset_presence_hook(Acc, JID, Status).
+    mongoose_hooks:unset_presence_hook(Acc, JID, Status, Reason).
 
 
 -spec get_session_pid(JID) -> none | pid() when

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -57,7 +57,7 @@
          sm_filter_offline_message/4,
          sm_register_connection_hook/4,
          sm_remove_connection_hook/5,
-         unset_presence_hook/3,
+         unset_presence_hook/4,
          xmpp_bounce_message/1]).
 
 -export([roster_get/2,
@@ -635,13 +635,14 @@ sm_remove_connection_hook(Acc, SID, JID, Info, Reason) ->
     HostType = mongoose_acc:host_type(Acc),
     run_hook_for_host_type(sm_remove_connection_hook, HostType, Acc, Params).
 
--spec unset_presence_hook(Acc, JID, Status) -> Result when
+-spec unset_presence_hook(Acc, JID, Status, Reason) -> Result when
     Acc :: mongoose_acc:t(),
     JID:: jid:jid(),
     Status :: binary(),
+    Reason :: term(),
     Result :: mongoose_acc:t().
-unset_presence_hook(Acc, JID, Status) ->
-    Params = #{jid => JID, status => Status},
+unset_presence_hook(Acc, JID, Status, Reason) ->
+    Params = #{jid => JID, status => Status, reason => Reason},
     HostType = mongoose_acc:host_type(Acc),
     run_hook_for_host_type(unset_presence_hook, HostType, Acc, Params).
 

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -128,7 +128,7 @@ handle_user_terminate(Acc, StateData, Presences, Reason) ->
     Acc1 = mongoose_acc:update_stanza(ParamsAcc, Acc),
     presence_broadcast(Acc1, Presences#presences_state.pres_a),
     presence_broadcast(Acc1, Presences#presences_state.pres_i),
-    mongoose_hooks:unset_presence_hook(Acc1, Jid, Status),
+    mongoose_hooks:unset_presence_hook(Acc1, Jid, Status, Reason),
     {ok, Acc}.
 
 -spec foreign_event(Acc, Params, Extra) -> Result when
@@ -404,7 +404,7 @@ presence_update_to_unavailable(Acc, _FromJid, _ToJid, Packet, StateData, Presenc
     Sid = mongoose_c2s:get_sid(StateData),
     Jid = mongoose_c2s:get_jid(StateData),
     Info = mongoose_c2s:get_info(StateData),
-    Acc1 = ejabberd_sm:unset_presence(Acc, Sid, Jid, Status, Info),
+    Acc1 = ejabberd_sm:unset_presence(Acc, Sid, Jid, Status, Info, presence_unavailable),
     presence_broadcast(Acc1, Presences#presences_state.pres_a),
     presence_broadcast(Acc1, Presences#presences_state.pres_i),
     NewPresences = Presences#presences_state{pres_last = undefined,


### PR DESCRIPTION
This PR is initiated by the question "There is no way to know in mod_last if the session is killed by mod_ping".

Proposed changes include:
* Add Reason into unset_presence_hook
* Add a test logic
* **Add hook_helper to monitor hook activity** - that should make our life much easier

TODO:
* Maybe we should put into `status` info about mod_ping?
* Tests for hook_helper
* Hook helper could be named hook_monitor or hook_observer

