### PR TITLE
Put startup in mongooseim:start

### DIFF
--- a/src/ejabberd.erl
+++ b/src/ejabberd.erl
@@ -25,13 +25,9 @@
 
 -module(ejabberd).
 -author('alexey@process-one.net').
--export([start/0,
-         stop/0,
-         get_pid_file/0,
+-export([get_pid_file/0,
          get_status_file/0,
          get_so_path/0]).
-
--ignore_xref([stop/0]).
 
 -type lang() :: binary().
 
@@ -44,12 +40,6 @@
                           | {'xmlstreamstart', Name :: any(), Attrs :: list()}.
 
 -export_type([lang/0, xml_stream_item/0]).
-
-start() ->
-    application:ensure_all_started(mongooseim).
-
-stop() ->
-    application:stop(mongooseim).
 
 -spec get_so_path() -> binary() | string().
 get_so_path() ->

--- a/src/ejabberd.erl
+++ b/src/ejabberd.erl
@@ -29,10 +29,9 @@
          stop/0,
          get_pid_file/0,
          get_status_file/0,
-         get_so_path/0,
-         get_bin_path/0]).
+         get_so_path/0]).
 
--ignore_xref([get_bin_path/0, stop/0]).
+-ignore_xref([stop/0]).
 
 -type lang() :: binary().
 
@@ -44,9 +43,7 @@
                           | {'xmlstreamerror', _}
                           | {'xmlstreamstart', Name :: any(), Attrs :: list()}.
 
--export_type([lang/0,
-              xml_stream_item/0
-             ]).
+-export_type([lang/0, xml_stream_item/0]).
 
 start() ->
     application:ensure_all_started(mongooseim).
@@ -63,20 +60,6 @@ get_so_path() ->
                     ".";
                 Path ->
                     filename:join([Path, "lib"])
-            end;
-        Path ->
-            Path
-    end.
-
--spec get_bin_path() -> binary() | string().
-get_bin_path() ->
-    case os:getenv("EJABBERD_BIN_PATH") of
-        false ->
-            case code:priv_dir(ejabberd) of
-                {error, _} ->
-                    ".";
-                Path ->
-                    filename:join([Path, "bin"])
             end;
         Path ->
             Path

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -46,7 +46,6 @@ start(normal, _Args) ->
     mongoose_config:start(),
     mongoose_metrics:init(),
     db_init(),
-    application:start(cache_tab),
 
     mongoose_graphql:init(),
     translate:start(),

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -97,7 +97,6 @@ stop(_State) ->
     ?LOG_NOTICE(#{what => mongooseim_node_stopped, version => ?MONGOOSE_VERSION, node => node()}),
     delete_pid_file(),
     update_status_file(stopped),
-    %%ejabberd_debug:stop(),
     ok.
 
 

--- a/src/mongooseim.erl
+++ b/src/mongooseim.erl
@@ -21,10 +21,12 @@
 -export_type([host_type/0, host_type_or_global/0, domain_name/0]).
 
 %% API
--export([start/0]).
+-export([start/0, stop/0]).
 
--ignore_xref([start/0]).
+-ignore_xref([start/0, stop/0]).
 
 start() ->
-    application:start(mongooseim),
-    ejabberd:start().
+    application:ensure_all_started(mongooseim).
+
+stop() ->
+    application:stop(mongooseim).

--- a/test/cowboy_SUITE.erl
+++ b/test/cowboy_SUITE.erl
@@ -22,9 +22,7 @@
 
 -define(SERVER, "http://localhost:8080").
 
--import(ejabberd_helper, [start_ejabberd/1,
-                          stop_ejabberd/0,
-                          use_config_file/2,
+-import(ejabberd_helper, [use_config_file/2,
                           start_ejabberd_with_config/2]).
 -import(config_parser_helper, [default_config/1]).
 

--- a/test/ejabberd_helper.erl
+++ b/test/ejabberd_helper.erl
@@ -1,22 +1,11 @@
 -module(ejabberd_helper).
 
--export([start_ejabberd/1,
-         stop_ejabberd/0,
-         use_config_file/2,
+-export([use_config_file/2,
          start_ejabberd_with_config/2,
          copy/2,
          data/2,
          priv/2,
          suite_priv/2]).
-
-
--spec start_ejabberd(any()) -> 'ok' | {error, any()}.
-start_ejabberd(_Config) ->
-    {ok, _} = ejabberd:start().
-
--spec stop_ejabberd() -> 'ok' | {error, any()}.
-stop_ejabberd() ->
-    application:stop(mongooseim).
 
 -spec use_config_file(any(), file:name_all()) -> ok.
 use_config_file(Config, ConfigFile) ->
@@ -31,7 +20,7 @@ use_config_file(Config, ConfigFile) ->
 -spec start_ejabberd_with_config(any(), file:name_all()) -> ok.
 start_ejabberd_with_config(Config, ConfigFile) ->
     use_config_file(Config, ConfigFile),
-    {ok, _} = start_ejabberd(Config).
+    {ok, _} = mongooseim:start().
 
 copy(Src, Dst) ->
     {ok, _} = file:copy(Src, Dst).
@@ -63,4 +52,3 @@ suite_priv(Config, PathSuffix) ->
 
 preserve_trailing_slash($/, Path) -> Path ++ [$/];
 preserve_trailing_slash(__, Path) -> Path.
-

--- a/test/mongoose_config_SUITE.erl
+++ b/test/mongoose_config_SUITE.erl
@@ -3,9 +3,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--import(ejabberd_helper, [start_ejabberd/1,
-                          start_ejabberd_with_config/2,
-                          stop_ejabberd/0,
+-import(ejabberd_helper, [start_ejabberd_with_config/2,
                           use_config_file/2,
                           copy/2,
                           data/2]).
@@ -152,7 +150,7 @@ cluster_load_from_file(Config) ->
     [State, State] = mongoose_config:config_states(),
     check_loaded_config(State),
 
-    ok = stop_ejabberd(),
+    ok = mongooseim:stop(),
     stop_remote_ejabberd(SlaveNode),
     check_removed_config().
 
@@ -238,7 +236,7 @@ start_remote_ejabberd_with_config(RemoteNode, C, ConfigFile) ->
     rpc:call(RemoteNode, ejabberd_helper, start_ejabberd_with_config, [C, ConfigFile]).
 
 stop_remote_ejabberd(SlaveNode) ->
-    rpc:call(SlaveNode, ejabberd_helper, stop_ejabberd, []).
+    rpc:call(SlaveNode, mongooseim, stop, []).
 
 code_paths() ->
     [filename:absname(Path) || Path <- code:get_path()].

--- a/test/mongoose_listener_SUITE.erl
+++ b/test/mongoose_listener_SUITE.erl
@@ -148,7 +148,7 @@ tcp_start_stop_reload(C) ->
     {ok, Sock2} = gen_tcp:connect("localhost", ChgPort,[{active, false}, {packet, 2}]),
     assert_connected(Sock2, ChgPort),
 
-    ok = ejabberd_helper:stop_ejabberd(),
+    ok = mongooseim:stop(),
     ok.
 
 assert_open(PortNo) ->


### PR DESCRIPTION
Get rid of the circular dependency between `ejabberd:start/0` and `mongooseim:start/0`. Note that `mongooseim:start/0` used to do
```erl
    application:start(mongooseim),
    ejabberd:start().
```
which is buggy, because application:start will not start the dependencies.

Now there's simply no `ejabberd:start/0` and `mongooseim:start/0` does `application:ensure_all_started(mongooseim)` instead. The `ejabberd` module then only holds helpers for the pid-file that are really only called from `ejabberd_app:start/0`. We can do a bit of shuffling here, old code mixes a bit getting the file and modifying it, we can leave all of it in a single module.