### PR TITLE
Fixing global distrib suite

### DIFF
--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -270,7 +270,7 @@ get_inbox(Client, GetParams, #{count := ExpectedCount} = ExpectedResult, Check) 
     Validator = fun(#{respond_messages := Val}) -> ExpectedCount =:= length(Val) end,
     {ok, Inbox} = mongoose_helper:wait_until(
                     fun() -> Check(do_get_inbox(Client, GetInbox)) end,
-                    ExpectedCount, #{validator => Validator, name => inbox_size}),
+                    Validator, #{name => inbox_size}),
     #{respond_iq := ResIQ} = Inbox,
     ?assert(escalus_pred:is_iq_result(GetInbox, ResIQ)),
     check_result(ResIQ, ExpectedResult),
@@ -576,7 +576,7 @@ make_members(Room, Admin, Users) ->
     % gets iq result and affs changes from all users
     escalus:wait_for_stanzas(Admin, 1 + length(Users)),
     % Everybody gets aff changes of everybody
-    lists:foreach(fun(User) -> escalus:wait_for_stanzas(User, length(Users)) end, Users). 
+    lists:foreach(fun(User) -> escalus:wait_for_stanzas(User, length(Users)) end, Users).
 
 % All users enter the room
 enter_room(Room, Users) ->

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -2932,7 +2932,7 @@ metrics_incremented_for_async_pools(Config) ->
     Validator = fun(NewValue) -> OldValue =/= NewValue end,
     mongoose_helper:wait_until(
       fun get_mongoose_async_metrics/0,
-      true, #{validator => Validator, name => ?FUNCTION_NAME}).
+      Validator, #{name => ?FUNCTION_NAME}).
 
 get_mongoose_async_metrics() ->
     HostType = domain_helper:host_type(mim),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -382,7 +382,8 @@ test_advertised_endpoints_override_endpoints(_Config) ->
 %% from backend and starts appropriate pool.
 test_host_refreshing(_Config) ->
     mongoose_helper:wait_until(fun() -> trees_for_connections_present() end, true,
-                               #{name => trees_for_connections_present}),
+                               #{name => trees_for_connections_present,
+                                 time_left => timer:seconds(10)}),
     ConnectionSups = out_connection_sups(asia_node),
     {europe_node1, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
     EuropeSup = rpc(asia_node, mod_global_distrib_utils, server_to_sup_name, [EuropeHost]),

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -341,29 +341,39 @@ wait_until(Fun, ExpectedValue) ->
     wait_until(Fun, ExpectedValue, #{}).
 
 %% Example: wait_until(fun () -> ... end, SomeVal, #{time_left => timer:seconds(2)})
-wait_until(Fun, ExpectedValue, Opts) ->
-    Defaults = #{validator => fun(NewValue) -> ExpectedValue =:= NewValue end,
-                 expected_value => ExpectedValue,
-                 time_left => timer:seconds(5),
+%% if expected value is a function with arity 1, it's treated as a validation function.
+wait_until(Fun, ExpectedValue, Opts0) ->
+    Defaults = #{time_left => timer:seconds(5),
                  sleep_time => 100,
-                 history => [],
                  name => timeout},
-    do_wait_until(Fun, maps:merge(Defaults, Opts)).
+    Opts1 = maps:merge(Defaults, Opts0),
+    TimeLeft = maps:get(time_left, Opts1),
+    Opts = Opts1#{waiting_time => 0, max_waiting_time => TimeLeft,
+                  history => [], expected_value => ExpectedValue},
+    do_wait_until(Fun, Opts).
 
-do_wait_until(_Fun, #{expected_value := ExpectedValue,
-                      time_left := TimeLeft,
-                      history := History,
-                      name := Name} = Opts) when TimeLeft =< 0 ->
+do_wait_until(_Fun, #{expected_value := ExpectedValue, time_left := TimeLeft,
+                      history := History, name := Name} = Opts) when TimeLeft =< 0 ->
     error({Name, ExpectedValue, simplify_history(lists:reverse(History), 1), on_error(Opts)});
-do_wait_until(Fun, #{validator := Validator} = Opts) ->
+do_wait_until(Fun, #{expected_value := ExpectedValue, name := Name,
+                     waiting_time := WaitingTime} = Opts) ->
     try Fun() of
-        Value -> case Validator(Value) of
-                     true -> {ok, Value};
-                     _ -> wait_and_continue(Fun, Value, Opts)
-                 end
+        Value ->
+            case validate_returned_value(ExpectedValue, Value) of
+                true ->
+                    ct:pal("waiting for ~p is done in ~p miliseconds", [Name, WaitingTime]),
+                    {ok, Value};
+                _ ->
+                    wait_and_continue(Fun, Value, Opts)
+            end
     catch Error:Reason:Stacktrace ->
               wait_and_continue(Fun, {Error, Reason, Stacktrace}, Opts)
     end.
+
+validate_returned_value(ValidatorFn, Value) when is_function(ValidatorFn, 1) ->
+    ValidatorFn(Value);
+validate_returned_value(ExpectedValue, Value) ->
+    ExpectedValue =:= Value.
 
 on_error(#{on_error := F}) ->
     F();
@@ -377,11 +387,11 @@ simplify_history([H|T], Times) ->
 simplify_history([], 1) ->
     [].
 
-wait_and_continue(Fun, FunResult, #{time_left := TimeLeft,
-                                    sleep_time := SleepTime,
-                                    history := History} = Opts) ->
+wait_and_continue(Fun, FunResult, #{waiting_time := WaitingTime, history := History,
+                                    time_left := TimeLeft, sleep_time := SleepTime} = Opts) ->
     timer:sleep(SleepTime),
     do_wait_until(Fun, Opts#{time_left => TimeLeft - SleepTime,
+                             waiting_time => WaitingTime + SleepTime,
                              history => [FunResult | History]}).
 
 wait_for_user(Config, User, LeftTime) ->

--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -475,9 +475,10 @@ check_password(Config) ->
     OldValue = get_metric(MetricName),
     {_, 0} = mongooseimctl("check_password", [User, Domain, Pass], Config),
     {_, ErrCode} = mongooseimctl("check_password", [User, Domain, <<Pass/binary, "Bad">>], Config),
+    ValidatorFn = fun(NewValue) -> OldValue =/= NewValue end,
     mongoose_helper:wait_until(
-      fun() -> get_metric(MetricName) end, true,
-      #{validator => fun(NewValue) -> OldValue =/= NewValue end, name => ?FUNCTION_NAME}),
+      fun() -> get_metric(MetricName) end,
+      ValidatorFn, #{name => ?FUNCTION_NAME}),
     true = (ErrCode =/= 0). %% Must return code other than 0
 
 get_metric(MetricName) ->

--- a/big_tests/tests/smart_markers_SUITE.erl
+++ b/big_tests/tests/smart_markers_SUITE.erl
@@ -404,6 +404,7 @@ verify_marker_fetch(MarkingUser, MarkedUser, Thread, After) ->
                           _ -> [{<<"after">>, After}]
                       end,
         Iq = iq_fetch_marker(MarkedUserBJid ++ MaybeThread ++ MaybeAfter),
+        %% using wait_until to ensure that assertions are eventually passing
         mongoose_helper:wait_until(
           fun() ->
                   escalus:send(MarkingUser, Iq),
@@ -418,7 +419,9 @@ verify_marker_fetch(MarkingUser, MarkedUser, Thread, After) ->
                   ?assertEqual(Thread, exml_query:attr(Marker, <<"thread">>)),
                   ?assertNotEqual(undefined, exml_query:attr(Marker, <<"id">>)),
                   lists:sort(Markers)
-          end, ok, #{name => fetch_marker, validator => fun(_) -> true end}).
+          end,
+          fun(_) -> true end, %% always positively validate the return value.
+          #{name => fetch_marker}).
 
 verify_marker_fetch_is_empty(MarkingUser, MarkedUser) ->
         MarkedUserBJid = escalus_utils:jid_to_lower(escalus_client:short_jid(MarkedUser)),

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -124,7 +124,7 @@ get_new_tcp_metric_value(OldValue) ->
     Validator = fun(NewValue) -> OldValue =/= NewValue end,
     {ok, {ok, [{value, X}]}} = async_helper:wait_until(
       fun() -> mongoose_metrics:get_metric_value(global, tcpPortsUsed) end,
-      true, #{validator => Validator, sleep_time => 30, time_left => 500}
+      Validator, #{sleep_time => 30, time_left => 500}
      ),
     X.
 


### PR DESCRIPTION
Timeout for `trees_for_connections_present` action is increased from 5 to 10 seconds:
• in most cases waiting takes 4,5-5,5 seconds on GH Actions runner
• and almost always above 5 seconds for mysql_redis preset (as redis is used for session data as well)
so this test case failed a lot and practically blocked passing of GH Actions builds

Also, wait_until helper code is improved a bit.

Successful GH Actions build: https://github.com/esl/MongooseIM/actions/runs/5605253063