### PR TITLE
Run test-runner setup steps in parallel

### DIFF
--- a/tools/parallel.sh
+++ b/tools/parallel.sh
@@ -1,0 +1,57 @@
+# Include the file to add helpers for parallel tasks.
+# Example:
+# source tools/common-vars.sh
+# source tools/parallel.sh
+
+PARALLEL_ENABLED=${PARALLEL_ENABLED-true}
+
+# Add prefix to all lines of the output
+function exec_with_prefix
+{
+  NAME="$1"
+  shift
+  if [ "$NAME" = "false" ]; then
+    # no prefix
+    $@
+  else
+    # Apply a separate sed filter on stderr
+    $@ \
+     2> >($SED -e "s/^/$NAME stderr:\t/;" >&2) \
+      | $SED -e "s/^/$NAME:\t/;"
+  fi
+  echo "DONE $NAME"
+}
+
+function cleanup_parallel
+{
+  trap "" INT TERM ERR
+  echo "Cleanup parallel tasks $1"
+  kill 0
+}
+
+function init_parallel
+{
+  if [ "$PARALLEL_ENABLED" = "true" ]; then
+    X=$$
+    # Kill background jobs if the user clicks CTRL-C
+    trap "cleanup_parallel $1" INT TERM ERR
+  fi
+}
+
+function parallel
+{
+  if [ "$PARALLEL_ENABLED" = "true" ]; then
+    exec_with_prefix $@ &
+  else
+    shift # ignore an argument with a prefix
+    $@
+  fi
+}
+
+function wait_for_parallel
+{
+  if [ "$PARALLEL_ENABLED" = "true" ]; then
+    wait
+    echo "Done $1"
+  fi
+}

--- a/tools/setup-db.sh
+++ b/tools/setup-db.sh
@@ -269,10 +269,17 @@ function setup_db(){
     fi
 }
 
+# Kill background jobs if the user clicks CTRL-C
+trap "exit" INT TERM ERR
+trap "kill 0" EXIT
+
 # The DB env var may contain single value "mysql"
 # or list of values separated with a space "elasticsearch cassandra"
 # in case of list of values all listed database will be set up (or at least tried)
 
 for db in ${DB}; do
-    setup_db $db
+    setup_db $db &
 done
+
+wait
+echo "setup_db done"

--- a/tools/test-runner-complete.sh
+++ b/tools/test-runner-complete.sh
@@ -123,6 +123,7 @@ _run_all_tests() {
                           --skip-start-nodes \
                           --skip-stop-nodes \
                           --skip-setup-db \
+                          --no-parallel \
                           --tls-dist \
                           --verbose \
                           --help \


### PR DESCRIPTION
This PR addresses "Faster local tests" MIM-2004.

Proposed changes include:
* Rewrite wait_for_healthcheck script - now we run healthcheck command, instead of waiting for docker to run it. Saves 30 seconds for each DB start.
* Run tasks in parallel in setup_db and test_runner.
* Introduce tools/parallel.sh script.

* It does not improve setup time on CircleCI, only locally.

The parallel tasks output would have a prefix (similar how docker-compose outputs):

```
....
redis:  Setting up db: redis
pgsql:  Setting up db: pgsql
pgsql:  Configuring postgres with SSL
build-tests:    cp ../test/mim_ct_rest.erl ../test/mim_ct_rest_handler.erl ../test/mim_ct_sup.erl src/
build-tests:    ../tools/silent_exec.sh "get-deps.log" ../rebar3 deps
build-mim:      Certificate will not expire
build-mim:      if [ "$SKIP_CERT_BUILD" = 1 ]; then \
build-mim:                      echo "Skip cert build"; \
build-mim:              else \
build-mim:                      cd tools/ssl && make; \
build-mim:              fi
pgsql stderr:   sudo: a password is required
build-mim:      chmod -R a+r mongooseim ca ca-clients
pgsql:  Failed to stop pgsql
build-mim:      building mim1
build-mim:      (. ./configure.out && \
build-mim:              DEVNODE=true ./tools/silent_exec.sh "mim1.log" ./rebar3 as mim1 release)
build-tests:    RUN: ../rebar3 deps
build-tests:    LOG: /Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/get-deps.log
build-tests:
build-mim:      RUN: ./rebar3 as mim1 release
build-mim:      LOG: /Users/mikhailuvarov/erlang/esl/MongooseIM/mim1.log
build-mim:
...
```

Of course, you can disable this optimization to use the old behaviour (for debugging, for example):

```bash 
# --no-parallel flag example:
./tools/test-runner.sh --skip-small-tests --db redis pgsql --preset internal_mnesia --skip-cover  mod_global_distrib --no-parallel
```

