### PR TITLE
Updating XEP-0060 Publish-Subscribe

### DIFF
--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -476,7 +476,6 @@ unsubscribe_after_presence_unsubscription(Config) ->
 %%-----------------------------------------------------------------
 
 add_config_to_create_node_request(#xmlel{children = [PubsubEl]} = Request) ->
-    io:format("~p", [Request]),
     Fields = [#{values => [<<"friends">>, <<"enemies">>], var => <<"pubsub#roster_groups_allowed">>}],
     Form = form_helper:form(#{ns => <<"http://jabber.org/protocol/pubsub#node_config">>, fields => Fields}),
     ConfigureEl = #xmlel{name = <<"configure">>, children = [Form]},

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -127,8 +127,14 @@ publish_fails_with_invalid_item(Config) ->
             Item =
                 #xmlel{name = <<"invalid-item">>,
                        attrs = [{<<"xmlns">>, ?NS_PUSH}]},
+            
+            Options = [
+                {<<"device_id">>, <<"sometoken">>},
+                {<<"service">>, <<"apns">>}
+            ],
 
-            Publish = escalus_pubsub_stanza:publish(Alice, <<"itemid">>, Item, <<"id">>, Node),
+            Publish = escalus_pubsub_stanza:publish_with_options(Alice, <<"itemid">>, Item,
+                                                                 <<"id">>, Node, Options),
             escalus:send(Alice, Publish),
             escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
                            escalus:wait_for_stanza(Alice)),

--- a/src/event_pusher/mod_event_pusher_push.erl
+++ b/src/event_pusher/mod_event_pusher_push.erl
@@ -14,7 +14,7 @@
 -behavior(gen_mod).
 -behavior(mod_event_pusher).
 -behaviour(mongoose_module_metrics).
--xep([{xep, 357}, {version, "0.2.1"}]).
+-xep([{xep, 357}, {version, "0.4.1"}]).
 
 -include("mod_event_pusher_events.hrl").
 -include("mongoose.hrl").

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -3717,13 +3717,7 @@ convert_option_value(Element) when is_atom(Element) ->
 convert_option_value(Element) when is_integer(Element) ->
     [integer_to_binary(Element)];
 convert_option_value(List) when is_list(List) ->
-    lists:map(
-        fun
-            (Element) when is_atom(Element) -> atom_to_binary(Element);
-            (Element) -> Element
-        end, List);
-convert_option_value(Element) ->
-    [Element].
+    List.
 
 node_options(Host, Type) ->
     ConfiguredOpts = lists:keysort(1, config(serverhost(Host), default_node_config)),

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -3693,7 +3693,7 @@ check_publish_options(Type, PublishOptions, Options) ->
             Result
     end.
 
--spec parse_publish_options(undefined | exml:element()) -> invalid_form | #{binary() => binary()}.
+-spec parse_publish_options(undefined | exml:element()) -> invalid_form | #{binary() => [binary()]}.
 parse_publish_options(undefined) ->
     #{};
 parse_publish_options(PublishOptions) ->
@@ -3717,7 +3717,11 @@ convert_option_value(Element) when is_atom(Element) ->
 convert_option_value(Element) when is_integer(Element) ->
     [integer_to_binary(Element)];
 convert_option_value(List) when is_list(List) ->
-    lists:map(fun(Element) -> atom_to_binary(Element) end, List);
+    lists:map(
+        fun
+            (Element) when is_atom(Element) -> atom_to_binary(Element);
+            (Element) -> Element
+        end, List);
 convert_option_value(Element) ->
     [Element].
 

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -3683,6 +3683,8 @@ get_option(Options, Var, Def) ->
         _ -> Def
     end.
 
+-spec check_publish_options(binary(), undefined | exml:element(), mod_pubsub:nodeOptions()) ->
+    boolean().
 check_publish_options(Type, PublishOptions, Options) ->
     ParsedPublishOptions = parse_publish_options(PublishOptions),
     ConvertedOptions = convert_options(Options),
@@ -3704,10 +3706,14 @@ parse_publish_options(PublishOptions) ->
             invalid_form
     end.
 
+-spec convert_options(mod_pubsub:nodeOptions()) -> #{binary() => [binary()]}.
 convert_options(Options) ->
-    OptionsMap = maps:from_list(Options),
-    maps:map(fun(_, Value) -> convert_option_value(Value) end, OptionsMap).
+    ConvertedOptions = lists:map(fun({Key, Value}) ->
+                                     {atom_to_binary(Key), convert_option_value(Value)}
+                                 end, Options),
+    maps:from_list(ConvertedOptions).
 
+-spec convert_option_value(binary() | [binary()] | atom() | non_neg_integer()) -> [binary()].
 convert_option_value(true) ->
     [<<"1">>];
 convert_option_value(false) ->

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -47,7 +47,7 @@
 -behaviour(mongoose_module_metrics).
 -author('christophe.romain@process-one.net').
 
--xep([{xep, 60}, {version, "1.13-1"}]).
+-xep([{xep, 60}, {version, "1.25.0"}]).
 -xep([{xep, 163}, {version, "1.2.2"}]).
 -xep([{xep, 248}, {version, "0.3.0"}]).
 -xep([{xep, 277}, {version, "0.6.5"}]).
@@ -3688,7 +3688,7 @@ check_publish_options(Type, PublishOptions, Options) ->
     ConvertedOptions = convert_options(Options),
     case node_call(Type, check_publish_options, [ParsedPublishOptions, ConvertedOptions]) of
         {error, _} ->
-            false;
+            true;
         {result, Result} ->
             Result
     end.

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -39,8 +39,8 @@
          unsubscribe_node/4, node_to_path/1,
          get_entity_affiliations/2, get_entity_affiliations/3,
          get_entity_subscriptions/2, get_entity_subscriptions/4,
-         should_delete_when_owner_removed/0
-         ]).
+         should_delete_when_owner_removed/0, check_publish_options/2
+        ]).
 
 -ignore_xref([get_entity_affiliations/3, get_entity_subscriptions/4]).
 
@@ -91,6 +91,15 @@ features() ->
         <<"retrieve-items">>,
         <<"retrieve-subscriptions">>,
         <<"subscribe">>].
+
+-spec check_publish_options(#{binary() => [binary()]}, #{atom() => binary()}) -> boolean().
+check_publish_options(PublishOptions, NodeOptions) ->
+    F = fun(Key, Value) ->
+            Value =/= maps:get(binary_to_atom(Key), NodeOptions)
+        end,
+    maps:size(maps:filter(F, PublishOptions)) =/= 0;
+check_publish_options(_, _) ->
+    false.
 
 create_node_permission(Host, _ServerHost, _Node, _ParentNode,
                        #jid{ luser = <<>>, lserver = Host, lresource = <<>> }, _Access) ->

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -42,7 +42,7 @@
          should_delete_when_owner_removed/0, check_publish_options/2
         ]).
 
--ignore_xref([get_entity_affiliations/3, get_entity_subscriptions/4]).
+-ignore_xref([get_entity_affiliations/3, get_entity_subscriptions/4, check_publish_options/2]).
 
 based_on() ->  node_flat.
 
@@ -95,11 +95,13 @@ features() ->
 -spec check_publish_options(#{binary() => [binary()]}, #{atom() => binary()}) -> boolean().
 check_publish_options(PublishOptions, NodeOptions) ->
     F = fun(Key, Value) ->
-            Value =/= maps:get(binary_to_atom(Key), NodeOptions)
+            case string:split(Key, "#") of
+                [<<"pubsub">>, Key2] ->
+                    Value =/= maps:get(binary_to_atom(Key2), NodeOptions, null);
+                _ -> true
+            end
         end,
-    maps:size(maps:filter(F, PublishOptions)) =/= 0;
-check_publish_options(_, _) ->
-    false.
+    maps:size(maps:filter(F, PublishOptions)) =/= 0.
 
 create_node_permission(Host, _ServerHost, _Node, _ParentNode,
                        #jid{ luser = <<>>, lserver = Host, lresource = <<>> }, _Access) ->

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -92,16 +92,26 @@ features() ->
         <<"retrieve-subscriptions">>,
         <<"subscribe">>].
 
--spec check_publish_options(#{binary() => [binary()]}, #{atom() => binary()}) -> boolean().
+-spec check_publish_options(#{binary() => [binary()]} | invalid_form, #{atom() => binary()}) ->
+    boolean().
+check_publish_options(invalid_form, _) ->
+    true;
 check_publish_options(PublishOptions, NodeOptions) ->
+    io:format("~p\n", [{NodeOptions, PublishOptions}]),
     F = fun(Key, Value) ->
             case string:split(Key, "#") of
                 [<<"pubsub">>, Key2] ->
-                    Value =/= maps:get(binary_to_atom(Key2), NodeOptions, null);
+                    AtomKey = binary_to_atom(Key2),
+                    compare_values(Value, maps:get(AtomKey, NodeOptions, null));
                 _ -> true
             end
         end,
     maps:size(maps:filter(F, PublishOptions)) =/= 0.
+
+compare_values(_, null) ->
+    true;
+compare_values(Value1, Value2) ->
+    lists:sort(Value1) =/= lists:sort(Value2).
 
 create_node_permission(Host, _ServerHost, _Node, _ParentNode,
                        #jid{ luser = <<>>, lserver = Host, lresource = <<>> }, _Access) ->

--- a/src/pubsub/node_pep.erl
+++ b/src/pubsub/node_pep.erl
@@ -92,22 +92,21 @@ features() ->
         <<"retrieve-subscriptions">>,
         <<"subscribe">>].
 
--spec check_publish_options(#{binary() => [binary()]} | invalid_form, #{atom() => binary()}) ->
+-spec check_publish_options(#{binary() => [binary()]} | invalid_form, #{binary() => [binary()]}) ->
     boolean().
 check_publish_options(invalid_form, _) ->
     true;
 check_publish_options(PublishOptions, NodeOptions) ->
-    io:format("~p\n", [{NodeOptions, PublishOptions}]),
     F = fun(Key, Value) ->
             case string:split(Key, "#") of
                 [<<"pubsub">>, Key2] ->
-                    AtomKey = binary_to_atom(Key2),
-                    compare_values(Value, maps:get(AtomKey, NodeOptions, null));
+                    compare_values(Value, maps:get(Key2, NodeOptions, null));
                 _ -> true
             end
         end,
     maps:size(maps:filter(F, PublishOptions)) =/= 0.
 
+-spec compare_values([binary()], [binary()] | null) -> boolean().
 compare_values(_, null) ->
     true;
 compare_values(Value1, Value2) ->

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -21,6 +21,8 @@
          publish_item/9, node_to_path/1, should_delete_when_owner_removed/0,
          check_publish_options/2]).
 
+-ignore_xref([check_publish_options/2]).
+
 based_on() ->  node_flat.
 
 init(Host, ServerHost, Opts) ->

--- a/src/pubsub/node_push.erl
+++ b/src/pubsub/node_push.erl
@@ -75,6 +75,8 @@ publish_item(ServerHost, Nidx, Publisher, Model, _MaxItems, _ItemId, _ItemPublis
             {error, mongoose_xmpp_errors:forbidden()}
     end.
 
+-spec check_publish_options(#{binary() => [binary()]} | invalid_form, #{binary() => [binary()]}) ->
+    boolean().
 check_publish_options(#{<<"device_id">> := _, <<"service">> := _}, _) ->
     false;
 check_publish_options(_, _) ->


### PR DESCRIPTION
Include a feature of http://jabber.org/protocol/pubsub#rsm in disco#info response. 

Check preconditions when accepting publish-options along with a publish request. We have two node types which advertise support for the publish-options feature.
In node push the preconditions are not checked. This node type is supporting xep-0163.
In node pep the changes are implemented, and the publish-options are being checked.