### PR TITLE
Disable mnesia in pgsql_cets preset

### DIFF
--- a/big_tests/src/mim_loglevel.erl
+++ b/big_tests/src/mim_loglevel.erl
@@ -1,6 +1,8 @@
 -module(mim_loglevel).
 -export([enable_logging/2]).
 -export([disable_logging/2]).
+-export([save_log_level/1]).
+-export([restore_log_level/1]).
 
 enable_logging(Hosts, Levels) ->
     [set_custom(Host, Module, Level) || Host <- Hosts, {Module, Level} <- Levels].
@@ -15,3 +17,14 @@ set_custom(Host, Module, Level) ->
 clear_custom(Host, Module, _Level) ->
     Node = ct:get_config({hosts, Host, node}),
     mongoose_helper:successful_rpc(#{node => Node}, mongoose_logs, clear_module_loglevel, [Module]).
+
+save_log_level(Config) ->
+    Node = distributed_helper:mim(),
+    OldLogLevel = distributed_helper:rpc(Node, mongoose_logs, get_global_loglevel, []),
+    [{old_log_level, OldLogLevel} | Config].
+
+restore_log_level(Config) ->
+    Node = distributed_helper:mim(),
+    {old_log_level, OldLogLevel} = lists:keyfind(old_log_level, 1, Config),
+    ok = distributed_helper:rpc(Node, mongoose_logs, set_global_loglevel, [OldLogLevel]),
+    ok.

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -248,8 +248,7 @@
       {jingle_sip_backend, cets},
       {auth_method, "rdbms"},
       {internal_databases, "[internal_databases.cets]
-  cluster_name = \"{{cluster_name}}\"
-[internal_databases.mnesia]"}, %% We still using mnesia for modules that are not converted to use CETS
+  cluster_name = \"{{cluster_name}}\""},
       {outgoing_pools, "[outgoing_pools.redis.global_distrib]
   scope = \"global\"
   workers = 10

--- a/big_tests/tests/graphql_server_SUITE.erl
+++ b/big_tests/tests/graphql_server_SUITE.erl
@@ -96,9 +96,16 @@ end_per_group(Group, _Config) when Group =:= admin_http;
 end_per_group(_, _Config) ->
     escalus_fresh:clean().
 
+init_per_testcase(set_and_get_loglevel_test = CaseName, Config) ->
+    Config1 = mim_loglevel:save_log_level(Config),
+    escalus:init_per_testcase(CaseName, Config1);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
+
+end_per_testcase(set_and_get_loglevel_test = CaseName, Config) ->
+    mim_loglevel:restore_log_level(Config),
+    escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName, Config) when CaseName == join_successful
                                    orelse CaseName == join_successful_http
                                    orelse CaseName == join_twice ->

--- a/big_tests/tests/graphql_server_SUITE.erl
+++ b/big_tests/tests/graphql_server_SUITE.erl
@@ -79,7 +79,7 @@ init_per_group(admin_http, Config) ->
     graphql_helper:init_admin_handler(Config);
 init_per_group(admin_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
-init_per_group(clustering_tests, Config) ->
+init_per_group(Group, Config) when Group =:= clustering_tests; Group =:= clustering_http_tests ->
     case is_sm_distributed() of
         true ->
             Config;

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -170,10 +170,12 @@ init_per_group(GroupName, Config) when GroupName =:= regular; GroupName =:= asyn
     Config1 = dynamic_modules:save_modules(HostType, Config),
     Config2 = dynamic_modules:save_modules(SecHostType, Config1),
     InboxOptions = inbox_helper:inbox_opts(GroupName),
+    Backend = mongoose_helper:mnesia_or_rdbms_backend(),
+    ModOffline = config_parser_helper:mod_config(mod_offline, #{backend => Backend}),
     ok = dynamic_modules:ensure_modules(HostType,
            inbox_helper:inbox_modules(GroupName)
            ++ inbox_helper:muclight_modules()
-           ++ [{mod_offline, config_parser_helper:default_mod_config(mod_offline)}]),
+           ++ [{mod_offline, ModOffline}]),
     ok = dynamic_modules:ensure_modules(SecHostType,
            [{mod_inbox, InboxOptions#{aff_changes := false}}]),
     [{inbox_opts, InboxOptions} | Config2];

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -1015,8 +1015,9 @@ mongoose_push_api_for_group(_) ->
     <<"v3">>.
 
 required_modules_for_group(pm_notifications_with_inbox, API, PubSubHost) ->
+    Backend = mongoose_helper:mnesia_or_rdbms_backend(),
     [{mod_inbox, inbox_opts()},
-     {mod_offline, config_parser_helper:mod_config(mod_offline, #{})} |
+     {mod_offline, config_parser_helper:mod_config(mod_offline, #{backend => Backend})} |
      required_modules(API, PubSubHost)];
 required_modules_for_group(groupchat_notifications_with_inbox, API, PubSubHost)->
     [{mod_inbox, inbox_opts()}, {mod_muc_light, muc_light_opts()}
@@ -1024,10 +1025,11 @@ required_modules_for_group(groupchat_notifications_with_inbox, API, PubSubHost)-
 required_modules_for_group(muclight_msg_notifications, API, PubSubHost) ->
     [{mod_muc_light, muc_light_opts()} | required_modules(API, PubSubHost)];
 required_modules_for_group(integration_with_sm_and_offline_storage, API, PubSubHost) ->
+    Backend = mongoose_helper:mnesia_or_rdbms_backend(),
     [{mod_muc_light, muc_light_opts()},
      {mod_stream_management, config_parser_helper:mod_config(mod_stream_management,
                                                              #{ack_freq => never, resume_timeout => 1})},
-     {mod_offline, config_parser_helper:mod_config(mod_offline, #{})} |
+     {mod_offline, config_parser_helper:mod_config(mod_offline, #{backend => Backend})} |
      required_modules(API, PubSubHost)];
 required_modules_for_group(enhanced_integration_with_sm, API, PubSubHost) ->
     [{mod_stream_management, config_parser_helper:mod_config(mod_stream_management, #{ack_freq => never})} |

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -425,7 +425,8 @@ required_modules(APIVersion) ->
     [{mod_pubsub, config_parser_helper:mod_config(mod_pubsub, #{
         plugins => [<<"dag">>, <<"push">>],
         nodetree => nodetree_dag,
-        host => subhost_pattern(?PUBSUB_SUB_DOMAIN ++ ".@HOST@")
+        host => subhost_pattern(?PUBSUB_SUB_DOMAIN ++ ".@HOST@"),
+        backend => mongoose_helper:mnesia_or_rdbms_backend()
     })},
      {mod_push_service_mongoosepush,
       config_parser_helper:mod_config(mod_push_service_mongoosepush, #{pool_name => mongoose_push_http,

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -209,7 +209,8 @@ muc_light_opts(suite) ->
     #{}.
 
 common_muc_light_opts() ->
-    #{rooms_in_rosters => true}.
+    #{rooms_in_rosters => true,
+      backend => mongoose_helper:mnesia_or_rdbms_backend()}.
 
 %% --------------------------------------------------------------------
 %% Test cases

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -194,8 +194,9 @@ required_modules(Config, Scope, Name) ->
                    stopped -> stopped;
                    ExtraOpts -> maps:merge(common_sm_opts(Config), ExtraOpts)
                end,
+    Backend = mongoose_helper:mnesia_or_rdbms_backend(),
     [{mod_stream_management, config_parser_helper:mod_config(mod_stream_management, SMConfig)},
-     {mod_offline, config_parser_helper:mod_config(mod_offline, #{})}].
+     {mod_offline, config_parser_helper:mod_config(mod_offline, #{backend => Backend})}].
 
 required_sm_opts(group, parallel) ->
     #{ack_freq => never};

--- a/big_tests/tests/vcard_simple_SUITE.erl
+++ b/big_tests/tests/vcard_simple_SUITE.erl
@@ -465,7 +465,8 @@ prepare_vcard_module(Config) ->
     %% Keep the old config, so we can undo our changes, once finished testing
     Config1 = dynamic_modules:save_modules(host_types(), Config),
     %% Get a list of options, we can use as a prototype to start new modules
-    VCardOpts = config_parser_helper:default_mod_config(mod_vcard),
+    Backend = mongoose_helper:mnesia_or_rdbms_backend(),
+    VCardOpts = config_parser_helper:mod_config(mod_vcard, #{backend => Backend}),
     [{mod_vcard_opts, VCardOpts} | Config1].
 
 restore_vcard_module(Config) ->

--- a/big_tests/tests/xep_0352_csi_SUITE.erl
+++ b/big_tests/tests/xep_0352_csi_SUITE.erl
@@ -37,8 +37,9 @@ suite() ->
 
 init_per_suite(Config) ->
     NewConfig = dynamic_modules:save_modules(host_type(), Config),
+    Backend = mongoose_helper:mnesia_or_rdbms_backend(),
     dynamic_modules:ensure_modules(
-      host_type(), [{mod_offline, default_mod_config(mod_offline)},
+      host_type(), [{mod_offline, mod_config(mod_offline, #{backend => Backend})},
                     {mod_csi, mod_config(mod_csi, #{buffer_max => ?CSI_BUFFER_MAX})}]),
     [{escalus_user_db, {module, escalus_ejabberd}} | escalus:init_per_suite(NewConfig)].
 


### PR DESCRIPTION
This PR addresses "Once all backends have CETS backend, we could try to remove mnesia from the config and check which tests break".

Proposed changes include:
* Remove mnesia from internal_databases for pgsql_cets preset.
* Add backend option where it was missing.

