### PR TITLE
Fixing global distrib suite

### DIFF
--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -382,7 +382,8 @@ test_advertised_endpoints_override_endpoints(_Config) ->
 %% from backend and starts appropriate pool.
 test_host_refreshing(_Config) ->
     mongoose_helper:wait_until(fun() -> trees_for_connections_present() end, true,
-                               #{name => trees_for_connections_present}),
+                               #{name => trees_for_connections_present,
+                                 time_left => timer:seconds(10)}),
     ConnectionSups = out_connection_sups(asia_node),
     {europe_node1, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
     EuropeSup = rpc(asia_node, mod_global_distrib_utils, server_to_sup_name, [EuropeHost]),


### PR DESCRIPTION
Timeout for trees_for_connections_present action is increased from 5 to 10 seconds:
• in most cases waiting takes 4,5-5,5 seconds on GH Actions runner
• and almost always above 5 seconds for mysql_redis preset (as redis is used for session data as well)
so this test case failed a lot and practically blocked passing of GH Actions builds

GH Actions build: https://github.com/esl/MongooseIM/actions/runs/5608903520