### PR TITLE
Initialise domain workers in the supervision tree instead of manually

### DIFF
--- a/big_tests/tests/domain_helper.erl
+++ b/big_tests/tests/domain_helper.erl
@@ -26,6 +26,12 @@ domain_to_host_type(Node, Domain) ->
     {ok, HostType} = rpc(Node, mongoose_domain_core, get_host_type, [Domain]),
     HostType.
 
+restart_domain_core(Node) ->
+    {ok, _} = rpc(Node, mongoose_domain_sup, restart_core, [[]]).
+
+restart_domain_core(Node, Pairs, AllowedHostTypes) ->
+    {ok, _} = rpc(Node, mongoose_domain_sup, restart_core, [[Pairs, AllowedHostTypes]]).
+
 domain(NodeKey) ->
     get_or_fail({hosts, NodeKey, domain}).
 

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -1110,12 +1110,10 @@ service_disabled(Node) ->
     false = rpc(Node, service_domain_db, enabled, []).
 
 restart_domain_core(Node, Pairs, AllowedHostTypes) ->
-    ok = rpc(Node, mongoose_domain_core, stop, []),
-    ok = rpc(Node, mongoose_domain_core, start, [Pairs, AllowedHostTypes]).
+    domain_helper:restart_domain_core(Node, Pairs, AllowedHostTypes).
 
 restart_domain_core(Node) ->
-    ok = rpc(Node, mongoose_domain_core, stop, []),
-    ok = rpc(Node, mongoose_domain_core, start, []).
+    domain_helper:restart_domain_core(Node).
 
 insert_domain(Node, Domain, HostType) ->
     rpc(Node, mongoose_domain_api, insert_domain, [Domain, HostType]).

--- a/doc/developers-guide/domain_management.md
+++ b/doc/developers-guide/domain_management.md
@@ -19,7 +19,7 @@ It provides the following interfaces:
   Any of these lists can be empty, initial list of domain/host\_type pairs can
   have some unique host\_types not mentioned in the host\_types list.
   The component is initialised by the main MIM supervisor.
-  Implemented in `mongoose_domain_api:init()`.
+  Implemented in `mongoose_domain_sup:start_link/0`.
 - Insert - adding new domain/host\_type pair.
   This function is idempotent. It returns success on an attempt to insert the existing data,
   but fails if ETS already has the domain name associated with another host type.

--- a/src/domain/mongoose_domain_api.erl
+++ b/src/domain/mongoose_domain_api.erl
@@ -4,9 +4,7 @@
 
 -include("mongoose_logger.hrl").
 
--export([init/0,
-         stop/0,
-         get_host_type/1]).
+-export([get_host_type/1]).
 
 %% external domain API for GraphQL or REST handlers
 -export([insert_domain/2,
@@ -45,7 +43,6 @@
 
 -ignore_xref([get_all_static/0]).
 -ignore_xref([get_all_dynamic/0]).
--ignore_xref([stop/0]).
 
 -type status() :: enabled | disabled | deleting.
 -type domain() :: jid:lserver().
@@ -65,21 +62,6 @@
 -type get_domain_details_result() :: {ok, domain_info()} | {static | not_found, iodata()}.
 
 -export_type([status/0, remove_domain_acc/0]).
-
--spec init() -> ok | {error, term()}.
-init() ->
-    mongoose_domain_core:start(),
-    mongoose_subdomain_core:start(),
-    mongoose_lazy_routing:start().
-
-%% Stops gen_servers, that are started from init/0
-%% Does not fail, even if servers are already stopped
--spec stop() -> ok.
-stop() ->
-    catch mongoose_domain_core:stop(),
-    catch mongoose_subdomain_core:stop(),
-    catch mongoose_lazy_routing:stop(),
-    ok.
 
 -spec insert_domain(domain(), host_type()) -> insert_result().
 insert_domain(Domain, HostType) ->

--- a/src/domain/mongoose_domain_sup.erl
+++ b/src/domain/mongoose_domain_sup.erl
@@ -1,0 +1,44 @@
+-module(mongoose_domain_sup).
+
+-behaviour(supervisor).
+
+-type pair() :: {mongooseim:domain_name(), mongooseim:host_type()}.
+
+-export([start_link/0, init/1]).
+-ignore_xref([start_link/0]).
+
+-export([start_link/2, restart_core/1]).
+-ignore_xref([start_link/2, restart_core/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+start_link(Pairs, AllowedHostTypes) ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, [Pairs, AllowedHostTypes]).
+
+restart_core(Args) ->
+    supervisor:terminate_child(?MODULE, mongoose_domain_core),
+    supervisor:delete_child(?MODULE, mongoose_domain_core),
+    supervisor:start_child(?MODULE, worker_spec(mongoose_domain_core, fill_args(Args))).
+
+init(Args) ->
+    DomainCore = worker_spec(mongoose_domain_core, fill_args(Args)),
+    SubdomainCore = worker_spec(mongoose_subdomain_core, []),
+    LazyRouting = worker_spec(mongoose_lazy_routing, []),
+    {ok, {{one_for_one, 10, 1},
+          [DomainCore, SubdomainCore, LazyRouting]}}.
+
+worker_spec(Mod, Args) ->
+    {Mod, {Mod, start_link, Args}, permanent, timer:seconds(5), worker, [Mod]}.
+
+%% Domains should be nameprepped using `jid:nameprep'
+-spec get_static_pairs() -> [pair()].
+get_static_pairs() ->
+    [{H, H} || H <- mongoose_config:get_opt(hosts)].
+
+fill_args([]) ->
+    Pairs = get_static_pairs(),
+    AllowedHostTypes = mongoose_config:get_opt(host_types),
+    [Pairs, AllowedHostTypes];
+fill_args([_, _] = Args) ->
+    Args.

--- a/src/domain/mongoose_lazy_routing.erl
+++ b/src/domain/mongoose_lazy_routing.erl
@@ -19,8 +19,6 @@
 
 -include("mongoose_logger.hrl").
 
-%% start/stop API
--export([start/0, stop/0]).
 -export([start_link/0]).
 -export([sync/0]).
 
@@ -43,7 +41,7 @@
          terminate/2,
          code_change/3]).
 
--ignore_xref([start_link/0, stop/0, sync/0]).
+-ignore_xref([start_link/0, sync/0]).
 
 -define(IQ_TABLE, mongoose_lazy_routing_iqs).
 -define(ROUTING_TABLE, mongoose_lazy_routing).
@@ -66,29 +64,6 @@
 %%--------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
--ifdef(TEST).
-
-%% required for unit tests
-start() ->
-    just_ok(gen_server:start({local, ?MODULE}, ?MODULE, [], [])).
-
-stop() ->
-    gen_server:stop(?MODULE).
-
--else.
-
-start() ->
-    ChildSpec = {?MODULE, {?MODULE, start_link, []},
-                 permanent, infinity, worker, [?MODULE]},
-    just_ok(supervisor:start_child(ejabberd_sup, ChildSpec)).
-
-%% required for integration tests
-stop() ->
-    supervisor:terminate_child(ejabberd_sup, ?MODULE),
-    supervisor:delete_child(ejabberd_sup, ?MODULE),
-    ok.
-
--endif.
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
@@ -221,8 +196,6 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 %% local functions
 %%--------------------------------------------------------------------
-just_ok({ok, _}) -> ok;
-just_ok(Other) -> Other.
 
 -spec handle_register_iq_handler_for_domain(HostType :: mongooseim:host_type(),
                                             Namespace :: binary(),

--- a/src/domain/mongoose_subdomain_core.erl
+++ b/src/domain/mongoose_subdomain_core.erl
@@ -4,8 +4,8 @@
 -behaviour(gen_server).
 
 -include("mongoose_logger.hrl").
+
 %% API
--export([start/0, stop/0]).
 -export([start_link/0]).
 
 -export([register_subdomain/3,
@@ -26,7 +26,7 @@
          code_change/3,
          terminate/2]).
 
--ignore_xref([start_link/0, stop/0, sync/0]).
+-ignore_xref([start_link/0, sync/0]).
 
 -ifdef(TEST).
 
@@ -69,30 +69,8 @@
 %% API
 %%--------------------------------------------------------------------
 -ifdef(TEST).
-
-%% required for unit tests
-start() ->
-    just_ok(gen_server:start({local, ?MODULE}, ?MODULE, [], [])).
-
-stop() ->
-    gen_server:stop(?MODULE).
-
 %% this interface is required only to detect errors in unit tests
 log_error(_Function, _Error) -> ok.
-
--else.
-
-start() ->
-    ChildSpec = {?MODULE, {?MODULE, start_link, []},
-                 permanent, infinity, worker, [?MODULE]},
-    just_ok(supervisor:start_child(ejabberd_sup, ChildSpec)).
-
-%% required for integration tests
-stop() ->
-    supervisor:terminate_child(ejabberd_sup, ?MODULE),
-    supervisor:delete_child(ejabberd_sup, ?MODULE),
-    ok.
-
 -endif.
 
 start_link() ->
@@ -196,8 +174,6 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 %% local functions
 %%--------------------------------------------------------------------
-just_ok({ok, _}) -> ok;
-just_ok(Other) -> Other.
 
 -spec handle_register(host_type(), subdomain_pattern(),
                       mongoose_packet_handler:t(), any()) -> ok.

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -57,7 +57,6 @@ start(normal, _Args) ->
     mongoose_logs:set_global_loglevel(mongoose_config:get_opt(loglevel)),
     mongoose_deprecations:start(),
     {ok, _} = Sup = ejabberd_sup:start_link(),
-    mongoose_domain_api:init(),
     mongoose_wpool:ensure_started(),
     mongoose_wpool:start_configured_pools(),
     %% ejabberd_sm is started separately because it may use one of the outgoing_pools

--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -149,6 +149,10 @@ init([]) ->
         {mongoose_shaper_sup,
           {mongoose_shaper_sup, start_link, []},
           permanent, infinity, supervisor, [mongoose_shaper_sup]},
+    DomainSup =
+        {mongoose_domain_sup,
+          {mongoose_domain_sup, start_link, []},
+          permanent, infinity, supervisor, [mongoose_domain_sup]},
     PG =
         {pg,
           {pg, start_link, [mim_scope]},
@@ -170,7 +174,8 @@ init([]) ->
            IQSupervisor,
            Listener,
            MucIQ,
-           ShaperSup]}}.
+           ShaperSup,
+           DomainSup]}}.
 
 start_child(ChildSpec) ->
     case supervisor:start_child(ejabberd_sup, ChildSpec) of

--- a/test/acl_SUITE.erl
+++ b/test/acl_SUITE.erl
@@ -35,7 +35,6 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    mongoose_domain_api:stop(),
     meck:unload(),
     ok.
 
@@ -303,12 +302,10 @@ given_registered_domains(Config, DomainsList) ->
 register_static_domains(DomainsList) ->
     mongoose_config:set_opt(hosts, DomainsList),
     mongoose_config:set_opt(host_types, []),
-    mongoose_domain_api:stop(),
-    mongoose_domain_api:init().
+    mongoose_domain_sup:start_link().
 
 register_dynamic_domains(DomainsList) ->
     mongoose_config:set_opt(hosts, []),
     mongoose_config:set_opt(host_types, [<<"test type">>, <<"empty type">>]),
-    mongoose_domain_api:stop(),
-    mongoose_domain_api:init(),
+    mongoose_domain_sup:start_link(),
     [mongoose_domain_core:insert(Domain, <<"test type">>, test) || Domain <- DomainsList].

--- a/test/auth_internal_SUITE.erl
+++ b/test/auth_internal_SUITE.erl
@@ -16,16 +16,21 @@ init_per_suite(C) ->
                                                    internal => #{},
                                                    password => #{format => scram,
                                                                  scram_iterations => 10}}),
-    mongoose_domain_core:start([{domain(), host_type()}], []),
     ejabberd_auth_internal:start(host_type()),
     C.
 
 end_per_suite(_C) ->
     ejabberd_auth_internal:stop(host_type()),
-    mongoose_domain_core:stop(),
     mongoose_config:unset_opt({auth, host_type()}),
     mnesia:stop(),
     mnesia:delete_schema([node()]).
+
+init_per_testcase(_TC, Config) ->
+    mongoose_domain_core:start_link([{domain(), host_type()}], []),
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    ok.
 
 passwords_as_records_are_still_supported(_C) ->
     %% given in mnesia there is a user with password in old scram format

--- a/test/mod_global_distrib_SUITE.erl
+++ b/test/mod_global_distrib_SUITE.erl
@@ -66,7 +66,7 @@ end_per_group(_GroupName, Config) ->
 init_per_testcase(_CaseName, Config) ->
     set_meck(),
     [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
-    mongoose_domain_api:init(),
+    mongoose_domain_sup:start_link(),
     mim_ct_sup:start_link(ejabberd_sup),
     gen_hook:start_link(),
     mongoose_modules:start(),
@@ -74,7 +74,6 @@ init_per_testcase(_CaseName, Config) ->
 
 end_per_testcase(_CaseName, Config) ->
     mongoose_modules:stop(),
-    mongoose_domain_api:stop(),
     [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
     unset_meck(),
     Config.

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -36,11 +36,9 @@ init_per_suite(Config) ->
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
     [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
-    mongoose_domain_api:init(),
     Config.
 
 end_per_suite(Config) ->
-    mongoose_domain_api:stop(),
     [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
     mnesia:stop(),
     mnesia:delete_schema([node()]),
@@ -48,6 +46,7 @@ end_per_suite(Config) ->
 
 init_per_testcase(TestCase, Config) ->
     {ok, _HooksServer} = gen_hook:start_link(),
+    {ok, _DomainSup} = mongoose_domain_sup:start_link(),
     setup_meck(meck_mods(TestCase)),
     Config.
 

--- a/test/mongoose_domain_core_SUITE.erl
+++ b/test/mongoose_domain_core_SUITE.erl
@@ -40,12 +40,11 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(_, Config) ->
-    ok = mongoose_domain_core:start(?STATIC_PAIRS, ?ALLOWED_TYPES),
+    {ok, _} = mongoose_domain_core:start_link(?STATIC_PAIRS, ?ALLOWED_TYPES),
     [meck:reset(M) || M <- [mongoose_lazy_routing, mongoose_subdomain_core]],
     Config.
 
 end_per_testcase(_, Config) ->
-    mongoose_domain_core:stop(),
     Config.
 
 can_get_init_arguments(_) ->

--- a/test/mongoose_lazy_routing_SUITE.erl
+++ b/test/mongoose_lazy_routing_SUITE.erl
@@ -47,12 +47,11 @@ all() ->
      handles_double_iq_handler_registration_deregistration_for_subdomain].
 
 init_per_testcase(_, Config) ->
-    mongoose_lazy_routing:start(),
+    mongoose_lazy_routing:start_link(),
     setup_meck(),
     Config.
 
 end_per_testcase(_, Config) ->
-    mongoose_lazy_routing:stop(),
     meck:unload(),
     Config.
 

--- a/test/mongoose_subdomain_core_SUITE.erl
+++ b/test/mongoose_subdomain_core_SUITE.erl
@@ -40,16 +40,13 @@ init_per_testcase(TestCase, Config) ->
     %% initial mongoose_subdomain_core conditions:
     %%   - no subdomains configured for any host type
     gen_hook:start_link(),
-    ok = mongoose_domain_core:start(?STATIC_PAIRS, ?ALLOWED_HOST_TYPES),
-    ok = mongoose_subdomain_core:start(),
+    mongoose_domain_sup:start_link(?STATIC_PAIRS, ?ALLOWED_HOST_TYPES),
     [mongoose_domain_core:insert(Domain, ?DYNAMIC_HOST_TYPE2, dummy_source)
      || Domain <- ?DYNAMIC_DOMAINS],
     setup_meck(TestCase),
     Config.
 
 end_per_testcase(_, Config) ->
-    mongoose_domain_core:stop(),
-    mongoose_subdomain_core:stop(),
     meck:unload(),
     Config.
 


### PR DESCRIPTION
Follow cleaner OTP supervision conventions, we want these workers supervised by their common supervisor, started cleanly within the supervision tree.