### PR TITLE
Add prototype for backend = auto support [DO NOT MERGE]

### DIFF
--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -201,7 +201,13 @@ general() ->
                                                     wrap = global_config},
                  <<"domain_certfile">> => #list{items = domain_cert(),
                                                 format_items = map,
-                                                wrap = global_config}
+                                                wrap = global_config},
+                 <<"default_persistent_db">> => #option{type = atom,
+                                                        validate = {enum, [rdbms, mnesia]},
+                                                        wrap = global_config},
+                 <<"default_volotile_db">> => #option{type = atom,
+                                                      validate = {enum, [cets, mnesia]},
+                                                      wrap = global_config}
                 },
        wrap = none,
        format_items = list
@@ -221,7 +227,9 @@ general_defaults() ->
       <<"mongooseimctl_access_commands">> => #{},
       <<"routing_modules">> => mongoose_router:default_routing_modules(),
       <<"replaced_wait_timeout">> => 2000,
-      <<"hide_service_name">> => false}.
+      <<"hide_service_name">> => false,
+      <<"default_volotile_db">> => mnesia,
+      <<"default_persistent_db">> => mnesia}.
 
 ctl_access_rule() ->
     #section{

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -93,9 +93,9 @@ config_spec() ->
     #section{
        items = #{<<"iqdisc">> => mongoose_config_spec:iqdisc(),
                  <<"backend">> => #option{type = atom,
-                                          validate = {module, mod_private}}},
+                                          validate = {module, mod_private, persistent_db}}},
        defaults = #{<<"iqdisc">> => one_queue,
-                    <<"backend">> => rdbms}
+                    <<"backend">> => auto}
     }.
 
 %% ------------------------------------------------------------------

--- a/src/mod_private_backend.erl
+++ b/src/mod_private_backend.erl
@@ -61,7 +61,7 @@
     Opts :: gen_mod:module_opts().
 init(HostType, Opts) ->
     TrackedFuns = [multi_get_data, multi_set_data],
-    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts, persistent_db),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 


### PR DESCRIPTION
This PR addresses "experimenting how to set auto backend". Probably will do inside the config parser instead (?)

Proposed changes include:
* Do not merge

Auto-selecting backend

Allow to set backend = auto (i.e. disables validation that auto module exists).

mongoose_backend:init would have to take an extra option ModuleType = external_db | internal_db.

We actually do not call config module directly from mongoose_backend module.
So, if we wanna know which backend is running - use mongoose_backend:get_backend_module/2.
And config API would return backend = auto, which we are fine with (we don't have logic which would use backend name anyway).


Also, mongoose_backend could call is_backend_present/1 which would do check:
- for rdbms - that rdbms is configured in outgoing pools
- for mnesia - that mnesia is configured in internal_databases
- for cets - that cets is configured in internal_databases
- for unknown backends it will do nothing

(it is just quick config check, so should be fast)


Autoselecting would just use mnesia for both internal and persistent data, if
preferred_persistent_db and preferred_internal_db options are not set
(so, we would not have issues with old configs, that assume that the default backend is mnesia).

But, we could do default backend = auto now, so config should be really clean
(i.e. no need to specify backend = "rdbms" for every module, could just say preferred_persistent_db = "rdbms" in the general options).

Naming

Could be auto_persistent_database or preferred_persistent_db.
While we could try allowing a list there `auto_persistent_database = [cets, mnesia]`, a single database is fine and simple.


Enabling:

```
[general]
  default_volotile_db = "cets"
  default_persistent_db = "rdbms"

[modules.mod_private]
```

Check:

```
mongoose_backend:get_backend_module(<<"localhost">>, mod_private).
mod_private_rdbms
```

Motivation:

Removes these three options, but adds two new:
```
[general]
  sm_backend = "cets"
  component_backend = "cets"
  s2s_backend = "cets"
```

Also, we don't need to specify `backend = "rdbms"` anymore in modules, which is good (it is a common bug to have it unspecified).

The issue it does not reduces the size of the default config that much, sadly.
But it could be a first step :)

We could try to autocreate shapers as the next step.

