### PR TITLE
Config in one persistent term

### DIFF
--- a/src/config/mongoose_config_parser.erl
+++ b/src/config/mongoose_config_parser.erl
@@ -7,7 +7,12 @@
 -export([parse_file/1]).
 
 %% state API
--export([build_state/3, get_opts/1]).
+-export([build_state/3]).
+
+%% only for tests
+-export([get_opts/1]).
+
+-ignore_xref([get_opts/1]).
 
 -callback parse_file(FileName :: string()) -> state().
 
@@ -25,11 +30,12 @@
 
 %% Parser API
 
--spec parse_file(FileName :: string()) -> state().
+-spec parse_file(FileName :: string()) -> opts().
 parse_file(FileName) ->
     ParserModule = parser_module(filename:extension(FileName)),
-    try
-        ParserModule:parse_file(FileName)
+    try ParserModule:parse_file(FileName) of
+        State ->
+            get_opts(State)
     catch
         error:{config_error, ExitMsg, Errors} ->
             halt_with_msg(ExitMsg, Errors)

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -4078,7 +4078,7 @@ host_to_host_type(Host) ->
 -spec tree(HostType :: mongooseim:host_type() | host()) -> module() | nodetree_virtual.
 tree(HostType) ->
     try gen_mod:get_module_opt(HostType, ?MODULE, nodetree)
-    catch error:badarg ->
+    catch error:{badkey, _} ->
         %todo remove when pubsub supports dynamic domains
         HT = host_to_host_type(HostType),
         gen_mod:get_module_opt(HT, ?MODULE, nodetree)

--- a/test/acl_SUITE.erl
+++ b/test/acl_SUITE.erl
@@ -47,10 +47,11 @@ end_per_group(_Group, Config) ->
     Config.
 
 init_per_testcase(_TC, Config) ->
+    mongoose_config:set_opts(#{}),
     Config.
 
 end_per_testcase(_TC, _Config) ->
-    clean_config().
+    mongoose_config:erase_opts().
 
 host_type() ->
     <<"test host type">>.
@@ -286,10 +287,6 @@ different_specs_matching_the_same_user(Config) ->
 
 acl(Spec) ->
     [maps:merge(#{match => current_domain}, Spec)].
-
-clean_config() ->
-    [persistent_term:erase(Key) || {Key = {mongoose_config, _}, _Value} <- persistent_term:get()],
-    ok.
 
 given_registered_domains(Config, DomainsList) ->
     case proplists:get_value(dynamic_domains, Config, false) of

--- a/test/auth_dummy_SUITE.erl
+++ b/test/auth_dummy_SUITE.erl
@@ -35,13 +35,13 @@ all() -> [
 
 init_per_suite(C) ->
     {ok, _} = application:ensure_all_started(jid),
-    mongoose_config:set_opt({auth, ?HOST_TYPE}, #{methods => [dummy],
-                                                  dummy => #{base_time => 5,
-                                                             variance => 10}}),
+    AuthOpts = #{methods => [dummy],
+                 dummy => #{base_time => 5, variance => 10}},
+    mongoose_config:set_opts(#{{auth, ?HOST_TYPE} => AuthOpts}),
     C.
 
 end_per_suite(_C) ->
-    mongoose_config:unset_opt({auth, ?HOST_TYPE}).
+    mongoose_config:erase_opts().
 
 %%--------------------------------------------------------------------
 %% Authentication tests

--- a/test/auth_external_SUITE.erl
+++ b/test/auth_external_SUITE.erl
@@ -79,12 +79,12 @@ given_user_registered() ->
 
 set_opts(Config) ->
     DataDir = ?config(data_dir, Config),
-    mongoose_config:set_opt({auth, ?HOST_TYPE},
-                            #{external => #{program => DataDir ++ "sample_external_auth.py",
-                                            instances => 1}}).
+    mongoose_config:set_opts(#{{auth, ?HOST_TYPE} =>
+                                   #{external => #{program => DataDir ++ "sample_external_auth.py",
+                                                   instances => 1}}}).
 
 unset_opts() ->
-    mongoose_config:unset_opt({auth, ?HOST_TYPE}).
+    mongoose_config:erase_opts().
 
 gen_user() ->
     U = random_binary(5),

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -244,13 +244,13 @@ set_opts(Config) ->
                          _ -> scram
                      end,
     HttpOpts = #{basic_auth => ?BASIC_AUTH},
-    mongoose_config:set_opt({auth, ?HOST_TYPE}, #{methods => [http],
-                                                  password => #{format => PasswordFormat,
-                                                                scram_iterations => 10},
-                                                  http => HttpOpts}).
+    mongoose_config:set_opts(#{{auth, ?HOST_TYPE} => #{methods => [http],
+                                                       password => #{format => PasswordFormat,
+                                                                     scram_iterations => 10},
+                                                       http => HttpOpts}}).
 
 unset_opts() ->
-    mongoose_config:unset_opt({auth, ?HOST_TYPE}).
+    mongoose_config:erase_opts().
 
 do_scram(Pass, Config) ->
     case lists:keyfind(scram_group, 1, Config) of

--- a/test/auth_internal_SUITE.erl
+++ b/test/auth_internal_SUITE.erl
@@ -12,16 +12,16 @@ init_per_suite(C) ->
     application:ensure_all_started(jid),
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
-    mongoose_config:set_opt({auth, host_type()}, #{methods => [internal],
-                                                   internal => #{},
-                                                   password => #{format => scram,
-                                                                 scram_iterations => 10}}),
+    AuthOpts = #{methods => [internal],
+                 internal => #{},
+                 password => #{format => scram, scram_iterations => 10}},
+    mongoose_config:set_opts(#{{auth, host_type()} => AuthOpts}),
     ejabberd_auth_internal:start(host_type()),
     C.
 
 end_per_suite(_C) ->
     ejabberd_auth_internal:stop(host_type()),
-    mongoose_config:unset_opt({auth, host_type()}),
+    mongoose_config:erase_opts(),
     mnesia:stop(),
     mnesia:delete_schema([node()]).
 

--- a/test/auth_jwt_SUITE.erl
+++ b/test/auth_jwt_SUITE.erl
@@ -124,12 +124,12 @@ check_password_succeeds_for_pubkey_signed_token(C) ->
 %%--------------------------------------------------------------------
 
 set_auth_opts(Secret, Algorithm, Key) ->
-    mongoose_config:set_opt({auth, ?HOST_TYPE}, #{jwt => #{secret => Secret,
-                                                           algorithm => Algorithm,
-                                                           username_key => Key}}).
+    mongoose_config:set_opts(#{{auth, ?HOST_TYPE} => #{jwt => #{secret => Secret,
+                                                                algorithm => Algorithm,
+                                                                username_key => Key}}}).
 
 unset_auth_opts() ->
-    mongoose_config:unset_opt({auth, ?HOST_TYPE}).
+    mongoose_config:erase_opts().
 
 generate_token(Alg, NbfDelta, Key) ->
     Now = erlang:system_time(second),

--- a/test/auth_tokens_SUITE.erl
+++ b/test/auth_tokens_SUITE.erl
@@ -41,13 +41,14 @@ groups() ->
 
 init_per_suite(C) ->
     {ok, _} = application:ensure_all_started(jid),
-    mongoose_config:set_opt({modules, host_type()},
-                            #{?TESTED => config_parser_helper:default_mod_config(?TESTED)}),
+    mongoose_config:set_opts(opts()),
     C.
 
-end_per_suite(C) ->
-    mongoose_config:unset_opt({modules, host_type()}),
-    C.
+end_per_suite(_C) ->
+    mongoose_config:erase_opts().
+
+opts() ->
+    #{{modules, host_type()} => #{?TESTED => config_parser_helper:default_mod_config(?TESTED)}}.
 
 init_per_testcase(Test, Config)
         when Test =:= serialize_deserialize_property;

--- a/test/component_reg_SUITE.erl
+++ b/test/component_reg_SUITE.erl
@@ -13,7 +13,7 @@ init_per_suite(C) ->
     {ok, _} = application:ensure_all_started(jid),
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
+    mongoose_config:set_opts(opts()),
     meck:new(mongoose_domain_api, [no_link]),
     meck:expect(mongoose_domain_api, get_host_type,
                 fun(_) -> {error, not_found} end),
@@ -31,13 +31,12 @@ end_per_suite(_C) ->
     mnesia:stop(),
     mnesia:delete_schema([node()]),
     meck:unload(),
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
-    ok.
+    mongoose_config:erase_opts().
 
 opts() ->
-    [{all_metrics_are_global, false},
-     {component_backend, mnesia},
-     {routing_modules, [xmpp_router_a, xmpp_router_b, xmpp_router_c]}].
+    #{all_metrics_are_global => false,
+      component_backend => mnesia,
+      routing_modules => [xmpp_router_a, xmpp_router_b, xmpp_router_c]}.
 
 registering(_C) ->
     Dom = <<"aaa.bbb.com">>,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -3040,8 +3040,7 @@ test_config_file(Config, File) ->
     ExpectedOpts = config_parser_helper:options(File),
 
     TOMLPath = ejabberd_helper:data(Config, File ++ ".toml"),
-    State = mongoose_config_parser:parse_file(TOMLPath),
-    TOMLOpts = mongoose_config_parser:get_opts(State),
+    TOMLOpts = mongoose_config_parser:parse_file(TOMLPath),
 
     %% Save the parsed TOML options
     %% - for debugging

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -115,7 +115,7 @@ end_per_testcase(_, Config) ->
     clean_sessions(Config),
     terminate_sm(),
     unload_meck(),
-    unset_opts(Config).
+    mongoose_config:erase_opts().
 
 open_session(C) ->
     {Sid, USR} = generate_random_user(<<"localhost">>),
@@ -610,7 +610,7 @@ is_redis_running() ->
     end.
 
 setup_sm(Config) ->
-    set_opts(Config),
+    mongoose_config:set_opts(opts(Config)),
     set_meck(),
     ejabberd_sm:start_link(),
     case ?config(backend, Config) of
@@ -625,17 +625,11 @@ setup_sm(Config) ->
 terminate_sm() ->
     gen_server:stop(ejabberd_sm).
 
-set_opts(Config) ->
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts(Config)].
-
-unset_opts(Config) ->
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts(Config)].
-
 opts(Config) ->
-    [{hosts, [<<"localhost">>]},
-     {host_types, []},
-     {all_metrics_are_global, false},
-     {sm_backend, sm_backend(?config(backend, Config))}].
+    #{hosts => [<<"localhost">>],
+      host_types => [],
+      all_metrics_are_global => false,
+      sm_backend => sm_backend(?config(backend, Config))}.
 
 sm_backend(ejabberd_sm_redis) -> redis;
 sm_backend(ejabberd_sm_mnesia) -> mnesia;

--- a/test/event_pusher_sns_SUITE.erl
+++ b/test/event_pusher_sns_SUITE.erl
@@ -197,18 +197,18 @@ sns_config(_) ->
     common_sns_opts().
 
 start_modules(SNSExtra) ->
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts(SNSExtra)],
+    mongoose_config:set_opts(opts(SNSExtra)),
     mongoose_modules:start().
 
 stop_modules() ->
     mongoose_modules:stop(),
-    [mongoose_config:unset_opt(Key) || {Key, _} <- opts(#{})].
+    mongoose_config:erase_opts().
 
 opts(SNSExtra) ->
-    [{hosts, [host_type()]},
-     {host_types, []},
-     {all_metrics_are_global, false},
-     {{modules, host_type()}, modules(SNSExtra)}].
+    #{hosts => [host_type()],
+      host_types => [],
+      all_metrics_are_global => false,
+      {modules, host_type()} => modules(SNSExtra)}.
 
 modules(SNSExtra) ->
     gen_mod_deps:resolve_deps(host_type(), #{mod_event_pusher => module_opts(SNSExtra)}).

--- a/test/gen_hook_SUITE.erl
+++ b/test/gen_hook_SUITE.erl
@@ -24,11 +24,11 @@ all() ->
 
 init_per_suite(Config) ->
     application:ensure_all_started(exometer_core),
-    mongoose_config:set_opt(all_metrics_are_global, false),
+    mongoose_config:set_opts(#{all_metrics_are_global => false}),
     Config.
 
 end_per_suite(Config) ->
-    mongoose_config:unset_opt(all_metrics_are_global),
+    mongoose_config:erase_opts(),
     application:stop(exometer_core),
     Config.
 

--- a/test/gen_mod_SUITE.erl
+++ b/test/gen_mod_SUITE.erl
@@ -37,12 +37,12 @@ all() ->
      hosts_and_opts_with_module].
 
 init_per_testcase(_, Config) ->
-    [mongoose_config:set_opt(Opt, Val) || {Opt, Val} <- opts()],
+    mongoose_config:set_opts(opts()),
     [setup_meck(Module) || Module <- [a_module, b_module]],
     Config.
 
 end_per_testcase(_, Config) ->
-    [mongoose_config:unset_opt(Opt) || Opt <- opts()],
+    mongoose_config:erase_opts(),
     [meck:unload(Module) || Module <- [a_module, b_module]],
     Config.
 
@@ -113,8 +113,8 @@ setup_meck(Module) ->
     meck:expect(Module, stop, fun(_) -> ok end).
 
 opts() ->
-    [{hosts, [host(a), host(b)]},
-     {host_types, []},
-     {services, #{}},
-     {{modules, host(a)}, #{a_module => #{}}},
-     {{modules, host(b)}, #{b_module => #{k => v}}}].
+    #{hosts => [host(a), host(b)],
+      host_types => [],
+      services => #{},
+      {modules, host(a)} => #{a_module => #{}},
+      {modules, host(b)} => #{b_module => #{k => v}}}.

--- a/test/keystore_SUITE.erl
+++ b/test/keystore_SUITE.erl
@@ -28,21 +28,21 @@ end_per_suite(_C) ->
 init_per_testcase(_, Config) ->
     mock_mongoose_metrics(),
     Config1 = async_helper:start(Config, gen_hook, start_link, []),
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
+    mongoose_config:set_opts(opts()),
     Config1.
 
 end_per_testcase(_, C) ->
     mongoose_modules:stop(),
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
+    mongoose_config:erase_opts(),
     meck:unload(mongoose_metrics),
     async_helper:stop_all(C),
     mnesia:delete_table(key).
 
 opts() ->
-    [{hosts, hosts()},
-     {host_types, []},
-     {all_metrics_are_global, false}]
-    ++ [{{modules, Host}, #{}} || Host <- hosts()].
+    maps:from_list([{hosts, hosts()},
+                    {host_types, []},
+                    {all_metrics_are_global, false} |
+                    [{{modules, Host}, #{}} || Host <- hosts()]]).
 
 hosts() ->
     [<<"localhost">>, <<"first.com">>, <<"second.com">>].

--- a/test/mod_global_distrib_SUITE.erl
+++ b/test/mod_global_distrib_SUITE.erl
@@ -65,7 +65,7 @@ end_per_group(_GroupName, Config) ->
 
 init_per_testcase(_CaseName, Config) ->
     set_meck(),
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
+    mongoose_config:set_opts(opts()),
     mongoose_domain_sup:start_link(),
     mim_ct_sup:start_link(ejabberd_sup),
     gen_hook:start_link(),
@@ -74,15 +74,15 @@ init_per_testcase(_CaseName, Config) ->
 
 end_per_testcase(_CaseName, Config) ->
     mongoose_modules:stop(),
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
+    mongoose_config:erase_opts(),
     unset_meck(),
     Config.
 
 opts() ->
-    [{hosts, hosts()},
-     {host_types, []},
-     {all_metrics_are_global, false} |
-     [{{modules, HostType}, modules(HostType)} || HostType <- hosts()]].
+    maps:from_list([{hosts, hosts()},
+                    {host_types, []},
+                    {all_metrics_are_global, false} |
+                    [{{modules, HostType}, modules(HostType)} || HostType <- hosts()]]).
 
 hosts() ->
     [global_host(), local_host()].

--- a/test/mod_websockets_SUITE.erl
+++ b/test/mod_websockets_SUITE.erl
@@ -51,8 +51,8 @@ setup() ->
                 fun(mongoose_listener_sup, _) -> {ok, self()};
                    (A, B) -> meck:passthrough([A, B])
                 end),
+    mongoose_config:set_opts(#{default_server_name => <<"localhost">>}),
     %% Start websocket cowboy listening
-
     Handlers = [config([listen, http, handlers, mod_bosh],
                        #{host => '_', path => "/http-bind"}),
                 config([listen, http, handlers, mod_websockets],
@@ -70,6 +70,7 @@ setup() ->
 teardown() ->
     meck:unload(),
     cowboy:stop_listener(ejabberd_cowboy:ref({?PORT, ?IP, tcp})),
+    mongoose_config:erase_opts(),
     application:stop(cowboy),
     %% Do not stop jid, Erlang 21 does not like to reload nifs
     ok.

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -57,11 +57,11 @@ init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(jid),
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
+    mongoose_config:set_opts(opts()),
     Config.
 
 end_per_suite(Config) ->
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
+    mongoose_config:erase_opts(),
     mnesia:stop(),
     mnesia:delete_schema([node()]),
     Config.
@@ -116,11 +116,11 @@ needs_component(TestCase) ->
     lists:member(TestCase, component_cases()).
 
 opts() ->
-    [{hosts, [?HOST]},
-     {host_types, []},
-     {all_metrics_are_global, false},
-     {s2s_backend, mnesia},
-     {{modules, ?HOST}, #{}}].
+    #{hosts => [?HOST],
+      host_types => [],
+      all_metrics_are_global => false,
+      s2s_backend => mnesia,
+      {modules, ?HOST} => #{}}.
 
 meck_mods(bosh) -> [exometer, mod_bosh_socket];
 meck_mods(s2s) -> [exometer, ejabberd_commands, mongoose_bin];

--- a/test/mongoose_modules_SUITE.erl
+++ b/test/mongoose_modules_SUITE.erl
@@ -18,12 +18,11 @@ all() ->
      replaces_modules_with_same_deps].
 
 init_per_suite(C) ->
-    [mongoose_config:set_opt(Opt, Val) || {Opt, Val} <- opts()],
+    mongoose_config:set_opts(opts()),
     C.
 
 end_per_suite(_C) ->
-    [mongoose_config:unset_opt(Opt) || {Opt, _} <- opts()],
-    ok.
+    mongoose_config:erase_opts().
 
 init_per_testcase(_TC, C) ->
     meck:new(gen_mod, [passthrough]),
@@ -156,8 +155,7 @@ check_modules(ExpectedModules) ->
     ?assertEqual(ExpectedModules, gen_mod:loaded_modules_with_opts(?HOST)).
 
 opts() ->
-    [{hosts, [?HOST]},
-     {host_types, []}].
+    #{hosts => [?HOST], host_types => []}.
 
 set_modules(Modules) ->
     mongoose_config:set_opt({modules, ?HOST}, Modules).

--- a/test/mongoose_rdbms_SUITE.erl
+++ b/test/mongoose_rdbms_SUITE.erl
@@ -135,14 +135,14 @@ meck_unload_rand() ->
     meck:unload(rand).
 
 set_opts() ->
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()].
+    mongoose_config:set_opts(opts()).
 
 unset_opts() ->
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()].
+    mongoose_config:erase_opts().
 
 opts() ->
-    [{all_metrics_are_global, false},
-     {max_fsm_queue, 1024}].
+    #{all_metrics_are_global => false,
+      max_fsm_queue => 1024}.
 
 meck_db(odbc) ->
     meck:new(eodbc, [no_link]),

--- a/test/mongoose_service_SUITE.erl
+++ b/test/mongoose_service_SUITE.erl
@@ -25,7 +25,7 @@ init_per_testcase(_TC, C) ->
     C.
 
 end_per_testcase(_, _C) ->
-    mongoose_config:unset_opt(services),
+    mongoose_config:erase_opts(),
     meck:unload(test_services()).
 
 %% Test cases
@@ -133,7 +133,7 @@ replaces_services_with_same_deps(_Config) ->
 %% Helpers
 
 set_services(Services) ->
-    mongoose_config:set_opt(services, Services).
+    mongoose_config:set_opts(#{services => Services}).
 
 get_services() ->
     mongoose_config:get_opt(services).

--- a/test/mongoose_wpool_SUITE.erl
+++ b/test/mongoose_wpool_SUITE.erl
@@ -48,7 +48,7 @@ all() ->
 init_per_suite(Config) ->
     ok = meck:new(wpool, [no_link, passthrough]),
     ok = meck:new(mongoose_wpool, [no_link, passthrough]),
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
+    mongoose_config:set_opts(opts()),
     Self = self(),
     spawn(fun() ->
                   register(test_helper, self()),
@@ -62,12 +62,11 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     meck:unload(wpool),
     whereis(test_helper) ! stop,
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
+    mongoose_config:erase_opts(),
     Config.
 
 opts() ->
-    [{hosts, [<<"a.com">>, <<"b.com">>, <<"c.eu">>]},
-     {host_types, []}].
+    #{hosts => [<<"a.com">>, <<"b.com">>, <<"c.eu">>], host_types => []}.
 
 init_per_testcase(_Case, Config) ->
     cleanup_pools(),

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -68,16 +68,15 @@ end_per_suite(C) ->
     C.
 
 init_per_group(Group, C) ->
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts(Group)],
+    mongoose_config:set_opts(opts(Group)),
     mongoose_metrics:init(),
     mongoose_metrics:init_mongooseim_metrics(),
     C.
 
-end_per_group(Group, C) ->
+end_per_group(_Group, _C) ->
     mongoose_metrics:remove_host_type_metrics(<<"localhost">>),
     mongoose_metrics:remove_host_type_metrics(global),
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts(Group)],
-    C.
+    mongoose_config:erase_opts().
 
 init_per_testcase(CN, C) when tcp_connections_detected =:= CN;
                               tcp_metric_varies_with_tcp_variations =:= CN ->
@@ -165,9 +164,9 @@ wait_for_update({ok, [{count,0}]}, N) ->
     wait_for_update(exometer:get_value([carbon, packets], count), N-1).
 
 opts(Group) ->
-    [{hosts, [<<"localhost">>]},
-     {host_types, []},
-     {all_metrics_are_global, Group =:= all_metrics_are_global}].
+    #{hosts => [<<"localhost">>],
+      host_types => [],
+      all_metrics_are_global => Group =:= all_metrics_are_global}.
 
 get_reporters_cfg(Port) ->
     [{reporters, [

--- a/test/muc_light_SUITE.erl
+++ b/test/muc_light_SUITE.erl
@@ -51,7 +51,7 @@ end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(codec_calls, Config) ->
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
+    mongoose_config:set_opts(opts()),
     meck_mongoose_subdomain_core(),
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
@@ -73,17 +73,17 @@ end_per_testcase(codec_calls, Config) ->
     mnesia:delete_schema([node()]),
     application:stop(exometer_core),
     meck:unload(),
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
+    mongoose_config:erase_opts(),
     Config;
 end_per_testcase(_, Config) ->
     Config.
 
 opts() ->
-    [{hosts, [host_type()]},
-     {host_types, []},
-     {all_metrics_are_global, false},
-     {component_backend, mnesia},
-     {{modules, host_type()}, #{mod_muc_light => default_mod_config(mod_muc_light)}}].
+    #{hosts => [host_type()],
+      host_types => [],
+      all_metrics_are_global => false,
+      component_backend => mnesia,
+      {modules, host_type()} => #{mod_muc_light => default_mod_config(mod_muc_light)}}.
 
 %% ------------------------------------------------------------------
 %% Test cases

--- a/test/privacy_SUITE.erl
+++ b/test/privacy_SUITE.erl
@@ -37,11 +37,9 @@ init_per_suite(C) ->
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
     {ok, _} = application:ensure_all_started(exometer_core),
-    mongoose_config:set_opt(all_metrics_are_global, false),
     C.
 
 end_per_suite(_C) ->
-    mongoose_config:unset_opt(all_metrics_are_global),
     mnesia:stop(),
     mnesia:delete_schema([node()]),
     application:stop(exometer_core),
@@ -49,19 +47,20 @@ end_per_suite(_C) ->
 
 init_per_testcase(_, C) ->
     gen_hook:start_link(),
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
+    mongoose_config:set_opts(opts()),
     mongoose_modules:start(),
     C.
 
 end_per_testcase(_, _) ->
     mongoose_modules:stop(),
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()].
+    mongoose_config:erase_opts().
 
 opts() ->
-    [{hosts, [<<"localhost">>]},
-     {host_types, []},
-     {{modules, <<"localhost">>},
-      #{mod_privacy => config_parser_helper:default_mod_config(mod_privacy)}}].
+    #{hosts => [<<"localhost">>],
+      host_types => [],
+      all_metrics_are_global => false,
+      {modules, <<"localhost">>} =>
+          #{mod_privacy => config_parser_helper:default_mod_config(mod_privacy)}}.
 
 check_with_allowed(_C) ->
     Acc = mongoose_acc:new(?ACC_PARAMS#{element => message()}),

--- a/test/roster_SUITE.erl
+++ b/test/roster_SUITE.erl
@@ -37,15 +37,14 @@ init_per_suite(C) ->
     meck:expect(gen_iq_handler, remove_iq_handler_for_domain, fun(_, _, _) -> ok end),
     meck:new(mongoose_domain_api, [no_link]),
     meck:expect(mongoose_domain_api, get_domain_host_type, fun(_) -> {ok, host_type()} end),
-    [mongoose_config:set_opt(Key, Value) || {Key, Value} <- opts()],
+    mongoose_config:set_opts(opts()),
     C.
 
-end_per_suite(C) ->
-    [mongoose_config:unset_opt(Key) || {Key, _Value} <- opts()],
+end_per_suite(_C) ->
+    mongoose_config:erase_opts(),
     meck:unload(),
     mnesia:stop(),
-    mnesia:delete_schema([node()]),
-    C.
+    mnesia:delete_schema([node()]).
 
 init_per_testcase(_TC, C) ->
     init_ets(),
@@ -62,10 +61,10 @@ end_per_testcase(_TC, C) ->
     C.
 
 opts() ->
-    [{hosts, [host_type()]},
-     {host_types, []},
-     {all_metrics_are_global, false},
-     {{modules, host_type()}, #{mod_roster => config_parser_helper:default_mod_config(mod_roster)}}].
+    #{hosts => [host_type()],
+      host_types => [],
+      all_metrics_are_global => false,
+      {modules, host_type()} => #{mod_roster => config_parser_helper:default_mod_config(mod_roster)}}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%% TESTS %%%%%%%%%%%%%%%%%%%%%%%

--- a/test/router_SUITE.erl
+++ b/test/router_SUITE.erl
@@ -37,14 +37,13 @@ end_per_suite(_C) ->
     ok.
 
 init_per_group(routing, Config) ->
-    RoutingModules = [xmpp_router_a, xmpp_router_b, xmpp_router_c],
-    mongoose_config:set_opt(routing_modules, xmpp_router:expand_routing_modules(RoutingModules)),
+    mongoose_config:set_opts(opts()),
     gen_hook:start_link(),
     ejabberd_router:start_link(),
     Config.
 
 end_per_group(routing, _Config) ->
-    mongoose_config:unset_opt(routing_modules).
+    mongoose_config:erase_opts().
 
 init_per_testcase(_CaseName, Config) ->
     Config.
@@ -170,3 +169,9 @@ resend_as_error(From0, To0, Acc0, Packet0) ->
     {Acc1, Packet1} = jlib:make_error_reply(Acc0, Packet0, #xmlel{}),
     Acc2 = ejabberd_router:route(To0, From0, Acc1, Packet1),
     {done, Acc2}.
+
+opts() ->
+    RoutingModules = [xmpp_router_a, xmpp_router_b, xmpp_router_c],
+    #{all_metrics_are_global => false,
+      component_backend => mnesia,
+      routing_modules => xmpp_router:expand_routing_modules(RoutingModules)}.

--- a/test/translate_SUITE.erl
+++ b/test/translate_SUITE.erl
@@ -10,9 +10,8 @@ all() ->
     ].
 
 
-end_per_testcase(_, C) ->
-    mongoose_config:unset_opt(language),
-    C.
+end_per_testcase(_, _C) ->
+    mongoose_config:erase_opts().
 
 test_english_translation(_Config) ->
     %% given
@@ -61,4 +60,4 @@ given_loaded_translations() ->
     translate:start().
 
 given_default_language(Language) ->
-    mongoose_config:set_opt(language, Language).
+    mongoose_config:set_opts(#{language => Language}).


### PR DESCRIPTION
Put the whole config in one persistent term.

Motivation:
- No need for a separate persistent term with config state.
- More consistent get/set operations.
- No leftover terms in small tests.
- Marginally increased performance.

