### PR TITLE
CETS backend for mod_muc

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -244,7 +244,7 @@
       {component_backend, "\"cets\""},
       {s2s_backend, "\"cets\""},
       {stream_management_backend, cets},
-      {muc_backend, cets},
+      {muc_online_backend, cets},
       {auth_method, "rdbms"},
       {internal_databases, "[internal_databases.cets]
   cluster_name = \"{{cluster_name}}\"

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -244,6 +244,7 @@
       {component_backend, "\"cets\""},
       {s2s_backend, "\"cets\""},
       {stream_management_backend, cets},
+      {muc_backend, cets},
       {auth_method, "rdbms"},
       {internal_databases, "[internal_databases.cets]
   cluster_name = \"{{cluster_name}}\"

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -162,7 +162,7 @@ is_internal_or_rdbms() ->
 %%%===================================================================
 
 init_per_testcase(muc_removal, Config) ->
-    muc_helper:load_muc(),
+    muc_helper:load_muc(Config),
     mongoose_helper:ensure_muc_clean(),
     escalus:init_per_testcase(muc_removal, Config);
 init_per_testcase(roster_removal, ConfigIn) ->

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -316,7 +316,7 @@ end_per_testcase(CN, Config) when
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(CN, Config) when CN =:= retrieve_inbox_muc;
                                   CN =:= remove_inbox_muc ->
-    muc_helper:unload_muc(Config),
+    muc_helper:unload_muc(),
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(CN, Config) ->
     escalus_fresh:clean(),

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -180,7 +180,7 @@ all_mam_testcases() ->
 init_per_suite(Config) ->
     #{node := MimNode} = distributed_helper:mim(),
     Config1 = [{{ejabberd_cwd, MimNode}, get_mim_cwd()} | dynamic_modules:save_modules(host_type(), Config)],
-    muc_helper:load_muc(),
+    muc_helper:load_muc(Config),
     escalus:init_per_suite(Config1).
 
 end_per_suite(Config) ->
@@ -243,7 +243,7 @@ init_per_testcase(CN, Config) when
     Config1;
 init_per_testcase(CN, Config) when CN =:= retrieve_inbox_muc;
                                    CN =:= remove_inbox_muc ->
-    muc_helper:load_muc(),
+    muc_helper:load_muc(Config),
     Config0 = init_inbox(CN, Config, muc),
     Config0;
 
@@ -316,7 +316,7 @@ end_per_testcase(CN, Config) when
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(CN, Config) when CN =:= retrieve_inbox_muc;
                                   CN =:= remove_inbox_muc ->
-    muc_helper:unload_muc(),
+    muc_helper:unload_muc(Config),
     escalus:end_per_testcase(CN, Config);
 end_per_testcase(CN, Config) ->
     escalus_fresh:clean(),

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -280,7 +280,7 @@ maybe_enable_mam() ->
 ensure_muc_started(Config) ->
     SecondaryHostType = domain_helper:secondary_host_type(),
     muc_helper:load_muc(Config),
-    muc_helper:load_muc(SecondaryHostType),
+    muc_helper:load_muc(Config, SecondaryHostType),
     mongoose_helper:ensure_muc_clean().
 
 ensure_muc_stopped() ->

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -227,7 +227,7 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     mongoose_helper:ensure_muc_clean(),
-    muc_helper:unload_muc(),
+    muc_helper:unload_muc(Config),
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
@@ -237,20 +237,20 @@ init_per_group(admin_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
 init_per_group(domain_admin_muc, Config) ->
     maybe_enable_mam(),
-    ensure_muc_started(),
+    ensure_muc_started(Config),
     graphql_helper:init_domain_admin_handler(Config);
 init_per_group(user, Config) ->
     graphql_helper:init_user(Config);
 init_per_group(Group, Config) when Group =:= admin_muc_configured;
                                    Group =:= user_muc_configured ->
     disable_mam(),
-    ensure_muc_started(),
+    ensure_muc_started(Config),
     Config;
 init_per_group(Group, Config) when Group =:= admin_muc_and_mam_configured;
                                    Group =:= user_muc_and_mam_configured ->
     case maybe_enable_mam() of
         true ->
-            ensure_muc_started(),
+            ensure_muc_started(Config),
             ensure_muc_light_started(Config);
         false ->
             {skip, "No MAM backend available"}
@@ -277,9 +277,9 @@ maybe_enable_mam() ->
             true
     end.
 
-ensure_muc_started() ->
+ensure_muc_started(Config) ->
     SecondaryHostType = domain_helper:secondary_host_type(),
-    muc_helper:load_muc(),
+    muc_helper:load_muc(Config),
     muc_helper:load_muc(SecondaryHostType),
     mongoose_helper:ensure_muc_clean().
 

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -227,7 +227,7 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     mongoose_helper:ensure_muc_clean(),
-    muc_helper:unload_muc(Config),
+    muc_helper:unload_muc(),
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -237,7 +237,7 @@ init_per_group(Group, Config) when Group =:= user_muc_light_with_mam;
                                    Group =:= domain_admin_muc_light_with_mam ->
     case maybe_enable_mam() of
         true ->
-            ensure_muc_started(),
+            ensure_muc_started(Config),
             ensure_muc_light_started(Config);
         false ->
             {skip, "No MAM backend available"}
@@ -281,8 +281,8 @@ ensure_muc_light_stopped(Config) ->
     dynamic_modules:ensure_modules(SecondaryHostType, [{mod_muc_light, stopped}]),
     [{muc_light_host, <<"NON_EXISTING">>} | Config].
 
-ensure_muc_started() ->
-    muc_helper:load_muc(),
+ensure_muc_started(Config) ->
+    muc_helper:load_muc(Config),
     mongoose_helper:ensure_muc_clean().
 
 ensure_muc_stopped() ->

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -186,7 +186,7 @@ init_per_group(muclight_config, Config) ->
     Config1 = inbox_helper:reload_inbox_option(Config, groupchat, [muclight]),
     escalus:create_users(Config1, escalus:get_users([alice, alice_bis, bob, kate, mike]));
 init_per_group(muc, Config) ->
-    muc_helper:load_muc(),
+    muc_helper:load_muc(Config),
     inbox_helper:reload_inbox_option(Config, groupchat, [muc]);
 init_per_group(limit_result, Config) ->
     OptKey = [{modules, domain_helper:host_type()}, mod_inbox, max_result_limit],

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -540,7 +540,7 @@ suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 init_per_suite(Config) ->
-    muc_helper:load_muc(),
+    muc_helper:load_muc(Config),
     mam_helper:prepare_for_suite(
       increase_limits(
         delete_users([{escalus_user_db, {module, escalus_ejabberd}}

--- a/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
@@ -110,7 +110,7 @@ init_per_suite(Config) ->
         true ->
             start_rabbit_wpool(domain()),
             {ok, _} = application:ensure_all_started(amqp_client),
-            muc_helper:load_muc(),
+            muc_helper:load_muc(Config),
             escalus:init_per_suite(Config);
         false ->
             {skip, "RabbitMQ server is not available on default port."}

--- a/big_tests/tests/mod_event_pusher_sns_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_sns_SUITE.erl
@@ -60,7 +60,7 @@ init_per_suite(Config) ->
             %% For mocking with unnamed functions
             mongoose_helper:inject_module(?MODULE),
 
-            muc_helper:load_muc(),
+            muc_helper:load_muc(Config),
             escalus:init_per_suite(Config);
         {error, _} ->
             {skip, "erlcloud dependency is not enabled"}

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -254,7 +254,7 @@ init_per_testcase(CaseName, Config)
     {_, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
     trigger_rebalance(asia_node, EuropeHost),
     %% Load muc on mim node
-    muc_helper:load_muc(),
+    muc_helper:load_muc(Config),
     RegNode = ct:get_config({hosts, reg, node}),
     %% Wait for muc.localhost to become visible from reg node
     wait_for_domain(RegNode, muc_helper:muc_host()),

--- a/big_tests/tests/mongoose_helper.erl
+++ b/big_tests/tests/mongoose_helper.erl
@@ -242,7 +242,8 @@ stop_online_rooms() ->
         false -> ct:fail({ejabberd_mod_muc_sup_not_found, Supervisor, HostType})
     end,
     rpc(mim(), erlang, exit, [SupervisorPid, kill]),
-    rpc(mim(), mnesia, clear_table, [muc_online_room]),
+    %% That's a pretty dirty way
+    rpc(mim(), mongoose_muc_online_backend, clear_table, [HostType]),
     ok.
 
 forget_persistent_rooms() ->

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -29,8 +29,6 @@
 
 -import(muc_helper,
         [muc_host/0,
-         load_muc/0,
-         unload_muc/0,
          start_room/5,
          generate_rpc_jid/1,
          destroy_room/1,
@@ -331,14 +329,14 @@ init_per_suite(Config) ->
     Config2 = escalus:init_per_suite(Config),
     Config3 = dynamic_modules:save_modules(host_type(), Config2),
     dynamic_modules:restart(host_type(), mod_disco, default_mod_config(mod_disco)),
-    load_muc(),
+    muc_helper:load_muc(Config),
     mongoose_helper:ensure_muc_clean(),
     Config3.
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     mongoose_helper:ensure_muc_clean(),
-    unload_muc(),
+    muc_helper:unload_muc(),
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -87,7 +87,7 @@ muc_host_pattern() ->
 muc_backend() ->
     mongoose_helper:mnesia_or_rdbms_backend().
 
-muc_online_backend(Config) ->
+muc_online_backend(Config) when is_list(Config) ->
     ct_helper:get_preset_var(Config, muc_backend, mnesia).
 
 start_room(Config, User, Room, Nick, Opts) ->

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -88,7 +88,7 @@ muc_backend() ->
     mongoose_helper:mnesia_or_rdbms_backend().
 
 muc_online_backend(Config) when is_list(Config) ->
-    ct_helper:get_preset_var(Config, muc_backend, mnesia).
+    ct_helper:get_preset_var(Config, muc_online_backend, mnesia).
 
 start_room(Config, User, Room, Nick, Opts) ->
     From = generate_rpc_jid(User),

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -52,14 +52,15 @@ foreach_recipient(Users, VerifyFun) ->
               VerifyFun(escalus:wait_for_stanza(Recipient))
       end, Users).
 
-load_muc() ->
-    load_muc(domain_helper:host_type()).
+load_muc(Config) ->
+    load_muc(Config, domain_helper:host_type()).
 
-load_muc(HostType) ->
+load_muc(Config, HostType) ->
     Backend = muc_backend(),
     MucHostPattern = ct:get_config({hosts, mim, muc_service_pattern}),
     ct:log("Starting MUC for ~p", [HostType]),
     Opts = #{host => subhost_pattern(MucHostPattern), backend => Backend,
+             online_backend => muc_online_backend(Config),
              hibernate_timeout => 2000,
              hibernated_room_check_interval => 1000,
              hibernated_room_timeout => 2000,
@@ -85,6 +86,9 @@ muc_host_pattern() ->
 
 muc_backend() ->
     mongoose_helper:mnesia_or_rdbms_backend().
+
+muc_online_backend(Config) ->
+    ct_helper:get_preset_var(Config, muc_backend, mnesia).
 
 start_room(Config, User, Room, Nick, Opts) ->
     From = generate_rpc_jid(User),

--- a/big_tests/tests/muc_http_api_SUITE.erl
+++ b/big_tests/tests/muc_http_api_SUITE.erl
@@ -66,7 +66,7 @@ failure_response() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    muc_helper:load_muc(),
+    muc_helper:load_muc(Config),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->

--- a/include/mod_muc.hrl
+++ b/include/mod_muc.hrl
@@ -7,8 +7,3 @@
                           host_type,
                           pid
                          }).
-
--record(muc_registered, {
-          us_host,
-          nick
-         }).

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"458e2e1df3fb51896fe334385bb0d2c9c53ef87f"}},
+       {ref,"7d4876fe5285118f5349970ffb20080ea62293db"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -138,9 +138,10 @@
          mod_global_distrib_unknown_recipient/2]).
 
 -export([remove_domain/2,
-         node_cleanup/1]).
+         node_cleanup/1,
+         node_cleanup_for_host_type/2]).
 
--ignore_xref([node_cleanup/1, remove_domain/2]).
+-ignore_xref([remove_domain/2]).
 -ignore_xref([mam_archive_sync/1, mam_muc_archive_sync/1]).
 
 %% Just a map, used by some hooks as a first argument.
@@ -216,6 +217,11 @@ remove_domain(HostType, Domain) ->
 node_cleanup(Node) ->
     Params = #{node => Node},
     run_global_hook(node_cleanup, #{}, Params).
+
+-spec node_cleanup_for_host_type(HostType :: mongooseim:host_type(), Node :: node()) -> Acc :: map().
+node_cleanup_for_host_type(HostType, Node) ->
+    Params = #{node => Node},
+    run_hook_for_host_type(node_cleanup_for_host_type, HostType, #{}, Params).
 
 -spec failed_to_store_message(Acc) -> Result when
     Acc :: mongoose_acc:t(),

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -446,7 +446,6 @@ get_nick(HostType, MucHost, From) ->
 init({HostType, Opts}) ->
     mod_muc_backend:init(HostType, Opts),
     catch ets:new(muc_online_users, [bag, named_table, public, {keypos, 2}]),
-    node_cleanup(HostType, node()),
     #{access := Access,
       access_create := AccessCreate,
       access_admin := AccessAdmin,

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -921,8 +921,12 @@ register_room(HostType, MucHost, Room, Pid) ->
 
 -spec room_jid_to_pid(RoomJID :: jid:jid()) -> {ok, pid()} | {error, not_found}.
 room_jid_to_pid(#jid{luser = Room, lserver = MucHost}) ->
-    {ok, HostType} = mongoose_domain_api:get_subdomain_host_type(MucHost),
-    find_room_pid(HostType, MucHost, Room).
+    case mongoose_domain_api:get_subdomain_host_type(MucHost) of
+        {ok, HostType} ->
+            find_room_pid(HostType, MucHost, Room);
+        _ ->
+            {error, not_found}
+    end.
 
 find_room_pid(HostType, MucHost, Room) ->
     mongoose_muc_online_backend:find_room_pid(HostType, MucHost, Room).

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -1164,10 +1164,8 @@ broadcast_service_message(MucHost, Msg) ->
 
 -spec get_vh_rooms(muc_host()) -> [muc_online_room()].
 get_vh_rooms(MucHost) ->
-    mnesia:dirty_select(muc_online_room,
-                        [{#muc_online_room{name_host = '$1', _ = '_'},
-                          [{'==', {element, 2, '$1'}, MucHost}],
-                          ['$_']}]).
+    {ok, HostType} = mongoose_domain_api:get_subdomain_host_type(MucHost),
+    mongoose_muc_online_backend:get_online_rooms(HostType, MucHost).
 
 -spec get_persistent_vh_rooms(muc_host()) -> [muc_room()].
 get_persistent_vh_rooms(MucHost) ->

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -444,10 +444,6 @@ get_nick(HostType, MucHost, From) ->
 -spec init({host_type(), map()}) -> {ok, state()}.
 init({HostType, Opts}) ->
     mod_muc_backend:init(HostType, Opts),
-    mnesia:create_table(muc_online_room,
-                        [{ram_copies, [node()]},
-                         {attributes, record_info(fields, muc_online_room)}]),
-    mnesia:add_table_copy(muc_online_room, node(), ram_copies),
     catch ets:new(muc_online_users, [bag, named_table, public, {keypos, 2}]),
     clean_table_from_bad_node(node(), HostType),
     mnesia:subscribe(system),

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -119,11 +119,6 @@
     pid       :: pid()
 }.
 
--type muc_registered() :: #muc_registered{
-                             us_host    :: jid:literal_jid(),
-                             nick       :: nick()
-                            }.
-
 -type room_event_data() :: #{
                   from_nick := nick(),
                   from_jid := jid:jid(),
@@ -146,7 +141,7 @@
 
 -type state() :: #muc_state{}.
 
--export_type([muc_room/0, muc_registered/0]).
+-export_type([muc_room/0]).
 
 -define(PROCNAME, ejabberd_mod_muc).
 

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -921,22 +921,7 @@ register_room_or_stop_if_duplicate(HostType, MucHost, Room, Pid) ->
 -spec register_room(HostType :: host_type(), jid:server(), room(),
                     pid()) -> ok | {exists, pid()} | {error, term()}.
 register_room(HostType, MucHost, Room, Pid) ->
-    F = fun() ->
-            case mnesia:read(muc_online_room,  {Room, MucHost}, write) of
-                [] ->
-                    mnesia:write(#muc_online_room{name_host = {Room, MucHost},
-                                                  host_type = HostType,
-                                                  pid = Pid});
-                [R] ->
-                    {exists, R#muc_online_room.pid}
-            end
-        end,
-    simple_transaction_result(mnesia:transaction(F)).
-
-simple_transaction_result({atomic, Res}) ->
-    Res;
-simple_transaction_result({aborted, Reason}) ->
-    {error, Reason}.
+    mongoose_muc_online_backend:register_room(HostType, MucHost, Room, Pid).
 
 -spec room_jid_to_pid(RoomJID :: jid:jid()) -> {ok, pid()} | {error, not_found}.
 room_jid_to_pid(#jid{luser=RoomName, lserver=MucService}) ->

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -119,6 +119,7 @@
     host_type :: host_type(),
     pid       :: pid()
 }.
+-export_type([muc_online_room/0]).
 
 -type room_event_data() :: #{
                   from_nick := nick(),

--- a/src/mod_muc_mnesia.erl
+++ b/src/mod_muc_mnesia.erl
@@ -41,6 +41,11 @@
 -include("jlib.hrl").
 -include("mod_muc.hrl").
 
+-record(muc_registered, {
+            us_host    :: {US :: jid:simple_bare_jid(), MucHost :: jid:lserver()} | '$1',
+            nick       :: mod_muc:nick()
+         }).
+
 init(_HostType, _Opts) ->
     mnesia:create_table(muc_room,
                         [{disc_copies, [node()]},

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -154,13 +154,11 @@
 %%% API
 %%%----------------------------------------------------------------------
 
--spec start_new(HostType :: mongooseim:host_type(), Host :: jid:server(), ServerHost :: jid:server(),
+-spec start_new(HostType :: mongooseim:host_type(), Host :: jid:lserver(), ServerHost :: jid:lserver(),
             Access :: _, Room :: mod_muc:room(), HistorySize :: integer(),
             RoomShaper :: shaper:shaper(), HttpAuthPool :: none | mongoose_http_client:pool(),
             Creator :: jid:jid(), Nick :: mod_muc:nick(),
-            DefRoomOpts :: list()) -> {'error', _}
-                                          | {'ok', 'undefined' | pid()}
-                                          | {'ok', 'undefined' | pid(), _}.
+            DefRoomOpts :: list()) -> {ok, pid()}.
 start_new(HostType, Host, ServerHost, Access, Room,
           HistorySize, RoomShaper, HttpAuthPool, Creator, Nick, DefRoomOpts) ->
     Supervisor = gen_mod:get_module_proc(HostType, ejabberd_mod_muc_sup),
@@ -171,12 +169,10 @@ start_new(HostType, Host, ServerHost, Access, Room,
              creator => Creator, nick => Nick, def_opts => DefRoomOpts},
     supervisor:start_child(Supervisor, [Args]).
 
--spec start_restored(HostType :: mongooseim:host_type(), Host :: jid:server(), ServerHost :: jid:server(),
+-spec start_restored(HostType :: mongooseim:host_type(), Host :: jid:lserver(), ServerHost :: jid:lserver(),
             Access :: _, Room :: mod_muc:room(), HistorySize :: integer(),
             RoomShaper :: shaper:shaper(), HttpAuthPool :: none | mongoose_http_client:pool(),
-            Opts :: list()) -> {'error', _}
-                                   | {'ok', 'undefined' | pid()}
-                                   | {'ok', 'undefined' | pid(), _}.
+            Opts :: list()) -> {ok, pid()}.
 start_restored(HostType, Host, ServerHost, Access, Room,
                HistorySize, RoomShaper, HttpAuthPool, Opts)
     when is_list(Opts) ->

--- a/src/mongoose_cleaner.erl
+++ b/src/mongoose_cleaner.erl
@@ -87,7 +87,11 @@ cleanup_modules(Node) ->
     end.
 
 run_node_cleanup(Node) ->
-    {Elapsed, RetVal} = timer:tc(mongoose_hooks, node_cleanup, [Node]),
+    {Elapsed, RetVal} = timer:tc(fun() ->
+            mongoose_hooks:node_cleanup(Node),
+            [mongoose_hooks:node_cleanup_for_host_type(HostType, Node) || HostType <- ?ALL_HOST_TYPES],
+            ok
+        end),
     ?LOG_NOTICE(#{what => cleaner_done,
                   text => <<"Finished cleaning after dead node">>,
                   duration => erlang:round(Elapsed / 1000),

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -3,7 +3,8 @@
 -export([start/2,
          register_room/4,
          room_destroyed/4,
-         find_room_pid/3]).
+         find_room_pid/3,
+         get_online_rooms/2]).
 
 -define(MAIN_MODULE, mongoose_muc_online).
 
@@ -32,4 +33,8 @@ room_destroyed(HostType, MucHost, Room, Pid) ->
 
 find_room_pid(HostType, MucHost, Room) ->
     Args = [HostType, MucHost, Room],
+    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+get_online_rooms(HostType, MucHost) ->
+    Args = [HostType, MucHost],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -11,6 +11,24 @@
 
 %% Callbacks
 
+-callback start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+
+-callback register_room(
+        HostType :: mongooseim:host_type(),
+        MucHost :: jid:lserver(),
+        Room :: mod_muc:room(),
+        Pid :: pid()) -> ok | {exists, pid()} | {error, term()}.
+
+-callback room_destroyed(mongooseim:host_type(), jid:lserver(), mod_muc:room(), pid()) -> ok.
+
+-callback find_room_pid(mongooseim:host_type(), jid:server(), mod_muc:room()) ->
+    {ok, pid()} | {error, not_found}.
+
+-callback get_online_rooms(mongooseim:host_type(), jid:lserver()) ->
+    [mod_muc:muc_online_room()].
+
+-callback node_cleanup(mongooseim:host_type(), node()) -> ok.
+
 %% API Functions
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> any().
@@ -24,23 +42,33 @@ tracked_funs() ->
      room_destroyed,
      get_online_rooms].
 
+-spec register_room(
+        HostType :: mongooseim:host_type(),
+        MucHost :: jid:lserver(),
+        Room :: mod_muc:room(),
+        Pid :: pid()) -> ok | {exists, pid()} | {error, term()}.
 register_room(HostType, MucHost, Room, Pid) ->
     Args = [HostType, MucHost, Room, Pid],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec room_destroyed(mongooseim:host_type(), jid:server(), mod_muc:room(), pid()) -> ok.
+-spec room_destroyed(mongooseim:host_type(), jid:lserver(), mod_muc:room(), pid()) -> ok.
 room_destroyed(HostType, MucHost, Room, Pid) ->
     Args = [HostType, MucHost, Room, Pid],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
+-spec find_room_pid(mongooseim:host_type(), jid:server(), mod_muc:room()) ->
+    {ok, pid()} | {error, not_found}.
 find_room_pid(HostType, MucHost, Room) ->
     Args = [HostType, MucHost, Room],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
+-spec get_online_rooms(mongooseim:host_type(), jid:lserver()) ->
+    [mod_muc:muc_online_room()].
 get_online_rooms(HostType, MucHost) ->
     Args = [HostType, MucHost],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
+-spec node_cleanup(mongooseim:host_type(), node()) -> ok.
 node_cleanup(HostType, Node) ->
     Args = [HostType, Node],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -1,0 +1,24 @@
+-module(mongoose_muc_online_backend).
+
+-export([start/2,
+         room_destroyed/4]).
+
+-define(MAIN_MODULE, mongoose_muc_online).
+
+%% Callbacks
+
+%% API Functions
+
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> any().
+start(HostType, Opts = #{online_backend := Backend}) ->
+    mongoose_backend:init(HostType, ?MAIN_MODULE, tracked_funs(), #{backend => Backend}),
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, [HostType, Opts]).
+
+-spec tracked_funs() -> atom().
+tracked_funs() ->
+    [room_destroyed].
+
+-spec room_destroyed(mongooseim:host_type(), jid:server(), mod_muc:room(), pid()) -> ok.
+room_destroyed(HostType, MucHost, Room, Pid) ->
+    Args = [HostType, MucHost, Room, Pid],
+    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -66,7 +66,7 @@ room_destroyed(HostType, MucHost, Room, Pid) ->
     {ok, pid()} | {error, not_found}.
 find_room_pid(HostType, MucHost, Room) ->
     Args = [HostType, MucHost, Room],
-    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
 -spec get_online_rooms(mongooseim:host_type(), jid:lserver()) ->
     [mod_muc:muc_online_room()].
@@ -77,7 +77,7 @@ get_online_rooms(HostType, MucHost) ->
 -spec node_cleanup(mongooseim:host_type(), node()) -> ok.
 node_cleanup(HostType, Node) ->
     Args = [HostType, Node],
-    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
 clear_table(HostType) ->
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, [HostType]).

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -8,6 +8,9 @@
          node_cleanup/2,
          clear_table/1]).
 
+%% Used in tests
+-ignore_xref([clear_table/1]).
+
 -define(MAIN_MODULE, mongoose_muc_online).
 
 %% Callbacks

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -18,7 +18,7 @@ start(HostType, Opts = #{online_backend := Backend}) ->
     mongoose_backend:init(HostType, ?MAIN_MODULE, tracked_funs(), #{backend => Backend}),
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, [HostType, Opts]).
 
--spec tracked_funs() -> atom().
+-spec tracked_funs() -> [atom()].
 tracked_funs() ->
     [register_room,
      room_destroyed,

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -25,7 +25,7 @@
 
 -callback room_destroyed(mongooseim:host_type(), jid:lserver(), mod_muc:room(), pid()) -> ok.
 
--callback find_room_pid(mongooseim:host_type(), jid:server(), mod_muc:room()) ->
+-callback find_room_pid(mongooseim:host_type(), jid:lserver(), mod_muc:room()) ->
     {ok, pid()} | {error, not_found}.
 
 -callback get_online_rooms(mongooseim:host_type(), jid:lserver()) ->
@@ -62,7 +62,7 @@ room_destroyed(HostType, MucHost, Room, Pid) ->
     Args = [HostType, MucHost, Room, Pid],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
--spec find_room_pid(mongooseim:host_type(), jid:server(), mod_muc:room()) ->
+-spec find_room_pid(mongooseim:host_type(), jid:lserver(), mod_muc:room()) ->
     {ok, pid()} | {error, not_found}.
 find_room_pid(HostType, MucHost, Room) ->
     Args = [HostType, MucHost, Room],

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -1,6 +1,7 @@
 -module(mongoose_muc_online_backend).
 
 -export([start/2,
+         register_room/4,
          room_destroyed/4]).
 
 -define(MAIN_MODULE, mongoose_muc_online).
@@ -16,7 +17,12 @@ start(HostType, Opts = #{online_backend := Backend}) ->
 
 -spec tracked_funs() -> atom().
 tracked_funs() ->
-    [room_destroyed].
+    [register_room,
+     room_destroyed].
+
+register_room(HostType, MucHost, Room, Pid) ->
+    Args = [HostType, MucHost, Room, Pid],
+    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
 -spec room_destroyed(mongooseim:host_type(), jid:server(), mod_muc:room(), pid()) -> ok.
 room_destroyed(HostType, MucHost, Room, Pid) ->

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -5,7 +5,8 @@
          room_destroyed/4,
          find_room_pid/3,
          get_online_rooms/2,
-         node_cleanup/2]).
+         node_cleanup/2,
+         clear_table/1]).
 
 -define(MAIN_MODULE, mongoose_muc_online).
 
@@ -28,6 +29,8 @@
     [mod_muc:muc_online_room()].
 
 -callback node_cleanup(mongooseim:host_type(), node()) -> ok.
+
+-callback clear_table(mongooseim:host_type()) -> ok.
 
 %% API Functions
 
@@ -72,3 +75,6 @@ get_online_rooms(HostType, MucHost) ->
 node_cleanup(HostType, Node) ->
     Args = [HostType, Node],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+clear_table(HostType) ->
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, [HostType]).

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -4,7 +4,8 @@
          register_room/4,
          room_destroyed/4,
          find_room_pid/3,
-         get_online_rooms/2]).
+         get_online_rooms/2,
+         node_cleanup/2]).
 
 -define(MAIN_MODULE, mongoose_muc_online).
 
@@ -20,7 +21,8 @@ start(HostType, Opts = #{online_backend := Backend}) ->
 -spec tracked_funs() -> atom().
 tracked_funs() ->
     [register_room,
-     room_destroyed].
+     room_destroyed,
+     get_online_rooms].
 
 register_room(HostType, MucHost, Room, Pid) ->
     Args = [HostType, MucHost, Room, Pid],
@@ -37,4 +39,8 @@ find_room_pid(HostType, MucHost, Room) ->
 
 get_online_rooms(HostType, MucHost) ->
     Args = [HostType, MucHost],
+    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+node_cleanup(HostType, Node) ->
+    Args = [HostType, Node],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/muc/mongoose_muc_online_backend.erl
+++ b/src/muc/mongoose_muc_online_backend.erl
@@ -2,7 +2,8 @@
 
 -export([start/2,
          register_room/4,
-         room_destroyed/4]).
+         room_destroyed/4,
+         find_room_pid/3]).
 
 -define(MAIN_MODULE, mongoose_muc_online).
 
@@ -27,4 +28,8 @@ register_room(HostType, MucHost, Room, Pid) ->
 -spec room_destroyed(mongooseim:host_type(), jid:server(), mod_muc:room(), pid()) -> ok.
 room_destroyed(HostType, MucHost, Room, Pid) ->
     Args = [HostType, MucHost, Room, Pid],
+    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+find_room_pid(HostType, MucHost, Room) ->
+    Args = [HostType, MucHost, Room],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/muc/mongoose_muc_online_cets.erl
+++ b/src/muc/mongoose_muc_online_cets.erl
@@ -6,7 +6,8 @@
          room_destroyed/4,
          find_room_pid/3,
          get_online_rooms/2,
-         node_cleanup/2]).
+         node_cleanup/2,
+         clear_table/1]).
 
 -export([handle_conflict/2]).
 
@@ -100,4 +101,13 @@ node_cleanup(HostType, Node) ->
     Pattern = {'_', '$1'},
     Guard = {'==', {node, '$1'}, Node},
     ets:select_delete(Tab, [{Pattern, [Guard], [true]}]),
+    ok.
+
+%% Clear table for tests
+-spec clear_table(mongooseim:host_type()) -> ok.
+clear_table(HostType) ->
+    Tab = table_name(HostType),
+    ets:match_delete(Tab, '_'),
+    Nodes = cets:other_nodes(Tab),
+    [rpc:call(Node, ets, match_delete, [Tab, '_']) || Node <- Nodes],
     ok.

--- a/src/muc/mongoose_muc_online_cets.erl
+++ b/src/muc/mongoose_muc_online_cets.erl
@@ -1,0 +1,88 @@
+-module(mongoose_muc_online_cets).
+-export([start/2,
+         register_room/4,
+         room_destroyed/4,
+         find_room_pid/3,
+         get_online_rooms/2,
+         node_cleanup/2]).
+
+-export([handle_conflict/2]).
+
+-include_lib("mod_muc.hrl").
+
+%% Use MucHost first for prefix select optimization in get_online_rooms
+-type muc_tuple() :: {{MucHost :: jid:lserver(), Room :: mod_muc:room()}, Pid :: pid()}.
+
+table_name(HostType) ->
+    binary_to_atom(<<"cets_muc_online_room_", HostType/binary>>).
+
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, _Opts) ->
+    Tab = table_name(HostType),
+    %% Non-random, non-node-specific keys
+    %% This means that default merging would not work
+    cets:start(Tab, #{handle_conflict => fun ?MODULE:handle_conflict/2}),
+    cets_discovery:add_table(mongoose_cets_discovery, Tab),
+    ok.
+
+%% We should keep one room and stop another room
+%% But stopping logic needs to be tested heavily and designed
+%% because we would need to figure out how to send presences to participants
+%% (and maybe document how to rejoin the kicked room)
+-spec handle_conflict(muc_tuple(), muc_tuple()) -> muc_tuple().
+handle_conflict(Rec1, Rec2) when Rec1 > Rec2 ->
+    Rec1;
+handle_conflict(_Rec1, Rec2) ->
+    Rec2.
+
+-spec register_room(
+        HostType :: mongooseim:host_type(),
+        MucHost :: jid:lserver(),
+        Room :: mod_muc:room(),
+        Pid :: pid()) -> ok | {exists, pid()} | {error, term()}.
+register_room(HostType, MucHost, Room, Pid) ->
+    Tab = table_name(HostType),
+    Rec = {{MucHost, Room}, Pid},
+    case find_room_pid(HostType, MucHost, Room) of
+        %% Race condition is possible
+        %% TODO use cets:insert_new/2 once available
+        %% Otherwise cets:insert could overwrite an existing registration
+        {ok, OtherPid} ->
+            {exists, OtherPid};
+        {error, not_found} ->
+            cets:insert(Tab, Rec),
+            ok
+    end.
+
+%% Race condition is possible between register and room_destroyed
+%% (Because register is outside of the room process)
+-spec room_destroyed(mongooseim:host_type(), jid:server(), mod_muc:room(), pid()) -> ok.
+room_destroyed(HostType, MucHost, Room, Pid) ->
+    Tab = table_name(HostType),
+    Rec = {{MucHost, Room}, Pid},
+    cets:delete_object(Tab, Rec),
+    ok.
+
+find_room_pid(HostType, MucHost, Room) ->
+    Tab = table_name(HostType),
+    case ets:lookup(Tab, {MucHost, Room}) of
+        [{_, Pid}] ->
+            {ok, Pid};
+        [] ->
+            {error, not_found}
+    end.
+
+%% This is used by MUC discovery but it is not very scalable.
+%% This function should look like get_online_rooms(HostType, MucHost, AfterRoomName, Limit)
+%% to reduce the load and still have pagination working.
+get_online_rooms(HostType, MucHost) ->
+    Tab = table_name(HostType),
+    [#muc_online_room{name_host = {Room, MucHost}, pid = Pid}
+     || [Room, Pid] <- ets:match(Tab, {{MucHost, '$1'}, '$2'})].
+
+node_cleanup(HostType, Node) ->
+    Tab = table_name(HostType),
+    Pattern = {'_', '$1'},
+    Guard = {'==', {node, '$1'}, Node},
+    ets:select_delete(Tab, [{Pattern, [Guard], [true]}]),
+    ok.

--- a/src/muc/mongoose_muc_online_mnesia.erl
+++ b/src/muc/mongoose_muc_online_mnesia.erl
@@ -6,7 +6,8 @@
          room_destroyed/4,
          find_room_pid/3,
          get_online_rooms/2,
-         node_cleanup/2]).
+         node_cleanup/2,
+         clear_table/1]).
 
 -include_lib("mod_muc.hrl").
 
@@ -84,4 +85,10 @@ node_cleanup(HostType, Node) ->
                               end, Es)
         end,
     mnesia:async_dirty(F),
+    ok.
+
+%% Clear table for tests
+-spec clear_table(mongooseim:host_type()) -> ok.
+clear_table(_HostType) ->
+    mnesia:clear_table(muc_online_room),
     ok.

--- a/src/muc/mongoose_muc_online_mnesia.erl
+++ b/src/muc/mongoose_muc_online_mnesia.erl
@@ -1,7 +1,8 @@
 -module(mongoose_muc_online_mnesia).
 -export([start/2,
          register_room/4,
-         room_destroyed/4]).
+         room_destroyed/4,
+         find_room_pid/3]).
 
 -include_lib("mod_muc.hrl").
 
@@ -35,8 +36,15 @@ room_destroyed(HostType, MucHost, Room, Pid) ->
     {atomic, ok} = mnesia:transaction(F),
     ok.
 
-
 simple_transaction_result({atomic, Res}) ->
     Res;
 simple_transaction_result({aborted, Reason}) ->
     {error, Reason}.
+
+find_room_pid(HostType, MucHost, Room) ->
+    case mnesia:dirty_read(muc_online_room, {Room, MucHost}) of
+        [R] ->
+            {ok, R#muc_online_room.pid};
+        [] ->
+            {error, not_found}
+    end.

--- a/src/muc/mongoose_muc_online_mnesia.erl
+++ b/src/muc/mongoose_muc_online_mnesia.erl
@@ -4,7 +4,11 @@
 
 -include_lib("mod_muc.hrl").
 
-start(HostType, Opts) ->
+start(_HostType, _Opts) ->
+    mnesia:create_table(muc_online_room,
+                        [{ram_copies, [node()]},
+                         {attributes, record_info(fields, muc_online_room)}]),
+    mnesia:add_table_copy(muc_online_room, node(), ram_copies),
     ok.
 
 %% Race condition is possible between register and room_destroyed

--- a/src/muc/mongoose_muc_online_mnesia.erl
+++ b/src/muc/mongoose_muc_online_mnesia.erl
@@ -2,7 +2,8 @@
 -export([start/2,
          register_room/4,
          room_destroyed/4,
-         find_room_pid/3]).
+         find_room_pid/3,
+         get_online_rooms/2]).
 
 -include_lib("mod_muc.hrl").
 
@@ -41,10 +42,16 @@ simple_transaction_result({atomic, Res}) ->
 simple_transaction_result({aborted, Reason}) ->
     {error, Reason}.
 
-find_room_pid(HostType, MucHost, Room) ->
+find_room_pid(_HostType, MucHost, Room) ->
     case mnesia:dirty_read(muc_online_room, {Room, MucHost}) of
         [R] ->
             {ok, R#muc_online_room.pid};
         [] ->
             {error, not_found}
     end.
+
+get_online_rooms(_HostType, MucHost) ->
+    mnesia:dirty_select(muc_online_room,
+                        [{#muc_online_room{name_host = '$1', _ = '_'},
+                          [{'==', {element, 2, '$1'}, MucHost}],
+                          ['$_']}]).

--- a/src/muc/mongoose_muc_online_mnesia.erl
+++ b/src/muc/mongoose_muc_online_mnesia.erl
@@ -8,6 +8,7 @@
 
 -include_lib("mod_muc.hrl").
 
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 start(_HostType, _Opts) ->
     mnesia:create_table(muc_online_room,
                         [{ram_copies, [node()]},
@@ -15,6 +16,11 @@ start(_HostType, _Opts) ->
     mnesia:add_table_copy(muc_online_room, node(), ram_copies),
     ok.
 
+-spec register_room(
+        HostType :: mongooseim:host_type(),
+        MucHost :: jid:lserver(),
+        Room :: mod_muc:room(),
+        Pid :: pid()) -> ok | {exists, pid()} | {error, term()}.
 register_room(HostType, MucHost, Room, Pid) ->
     F = fun() ->
             case mnesia:read(muc_online_room,  {Room, MucHost}, write) of

--- a/src/muc/mongoose_muc_online_mnesia.erl
+++ b/src/muc/mongoose_muc_online_mnesia.erl
@@ -1,0 +1,18 @@
+-module(mongoose_muc_online_mnesia).
+-export([start/2,
+         room_destroyed/4]).
+
+-include_lib("mod_muc.hrl").
+
+start(HostType, Opts) ->
+    ok.
+
+%% Race condition is possible between register and room_destroyed
+%% (Because register is outside of the room process)
+-spec room_destroyed(mongooseim:host_type(), jid:server(), mod_muc:room(), pid()) -> ok.
+room_destroyed(HostType, MucHost, Room, Pid) ->
+    Obj = #muc_online_room{name_host = {Room, MucHost},
+                           host_type = HostType, pid = Pid},
+    F = fun() -> mnesia:delete_object(Obj) end,
+    {atomic, ok} = mnesia:transaction(F),
+    ok.

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -905,6 +905,7 @@ default_mod_config(mod_mam_muc_rdbms_arch) ->
       db_jid_format => mam_jid_rfc};
 default_mod_config(mod_muc) ->
     #{backend => mnesia,
+      online_backend => mnesia,
       host => {prefix,<<"conference.">>},
       access => all,
       access_create => all,


### PR DESCRIPTION
This PR addresses MIM-1933

Proposed changes include:
* Add a (configurable) backend support for online MUC rooms.
* Subscription to Mnesia events is replaced with a hook. 
* node_cleanup_for_host_type hook introduced.
* CETS backend. One table per host_type.
* Test for node_cleanup added.


Kicking logic for one of the rooms in handle_conflict could be done in a separate PR (easier to review, slightly different concerns when implementing and reviewing - i.e. would need new tests, because of new functionality).
