### PR TITLE
Wait for async writer to flush messages before removing archive

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -207,7 +207,6 @@
          run_set_and_get_prefs_case/4,
          muc_light_host/0,
          host_type/0,
-         set_wait_for_parallel_writer/2,
          config_opts/1
         ]).
 

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -717,12 +717,16 @@ clean_archives(Config) ->
         false ->
             ok
     end,
+    %% Wait until messages are flushed before removing them
+    wait_for_parallel_writer(Config),
     [ok = delete_archive(S, U) || {S, U} <- SUs],
     %% Wait for archive to be empty
     [wait_for_archive_size(S, U, 0) || {S, U} <- SUs],
     Config.
 
 destroy_room(Config) ->
+    %% Wait until messages are flushed before removing them
+    wait_for_parallel_writer(Config),
     clean_room_archive(Config),
     muc_helper:destroy_room(Config).
 

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -54,7 +54,6 @@
          start_alice_protected_room/1,
          start_alice_anonymous_room/1,
          maybe_wait_for_archive/1,
-         set_wait_for_parallel_writer/2,
          stanza_archive_request/2,
          stanza_text_search_archive_request/3,
          stanza_date_range_archive_request_not_empty/3,
@@ -1106,11 +1105,6 @@ maybe_wait_for_archive(Config) ->
         Value ->
             timer:sleep(Value)
     end.
-
-set_wait_for_parallel_writer(Type, Config) ->
-    Old = proplists:get_value(wait_for_parallel_writer, Config, []),
-    Config2 = proplists:delete(wait_for_parallel_writer, Config),
-    [{wait_for_parallel_writer, lists:usort([Type] ++ Old)}|Config2].
 
 wait_for_parallel_writer(Config) ->
     case ?config(wait_for_parallel_writer, Config) of


### PR DESCRIPTION
This PR addresses "".

[test failing](https://circleci-mim-results.s3.eu-central-1.amazonaws.com/PR/4103/188031/pgsql_cets.25.3-amd64/big/ct_run.test%408439e5e90a30.2023-08-16_17.28.34/big_tests.tests.mam_SUITE.logs/run.2023-08-16_17.34.38/mam_suite.muc_no_elements.158466.html)

Test: mam_SUITE:muc_no_elements
Group: rdbms_async_cache

            
Reason:
```erlang
=== WARNING: end_per_testcase crashed!
Reason: {room_archive_size,0,[{times,200,1}],ok}
Line: [{mongoose_helper,do_wait_until,358},
              {mam_helper,wait_for_room_archive_size,789},
              {mam_helper,clean_room_archive,733},
              {mam_helper,destroy_room,726},
              {mam_SUITE,end_per_testcase,...
```

Proposed changes include:
* Wait for async writer to flush messages before removing archive
* Remove unused mam_helper:set_wait_for_parallel_writer/2


