### PR TITLE
Skip setting priority to zero in SM unset_presence

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -293,7 +293,8 @@ set_presence(Acc, SID, JID, Priority, Presence, Info) ->
       Status :: binary(),
       Info :: info().
 unset_presence(Acc, SID, JID, Status, Info) ->
-    set_session(SID, JID, undefined, Info),
+    %% We don't need to write to SM store, because close_session would be called next
+%   set_session(SID, JID, undefined, Info),
     mongoose_hooks:unset_presence_hook(Acc, JID, Status).
 
 

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -409,6 +409,7 @@ presence_update_to_unavailable(Acc, _FromJid, _ToJid, Packet, StateData, Presenc
     presence_broadcast(Acc1, Presences#presences_state.pres_i),
     NewPresences = Presences#presences_state{pres_last = undefined,
                                    pres_timestamp = undefined,
+                                   pres_pri = 0,
                                    pres_a = gb_sets:new(),
                                    pres_i = gb_sets:new(),
                                    pres_invis = false},


### PR DESCRIPTION
We do:

- unset_prenence (sets priority to 0)
- remove session from SM table

It does not make sense, the session would be removed.

TODO:
- Confirm that it works correctly with steam resumption.

This PR addresses "Optimisation".

Proposed changes include:
* Skip one write to CETS/Mnesia on logout.

