### PR TITLE
Fix handling of the undefined host type for stream errors

### DIFF
--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -962,7 +962,7 @@ sm_unset_reason(_) ->
 
 %% @doc This is the termination point - from here stanza is sent to the user
 -spec do_send_element(data(), exml:element(), mongoose_acc:t()) -> mongoose_acc:t().
-do_send_element(StateData = #c2s_data{host_type = <<>>}, El, Acc) ->
+do_send_element(StateData = #c2s_data{host_type = undefined}, El, Acc) ->
     send_xml(StateData, El),
     Acc;
 do_send_element(StateData = #c2s_data{host_type = HostType}, #xmlel{} = El, Acc) ->


### PR DESCRIPTION
Stream errors are often sent before the host type is known. The 'host_type' in the c2s state is then undefined, not '<<>>'.

By fixing this line:
- There are no more errors in the logs about running hooks for undefined host type.
- The line should be covered by the tests now (it was **not** covered before).

