### PR TITLE
C2S/SASL

### DIFF
--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -429,7 +429,7 @@ handle_sasl_continue(StateData, SaslAcc, #{server_out := ServerOut}, Retries) ->
 handle_sasl_failure(#c2s_data{host_type = HostType, lserver = LServer} = StateData, SaslAcc,
                     #{server_out := ServerOut, maybe_username := Username}, Retries) ->
     ?LOG_INFO(#{what => auth_failed, text => <<"Failed SASL authentication">>,
-                jid => Username, c2s_state => StateData}),
+                username => Username, lserver => LServer, c2s_state => StateData}),
     mongoose_hooks:auth_failed(HostType, LServer, Username),
     El = mongoose_c2s_stanzas:sasl_failure_stanza(ServerOut),
     NewSaslAcc = send_acc_from_server_jid(StateData, SaslAcc, El),
@@ -443,7 +443,7 @@ handle_sasl_error(#c2s_data{lang = Lang} = StateData, _SaslAcc,
 
 -spec handle_sasl_abort(data(), mongoose_acc:t(), retries()) -> fsm_res().
 handle_sasl_abort(StateData, SaslAcc, Retries) ->
-    Error = #{server_out => <<"aborted">>, maybe_username => StateData#c2s_data.jid},
+    Error = #{server_out => <<"aborted">>, maybe_username => undefined},
     handle_sasl_failure(StateData, SaslAcc, Error, Retries).
 
 -spec stream_start_features_before_auth(data()) -> fsm_res().

--- a/src/c2s/mongoose_c2s_sasl.erl
+++ b/src/c2s/mongoose_c2s_sasl.erl
@@ -1,0 +1,113 @@
+%% @doc SASL layer between C2S and MIM internal mongoose_acc.
+%%
+%% Implements RFC6120 Section 6 – but stanza agnostic, uses mongoose_acc instead
+%%
+%% This module is intended to have no side-effects, that is, it proccesses between XMPP contents
+%% (c2s data, xml stanzas), and MongooseIM internal mongoose_acc,
+%% which enables tracing by refs and timestamps.
+%% It does not send anything on the socket nor changes the state of the client process.
+%% This way, we can decouple SASL from the client process core code.
+%% @end
+-module(mongoose_c2s_sasl).
+
+-include_lib("kernel/include/logger.hrl").
+-include("jlib.hrl").
+
+-export([new/1, start/4, continue/3]).
+
+-type mechanism() :: binary().
+-type maybe_username() :: undefined | jid:luser().
+-type success() :: #{server_out := undefined | binary(),
+                     jid := jid:jid(),
+                     auth_module := cyrsasl:sasl_module()}.
+-type continue() :: #{server_out := binary()}.
+-type failure()  :: #{server_out := binary() | {binary(), undefined | iodata()},
+                      maybe_username := maybe_username()}.
+-type error() :: #{type := atom(), text := binary()}.
+-type result() :: {success,  mongoose_acc:t(), success()}
+                | {continue, mongoose_acc:t(), continue()}
+                | {failure,  mongoose_acc:t(), failure()}
+                | {error,  mongoose_acc:t(), error()}.
+-export_type([result/0, success/0, continue/0, failure/0, error/0, mechanism/0]).
+
+-spec new(mongoose_c2s:data()) -> mongoose_acc:t().
+new(C2SData) ->
+    HostType = mongoose_c2s:get_host_type(C2SData),
+    LServer = mongoose_c2s:get_lserver(C2SData),
+    LOpts = mongoose_c2s:get_listener_opts(C2SData),
+    CredOpts = mongoose_credentials:make_opts(LOpts),
+    Creds = mongoose_credentials:new(LServer, HostType, CredOpts),
+    CyrSaslState = cyrsasl:server_new(<<"jabber">>, LServer, HostType, <<>>, [], Creds),
+    sasl_acc(HostType, LServer, CyrSaslState, Creds).
+
+-spec start(mongoose_c2s:data(), mongoose_acc:t(), mechanism(), binary()) -> result().
+start(C2SData, SaslAcc, Mech, ClientIn) ->
+    Socket = mongoose_c2s:get_socket(C2SData),
+    LOpts = mongoose_c2s:get_listener_opts(C2SData),
+    case {mongoose_c2s_socket:is_ssl(Socket), LOpts} of
+        {false, #{tls := #{mode := starttls_required}}} ->
+            {error, SaslAcc, #{type => policy_violation, text => <<"Use of STARTTLS required">>}};
+        _ ->
+            AuthMech = mongoose_c2s:get_auth_mechs(C2SData),
+            SocketData = #{socket => Socket, auth_mech => AuthMech, listener_opts => LOpts},
+            CyrSaslState = get_cyrsasl_state_from_acc(SaslAcc),
+            CyrSaslResult = cyrsasl:server_start(CyrSaslState, Mech, ClientIn, SocketData),
+            handle_sasl_step(C2SData, CyrSaslResult, SaslAcc)
+    end.
+
+-spec continue(mongoose_c2s:data(), mongoose_acc:t(), binary()) -> result().
+continue(C2SData, SaslAcc, ClientIn) ->
+    CyrSaslState = get_cyrsasl_state_from_acc(SaslAcc),
+    CyrSaslResult = cyrsasl:server_step(CyrSaslState, ClientIn),
+    handle_sasl_step(C2SData, CyrSaslResult, SaslAcc).
+
+-spec handle_sasl_step(mongoose_c2s:data(), cyrsasl:sasl_result(), mongoose_acc:t()) -> result().
+handle_sasl_step(C2SData, {ok, Creds}, SaslAcc) ->
+    handle_sasl_success(C2SData, Creds, SaslAcc);
+handle_sasl_step(C2SData, {continue, ServerOut, NewCyrSaslState}, SaslAcc) ->
+    handle_sasl_continue(C2SData, ServerOut, NewCyrSaslState, SaslAcc);
+handle_sasl_step(C2SData, {error, Error, Username}, SaslAcc) ->
+    handle_sasl_failure(C2SData, Error, Username, undefined, SaslAcc);
+handle_sasl_step(C2SData, {error, Error}, SaslAcc) ->
+    Jid = mongoose_c2s:get_jid(C2SData),
+    handle_sasl_failure(C2SData, Error, undefined, Jid, SaslAcc).
+
+-spec handle_sasl_success(mongoose_c2s:data(), mongoose_credentials:t(), mongoose_acc:t()) -> result().
+handle_sasl_success(C2SData, Creds, SaslAcc) ->
+    ServerOut = mongoose_credentials:get(Creds, sasl_success_response, undefined),
+    AuthModule = mongoose_credentials:get(Creds, auth_module),
+    User = mongoose_credentials:get(Creds, username),
+    LServer = mongoose_c2s:get_lserver(C2SData),
+    Jid = jid:make_bare(User, LServer),
+    Ret = #{server_out => ServerOut, jid => Jid, auth_module => AuthModule},
+    {success, SaslAcc, Ret}.
+
+-spec handle_sasl_continue(
+        mongoose_c2s:data(), binary(), cyrsasl:sasl_state(), mongoose_acc:t()) -> result().
+handle_sasl_continue(_C2SData, ServerOut, NewCyrSaslState, SaslAcc) ->
+    SaslAcc1 = set_cyrsasl_state_in_acc(SaslAcc, NewCyrSaslState),
+    {continue, SaslAcc1, #{server_out => ServerOut}}.
+
+-spec handle_sasl_failure(
+        mongoose_c2s:data(), term(), maybe_username(), maybe_username(), mongoose_acc:t()) -> result().
+handle_sasl_failure(_C2SData, Error, undefined, undefined, SaslAcc) ->
+    {failure, SaslAcc, #{server_out => Error, maybe_username => undefined}};
+handle_sasl_failure(_C2SData, Error, undefined, #jid{luser = Username}, SaslAcc) ->
+    {failure, SaslAcc, #{server_out => Error, maybe_username => Username}};
+handle_sasl_failure(C2SData, Error, Username, _, SaslAcc) ->
+    LServer = mongoose_c2s:get_lserver(C2SData),
+    NewJid = jid:make_bare(Username, LServer),
+    {failure, SaslAcc, #{server_out => Error, maybe_username => NewJid}}.
+
+sasl_acc(HostType, LServer, CyrSaslState, Creds) ->
+    Acc = mongoose_acc:new(#{host_type => HostType, lserver => LServer, location => ?LOCATION}),
+    Fields = [{creds, Creds}, {cyrsasl, CyrSaslState}],
+    mongoose_acc:set(?MODULE, Fields, Acc).
+
+-spec set_cyrsasl_state_in_acc(mongoose_acc:t(), cyrsasl:sasl_state()) -> mongoose_acc:t().
+set_cyrsasl_state_in_acc(SaslAcc, NewCyrSaslState) ->
+    mongoose_acc:set(?MODULE, cyrsasl, NewCyrSaslState, SaslAcc).
+
+-spec get_cyrsasl_state_from_acc(mongoose_acc:t()) -> cyrsasl:sasl_state().
+get_cyrsasl_state_from_acc(SaslAcc) ->
+    mongoose_acc:get(?MODULE, cyrsasl, SaslAcc).

--- a/src/c2s/mongoose_c2s_stanzas.erl
+++ b/src/c2s/mongoose_c2s_stanzas.erl
@@ -116,7 +116,7 @@ hook_enabled_features(StateData) ->
     StreamFeaturesParams = #{c2s_data => StateData, lserver => LServer},
     mongoose_hooks:c2s_stream_features(HostType, StreamFeaturesParams, InitialFeatures).
 
--spec sasl_success_stanza(binary()) -> exml:element().
+-spec sasl_success_stanza(undefined | binary()) -> exml:element().
 sasl_success_stanza(ServerOut) ->
     C = case ServerOut of
             undefined -> [];
@@ -139,11 +139,11 @@ maybe_text_tag(Text) ->
     [#xmlel{name = <<"text">>,
             children = [#xmlcdata{content = Text}]}].
 
--spec sasl_challenge_stanza([exml:element() | exml:cdata()]) -> exml:element().
-sasl_challenge_stanza(Challenge) ->
+-spec sasl_challenge_stanza(binary()) -> exml:element().
+sasl_challenge_stanza(ServerOut) ->
     #xmlel{name = <<"challenge">>,
            attrs = [{<<"xmlns">>, ?NS_SASL}],
-           children = Challenge}.
+           children = [#xmlcdata{content = jlib:encode_base64(ServerOut)}]}.
 
 -spec successful_resource_binding(jlib:iq(), jid:jid()) -> exml:element().
 successful_resource_binding(IQ, Jid) ->

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -190,7 +190,7 @@ anonymous_purge_hook(LServer, Acc, LUser) ->
 -spec auth_failed(HostType, Server, Username) -> Result when
     HostType :: mongooseim:host_type(),
     Server :: jid:server(),
-    Username :: jid:user() | unknown,
+    Username :: jid:user() | undefined,
     Result :: ok.
 auth_failed(HostType, Server, Username) ->
     Params = #{username => Username, server => Server},


### PR DESCRIPTION
An initial refactoring of SASL out of C2S.

I chose accumulators as the SASL state because they also enable tracing trough refs and timing through their timestamps.