### PR TITLE
Use peer module in mongoose_config_SUITE (resurrect it after Erlang24 is dropped)

### DIFF
--- a/test/mongoose_config_SUITE.erl
+++ b/test/mongoose_config_SUITE.erl
@@ -2,6 +2,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 -import(ejabberd_helper, [start_ejabberd_with_config/2,
                           use_config_file/2,
@@ -43,12 +44,12 @@ end_per_testcase(_TestCase, _Config) ->
     ok.
 
 init_per_group(cluster, Config) ->
-    start_slave_node(Config);
+    start_peer_node(Config);
 init_per_group(_GroupName, Config) ->
     Config.
 
 end_per_group(cluster, Config) ->
-    stop_slave_node(Config),
+    stop_peer_node(Config),
     ok;
 end_per_group(_GroupName, _Config) ->
     ok.
@@ -140,18 +141,18 @@ load_from_file(Config) ->
     {error, not_started} = mongoose_config:stop().
 
 cluster_load_from_file(Config) ->
-    SlaveNode = slave_node(Config),
+    PeerNode = peer_node(Config),
     copy(data(Config, "mongooseim.minimal.toml"), data(Config, "mongooseim.toml")),
 
     %% Start clustered MongooseIM and check the loaded config
     {ok, _} = start_ejabberd_with_config(Config, "mongooseim.toml"),
-    {ok, _} = start_remote_ejabberd_with_config(SlaveNode, Config, "mongooseim.toml"),
-    maybe_join_cluster(SlaveNode),
+    {ok, _} = start_remote_ejabberd_with_config(PeerNode, Config, "mongooseim.toml"),
+    maybe_join_cluster(PeerNode),
     [State, State] = mongoose_config:config_states(),
     check_loaded_config(State),
 
     ok = mongooseim:stop(),
-    stop_remote_ejabberd(SlaveNode),
+    stop_remote_ejabberd(PeerNode),
     check_removed_config().
 
 %%
@@ -190,36 +191,35 @@ minimal_config_opts() ->
      {{replaced_wait_timeout, <<"localhost">>}, 2000},
      {{s2s, <<"localhost">>}, config_parser_helper:default_s2s()}].
 
-start_slave_node(Config) ->
-    SlaveNode = do_start_slave_node(),
-    [{slave_node, SlaveNode}|Config].
+start_peer_node(Config) ->
+    do_start_peer_node() ++ Config.
 
-do_start_slave_node() ->
-    Opts = [{monitor_master, true},
-            {boot_timeout, 15}, %% in seconds
-            {init_timeout, 10}, %% in seconds
-            {startup_timeout, 10}], %% in seconds
-    {ok, SlaveNode} = ct_slave:start(slave_name(), Opts),
+do_start_peer_node() ->
+    {ok, Peer, PeerNode} = ?CT_PEER(#{name => mim_peer}),
+    unlink(Peer), %% Prevent link to init_per_group process
     {ok, CWD} = file:get_cwd(),
-    ok = rpc:call(SlaveNode, file, set_cwd, [CWD]),
+    ok = rpc:call(PeerNode, file, set_cwd, [CWD]),
     %% Tell the remote node where to find the SUITE code
     %% Be aware, that P1 likes to put there stuff into
     %% /usr/lib/erlang/lib/
     %% So add_paths is NOT enough here
-    ok = rpc:call(SlaveNode, code, add_pathsa, [lists:reverse(code_paths())]),
-    check_that_p1_tls_is_correct(SlaveNode),
-    SlaveNode.
+    ok = rpc:call(PeerNode, code, add_pathsa, [lists:reverse(code_paths())]),
+    check_that_p1_tls_is_correct(PeerNode),
+    [{peer_node, PeerNode}, {peer_ref, Peer}].
 
-check_that_p1_tls_is_correct(SlaveNode) ->
+check_that_p1_tls_is_correct(PeerNode) ->
     ?assertEqual(fast_tls:module_info(md5),
-                 rpc:call(SlaveNode, fast_tls, module_info, [md5])).
+                 rpc:call(PeerNode, fast_tls, module_info, [md5])).
 
-stop_slave_node(Config) ->
-    ct_slave:stop(slave_node(Config)),
+stop_peer_node(Config) ->
+    peer:stop(peer_ref(Config)),
     ok.
 
-slave_node(Config) ->
-    get_required_config(slave_node, Config).
+peer_node(Config) ->
+    get_required_config(peer_node, Config).
+
+peer_ref(Config) ->
+    get_required_config(peer_ref, Config).
 
 get_required_config(Key, Config) ->
     case proplists:get_value(Key, Config) of
@@ -229,20 +229,17 @@ get_required_config(Key, Config) ->
             Value
     end.
 
-slave_name() ->
-    'mim_slave'.
-
 start_remote_ejabberd_with_config(RemoteNode, C, ConfigFile) ->
     rpc:call(RemoteNode, ejabberd_helper, start_ejabberd_with_config, [C, ConfigFile]).
 
-stop_remote_ejabberd(SlaveNode) ->
-    rpc:call(SlaveNode, mongooseim, stop, []).
+stop_remote_ejabberd(PeerNode) ->
+    rpc:call(PeerNode, mongooseim, stop, []).
 
 code_paths() ->
     [filename:absname(Path) || Path <- code:get_path()].
 
-maybe_join_cluster(SlaveNode) ->
-    Result = rpc:call(SlaveNode, mongoose_server_api, join_cluster,
+maybe_join_cluster(PeerNode) ->
+    Result = rpc:call(PeerNode, mongoose_server_api, join_cluster,
                       [atom_to_list(node())]),
     case Result of
         {ok, _} ->


### PR DESCRIPTION
This PR addresses "Deprecated old module warnings".

Proposed changes include:
* Use peer module and naming

Blocked by OTP 24 still used.
