### PR TITLE
Metrics/init

### DIFF
--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -43,6 +43,8 @@ start(normal, _Args) ->
     mongoose_fips:notify(),
     write_pid_file(),
     update_status_file(starting),
+    mongoose_config:start(),
+    mongoose_metrics:init(),
     db_init(),
     application:start(cache_tab),
 
@@ -51,7 +53,6 @@ start(normal, _Args) ->
     ejabberd_node_id:start(),
     ejabberd_commands:init(),
     mongoose_graphql_commands:start(),
-    mongoose_config:start(),
     mongoose_router:start(),
     mongoose_logs:set_global_loglevel(mongoose_config:get_opt(loglevel)),
     mongoose_deprecations:start(),
@@ -67,9 +68,9 @@ start(normal, _Args) ->
     mongoose_service:start(),
     mongoose_modules:start(),
     service_mongoose_system_metrics:verify_if_configured(),
-    mongoose_metrics:init(),
     mongoose_listener:start(),
     ejabberd_admin:start(),
+    mongoose_metrics:init_mongooseim_metrics(),
     update_status_file(started),
     ?LOG_NOTICE(#{what => mongooseim_node_started, version => ?MONGOOSE_VERSION, node => node()}),
     Sup;

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -139,6 +139,9 @@ start() ->
 -spec start_link() -> 'ignore' | {'error', _} | {'ok', pid()}.
 start_link() ->
     mongoose_metrics:ensure_metric(global, ?UNIQUE_COUNT_CACHE, gauge),
+    mongoose_metrics:create_probe_metric(global, totalSessionCount, mongoose_metrics_probe_total_sessions),
+    mongoose_metrics:create_probe_metric(global, uniqueSessionCount, mongoose_metrics_probe_unique_sessions),
+    mongoose_metrics:create_probe_metric(global, nodeSessionCount, mongoose_metrics_probe_node_sessions),
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -65,10 +65,7 @@
 init() ->
     prepare_prefixes(),
     create_global_metrics(),
-    lists:foreach(
-        fun(HostType) ->
-            init_predefined_host_type_metrics(HostType)
-        end, ?ALL_HOST_TYPES),
+    lists:foreach(fun init_predefined_host_type_metrics/1, ?ALL_HOST_TYPES),
     init_subscriptions().
 
 create_global_metrics() ->

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -21,6 +21,7 @@
 %% API
 -export([init/0,
          create_generic_hook_metric/2,
+         create_probe_metric/3,
          ensure_db_pool_metric/1,
          update/3,
          ensure_metric/3,
@@ -96,6 +97,12 @@ init_subscriptions() ->
 create_generic_hook_metric(HostType, Hook) ->
     UseOrSkip = filter_hook(Hook),
     do_create_generic_hook_metric(HostType, Hook, UseOrSkip).
+
+-spec create_probe_metric(mongooseim:host_type_or_global(), atom(), module()) ->
+    ok | {ok, already_present} | {error, any()}.
+create_probe_metric(HostType, Name, Module) ->
+    {Metric, Spec} = ?PROBE(Name, Module),
+    ensure_metric(HostType, Metric, Spec).
 
 % TODO: change to HostType after mongoose_wpool_rdbms
 ensure_db_pool_metric({rdbms, Host, Tag} = Name) ->

--- a/src/metrics/mongoose_metrics_definitions.hrl
+++ b/src/metrics/mongoose_metrics_definitions.hrl
@@ -68,9 +68,6 @@
          {clusterSize,
           {function, mongoose_metrics, get_mnesia_running_db_nodes_count, [],
            tagged, [value]}},
-         ?PROBE(totalSessionCount, mongoose_metrics_probe_total_sessions),
-         ?PROBE(uniqueSessionCount, mongoose_metrics_probe_unique_sessions),
-         ?PROBE(nodeSessionCount, mongoose_metrics_probe_node_sessions),
          ?PROBE(tcpPortsUsed, mongoose_metrics_probe_tcp),
          ?PROBE(processQueueLengths, mongoose_metrics_probe_queues)
         ]

--- a/src/metrics/mongoose_metrics_definitions.hrl
+++ b/src/metrics/mongoose_metrics_definitions.hrl
@@ -65,11 +65,15 @@
         [{nodeUpTime,
           {function, mongoose_metrics, get_up_time, [],
            tagged, [value]}},
-         {clusterSize,
-          {function, mongoose_metrics, get_mnesia_running_db_nodes_count, [],
-           tagged, [value]}},
          ?PROBE(tcpPortsUsed, mongoose_metrics_probe_tcp),
          ?PROBE(processQueueLengths, mongoose_metrics_probe_queues)
+        ]
+).
+
+-define(MNESIA_COUNTERS,
+        [{clusterSize,
+          {function, mongoose_metrics, get_mnesia_running_db_nodes_count, [],
+           tagged, [value]}}
         ]
 ).
 


### PR DESCRIPTION
The goal is that the whole metrics system can be initialised early and without any dependencies, on hooks, session manager, or other subsystems. It should be such subsystems the ones that register the metrics they consider necessary, and metrics one of the first things to be initialised by the system.