### PR TITLE
fixing GH Actions condition for metrics uploading to GA4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         if: ${{ failure() }}
         run: tools/gh-upload-to-s3.sh big_tests/ct_report
       - name: upload big_tests results to GA4
-        if: github.ref_name == 'master'
+        if: ${{ !cancelled() && github.ref_name == 'master' }}
         run: tools/gh-report-failing-testcases-to-ga4.sh
 
   dynamic_domains_big_tests:
@@ -112,7 +112,7 @@ jobs:
         if: ${{ failure() }}
         run: tools/gh-upload-to-s3.sh big_tests/ct_report
       - name: upload big_tests results to GA4
-        if: github.ref_name == 'master'
+        if: ${{ !cancelled() && github.ref_name == 'master' }}
         run: tools/gh-report-failing-testcases-to-ga4.sh
 
   coveralls_webhook:


### PR DESCRIPTION
Minor fix to GH Actions.

here is a reference to the corresponding example in docs
https://docs.github.com/en/actions/learn-github-actions/expressions#example-of-failure-with-conditions