### PR TITLE
Update xep attributes for 178 and add for 220

### DIFF
--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -27,6 +27,9 @@
 -author('alexey@process-one.net').
 -behaviour(p1_fsm).
 
+% TODO this should be in a separate module after feature/cets is merged
+-xep([{xep, 220}, {version, "1.1.1"}]).
+
 %% External exports
 -export([start/3,
          start_link/3,

--- a/src/sasl/cyrsasl_external.erl
+++ b/src/sasl/cyrsasl_external.erl
@@ -20,7 +20,7 @@
 %%%=============================================================================
 -module(cyrsasl_external).
 
--xep([{xep, 178}, {version, "1.1"}, {status, partial}]).
+-xep([{xep, 178}, {version, "1.2"}, {status, partial}]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").


### PR DESCRIPTION
This PR updates XEP-0178 version. It's still partial since we support only client-server SASL EXTERNAL.
It also adds an attribute for XEP-0220 which was already fully supported and implemented in `ejabberd_s2s_in` and `ejabberd_s2s_out`. I decided to put it only in one module to avoid mess. In `feature/cets` branch there's ongoing refactor of diaback, so this attribute should be only in newly introduced module after merge.