### PR TITLE
put reporter init after app startup

### DIFF
--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -69,13 +69,13 @@ init() ->
     create_vm_metrics(),
     create_global_metrics(?GLOBAL_COUNTERS),
     create_data_metrics(),
-    create_host_type_metrics(),
-    init_subscriptions().
+    create_host_type_metrics().
 
 -spec init_mongooseim_metrics() -> ok.
 init_mongooseim_metrics() ->
     create_host_type_hook_metrics(),
-    create_global_metrics(?MNESIA_COUNTERS).
+    create_global_metrics(?MNESIA_COUNTERS),
+    init_subscriptions().
 
 init_subscriptions() ->
     Reporters = exometer_report:list_reporters(),

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -70,6 +70,7 @@ end_per_suite(C) ->
 init_per_group(Group, C) ->
     [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts(Group)],
     mongoose_metrics:init(),
+    mongoose_metrics:init_mongooseim_metrics(),
     C.
 
 end_per_group(Group, C) ->


### PR DESCRIPTION
Fixes MIM-1989

How to verify:
- Set a graphite node running, otherwise `exometer_repert_graphite` will crash.
- On a running node, execute in the shell `exometer_report:list_subscriptions(exometer_report_graphite)`.
    - On master, we will not find `totalSessionCount` available
    - In this branch it is there, similarly for all the other missing metrics.