### PR TITLE
Fix slow getaddrs call in global distribution

### DIFF
--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -225,8 +225,8 @@ get_addrs_in_parallel(Addr) ->
     %% Also, limit the time it could be running to 5 seconds
     %% (would fail with reason timeout if it takes too long)
     F = fun(Ver) -> ?MODULE:getaddrs(Addr, Ver) end,
-    [V4, V6] = mongoose_lib:pmap(F, [inet, inet6]),
-    {simplify_result(V4), simplify_result(V6)}.
+    [V6, V4] = mongoose_lib:pmap(F, [inet6, inet]),
+    {simplify_result(V6), simplify_result(V4)}.
 
 simplify_result({ok, Res}) -> Res;
 simplify_result(Res) -> Res.

--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -220,10 +220,21 @@ check_host(Domain) ->
             ok
     end.
 
+get_addrs_in_parallel(Addr) ->
+    %% getaddrs could be pretty slow, so do in parallel
+    %% Also, limit the time it could be running to 5 seconds
+    %% (would fail with reason timeout if it takes too long)
+    F = fun(Ver) -> ?MODULE:getaddrs(Addr, Ver) end,
+    [V4, V6] = mongoose_lib:pmap(F, [inet, inet6]),
+    {simplify_result(V4), simplify_result(V6)}.
+
+simplify_result({ok, Res}) -> Res;
+simplify_result(Res) -> Res.
+
 -spec to_ip_tuples(Addr :: inet:ip_address() | string()) ->
                          {ok, [inet:ip_address()]} | {error, {V6 :: atom(), V4 :: atom()}}.
 to_ip_tuples(Addr) ->
-    case {?MODULE:getaddrs(Addr, inet6), ?MODULE:getaddrs(Addr, inet)} of
+    case get_addrs_in_parallel(Addr) of
         {{error, Reason6}, {error, Reason4}} ->
             {error, {Reason6, Reason4}};
         {Addrs, {error, Msg}} ->


### PR DESCRIPTION
This PR addresses "MIM-1990". 
Fixes flaky mod_global_distrib_SUITE:test_host_refreshing testcase

There was an error happening from time to time (once every 10 CI jobs). [Report](https://circleci-mim-results.s3.eu-central-1.amazonaws.com/PR/4079/184400/internal_mnesia.25.3-amd64/big/ct_run.test%409828cde28154.2023-08-05_13.02.13/big_tests.tests.mod_global_distrib_SUITE.logs/run.2023-08-05_13.10.10/mod_global_distrib_suite.test_host_refreshing.html)

```erlang
mod_global_distrib_SUITE:hosts_refresher:test_host_refreshing
{error,
  {{trees_for_connections_present,true,[{times,50,false}],ok},
   [{mongoose_helper,do_wait_until,2,
      [{file,"/home/circleci/project/big_tests/tests/mongoose_helper.erl"},
       {line,358}]},
    {mod_global_distrib_SUITE,test_host_refreshing,1,
      [{file,
         "/home/circleci/project/big_tests/tests/mod_global_distrib_SUITE.erl"},
       {line,384}]},
    {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1782}]},
    {test_server,run_test_case_eval1,6,
      [{file,"test_server.erl"},{line,1291}]},
    {test_server,run_test_case_eval,9,
      [{file,"test_server.erl"},{line,1223}]}]}}
```

The error does not contain a lot of information, but we know that the previous test group was advertised_endpoints, where we try to do something with endpoints.

The `trees_for_connections_present` checks that `mod_global_distrib_server_mgr` creates a supervisor for each of global-distribution domains.

I.e. logic is:

```erlang
%% In mod_global_distrib_hosts_refresher.erl
refresh(LocalHost) ->
    Hosts = mod_global_distrib_mapping:hosts(),
    ?LOG_DEBUG(#{what => gd_refresher_fetched_hosts,
                 hosts => Hosts, local_host => LocalHost}),
    lists:foreach(fun mod_global_distrib_outgoing_conns_sup:ensure_server_started/1,
                  lists:delete(LocalHost, Hosts)).
```

While ensure_server_started looks like:

```erlang
-spec ensure_server_started(Server :: jid:lserver()) -> ok | {error, any()}.
ensure_server_started(Server) ->
    case mod_global_distrib_server_sup:is_available(Server) of
        false -> add_server(Server);
        true -> ok
    end.
```

The initial testcase had very little info. I.e. it only checked that one of the Erlang nodes had issues. Let's improve logging:

```erlang
{error,
  {{trees_for_connections_present,[],
     [{times,1,[europe_node1,europe_node2,asia_node]},
      {times,1,[europe_node2,asia_node]},
      {times,98,[europe_node2]}],
     ok},
   [{mongoose_helper,do_wait_until,2,
      [{file,"/home/circleci/project/big_tests/tests/mongoose_helper.erl"},
       {line,357}]},
    {mod_global_distrib_SUITE,test_host_refreshing,1,
      [{file,
         "/home/circleci/project/big_tests/tests/mod_global_distrib_SUITE.erl"},
       {line,404}]},
    {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1783}]},
    {test_server,run_test_case_eval1,6,
      [{file,"test_server.erl"},{line,1292}]},
    {test_server,run_test_case_eval,9,
      [{file,"test_server.erl"},{line,1224}]}]}}
```

`europe_node2` is `mim2` node.
So, we know that there is not enough outgoing connections on `mim2`.
But the only host we need to create connections is `reg1`. (i.e. refresh function only calls `mod_global_distrib_outgoing_conns_sup:ensure_server_started(<<"reg1">>)`).

```erlang
ensure_server_started(Server) ->
    case mod_global_distrib_server_sup:is_available(Server) of %% This call returns false, because this call fails with timeout
```

What is `is_available(Server)` call? it is a `gen_server:call`:

```erlang
%% In mod_global_distrib_server_mgr.erl
-spec ping_proc(Server :: jid:lserver()) -> pong | pang.
ping_proc(Server) ->
    case catch do_call(Server, ping_proc) of
        pong -> pong;
        _Error -> pang
    end.
```

So, the server process is busy.
It is actually could be blocked up to 16 seconds and it is doing inet:getaddrs:

```erlang
when=2023-08-08T09:18:12.474654+00:00 level=info what=long_task_progress pid=<0.4902.0> at=mongoose_long:monitor_loop/4:83 stacktrace="{current_stacktrace,[{inet_gethost_native,getit,2,[{file,\"inet_gethost_native.erl\"},{line,506}]},{inet,gethostbyname_tm_native,4,[{file,\"inet.erl\"},{line,1571}]},{inet,getaddrs_tm,3,[{file,\"inet.erl\"},{line,1522}]},{inet,getaddrs,3,[{file,\"inet.erl\"},{line,845}]},{mod_global_distrib_utils,getaddrs,2,[{file,\"/home/circleci/project/src/global_distrib/mod_global_distrib_utils.erl\"},{line,267}]},{mod_global_distrib_utils,to_ip_tuples,1,[{file,\"/home/circleci/project/src/global_distrib/mod_global_distrib_utils.erl\"},{line,226}]},{mod_global_distrib_utils,resolve_endpoint,1,[{file,\"/home/circleci/project/src/global_distrib/mod_global_distrib_utils.erl\"},{line,130}]},{lists,flatmap_1,2,[{file,\"lists.erl\"},{line,1335}]}]}" time_ms=15017 call=refresh_in_init
```

First of all, we see that it is sitting in `refresh_in_init`, which means it is in `init/1` callback of a gen_server.
Oh, it is also crashing after 16 seconds in init function:

```erlang
when=2023-08-08T08:43:18.139426+00:00 level=error pid=<0.7867.0> at=proc_lib:crash_report/4:539 report="[[{initial_call,{mod_global_distrib_server_mgr,init,['Argument__1']}},{pid,<0.7867.0>},{registered_name,[]},{error_info,{error,{domain_not_resolved,{\
"somefakedomain.com\",nxdomain,nxdomain}},[{mod_global_distrib_utils,resolve_endpoint,1,[{file,\"/home/circleci/project/src/global_distrib/mod_global_distrib_utils.erl\"},{line,143}]},{lists,flatmap_1,2,[{file,\"lists.erl\"},{line,1335}]},{mongoose_long,run_tracked,2,[{file,\"/home/circleci/project/src/mongoose_long.erl\"},{line,50}]},{mod_global_distrib_server_mgr,refresh_connections,1,[{file,\"/home/circleci/project/src/global_distrib/mod_global_distrib_server_mgr.erl\"},{line,389}]},{mongoose_long,ru
n_tracked,2,[{file,\"/home/circleci/project/src/mongoose_long.erl\"},{line,50}]},{mod_global_distrib_server_mgr,init,1,[{file,\"/home/circleci/project/src/global_distrib/mod_global_distrib_server_mgr.erl\"},{line,143}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,851}]},{gen_server,init_it,6,[{file,\"gen_server.erl\"},{line,814}]}]}},{ancestors,[mod_global_distrib_server_sup_reg1,mod_global_distrib_outgoing_conns_sup,ejabberd_sup,<0.3060.0>]},{message_queue_len,7},{messages,[{'$gen_call',{<0.7936.0>,[alias|#Ref<0.3796509223.2464219140.210594>]},ping_proc},{'$gen_cast',{call_timeout,<0.7936.0>,ping_proc}},{'$gen_call',{<0.7936.0>,[alias|#Ref<0.3796509223.2464219140.210620>]},ping_proc},{'$gen_call',{<0.8161.0>,[alias|#Ref<0.3796509223.2464481281.11871>]},ping_proc},{'$gen_cast',{call_timeout,<0.7936.0>,ping_proc}},{'$gen_call',{<0.7936.0>,[alias|#Ref<0.3796509223.2464481281.11886>]},ping_proc},{'EXIT',<0.7869.0>,normal}]},{links,[<0.7868.0>,<0.7866.0>]},{dictionary,[]},{trap_exit,true},{stat
us,running},{heap_size,4185},{stack_size,28},{reductions,68727}],[]]" label={proc_lib,crash}
```

So, this means it blocks the supervisor for 16 seconds, which is pretty bad (i.e. we cannot for example, init connections in parallel, because supervisor is busy). So, improvement - we could do delayed initialisation.

But what about our `nxdomain`?
Apparently, a single init:getaddrs call could take 2 seconds or more:

```erlang
when=2023-08-08T10:52:06.659501+00:00 level=info what=long_task_finished pid=<0.24064.1> at=mongoose_long:run_tracked/2:63 version=inet time_ms=2352 call=gd_getaddrs address=somefakedomain.com
```

Also, non-existing domain is set in the previous testcase `advertised_endpoints`.

```erlang
%% A fake address we don't try to connect to.
%% Used in test_advertised_endpoints_override_endpoints testcase.
advertised_endpoints() ->
    [
     {fake_domain(), get_port(reg, gd_endpoint_port)}
    ].

fake_domain() ->
    "somefakedomain.com".
```
_(investigating why a testcase is affected by a testcase, executed before is outside of the bug investigation. Eventually, GD would retry creating an outgoing connection with the proper endpoints. I would assume, that the mod_global_distrib is not fully restarted between test groups)._ I.e.:

```erlang
% This is from the previous test
when=2023-08-08T10:52:47.290249+00:00 level=info what=gd_get_endpoints pid=<0.24979.1> at=mod_global_distrib_server_mgr:get_endpoints/1:426 server=reg1 endpoints="[{\"somefakedomain.com\",7777}]"

wait a lot here...
crash of mod_global_distrib_server_mgr...

% Finally, something that we actually expect in our testcase
when=2023-08-08T10:52:47.767358+00:00 level=info what=gd_get_endpoints pid=<0.25055.1> at=mod_global_distrib_server_mgr:get_endpoints/1:426 server=reg1 endpoints=[{{127,0,0,1},7777}]
```

So, we could run `getaddrs` in parallel using pmap and limit maximum execution time to 5 seconds.
It fixes the testcase (verified with `{repeat_until_any_fail, 60}` for the compile PR which was able to consistently reproduce the bug without the fix).


Proposed changes include:
* Delayed initial_refresh in `src/global_distrib/mod_global_distrib_server_mgr.erl`
* Do `getaddrs` call in parallel and limit how long it can take to 5 seconds.


Stuff we've learned:
* inet functions could be slow, really slow.
* trap_exits are bad, please try not to use them (especially with code which does unsafe calls or blocks for 16 seconds).
* `gen_server:init/1` should be fast and not fail, ideally.
* Adding logging for slow tasks is pretty useful (i.e. to report time of a function, if it takes more than 1 second).
Though, I am not trying to redesign global distribution in this PR, just fix a flaky test :)

Debug code for this fix could be found in https://github.com/esl/MongooseIM/pull/4084 (just for the reference, if someone wants to debug something similar again).
