### PR TITLE
CETS backend for mod_bosh

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -240,6 +240,7 @@
     {pgsql_cets,
      [{dbs, [redis, pgsql]},
       {sm_backend, "\"cets\""},
+      {bosh_backend, "\"cets\""},
       {stream_management_backend, cets},
       {auth_method, "rdbms"},
       {internal_databases, "[internal_databases.cets]

--- a/doc/modules/mod_bosh.md
+++ b/doc/modules/mod_bosh.md
@@ -13,7 +13,7 @@ If you want to use BOSH, you must enable it both in the `listen` section of
 * **Default:** `"mnesia"`
 * **Example:** `backend = "mnesia"`
 
-Backend to use for storing BOSH connections. Currently only `"mnesia"` is supported.
+Backend to use for storing BOSH connections. `"cets"`, `"mnesia"` are supported.
 
 ### `modules.mod_bosh.inactivity`
  * **Syntax:** positive integer or the string `"infinity"`

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"351221c7a2f2c64f7ebc163428f8d340b71705ac"}},
+       {ref,"c4f47edbe1bc7d467986c8e9dca56991c14f6a77"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -246,6 +246,9 @@
 {{{mod_vcard}}}
 {{/mod_vcard}}
 [modules.mod_bosh]
+  {{#bosh_backend}}
+  backend = {{{bosh_backend}}}
+  {{/bosh_backend}}
 
 [modules.mod_carboncopy]
 

--- a/src/mod_bosh_cets.erl
+++ b/src/mod_bosh_cets.erl
@@ -1,0 +1,58 @@
+-module(mod_bosh_cets).
+
+-behaviour(mod_bosh_backend).
+
+%% mod_bosh_backend callbacks
+-export([start/0,
+         create_session/1,
+         delete_session/1,
+         get_session/1,
+         get_sessions/0,
+         node_cleanup/1]).
+
+-include("mod_bosh.hrl").
+
+-define(TABLE, cets_bosh).
+
+-spec start() -> any().
+start() ->
+    cets:start(?TABLE, #{}),
+    cets_discovery:add_table(mongoose_cets_discovery, ?TABLE).
+
+%% Session key (sid) is unique, so we don't expect conflicts
+%% So, the confict resolution could be avoided
+-spec create_session(mod_bosh:session()) -> any().
+create_session(Session) ->
+    cets:insert(?TABLE, session_to_tuple(Session)).
+
+-spec delete_session(mod_bosh:sid()) -> any().
+delete_session(Sid) ->
+    cets:delete(?TABLE, Sid).
+
+-spec get_session(mod_bosh:sid()) -> [mod_bosh:session()].
+get_session(Sid) ->
+    tuples_to_records(ets:lookup(?TABLE, Sid)).
+
+-spec get_sessions() -> [mod_bosh:session()].
+get_sessions() ->
+    tuples_to_records(ets:tab2list(?TABLE)).
+
+-spec node_cleanup(atom()) -> any().
+node_cleanup(Node) ->
+    Guard = {'==', {node, '$1'}, Node},
+    R = {'_', '$1'},
+    cets:sync(?TABLE),
+    %% We don't need to replicate deletes
+    %% We remove the local content here
+    ets:select_delete(?TABLE, [{R, [Guard], [true]}]),
+    ok.
+
+%% Simple format conversion
+session_to_tuple(#bosh_session{sid = Sid, socket = Pid}) when is_pid(Pid) ->
+    {Sid, Pid}.
+
+tuples_to_records(Tuples) ->
+    [tuple_to_record(Tuple) || Tuple <- Tuples].
+
+tuple_to_record({Sid, Pid}) ->
+    #bosh_session{sid = Sid, socket = Pid}.


### PR DESCRIPTION
This PR addresses MIM-1943.
We want to add CETS backend for mod_bosh.
There was already existing backend support in this module, so this PR is small.

Proposed changes include:
* Change SIDs generation to make them actually random. make_ref() UIDs are not cryptographically random.
* backend module for CETS.

