### PR TITLE
Change XEP-0050 version from 1.3 to 1.3.0

### DIFF
--- a/src/adhoc.erl
+++ b/src/adhoc.erl
@@ -25,7 +25,7 @@
 
 -module(adhoc).
 -author('henoch@dtek.chalmers.se').
--xep([{xep, 50}, {version, "1.3"}]).
+-xep([{xep, 50}, {version, "1.3.0"}]).
 -export([parse_request/1,
          produce_response/2,
          produce_response/4,


### PR DESCRIPTION
This PR changes XEP version in module attribute, so the table on xmpp.org is rendered correctly
