### PR TITLE
Xeps/bind2

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -20,6 +20,7 @@
 {suites, "tests", amp_big_SUITE}.
 {suites, "tests", anonymous_SUITE}.
 {suites, "tests", auth_methods_for_c2s_SUITE}.
+{suites, "tests", bind2_SUITE}.
 {suites, "tests", bosh_SUITE}.
 {suites, "tests", carboncopy_SUITE}.
 {suites, "tests", cluster_commands_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -23,6 +23,8 @@
 
 {suites, "tests", auth_methods_for_c2s_SUITE}.
 
+{suites, "tests", bind2_SUITE}.
+
 {suites, "tests", bosh_SUITE}.
 
 {suites, "tests", carboncopy_SUITE}.

--- a/big_tests/tests/bind2_SUITE.erl
+++ b/big_tests/tests/bind2_SUITE.erl
@@ -1,0 +1,213 @@
+-module(bind2_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("exml/include/exml.hrl").
+-include_lib("escalus/include/escalus.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+
+-define(NS_SASL_2, <<"urn:xmpp:sasl:2">>).
+-define(NS_BIND_2, <<"urn:xmpp:bind:0">>).
+-define(BAD_TAG, <<"\x{EFBB}"/utf8>>).
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+     {group, basic}
+    ].
+
+groups() ->
+    [
+     {basic, [parallel],
+      [
+       server_announces_bind2,
+       server_announces_bind2_with_sm,
+       auth_and_bind_ignores_invalid_resource_and_generates_a_new_one,
+       auth_and_bind_to_random_resource,
+       auth_and_bind_do_not_expose_user_agent_id_in_client,
+       auth_and_bind_contains_client_tag,
+       stream_resumption_failing_does_bind_and_contains_sm_status,
+       stream_resumption_overrides_bind_request
+      ]}
+    ].
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    Config1 = load_modules(Config),
+    escalus:init_per_suite(Config1).
+
+end_per_suite(Config) ->
+    escalus_fresh:clean(),
+    dynamic_modules:restore_modules(Config),
+    escalus:end_per_suite(Config).
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+init_per_testcase(Name, Config) ->
+    escalus:init_per_testcase(Name, Config).
+
+end_per_testcase(Name, Config) ->
+    escalus:end_per_testcase(Name, Config).
+
+load_modules(Config) ->
+    HostType = domain_helper:host_type(),
+    Config1 = dynamic_modules:save_modules(HostType, Config),
+    sasl2_helper:load_all_sasl2_modules(HostType),
+    Config1.
+
+%%--------------------------------------------------------------------
+%% tests
+%%--------------------------------------------------------------------
+
+server_announces_bind2(Config) ->
+    Steps = [create_connect_tls, start_stream_get_features],
+    #{features := Features} = sasl2_helper:apply_steps(Steps, Config),
+    Bind2 = exml_query:path(Features, [{element_with_ns, <<"authentication">>, ?NS_SASL_2},
+                                       {element, <<"inline">>},
+                                       {element_with_ns, <<"bind">>, ?NS_BIND_2}]),
+    ?assertNotEqual(undefined, Bind2).
+
+server_announces_bind2_with_sm(Config) ->
+    Steps = [create_connect_tls, start_stream_get_features],
+    #{features := Features} = sasl2_helper:apply_steps(Steps, Config),
+    SM = exml_query:path(Features, [{element_with_ns, <<"authentication">>, ?NS_SASL_2},
+                                    {element, <<"inline">>},
+                                    {element_with_ns, <<"bind">>, ?NS_BIND_2},
+                                    {element, <<"inline">>},
+                                    {element_with_attr, <<"var">>, ?NS_STREAM_MGNT_3}]),
+    ?assertNotEqual(undefined, SM).
+
+auth_and_bind_ignores_invalid_resource_and_generates_a_new_one(Config) ->
+    Steps = [create_connect_tls, start_stream_get_features,
+             {?MODULE, auth_and_bind_wrong_resource}, has_no_more_stanzas],
+    #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
+    Success = exml_query:path(Response, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
+    ?assertNotEqual(undefined, Success).
+
+auth_and_bind_to_random_resource(Config) ->
+    Steps = [create_connect_tls, start_stream_get_features,
+             {?MODULE, auth_and_bind}, has_no_more_stanzas],
+    #{answer := Success} = sasl2_helper:apply_steps(Steps, Config),
+    ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
+    Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
+    ?assertNotEqual(undefined, Bound),
+    Identifier = exml_query:path(Success, [{element, <<"authorization-identifier">>}, cdata]),
+    #jid{resource = LResource} = jid:from_binary(Identifier),
+    ?assert(0 =< byte_size(LResource), LResource).
+
+auth_and_bind_do_not_expose_user_agent_id_in_client(Config) ->
+    Steps = [create_connect_tls, start_stream_get_features,
+             {?MODULE, auth_and_bind_with_user_agent_uuid}, has_no_more_stanzas],
+    #{answer := Success, uuid := Uuid} = sasl2_helper:apply_steps(Steps, Config),
+    ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
+    Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
+    ?assertNotEqual(undefined, Bound),
+    Identifier = exml_query:path(Success, [{element, <<"authorization-identifier">>}, cdata]),
+    #jid{resource = LResource} = jid:from_binary(Identifier),
+    ?assertNotEqual(Uuid, LResource).
+
+auth_and_bind_contains_client_tag(Config) ->
+    Steps = [create_connect_tls, start_stream_get_features,
+             {?MODULE, auth_and_bind_with_tag}, has_no_more_stanzas],
+    #{answer := Success, tag := Tag} = sasl2_helper:apply_steps(Steps, Config),
+    ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
+    Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
+    ?assertNotEqual(undefined, Bound),
+    Identifier = exml_query:path(Success, [{element, <<"authorization-identifier">>}, cdata]),
+    #jid{resource = LResource} = jid:from_binary(Identifier),
+    ResourceParts = binary:split(LResource, <<"/">>, [global]),
+    ?assertMatch([Tag, _], ResourceParts).
+
+stream_resumption_failing_does_bind_and_contains_sm_status(Config) ->
+    Steps = [create_user, buffer_messages_and_die, connect_tls, start_stream_get_features,
+             {?MODULE, auth_and_bind_with_resumption_unknown_smid}, has_no_more_stanzas],
+    #{answer := Success, tag := Tag} = sasl2_helper:apply_steps(Steps, Config),
+    ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
+    Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
+    ?assertNotEqual(undefined, Bound),
+    Resumed = exml_query:path(Success, [{element_with_ns, <<"failed">>, ?NS_STREAM_MGNT_3}]),
+    escalus:assert(is_sm_failed, [<<"item-not-found">>], Resumed),
+    Identifier = exml_query:path(Success, [{element, <<"authorization-identifier">>}, cdata]),
+    #jid{resource = LResource} = jid:from_binary(Identifier),
+    ResourceParts = binary:split(LResource, <<"/">>, [global]),
+    ?assertMatch([Tag, _], ResourceParts).
+
+stream_resumption_overrides_bind_request(Config) ->
+    Steps = [create_user, buffer_messages_and_die, connect_tls, start_stream_get_features,
+             {?MODULE, auth_and_bind_with_resumption}, has_no_more_stanzas],
+    #{answer := Success, smid := SMID} = sasl2_helper:apply_steps(Steps, Config),
+    ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
+    Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
+    ?assertNotEqual(undefined, Bound),
+    Resumed = exml_query:path(Success, [{element_with_ns, <<"resumed">>, ?NS_STREAM_MGNT_3}]),
+    ?assert(escalus_pred:is_sm_resumed(SMID, Resumed)).
+
+
+%% Step helpers
+auth_and_bind(Config, Client, Data) ->
+    plain_auth(Config, Client, Data, [], []).
+
+auth_and_bind_wrong_resource(Config, Client, Data) ->
+    Tag = ?BAD_TAG,
+    plain_auth(Config, Client, Data#{tag => Tag}, [bind_tag(Tag)], []).
+
+auth_and_bind_with_user_agent_uuid(Config, Client, Data) ->
+    Uuid = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
+    plain_auth(Config, Client, Data#{uuid => Uuid}, [], [good_user_agent_elem(Uuid)]).
+
+auth_and_bind_with_tag(Config, Client, Data) ->
+    Tag = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
+    plain_auth(Config, Client, Data#{tag => Tag}, [bind_tag(Tag)], []).
+
+auth_and_bind_with_resumption_unknown_smid(Config, Client, Data) ->
+    Tag = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
+    Resume = escalus_stanza:resume(<<"123456">>, 1),
+    plain_auth(Config, Client, Data#{tag => Tag}, [bind_tag(Tag)], [Resume]).
+
+auth_and_bind_with_resumption(Config, Client, #{smid := SMID, texts := Texts} = Data) ->
+    Tag = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
+    Resume = escalus_stanza:resume(SMID, 1),
+    {Client1, Data1} = plain_auth(Config, Client, Data#{tag => Tag}, [bind_tag(Tag)], [Resume]),
+    Msgs = sm_helper:wait_for_messages(Client, Texts),
+    {Client1, Data1#{sm_storage => Msgs}}.
+
+plain_auth(_Config, Client, Data, BindElems, Extra) ->
+    InitEl = sasl2_helper:plain_auth_initial_response(Client),
+    BindEl = #xmlel{name = <<"bind">>,
+                  attrs = [{<<"xmlns">>, ?NS_BIND_2}],
+                  children = BindElems},
+    Authenticate = auth_elem(<<"PLAIN">>, [InitEl, BindEl | Extra]),
+    escalus:send(Client, Authenticate),
+    Answer = escalus_client:wait_for_stanza(Client),
+    {Client, Data#{answer => Answer}}.
+
+%% XML helpers
+auth_elem(Mech, Children) ->
+    #xmlel{name = <<"authenticate">>,
+           attrs = [{<<"xmlns">>, ?NS_SASL_2}, {<<"mechanism">>, Mech}],
+           children = Children}.
+
+bind_tag(Tag) ->
+    #xmlel{name = <<"tag">>, children = [#xmlcdata{content = Tag}]}.
+
+good_user_agent_elem(Uuid) ->
+    user_agent_elem(Uuid, <<"cool-xmpp-client">>, <<"latest-and-greatest-device">>).
+
+user_agent_elem(Id, Software, Device) ->
+    SoftEl = [#xmlel{name = <<"software">>, children = [#xmlcdata{content = Value}]}
+              || Value <- [Software], Value =/= undefined ],
+    DeviEl = [#xmlel{name = <<"device">>, children = [#xmlcdata{content = Value}]}
+              || Value <- [Device], Value =/= undefined ],
+    Attrs = [ {<<"id">>, Value} || Value <- [Id], Value =/= undefined ],
+    #xmlel{name = <<"user-agent">>, attrs = Attrs, children = SoftEl ++ DeviEl}.

--- a/big_tests/tests/sasl2_helper.erl
+++ b/big_tests/tests/sasl2_helper.erl
@@ -12,6 +12,12 @@
 ns() ->
     ?NS_SASL_2.
 
+load_all_sasl2_modules(HostType) ->
+    Modules = [{mod_bind2, config_parser_helper:default_mod_config(mod_bind2)},
+               {mod_sasl2, config_parser_helper:default_mod_config(mod_sasl2)},
+               {mod_stream_management, config_parser_helper:mod_config(mod_stream_management, #{ack_freq => never})}],
+    dynamic_modules:ensure_modules(HostType, Modules).
+
 apply_steps(Steps, Config) ->
     apply_steps(Steps, Config, undefined, #{}).
 
@@ -30,6 +36,10 @@ connect_non_tls_user(Config, _, Data) ->
     Spec = escalus_fresh:freshen_spec(Config, alice),
     Client1 = escalus_connection:connect(Spec),
     {Client1, Data#{spec => Spec}}.
+
+create_connect_tls(Config, Client, Data) ->
+    {Client1, Data1} = create_user(Config, Client, Data),
+    connect_tls(Config, Client1, Data1).
 
 create_user(Config, Client, Data) ->
     Spec = escalus_fresh:create_fresh_user(Config, alice),

--- a/doc/modules/mod_bind2.md
+++ b/doc/modules/mod_bind2.md
@@ -1,0 +1,3 @@
+## Module Description
+
+Implements [XEP-0386: Bind 2](http://xmpp.org/extensions/xep-0386.html).

--- a/include/mongoose_ns.hrl
+++ b/include/mongoose_ns.hrl
@@ -81,6 +81,7 @@
 -define(NS_SASL_2,              <<"urn:xmpp:sasl:2">>).
 -define(NS_SESSION,             <<"urn:ietf:params:xml:ns:xmpp-session">>).
 -define(NS_BIND,                <<"urn:ietf:params:xml:ns:xmpp-bind">>).
+-define(NS_BIND_2,              <<"urn:xmpp:bind:0">>).
 
 -define(NS_FEATURE_IQAUTH,      <<"http://jabber.org/features/iq-auth">>).
 -define(NS_FEATURE_IQREGISTER,  <<"http://jabber.org/features/iq-register">>).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
       - 'mod_adhoc': 'modules/mod_adhoc.md'
       - 'mod_amp': 'modules/mod_amp.md'
       - 'mod_auth_token': 'modules/mod_auth_token.md'
+      - 'mod_bind2': 'modules/mod_bind2.md'
       - 'mod_blocking': 'modules/mod_blocking.md'
       - 'mod_bosh': 'modules/mod_bosh.md'
       - 'mod_caps': 'modules/mod_caps.md'

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -39,6 +39,8 @@
 
 %% sasl2 handlers
 -export([sasl2_stream_features/2,
+         bind2_stream_features/2,
+         bind2_enable_features/3,
          sasl2_start/3,
          sasl2_success/3]).
 
@@ -496,6 +498,23 @@ sasl2_stream_features(C2SData, InitialFeatures) ->
     Params = #{c2s_data => C2SData},
     HostType = mongoose_c2s:get_host_type(C2SData),
     run_hook_for_host_type(sasl2_stream_features, HostType, InitialFeatures, Params).
+
+-spec bind2_stream_features(C2SData, InitialFeatures) -> Result when
+    C2SData :: mongoose_c2s:data(),
+    InitialFeatures :: [exml:element()],
+    Result :: [exml:element()].
+bind2_stream_features(C2SData, InitialFeatures) ->
+    Params = #{c2s_data => C2SData},
+    HostType = mongoose_c2s:get_host_type(C2SData),
+    run_hook_for_host_type(bind2_stream_features, HostType, InitialFeatures, Params).
+
+-spec bind2_enable_features(HostType, Acc, Params) -> Result when
+    HostType :: mongooseim:host_type(),
+    Acc :: mongoose_acc:t(),
+    Params :: mod_sasl2:c2s_state_data(),
+    Result :: mongoose_acc:t().
+bind2_enable_features(HostType, Acc, Params) ->
+    run_hook_for_host_type(bind2_enable_features, HostType, Acc, Params).
 
 %% This hook will cache in the accumulator all the requests from sasl2 inlined features
 -spec sasl2_start(HostType, Acc, Element) -> Result when

--- a/src/mod_bind2.erl
+++ b/src/mod_bind2.erl
@@ -1,0 +1,152 @@
+%% @doc Implement Bind2, allowing the inline specification of:
+%% - Resource binding
+%% - Stream management
+-module(mod_bind2).
+-xep([{xep, 386}, {version, "0.4.0"}, {status, partial}]).
+
+-include("jlib.hrl").
+
+-define(XMLNS_BIND2, {<<"xmlns">>, ?NS_BIND_2}).
+
+-behaviour(gen_mod).
+
+%% gen_mod callbacks
+-export([start/2, stop/1, deps/2, hooks/1, supported_features/0]).
+
+%% hooks handlers
+-export([
+         sasl2_stream_features/3,
+         sasl2_start/3,
+         sasl2_success/3
+        ]).
+
+%% gen_mod
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+start(_HostType, _Opts) ->
+    ok.
+
+-spec stop(mongooseim:host_type()) -> ok.
+stop(_HostType) ->
+    ok.
+
+-spec deps(mongooseim:host_type(), gen_mod:module_opts()) -> gen_mod_deps:deps().
+deps(_HostType, Opts) ->
+    [{mod_sasl2, Opts, hard}].
+
+-spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
+hooks(HostType) ->
+    [
+     {sasl2_stream_features, HostType, fun ?MODULE:sasl2_stream_features/3, #{}, 50},
+     {sasl2_start, HostType, fun ?MODULE:sasl2_start/3, #{}, 50},
+     {sasl2_success, HostType, fun ?MODULE:sasl2_success/3, #{}, 50} %% after SM
+    ].
+
+-spec supported_features() -> [atom()].
+supported_features() ->
+    [dynamic_domains].
+
+
+%% Hooks
+-spec sasl2_start(SaslAcc, #{stanza := exml:element()}, gen_hook:extra()) ->
+    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
+sasl2_start(SaslAcc, #{stanza := El}, _) ->
+    case exml_query:path(El, [{element_with_ns, <<"bind">>, ?NS_BIND_2}]) of
+        undefined ->
+            {ok, SaslAcc};
+        BindRequest ->
+            {ok, mod_sasl2:put_inline_request(SaslAcc, ?MODULE, BindRequest)}
+    end.
+
+-spec sasl2_success(SaslAcc, mod_sasl2:c2s_state_data(), gen_hook:extra()) ->
+    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
+sasl2_success(SaslAcc, _, _) ->
+    case mod_sasl2:get_inline_request(SaslAcc, ?MODULE) of
+        undefined ->
+            {ok, SaslAcc};
+        #{request := BindRequest} ->
+            Resource = generate_lresource(BindRequest),
+            SmRequest = get_stream_management_resumption_status(SaslAcc),
+            maybe_bind(SaslAcc, Resource, SmRequest)
+    end.
+
+-spec sasl2_stream_features(Acc, #{c2s_data := mongoose_c2s:data()}, gen_hook:extra()) ->
+    {ok, Acc} when Acc :: [exml:element()].
+sasl2_stream_features(Acc, #{c2s_data := C2SData}, _) ->
+    Bind2Feature = feature(C2SData),
+    {ok, lists:keystore(feature_name(), #xmlel.name, Acc, Bind2Feature)}.
+
+
+%% Helpers
+-spec generate_lresource(exml:element()) -> jid:lresource().
+generate_lresource(BindRequest) ->
+    GeneratedResource = mongoose_c2s:generate_random_resource(),
+    case exml_query:path(BindRequest, [{element, <<"tag">>}, cdata], not_provided) of
+        not_provided ->
+            GeneratedResource;
+        Tag ->
+            case jid:resourceprep(Tag) of
+                error ->
+                    %% The XEP does not specify how to fail in case of a bad resource requested,
+                    %% so we decide to ignore the tag and simply generate our own resource
+                    GeneratedResource;
+                Prefix -> %% https://xmpp.org/extensions/xep-0386.html#identifiers
+                    <<Prefix/binary, "/", GeneratedResource/binary>>
+            end
+    end.
+
+-spec get_stream_management_resumption_status(mongoose_acc:t()) -> mod_sasl2:inline_request().
+get_stream_management_resumption_status(SaslAcc) ->
+    mod_sasl2:get_inline_request(SaslAcc, mod_stream_management).
+
+-spec maybe_bind(
+        SaslAcc, jid:lresource(), undefined | mod_sasl2:inline_request()) ->
+    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
+maybe_bind(SaslAcc, _Resource, #{status := success, response := SmResponse}) ->
+    Bound = #xmlel{name = <<"bound">>, attrs = [?XMLNS_BIND2], children = [SmResponse]},
+    {ok, mod_sasl2:update_inline_request(SaslAcc, ?MODULE, Bound, success)};
+maybe_bind(SaslAcc, Resource, SmRequest) ->
+    SaslStateData = mod_sasl2:get_state_data(SaslAcc),
+    MaybeSmChild = case SmRequest of
+                       #{status := failure, response := Response} -> [Response];
+                       _ -> []
+                   end,
+    case do_bind(SaslAcc, SaslStateData, Resource) of
+        {ok, SaslAcc1, C2SData} ->
+            HostType = mongoose_acc:host_type(SaslAcc),
+            Bound = #xmlel{name = <<"bound">>, attrs = [?XMLNS_BIND2], children = MaybeSmChild},
+            NewStateData = SaslStateData#{c2s_data => C2SData, c2s_state => session_established},
+            SaslAcc2 = mod_sasl2:set_state_data(SaslAcc1, NewStateData),
+            SaslAcc3 = mod_sasl2:update_inline_request(SaslAcc2, ?MODULE, Bound, success),
+            SaslAcc4 = mongoose_hooks:bind2_enable_features(HostType, SaslAcc3, SaslStateData),
+            {ok, SaslAcc4};
+        {stop, SaslAcc1} ->
+            %% The XEP does not specify what to do if the resource wasn't bound
+            %% so we just set failed here and move along with SASL2
+            Error = #xmlel{name = <<"failed">>, attrs = [?XMLNS_BIND2], children = MaybeSmChild},
+            {ok, mod_sasl2:update_inline_request(SaslAcc1, ?MODULE, Error, failure)}
+    end.
+
+-spec do_bind(SaslAcc, mod_sasl2:c2s_state_data(), jid:lresource()) ->
+    {ok, SaslAcc, mongoose_c2s:data()} | {stop, SaslAcc}
+      when SaslAcc :: mongoose_acc:t().
+do_bind(SaslAcc, #{c2s_state := C2SState, c2s_data := C2SData}, Resource) ->
+    %% TODO the jid will be in the accumulator, not in the data, we just authenticated!
+    C2SData1 = mongoose_c2s:replace_resource(C2SData, Resource),
+    HookParams = mongoose_c2s:hook_arg(C2SData1, C2SState, internal, bind2, undefined),
+    mongoose_c2s:verify_user_and_open_session(HookParams, session_established, SaslAcc).
+
+-spec feature(mongoose_c2s:data()) -> exml:element().
+feature(C2SData) ->
+    Inlines = mongoose_hooks:bind2_stream_features(C2SData, []),
+    InlineElem = inlines(Inlines),
+    #xmlel{name = feature_name(),
+           attrs = [?XMLNS_BIND2],
+           children = [InlineElem]}.
+
+-spec inlines([exml:element()]) -> exml:element().
+inlines(Inlines) ->
+    #xmlel{name = <<"inline">>, children = Inlines}.
+
+-spec feature_name() -> binary().
+feature_name() ->
+    <<"bind">>.

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -17,6 +17,7 @@
          sasl2_stream_features/3,
          sasl2_start/3,
          sasl2_success/3,
+         bind2_stream_features/3,
          session_cleanup/3,
          user_send_packet/3,
          user_receive_packet/3,
@@ -101,7 +102,8 @@ hooks(HostType) ->
      {session_cleanup, HostType, fun ?MODULE:session_cleanup/3, #{}, 50},
      {sasl2_stream_features, HostType, fun ?MODULE:sasl2_stream_features/3, #{}, 50},
      {sasl2_start, HostType, fun ?MODULE:sasl2_start/3, #{}, 50},
-     {sasl2_success, HostType, fun ?MODULE:sasl2_success/3, #{}, 30}
+     {sasl2_success, HostType, fun ?MODULE:sasl2_success/3, #{}, 30},
+     {bind2_stream_features, HostType, fun ?MODULE:bind2_stream_features/3, #{}, 50}
      | c2s_hooks(HostType) ].
 
 -spec c2s_hooks(mongooseim:host_type()) -> gen_hook:hook_list(mongoose_c2s_hooks:fn()).
@@ -739,6 +741,12 @@ c2s_stream_features(Acc, _, _) ->
 sasl2_stream_features(Acc, _, _) ->
     Resume = #xmlel{name = <<"resume">>, attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}]},
     {ok, [Resume | Acc]}.
+
+-spec bind2_stream_features(Acc, #{c2s_data := mongoose_c2s:data()}, gen_hook:extra()) ->
+    {ok, Acc} when Acc :: [exml:element()].
+bind2_stream_features(Acc, _, _) ->
+    SmFeature = #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_STREAM_MGNT_3}]},
+    {ok, [SmFeature | Acc]}.
 
 -spec sasl2_start(SaslAcc, #{stanza := exml:element()}, gen_hook:extra()) ->
     {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -835,6 +835,8 @@ default_mod_config(mod_auth_token) ->
     #{backend => rdbms, iqdisc => no_queue,
       validity_period => #{access => #{unit => hours, value => 1},
                            refresh => #{unit => days, value => 25}}};
+default_mod_config(mod_bind2) ->
+    #{};
 default_mod_config(mod_blocking) ->
     #{backend => mnesia};
 default_mod_config(mod_bosh) ->


### PR DESCRIPTION
Implements partial support for bind2. Here we can already bind a resource and start a session directly after authentication, saving one more round-trip.

Support for carbons and csi on the same roundtrip coming in the next PR #4114 