### PR TITLE
Update CETS dependency

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"6094d51605315d4551107e41078538b5fec6585d"}},
+       {ref,"9965e3b35f3776dff5879effaab538a0ab94592d"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},


### PR DESCRIPTION
This PR uses the latest version of CETS.

Proposed changes include:
* parallel tests for CETS (i.e.  just update to ensure it is the latest version)

