### PR TITLE
updating MIM badges to release 6.1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: small_tests on OTP ${{matrix.otp}}
           path-to-lcov: ./lcov.info
+          parallel: true
       - name: upload common test results on failure
         if: ${{ failure() }}
         run: tools/gh-upload-to-s3.sh _build/test/logs test_logs

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # MongooseIM platform
 
 [![GitHub release](https://img.shields.io/github/release/esl/MongooseIM.svg)](https://github.com/esl/MongooseIM/releases)
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/esl/MongooseIM/tree/rel-6.0.svg?style=shield)](https://app.circleci.com/pipelines/github/esl/MongooseIM?branch=rel-6.0)
-[![Codecov](https://codecov.io/gh/esl/MongooseIM/branch/rel-6.0/graph/badge.svg)](https://app.codecov.io/gh/esl/MongooseIM/tree/rel-6.0)
-[![GitHub Actions](https://github.com/esl/MongooseIM/workflows/CI/badge.svg?branch=rel-6.0)](https://github.com/esl/MongooseIM/actions?query=workflow%3ACI+branch%3Arel-6.0)
-[![Coveralls](https://coveralls.io/repos/github/esl/MongooseIM/badge.svg?branch=rel-6.0)](https://coveralls.io/github/esl/MongooseIM?branch=rel-6.0)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/esl/MongooseIM/tree/rel-6.1.svg?style=shield)](https://app.circleci.com/pipelines/github/esl/MongooseIM?branch=rel-6.1)
+[![Codecov](https://codecov.io/gh/esl/MongooseIM/branch/rel-6.1/graph/badge.svg)](https://app.codecov.io/gh/esl/MongooseIM/tree/rel-6.1)
+[![GitHub Actions](https://github.com/esl/MongooseIM/workflows/CI/badge.svg?branch=rel-6.1)](https://github.com/esl/MongooseIM/actions/workflows/ci.yml?query=branch%3Arel-6.1)
+[![Coveralls](https://coveralls.io/repos/github/esl/MongooseIM/badge.svg?branch=rel-6.1)](https://coveralls.io/github/esl/MongooseIM?branch=rel-6.1)
 
 * [Getting started](https://esl.github.io/MongooseDocs/latest/getting-started/Installation/)
 * [Developer's guide](https://esl.github.io/MongooseDocs/latest/developers-guide/Testing-MongooseIM/)

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,10 +1,10 @@
 # MongooseIM platform overview
 
 [![GitHub release](https://img.shields.io/github/release/esl/MongooseIM.svg)](https://github.com/esl/MongooseIM/releases)
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/esl/MongooseIM/tree/rel-6.0.svg?style=shield)](https://app.circleci.com/pipelines/github/esl/MongooseIM?branch=rel-6.0)
-[![Codecov](https://codecov.io/gh/esl/MongooseIM/branch/rel-6.0/graph/badge.svg)](https://app.codecov.io/gh/esl/MongooseIM/tree/rel-6.0)
-[![GitHub Actions](https://github.com/esl/MongooseIM/workflows/CI/badge.svg?branch=rel-6.0)](https://github.com/esl/MongooseIM/actions?query=workflow%3ACI+branch%3Arel-6.0)
-[![Coveralls](https://coveralls.io/repos/github/esl/MongooseIM/badge.svg?branch=rel-6.0)](https://coveralls.io/github/esl/MongooseIM?branch=rel-6.0)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/esl/MongooseIM/tree/rel-6.1.svg?style=shield)](https://app.circleci.com/pipelines/github/esl/MongooseIM?branch=rel-6.1)
+[![Codecov](https://codecov.io/gh/esl/MongooseIM/branch/rel-6.1/graph/badge.svg)](https://app.codecov.io/gh/esl/MongooseIM/tree/rel-6.1)
+[![GitHub Actions](https://github.com/esl/MongooseIM/workflows/CI/badge.svg?branch=rel-6.1)](https://github.com/esl/MongooseIM/actions/workflows/ci.yml?query=branch%3Arel-6.1)
+[![Coveralls](https://coveralls.io/repos/github/esl/MongooseIM/badge.svg?branch=rel-6.1)](https://coveralls.io/github/esl/MongooseIM?branch=rel-6.1)
 
 * Home: [https://github.com/esl/MongooseIM](https://github.com/esl/MongooseIM)
 * Product page: [https://www.erlang-solutions.com/products/mongooseim.html](https://www.erlang-solutions.com/products/mongooseim.html)


### PR DESCRIPTION
updating MIM badges to release 6.1.x

FYI, documentation for 6.1.0 release is already updated:
- https://esl.github.io/MongooseDocs/6.1.0/

+adding missing parallel flag for coveralls GH action.

