### PR TITLE
Disable src_tests in systools:make_script/2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -122,6 +122,8 @@
 {relx, [{release, { mongooseim, {cmd, "cat VERSION | tr -d '\r\n'"} },
          []}, %%Apps list is dynamicaly set by rebar.config.script
 
+        %% Disable some warnings in systools:make_script/2 which are extremely slow (saves 30 seconds)
+        {src_tests, false},
         {dev_mode, true},
         %% TODO: extra copies waste space, but mongooseim script requires the files in a certain place
         {include_erts, true},


### PR DESCRIPTION
This PR addresses "Allow to run tests faster" MIM-2003.

Changes:

Disables src_tests check:
> If option src_tests is specified, a warning is issued if the source code for a module is missing or is newer than the object code.

We ignore these warnings anyway.
It saves 30 seconds for each `make rel1` call.

Also, rebar compiles code anyway, so we could be sure that it is up to date.


# Detailed description

Before:

```
time make mim1
make mim1  8.36s user 3.07s system 198% cpu 5.765 total
```

After:

```
time make mim1
make mim1  90.28s user 44.16s system 195% cpu 1:08.63 total
```


Rebar3 calls relx which calls systools:

```
systools:make_script("mongooseim", Opts)
```

Sadly, it takes a lot of time. And it does a lot of file operations:

```erlang
eprof:
...
gen:do_call/4                                          967514     3.06   1651009  [      1.71]
filename:join1/4                                     71324180    17.56   9456880  [      0.13]
file:file_name_1/2                                  132491710    61.17  32953029  [      0.25]
```

Adding logging to rebar3 to get options:

```diff
 make_start_script(Name, RelDir, Options, IsRelxSasl) ->
+    ?log_debug("release start script created ~p ~p", [Name, Options]),
     systools:make_script(Name, Options)
```

Run the command in the shell opened with `rebar3 shell apps=""`:
```erlang
X = ....long set of options here from the previous step...
% Disable src_tests
X2 = X -- [src_tests].
(mongooseim@localhost)11> timer:tc(fun() -> systools:make_script("mongooseim", X2) end).
{173420,{ok,systools_make,[]}}
(mongooseim@localhost)12> timer:tc(fun() -> systools:make_script("mongooseim", X) end).
{40752032,
 {ok,systools_make,
     [{warning,{source_not_found,{'ELDAPv3',eldap,
                                            "/Users/mikhailuvarov/erlang/esl/MongooseIM/_build/mim1/rel/mongooseim/lib/eldap-1.2.10/ebin"}}},
      {warning,{obj_out_of_date,{'XmppAddr',mongooseim,
                                            "/Users/mikhailuvarov/erlang/esl/MongooseIM/_build/mim1/rel/mongooseim/lib/mongooseim-6.1.0-358-gb92b56b13/ebin"}}}]}}
```

We loose these two warnings. Not sure if we need to wait 30 seconds to get them though.

# Layers of abstraction in tooling

How an option which slows down release by 30 seconds has not been found before?

Probably because it is spread between three projects: OTP's systools, relx and rebar3.

`src_tests` is an optional option for systools, disabled by default (probably because it is very slow and not-optimized). Relx enables it by default (probably because it sounds "useful" and maybe it is too fast to be a noticeable issue for small projects). Rebar3 just uses default relx options. Which was probably not a good idea, especially for our type of development, where we execute `make rel` for each test execution locally.

# PS

`{check_for_undefined_functions, false}` could safe one more second, because we don't need to run xref when building the release.
