### PR TITLE
Update version of XEP-0045: Multi-User Chat

### DIFF
--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -1874,7 +1874,9 @@ assert_is_message_correct(RoomJID, SenderNick, Type, Text, ReceivedMessage) ->
 
 enter_room(RoomJID, User, Nick) ->
     JID = jid:to_binary(jid:replace_resource(RoomJID, Nick)),
-    Pres = escalus_stanza:to(escalus_stanza:presence(<<"available">>, []), JID),
+    Pres = escalus_stanza:to(escalus_stanza:presence(<<"available">>,
+        [#xmlel{ name = <<"x">>, attrs=[{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}]}]),
+        JID),
     escalus:send(User, Pres),
     escalus:wait_for_stanza(User).
 

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -1869,6 +1869,8 @@ send_message_to_muc_room(User, Room, Body, Resource, Config) ->
 
 enter_muc_room(RoomJID, User, Nick) ->
     JID = jid:to_binary(jid:replace_resource(RoomJID, Nick)),
-    Pres = escalus_stanza:to(escalus_stanza:presence(<<"available">>, []), JID),
+    Pres = escalus_stanza:to(escalus_stanza:presence(<<"available">>,
+        [#xmlel{ name = <<"x">>, attrs=[{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}]}]),
+        JID),
     escalus:send(User, Pres),
     escalus:wait_for_stanza(User).

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -2495,8 +2495,12 @@ subject(ConfigIn) ->
     story_with_room(ConfigIn, RoomOpts, UserSpecs, fun(Config, Bob) ->
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Bob))),
         escalus:wait_for_stanza(Bob),
-        Subject = exml_query:path(escalus:wait_for_stanza(Bob), [{element, <<"subject">>}, cdata]),
-        Subject == ?SUBJECT
+        Stanza = escalus:wait_for_stanza(Bob),
+        Subject = exml_query:path(Stanza, [{element, <<"subject">>}, cdata]),
+        Subject == ?SUBJECT,
+        TimeStamp = exml_query:path(Stanza, [{element, <<"delay">>}, {attr, <<"stamp">>}]),
+        SystemTime = calendar:rfc3339_to_system_time(binary_to_list(TimeStamp), [{unit, second}]),
+        true = is_integer(SystemTime)
     end).
 
 %Example 43

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -3201,7 +3201,7 @@ disco_info_locked_room(Config) ->
                      Alice, stanza_to_room(escalus_stanza:iq_get(?NS_DISCO_INFO,[]), RoomName)),
 
         %% THEN receives MUC features
-        Namespaces = [?NS_MUC, ?NS_MUC_STABLE_ID,<<"muc_public">>, <<"muc_temporary">>,
+        Namespaces = [?NS_MUC, ?NS_MUC_STABLE_ID, <<"muc_public">>, <<"muc_temporary">>,
                       <<"muc_open">>, <<"muc_semianonymous">>, <<"muc_moderated">>,
                       <<"muc_unsecured">>],
         has_features(Stanza, Namespaces)
@@ -4862,22 +4862,22 @@ print(Element) ->
 %Basic MUC protocol
 stanza_groupchat_enter_room(Room, Nick) ->
     stanza_to_room(
-        escalus_stanza:presence(  <<"available">>,
-                                [#xmlel{ name = <<"x">>, attrs=[{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}]}]),
+        escalus_stanza:presence(<<"available">>,
+                                [#xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}]}]),
         Room, Nick).
 
 
 stanza_groupchat_enter_room_no_nick(Room) ->
     stanza_to_room(
-        escalus_stanza:presence(  <<"available">>,
-                                [#xmlel{ name = <<"x">>, attrs=[{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}]}]),
+        escalus_stanza:presence(<<"available">>,
+                                [#xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}]}]),
         Room).
 
 stanza_muc_enter_password_protected_room(Room, Nick, Password) ->
     stanza_to_room(
-        escalus_stanza:presence(  <<"available">>,
-                                [#xmlel{ name = <<"x">>, attrs=[{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}],
-                                             children=[#xmlel{name = <<"password">>, children = [#xmlcdata{content=[Password]}]} ]}]),
+        escalus_stanza:presence(<<"available">>,
+                                [#xmlel{name = <<"x">>, attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/muc">>}],
+                                            children = [#xmlel{name = <<"password">>, children = [#xmlcdata{content=[Password]}]} ]}]),
         Room, Nick).
 
 stanza_change_nick(Room, NewNick) ->
@@ -4914,9 +4914,9 @@ stanza_private_muc_message(To, Msg) ->
         #xmlel{name = <<"message">>,
             attrs = [{<<"to">>, To}, {<<"type">>, <<"chat">>}],
             children = [#xmlel{name = <<"body">>,
-                                children = [#xmlcdata{content = Msg}]},
+                               children = [#xmlcdata{content = Msg}]},
                         #xmlel{name = <<"x">>,
-                                attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/muc#user">>}]}]}.
+                               attrs = [{<<"xmlns">>, <<"http://jabber.org/protocol/muc#user">>}]}]}.
 
 stanza_change_availability(NewStatus, Room, Nick) ->
     stanza_to_room(

--- a/include/mod_muc_room.hrl
+++ b/include/mod_muc_room.hrl
@@ -82,6 +82,7 @@
                 history,
                 subject = <<>>,
                 subject_author = <<>>,
+                subject_timestamp = <<>>,
                 just_created = false     :: boolean(),
                 activity = treap:empty() :: treap:treap(),
                 room_shaper              :: shaper:shaper(),

--- a/include/mongoose_ns.hrl
+++ b/include/mongoose_ns.hrl
@@ -40,6 +40,7 @@
 -define(NS_MUC_UNIQUE,          <<"http://jabber.org/protocol/muc#unique">>).
 -define(NS_MUC_REQUEST,         <<"http://jabber.org/protocol/muc#request">>).
 -define(NS_MUC_CONFIG,          <<"http://jabber.org/protocol/muc#roomconfig">>).
+-define(NS_MUC_STABLE_ID,       <<"http://jabber.org/protocol/muc#stable_id">>).
 -define(NS_PING,                <<"urn:xmpp:ping">>).
 -define(NS_PUBSUB,              <<"http://jabber.org/protocol/pubsub">>).
 -define(NS_PUBSUB_EVENT,        <<"http://jabber.org/protocol/pubsub#event">>).

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -1266,7 +1266,7 @@ can_access_room(_, #{room := Room, user := User}, _) ->
     {ok, Acc}.
 
 -spec acc_room_affiliations(Acc, Params, Extra) -> {ok, Acc} when
-    Acc :: mongoose_acc:t(), 
+    Acc :: mongoose_acc:t(),
     Params :: #{room := jid:jid()},
     Extra :: gen_hook:extra().
 acc_room_affiliations(Acc, #{room := Room}, _) ->

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -25,7 +25,7 @@
 
 -module(mod_muc).
 -author('alexey@process-one.net').
--xep([{xep, 45}, {version, "1.25"}]).
+-xep([{xep, 45}, {version, "1.34.5"}]).
 -behaviour(gen_server).
 -behaviour(gen_mod).
 -behaviour(mongoose_packet_handler).


### PR DESCRIPTION
This PR updates implementation of MUC. 
The changes between version 1.25 and 1.34.5 include:
- Changes in the types of room config options
- Introduction of `<x/>` element in MUC-PMs
- Requirement to maintain the `id` attribute
- Removal of Group Chat 1.0 compatibility
- Use of a delay element in the initial subject message

Link to the full list of changes: https://xmpp.org/extensions/xep-0045.html#appendix-revs