### PR TITLE
Cache router, filter, and process handlers into funs

### DIFF
--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -186,6 +186,7 @@ general() ->
                                                            wrap = global_config},
                  <<"routing_modules">> => #list{items = #option{type = atom,
                                                                 validate = module},
+                                                process = fun xmpp_router:expand_routing_modules/1,
                                                 wrap = global_config},
                  <<"replaced_wait_timeout">> => #option{type = integer,
                                                         validate = positive,

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -118,7 +118,7 @@ route(From, To, #xmlel{} = Packet) ->
 route(From, To, Acc) ->
     ?LOG_DEBUG(#{what => route, acc => Acc}),
     El = mongoose_acc:element(Acc),
-    RoutingModules = routing_modules_list(),
+    RoutingModules = mongoose_router:routing_modules_list(),
     NewAcc = route(From, To, Acc, El, RoutingModules),
     ?LOG_DEBUG(#{what => routing_result,
                  routing_result => mongoose_acc:get(router, result, {drop, undefined}, NewAcc),
@@ -137,7 +137,7 @@ route(From, To, Acc, El) ->
                                          to_jid => To,
                                          element => El }, Acc),
     ?LOG_DEBUG(#{what => route, acc => Acc1}),
-    RoutingModules = routing_modules_list(),
+    RoutingModules = mongoose_router:routing_modules_list(),
     NewAcc = route(From, To, Acc1, El, RoutingModules),
     ?LOG_DEBUG(#{what => routing_result,
                  routing_result => mongoose_acc:get(router, result, {drop, undefined}, NewAcc),
@@ -375,14 +375,11 @@ code_change(_OldVsn, State, _Extra) ->
 hooks() ->
     [{node_cleanup, global, fun ?MODULE:routes_cleanup_on_nodedown/3, #{}, 90}].
 
-routing_modules_list() ->
-    mongoose_config:get_opt(routing_modules).
-
 -spec route(From   :: jid:jid(),
             To     :: jid:jid(),
             Acc    :: mongoose_acc:t(),
             Packet :: exml:element(),
-            [module()]) -> mongoose_acc:t().
+            [xmpp_router:t()]) -> mongoose_acc:t().
 route(_From, _To, Acc, _Packet, []) ->
     ?LOG_ERROR(#{what => no_more_routing_modules, acc => Acc}),
     mongoose_metrics:update(global, routingErrors, 1),

--- a/src/mongoose_router.erl
+++ b/src/mongoose_router.erl
@@ -2,7 +2,7 @@
 
 -define(TABLE, ?MODULE).
 
--export([start/0, default_routing_modules/0]).
+-export([start/0, routing_modules_list/0, default_routing_modules/0]).
 
 -export([get_all_domains/0, lookup_route/1, is_registered_route/1,
          register_route/2, unregister_route/1]).
@@ -47,9 +47,13 @@ start() ->
     mongoose_metrics:ensure_metric(global, routingErrors, spiral).
 
 default_routing_modules() ->
-    [mongoose_router_global,
-     mongoose_router_localdomain,
-     mongoose_router_external_localnode,
-     mongoose_router_external,
-     mongoose_router_dynamic_domains,
-     ejabberd_s2s].
+    List = [mongoose_router_global,
+            mongoose_router_localdomain,
+            mongoose_router_external_localnode,
+            mongoose_router_external,
+            mongoose_router_dynamic_domains,
+            ejabberd_s2s],
+    xmpp_router:expand_routing_modules(List).
+
+routing_modules_list() ->
+    mongoose_config:get_opt(routing_modules).

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -80,7 +80,7 @@ options("miscellaneous") ->
      {rdbms_server_type, mssql},
      {registration_timeout, 600},
      {routing_modules,
-      [mongoose_router_global, mongoose_router_localdomain]},
+      xmpp_router:expand_routing_modules([mongoose_router_global, mongoose_router_localdomain])},
      {services,
       #{service_mongoose_system_metrics => #{initial_report => 20000,
                                              periodic_report => 300000,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -415,7 +415,8 @@ mongooseimctl_access_commands(_Config) ->
 
 routing_modules(_Config) ->
     ?cfg(routing_modules, mongoose_router:default_routing_modules(), #{}), % default
-    ?cfg(routing_modules, [mongoose_router_global, mongoose_router_localdomain],
+    ?cfg(routing_modules,
+         xmpp_router:expand_routing_modules([mongoose_router_global, mongoose_router_localdomain]),
          #{<<"general">> => #{<<"routing_modules">> => [<<"mongoose_router_global">>,
                                                         <<"mongoose_router_localdomain">>]}}),
     ?err(#{<<"general">> => #{<<"routing_modules">> => [<<"moongoose_router_global">>]}}).

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -42,7 +42,8 @@ end_per_suite(_C) ->
     ok.
 
 init_per_group(routing, Config) ->
-    mongoose_config:set_opt(routing_modules, [xmpp_router_a, xmpp_router_b, xmpp_router_c]),
+    RoutingModules = [xmpp_router_a, xmpp_router_b, xmpp_router_c],
+    mongoose_config:set_opt(routing_modules, xmpp_router:expand_routing_modules(RoutingModules)),
     gen_hook:start_link(),
     ejabberd_router:start_link(),
     Config;


### PR DESCRIPTION
Following the advise from https://www.erlang.org/doc/efficiency_guide/functions.html#function-calls
> Caching callback functions into funs may be more efficient in the long run than apply calls for frequently-used callbacks.

Similar logic was applied in OTP itself in
https://github.com/erlang/otp/pull/5831
https://github.com/erlang/otp/pull/7419/