### PR TITLE
Put hooks into persistent_term using iterations

### DIFF
--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -145,7 +145,7 @@ get_global_metric_names() ->
 get_aggregated_values(Metric) ->
     exometer:aggregate([{{['_', Metric], '_', '_'}, [], [true]}], [one, count, value]).
 
--spec increment_generic_hook_metric(mongooseim:host_type(), atom()) -> ok | {error, any()}.
+-spec increment_generic_hook_metric(mongooseim:host_type_or_global(), atom()) -> ok | {error, any()}.
 increment_generic_hook_metric(HostType, Hook) ->
     UseOrSkip = filter_hook(Hook),
     do_increment_generic_hook_metric(HostType, Hook, UseOrSkip).

--- a/test/gen_hook_SUITE.erl
+++ b/test/gen_hook_SUITE.erl
@@ -338,4 +338,4 @@ get_hook_handler(ModName, FunName, Fun) when is_function(Fun, 3) ->
     fun ModName:FunName/3.
 
 get_handlers_for_all_hooks() ->
-    maps:to_list(persistent_term:get(gen_hook)).
+    [ {Key, Handler} || {{gen_hook, Key}, Handler} <- persistent_term:get() ].

--- a/test/gen_hook_SUITE.erl
+++ b/test/gen_hook_SUITE.erl
@@ -338,4 +338,4 @@ get_hook_handler(ModName, FunName, Fun) when is_function(Fun, 3) ->
     fun ModName:FunName/3.
 
 get_handlers_for_all_hooks() ->
-    ets:tab2list(gen_hook).
+    maps:to_list(persistent_term:get(gen_hook)).


### PR DESCRIPTION
Idea about hooks and persistent term: having no batching, that is, always writing to persistent terms on every insert. This means that as adding handlers triggers replaces, startup times can potentially go more expensive (measurements in my computer):
* In master for this PR `ejabberd_app:do_startup/0` currently takes `600-650ms`.
* Using a single big persistent_term entry it takes `800-850ms`.
* Using a persistent_term entry per hook tag takes `700-750ms`.

What would you say about that? We preserve all current properties except that inserting hooks becomes linearly slower, but that anyway should only happen at startup.

Perhaps https://github.com/esl/MongooseIM/pull/3878 is preferred, needs to be discussed.