### PR TITLE
C2S features small optimisation

### DIFF
--- a/src/c2s/mongoose_c2s_stanzas.erl
+++ b/src/c2s/mongoose_c2s_stanzas.erl
@@ -57,10 +57,11 @@ stream_features_before_auth(HostType, LServer, LOpts, StateData) ->
 determine_features(_, _, #{tls := #{mode := starttls_required}}, false, _StateData) ->
     [starttls_stanza(required)];
 determine_features(HostType, LServer, _, true, StateData) ->
-    mongoose_hooks:c2s_stream_features(HostType, LServer) ++ maybe_sasl_mechanisms(StateData);
+    InitialFeatures = maybe_sasl_mechanisms(StateData),
+    mongoose_hooks:c2s_stream_features(HostType, LServer, InitialFeatures);
 determine_features(HostType, LServer, _, _, StateData) ->
-    [starttls_stanza(optional)
-     | mongoose_hooks:c2s_stream_features(HostType, LServer) ++ maybe_sasl_mechanisms(StateData)].
+    InitialFeatures = [starttls_stanza(optional) | maybe_sasl_mechanisms(StateData)],
+    mongoose_hooks:c2s_stream_features(HostType, LServer, InitialFeatures).
 
 -spec maybe_sasl_mechanisms(mongoose_c2s:data()) -> [exml:element()].
 maybe_sasl_mechanisms(StateData) ->
@@ -103,8 +104,8 @@ stream_features_after_auth(HostType, LServer, #{backwards_compatible_session := 
     stream_features(Features).
 
 hook_enabled_features(HostType, LServer) ->
-    mongoose_hooks:roster_get_versioning_feature(HostType)
-    ++ mongoose_hooks:c2s_stream_features(HostType, LServer).
+    InitialFeatures = mongoose_hooks:roster_get_versioning_feature(HostType),
+    mongoose_hooks:c2s_stream_features(HostType, LServer, InitialFeatures).
 
 -spec sasl_success_stanza(binary()) -> exml:element().
 sasl_success_stanza(ServerOut) ->

--- a/src/c2s/mongoose_c2s_stanzas.erl
+++ b/src/c2s/mongoose_c2s_stanzas.erl
@@ -57,19 +57,19 @@ stream_features_before_auth(HostType, LServer, LOpts, StateData) ->
 determine_features(_, _, #{tls := #{mode := starttls_required}}, false, _StateData) ->
     [starttls_stanza(required)];
 determine_features(HostType, LServer, _, true, StateData) ->
-    mongoose_hooks:c2s_stream_features(HostType, LServer) ++ maybe_sasl_mechanisms(HostType, StateData);
+    mongoose_hooks:c2s_stream_features(HostType, LServer) ++ maybe_sasl_mechanisms(StateData);
 determine_features(HostType, LServer, _, _, StateData) ->
     [starttls_stanza(optional)
-     | mongoose_hooks:c2s_stream_features(HostType, LServer) ++ maybe_sasl_mechanisms(HostType, StateData)].
+     | mongoose_hooks:c2s_stream_features(HostType, LServer) ++ maybe_sasl_mechanisms(StateData)].
 
-maybe_sasl_mechanisms(HostType, StateData) ->
-    case cyrsasl:listmech(HostType) of
+-spec maybe_sasl_mechanisms(mongoose_c2s:data()) -> [exml:element()].
+maybe_sasl_mechanisms(StateData) ->
+    case mongoose_c2s:get_auth_mechs(StateData) of
         [] -> [];
         Mechanisms ->
             [#xmlel{name = <<"mechanisms">>,
                     attrs = [{<<"xmlns">>, ?NS_SASL}],
-                    children = [ mechanism(M)
-                                 || M <- Mechanisms, mongoose_c2s:filter_mechanism(StateData, M) ]}]
+                    children = [ mechanism(M) || M <- Mechanisms ]}]
     end.
 
 -spec mechanism(binary()) -> exml:element().

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -39,7 +39,7 @@
 
 -export([get_pep_recipients/2,
          filter_pep_recipient/3,
-         c2s_stream_features/2,
+         c2s_stream_features/3,
          check_bl_c2s/1,
          forbidden_session_hook/3,
          session_opening_allowed_for_user/2]).
@@ -469,13 +469,14 @@ filter_pep_recipient(C2SData, Feature, To) ->
     HostType = mongoose_c2s:get_host_type(C2SData),
     run_hook_for_host_type(filter_pep_recipient, HostType, true, Params).
 
--spec c2s_stream_features(HostType, LServer) -> Result when
+-spec c2s_stream_features(HostType, LServer, InitialFeatures) -> Result when
     HostType :: mongooseim:host_type(),
     LServer :: jid:lserver(),
+    InitialFeatures :: [exml:element()],
     Result :: [exml:element()].
-c2s_stream_features(HostType, LServer) ->
+c2s_stream_features(HostType, LServer, InitialFeatures) ->
     Params = #{lserver => LServer},
-    run_hook_for_host_type(c2s_stream_features, HostType, [], Params).
+    run_hook_for_host_type(c2s_stream_features, HostType, InitialFeatures, Params).
 
 -spec check_bl_c2s(IP) -> Result when
     IP ::  inet:ip_address(),


### PR DESCRIPTION
Two things here:
- First is that the hook `c2s_stream_features` can already take the initial list of pre-created features as an argument, instead of giving an empty list and then appending two lists. This way, the initial list can also be picked up from subsequent handlers and modified – which SASL2 will do with SASL1 ascribed earlier.
- `cyrsasl:listmech/1` output is given to `mongoose_c2s:filter_mechanism/1` twice, once in c2s itself, and another one when creating the features in c2s_stanza. Unify them.