### PR TITLE
Fix docs build task

### DIFF
--- a/doc/user-guide/Supported-standards.md
+++ b/doc/user-guide/Supported-standards.md
@@ -36,7 +36,7 @@
 ## Supported XEPs
 
 {%
-   include-markdown "Supported-XEPs.md"
+   include-markdown "./Supported-XEPs.md"
 %}
 
 ## Supported Open Extensions


### PR DESCRIPTION
This PR addresses [failing docs CI build](https://app.circleci.com/pipelines/github/esl/MongooseIM/11196/workflows/ef685cae-8af0-498e-85c6-42a6e8160861/jobs/186868)

Proposed changes include:
* Tweak path for Supported-XEPs.md in include-markdown

