### PR TITLE
Xeps/bind2 inlines

### DIFF
--- a/big_tests/tests/bind2_SUITE.erl
+++ b/big_tests/tests/bind2_SUITE.erl
@@ -89,15 +89,13 @@ server_announces_bind2_with_sm(Config) ->
     ?assertNotEqual(undefined, SM).
 
 auth_and_bind_ignores_invalid_resource_and_generates_a_new_one(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features,
-             {?MODULE, auth_and_bind_wrong_resource}, has_no_more_stanzas],
+    Steps = [start_new_user, {?MODULE, auth_and_bind_wrong_resource}, has_no_more_stanzas],
     #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
     Success = exml_query:path(Response, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
     ?assertNotEqual(undefined, Success).
 
 auth_and_bind_to_random_resource(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features,
-             {?MODULE, auth_and_bind}, has_no_more_stanzas],
+    Steps = [start_new_user, {?MODULE, auth_and_bind}, has_no_more_stanzas],
     #{answer := Success} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
@@ -107,8 +105,7 @@ auth_and_bind_to_random_resource(Config) ->
     ?assert(0 =< byte_size(LResource), LResource).
 
 auth_and_bind_do_not_expose_user_agent_id_in_client(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features,
-             {?MODULE, auth_and_bind_with_user_agent_uuid}, has_no_more_stanzas],
+    Steps = [start_new_user, {?MODULE, auth_and_bind_with_user_agent_uuid}, has_no_more_stanzas],
     #{answer := Success, uuid := Uuid} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
@@ -118,8 +115,7 @@ auth_and_bind_do_not_expose_user_agent_id_in_client(Config) ->
     ?assertNotEqual(Uuid, LResource).
 
 auth_and_bind_contains_client_tag(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features,
-             {?MODULE, auth_and_bind_with_tag}, has_no_more_stanzas],
+    Steps = [start_new_user, {?MODULE, auth_and_bind_with_tag}, has_no_more_stanzas],
     #{answer := Success, tag := Tag} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),

--- a/big_tests/tests/bind2_SUITE.erl
+++ b/big_tests/tests/bind2_SUITE.erl
@@ -88,13 +88,13 @@ server_announces_bind2_with_features(Config) ->
     check_var(InlineFeatures, ?NS_CSI).
 
 auth_and_bind_ignores_invalid_resource_and_generates_a_new_one(Config) ->
-    Steps = [start_new_user, {?MODULE, auth_and_bind_wrong_resource}, has_no_more_stanzas],
+    Steps = [start_new_user, {?MODULE, auth_and_bind_wrong_resource}, receive_features, has_no_more_stanzas],
     #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
     Success = exml_query:path(Response, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
     ?assertNotEqual(undefined, Success).
 
 auth_and_bind_to_random_resource(Config) ->
-    Steps = [start_new_user, {?MODULE, auth_and_bind}, has_no_more_stanzas],
+    Steps = [start_new_user, {?MODULE, auth_and_bind}, receive_features, has_no_more_stanzas],
     #{answer := Success} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
@@ -104,7 +104,7 @@ auth_and_bind_to_random_resource(Config) ->
     ?assert(0 =< byte_size(LResource), LResource).
 
 auth_and_bind_do_not_expose_user_agent_id_in_client(Config) ->
-    Steps = [start_new_user, {?MODULE, auth_and_bind_with_user_agent_uuid}, has_no_more_stanzas],
+    Steps = [start_new_user, {?MODULE, auth_and_bind_with_user_agent_uuid}, receive_features, has_no_more_stanzas],
     #{answer := Success, uuid := Uuid} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
@@ -114,7 +114,7 @@ auth_and_bind_do_not_expose_user_agent_id_in_client(Config) ->
     ?assertNotEqual(Uuid, LResource).
 
 auth_and_bind_contains_client_tag(Config) ->
-    Steps = [start_new_user, {?MODULE, auth_and_bind_with_tag}, has_no_more_stanzas],
+    Steps = [start_new_user, {?MODULE, auth_and_bind_with_tag}, receive_features, has_no_more_stanzas],
     #{answer := Success, tag := Tag} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
@@ -127,14 +127,14 @@ auth_and_bind_contains_client_tag(Config) ->
 carbons_are_enabled_with_bind_inline_request(Config) ->
     Steps = [start_new_user,
              {?MODULE, start_peer},
-             {?MODULE, auth_and_bind_with_carbon_copies},
-             {?MODULE, receive_message_carbon_arrives}],
+             {?MODULE, auth_and_bind_with_carbon_copies}, receive_features,
+             {?MODULE, receive_message_carbon_arrives}, has_no_more_stanzas],
     sasl2_helper:apply_steps(Steps, Config).
 
 csi_is_active_with_bind_inline_request(Config) ->
     Steps = [start_new_user,
              {?MODULE, start_peer},
-             {?MODULE, auth_and_bind_with_csi_active},
+             {?MODULE, auth_and_bind_with_csi_active}, receive_features,
              {?MODULE, inactive_csi_msg_wont_arrive}, has_no_more_stanzas],
     sasl2_helper:apply_steps(Steps, Config).
 
@@ -142,13 +142,16 @@ csi_is_inactive_with_bind_inline_request(Config) ->
     Steps = [start_new_user,
              {?MODULE, start_peer},
              {?MODULE, auth_and_bind_with_csi_inactive}, has_no_more_stanzas,
-             {?MODULE, active_csi_msg_arrives}],
+             {?MODULE, inactive_csi_msgs_do_not_arrive},
+             {?MODULE, activate_csi}, receive_features,
+             {?MODULE, receive_csi_msgs}, has_no_more_stanzas],
     sasl2_helper:apply_steps(Steps, Config).
 
 stream_resumption_enable_sm_on_bind(Config) ->
     Steps = [start_new_user,
              {?MODULE, start_peer},
-             {?MODULE, auth_and_bind_with_sm_enabled}, has_no_more_stanzas],
+             {?MODULE, auth_and_bind_with_sm_enabled},
+             receive_features, has_no_more_stanzas],
     #{answer := Success} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     Enabled = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2},
@@ -158,7 +161,8 @@ stream_resumption_enable_sm_on_bind(Config) ->
 stream_resumption_enable_sm_on_bind_with_resume(Config) ->
     Steps = [start_new_user,
              {?MODULE, start_peer},
-             {?MODULE, auth_and_bind_with_sm_resume_enabled}, has_no_more_stanzas],
+             {?MODULE, auth_and_bind_with_sm_resume_enabled},
+             receive_features, has_no_more_stanzas],
     #{answer := Success} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     Enabled = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2},
@@ -167,7 +171,8 @@ stream_resumption_enable_sm_on_bind_with_resume(Config) ->
 
 stream_resumption_failing_does_bind_and_contains_sm_status(Config) ->
     Steps = [create_user, buffer_messages_and_die, connect_tls, start_stream_get_features,
-             {?MODULE, auth_and_bind_with_resumption_unknown_smid}, has_no_more_stanzas],
+             {?MODULE, auth_and_bind_with_resumption_unknown_smid},
+             receive_features, has_no_more_stanzas],
     #{answer := Success, tag := Tag} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
@@ -184,8 +189,6 @@ stream_resumption_overrides_bind_request(Config) ->
              {?MODULE, auth_and_bind_with_resumption}, has_no_more_stanzas],
     #{answer := Success, smid := SMID} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
-    Bound = exml_query:path(Success, [{element_with_ns, <<"bound">>, ?NS_BIND_2}]),
-    ?assertNotEqual(undefined, Bound),
     Resumed = exml_query:path(Success, [{element_with_ns, <<"resumed">>, ?NS_STREAM_MGNT_3}]),
     ?assert(escalus_pred:is_sm_resumed(SMID, Resumed)).
 
@@ -227,15 +230,14 @@ auth_and_bind_with_carbon_copies(Config, Client, #{spec := Spec} = Data) ->
     Jid = <<(escalus_client:short_jid(Client2))/binary, "/", Resource/binary>>,
     {Client1, Data1#{client_2 => Client2, client_2_jid => Jid}}.
 
-auth_and_bind_with_csi_active(Config, Client, #{peer := Bob} = Data) ->
+auth_and_bind_with_csi_active(Config, Client, Data) ->
     CsiActive = csi_helper:csi_stanza(<<"active">>),
-    {Client1, Data1} = plain_auth(Config, Client, Data, [CsiActive], []),
-    escalus_client:send(Bob, escalus_stanza:chat_to(Client1, <<"hello 1">>)),
-    AliceReceived = escalus_client:wait_for_stanza(Client1),
-    escalus:assert(is_message, AliceReceived),
-    {Client1, Data1}.
+    plain_auth(Config, Client, Data, [CsiActive], []).
 
 inactive_csi_msg_wont_arrive(_Config, Client, #{peer := Bob} = Data) ->
+    escalus_client:send(Bob, escalus_stanza:chat_to(Client, <<"hello 1">>)),
+    AliceReceived = escalus_client:wait_for_stanza(Client),
+    escalus:assert(is_message, AliceReceived),
     csi_helper:given_client_is_inactive_and_no_messages_arrive(Client),
     csi_helper:given_messages_are_sent(Client, Bob, 1),
     csi_helper:then_client_does_not_receive_any_message(Client),
@@ -243,13 +245,18 @@ inactive_csi_msg_wont_arrive(_Config, Client, #{peer := Bob} = Data) ->
 
 auth_and_bind_with_csi_inactive(Config, Client, Data) ->
     CsiInactive = csi_helper:csi_stanza(<<"inactive">>),
-    {Client1, Data1} = plain_auth(Config, Client, Data, [CsiInactive], []),
-    {Client1, Data1}.
+    plain_auth(Config, Client, Data, [CsiInactive], []).
 
-active_csi_msg_arrives(_Config, Client, #{peer := Bob} = Data) ->
+inactive_csi_msgs_do_not_arrive(_Config, Client, #{peer := Bob} = Data) ->
     Msgs = csi_helper:given_messages_are_sent(Client, Bob, 2),
     csi_helper:then_client_does_not_receive_any_message(Client),
+    {Client, Data#{msgs => Msgs}}.
+
+activate_csi(_Config, Client, Data) ->
     csi_helper:given_client_is_active(Client),
+    {Client, Data}.
+
+receive_csi_msgs(_Config, Client, #{msgs := Msgs} = Data) ->
     csi_helper:then_client_receives_message(Client, Msgs),
     {Client, Data}.
 

--- a/big_tests/tests/csi_helper.erl
+++ b/big_tests/tests/csi_helper.erl
@@ -1,0 +1,36 @@
+-module(csi_helper).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("exml/include/exml.hrl").
+
+-define(NS_CSI, <<"urn:xmpp:csi:0">>).
+
+given_client_is_active(Alice) ->
+    escalus:send(Alice, csi_helper:csi_stanza(<<"active">>)).
+
+given_client_is_inactive_and_no_messages_arrive(Alice) ->
+    escalus:send(Alice, csi_stanza(<<"inactive">>)),
+    then_client_does_not_receive_any_message(Alice).
+
+given_messages_are_sent(Alice, Bob, N) ->
+    Msgs = gen_msgs(<<"Hi, Alice">>, N),
+    send_msgs(Bob, Alice, Msgs),
+    Msgs.
+
+then_client_does_not_receive_any_message(Alice) ->
+    [] = escalus:wait_for_stanzas(Alice, 1, 100),
+    escalus_assert:has_no_stanzas(Alice).
+
+then_client_receives_message(Alice, Msgs) ->
+    [escalus:assert(is_chat_message, [Msg], escalus:wait_for_stanza(Alice)) ||
+     Msg <- Msgs].
+
+gen_msgs(Prefix, N) ->
+    [<<Prefix/binary, ": ", (integer_to_binary(I))/binary>> || I <- lists:seq(1, N)].
+
+send_msgs(From, To, Msgs) ->
+    [escalus:send(From, escalus_stanza:chat_to(To, Msg)) || Msg <- Msgs].
+
+csi_stanza(Name) ->
+    #xmlel{name = Name,
+           attrs = [{<<"xmlns">>, ?NS_CSI}]}.

--- a/big_tests/tests/sasl2_SUITE.erl
+++ b/big_tests/tests/sasl2_SUITE.erl
@@ -31,6 +31,7 @@ groups() ->
        server_announces_sasl2_with_some_mechanism,
        authenticate_stanza_has_invalid_mechanism,
        user_agent_is_invalid,
+       user_agent_is_invalid_uuid_but_not_v4,
        authenticate_with_plain,
        authenticate_with_plain_and_user_agent_without_id,
        authenticate_again_results_in_stream_error
@@ -115,6 +116,11 @@ authenticate_stanza_has_invalid_mechanism(Config) ->
 
 user_agent_is_invalid(Config) ->
     Steps = [start_new_user, send_bad_user_agent],
+    #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
+    escalus:assert(is_stream_error, [<<"policy-violation">>, <<>>], Response).
+
+user_agent_is_invalid_uuid_but_not_v4(Config) ->
+    Steps = [start_new_user, send_bad_user_agent_uuid],
     #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
     escalus:assert(is_stream_error, [<<"policy-violation">>, <<>>], Response).
 

--- a/big_tests/tests/sasl2_SUITE.erl
+++ b/big_tests/tests/sasl2_SUITE.erl
@@ -109,21 +109,21 @@ server_announces_sasl2_with_some_mechanism(Config) ->
     ?assertNotEqual([], Mechs).
 
 authenticate_stanza_has_invalid_mechanism(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features, send_invalid_mech_auth_stanza],
+    Steps = [start_new_user, send_invalid_mech_auth_stanza],
     #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"failure">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Response).
 
 user_agent_is_invalid(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features, send_bad_user_agent],
+    Steps = [start_new_user, send_bad_user_agent],
     #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
     escalus:assert(is_stream_error, [<<"policy-violation">>, <<>>], Response).
 
 authenticate_with_plain(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features, plain_authentication, receive_features],
+    Steps = [start_new_user, plain_authentication, receive_features],
     auth_with_plain(Steps, Config).
 
 authenticate_with_plain_and_user_agent_without_id(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features, plain_auth_user_agent_without_id, receive_features],
+    Steps = [start_new_user, plain_auth_user_agent_without_id, receive_features],
     auth_with_plain(Steps, Config).
 
 auth_with_plain(Steps, Config) ->
@@ -136,25 +136,24 @@ auth_with_plain(Steps, Config) ->
     ?assertMatch(#xmlel{name = <<"stream:features">>}, Features).
 
 authenticate_with_scram_abort(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features, scram_step_1, scram_abort],
+    Steps = [start_new_user, scram_step_1, scram_abort],
     #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"failure">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Response),
     Aborted = exml_query:path(Response, [{element_with_ns, <<"aborted">>, ?NS_SASL}]),
     ?assertNotEqual(undefined, Aborted).
 
 authenticate_with_scram_bad_abort(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features, scram_step_1, scram_bad_abort],
+    Steps = [start_new_user, scram_step_1, scram_bad_abort],
     #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
     escalus:assert(is_stream_error, [<<"invalid-namespace">>, <<>>], Response).
 
 authenticate_with_scram_bad_response(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features, scram_step_1, scram_bad_ns_response],
+    Steps = [start_new_user, scram_step_1, scram_bad_ns_response],
     #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
     escalus:assert(is_stream_error, [<<"invalid-namespace">>, <<>>], Response).
 
 authenticate_with_scram(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features,
-             scram_step_1, scram_step_2, receive_features],
+    Steps = [start_new_user, scram_step_1, scram_step_2, receive_features],
     #{answer := Success, features := Features} = sasl2_helper:apply_steps(Steps, Config),
     ?assertMatch(#xmlel{name = <<"success">>, attrs = [{<<"xmlns">>, ?NS_SASL_2}]}, Success),
     CData = exml_query:path(Success, [{element, <<"additional-data">>}, cdata], <<>>),
@@ -164,8 +163,7 @@ authenticate_with_scram(Config) ->
     ?assertMatch(#xmlel{name = <<"stream:features">>}, Features).
 
 authenticate_again_results_in_stream_error(Config) ->
-    Steps = [create_connect_tls, start_stream_get_features,
-             plain_authentication, receive_features, plain_authentication],
+    Steps = [start_new_user, plain_authentication, receive_features, plain_authentication],
     #{answer := Response} = sasl2_helper:apply_steps(Steps, Config),
     escalus:assert(is_stream_error, [<<"policy-violation">>, <<>>], Response).
 

--- a/big_tests/tests/sasl2_SUITE.erl
+++ b/big_tests/tests/sasl2_SUITE.erl
@@ -28,7 +28,7 @@ groups() ->
      {basic, [parallel],
       [
        server_does_not_announce_if_not_tls,
-       server_announces_sasl2_with_some_mechanism,
+       server_announces_sasl2_with_some_mechanism_and_inline_sm,
        authenticate_stanza_has_invalid_mechanism,
        user_agent_is_invalid,
        user_agent_is_invalid_uuid_but_not_v4,
@@ -101,13 +101,16 @@ server_does_not_announce_if_not_tls(Config) ->
     Sasl2 = exml_query:path(Features, [{element_with_ns, <<"authentication">>, ?NS_SASL_2}]),
     ?assertEqual(undefined, Sasl2).
 
-server_announces_sasl2_with_some_mechanism(Config) ->
+server_announces_sasl2_with_some_mechanism_and_inline_sm(Config) ->
     Steps = [create_connect_tls, start_stream_get_features],
     #{features := Features} = sasl2_helper:apply_steps(Steps, Config),
     Sasl2 = exml_query:path(Features, [{element_with_ns, <<"authentication">>, ?NS_SASL_2}]),
     ?assertNotEqual(undefined, Sasl2),
     Mechs = exml_query:paths(Sasl2, [{element, <<"mechanism">>}]),
-    ?assertNotEqual([], Mechs).
+    ?assertNotEqual([], Mechs),
+    Sm = exml_query:path(Sasl2, [{element, <<"inline">>},
+                                 {element_with_ns, <<"sm">>, ?NS_STREAM_MGNT_3}]),
+    ?assertNotEqual(undefined, Sm).
 
 authenticate_stanza_has_invalid_mechanism(Config) ->
     Steps = [start_new_user, send_invalid_mech_auth_stanza],

--- a/big_tests/tests/sasl2_helper.erl
+++ b/big_tests/tests/sasl2_helper.erl
@@ -15,6 +15,8 @@ ns() ->
 load_all_sasl2_modules(HostType) ->
     Modules = [{mod_bind2, config_parser_helper:default_mod_config(mod_bind2)},
                {mod_sasl2, config_parser_helper:default_mod_config(mod_sasl2)},
+               {mod_csi, config_parser_helper:default_mod_config(mod_csi)},
+               {mod_carboncopy, config_parser_helper:default_mod_config(mod_carboncopy)},
                {mod_stream_management, config_parser_helper:mod_config(mod_stream_management, #{ack_freq => never})}],
     dynamic_modules:ensure_modules(HostType, Modules).
 

--- a/big_tests/tests/sasl2_helper.erl
+++ b/big_tests/tests/sasl2_helper.erl
@@ -5,6 +5,7 @@
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
 
+-define(VALID_UUID_BUT_NOT_V4, <<"a55c8fde-2cef-0655-a55c-8fde2cefc655">>).
 -define(NS_SASL_2, <<"urn:xmpp:sasl:2">>).
 
 -type step(Config, Client, Data) :: fun((Config, Client, Data) -> {Client, Data}).
@@ -78,6 +79,14 @@ send_invalid_ns_auth_stanza(_Config, Client, Data) ->
 send_bad_user_agent(_Config, Client, Data) ->
     InitialResponse = initial_response_elem(<<"some-random-payload">>),
     Agent = bad_user_agent_elem(),
+    Authenticate = auth_elem(<<"PLAIN">>, [InitialResponse, Agent]),
+    escalus:send(Client, Authenticate),
+    Answer = escalus_client:wait_for_stanza(Client),
+    {Client, Data#{answer => Answer}}.
+
+send_bad_user_agent_uuid(_Config, Client, Data) ->
+    InitialResponse = initial_response_elem(<<"some-random-payload">>),
+    Agent = bad_user_agent_elem(?VALID_UUID_BUT_NOT_V4),
     Authenticate = auth_elem(<<"PLAIN">>, [InitialResponse, Agent]),
     escalus:send(Client, Authenticate),
     Answer = escalus_client:wait_for_stanza(Client),
@@ -253,6 +262,9 @@ good_user_agent_elem() ->
 
 bad_user_agent_elem() ->
     user_agent_elem(<<"bad-id">>, undefined, undefined).
+
+bad_user_agent_elem(Uuid) ->
+    user_agent_elem(Uuid, undefined, undefined).
 
 user_agent_elem(Id, undefined, Device) ->
     user_agent_elem(Id, [], Device);

--- a/big_tests/tests/sasl2_helper.erl
+++ b/big_tests/tests/sasl2_helper.erl
@@ -41,17 +41,20 @@ create_connect_tls(Config, Client, Data) ->
     {Client1, Data1} = create_user(Config, Client, Data),
     connect_tls(Config, Client1, Data1).
 
+start_new_user(Config, Client, Data) ->
+    {Client1, Data1} = create_connect_tls(Config, Client, Data),
+    start_stream_get_features(Config, Client1, Data1).
+
 create_user(Config, Client, Data) ->
     Spec = escalus_fresh:create_fresh_user(Config, alice),
     {Client, Data#{spec => Spec}}.
 
 connect_tls(_Config, _, #{spec := Spec} = Data) ->
     TlsPort = ct:get_config({hosts, mim, c2s_tls_port}),
-    Spec1 = [{port, TlsPort}, {tls_module, ssl}, {ssl, true}, {ssl_opts, [{verify, verify_none}]},
-             {resource, <<"res1">>} | Spec],
+    Spec1 = [{port, TlsPort}, {tls_module, ssl}, {ssl, true}, {ssl_opts, [{verify, verify_none}]}
+             | Spec],
     Client1 = escalus_connection:connect(Spec1),
-    Jid = <<(escalus_client:short_jid(Client1))/binary, "/res1">>,
-    {Client1, Data#{spec => Spec1, client_1_jid => Jid}}.
+    {Client1, Data#{spec => Spec1}}.
 
 start_stream_get_features(_Config, Client, Data) ->
     Client1 = escalus_session:start_stream(Client),

--- a/big_tests/tests/xep_0352_csi_SUITE.erl
+++ b/big_tests/tests/xep_0352_csi_SUITE.erl
@@ -1,6 +1,5 @@
 -module(xep_0352_csi_SUITE).
 
--include_lib("exml/include/exml.hrl").
 -include_lib("escalus/include/escalus.hrl").
 
 -compile([export_all, nowarn_export_all]).
@@ -69,16 +68,16 @@ server_announces_csi(Config) ->
 
 invalid_csi_request_returns_error(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
-        escalus:send(Alice, csi_stanza(<<"invalid">>)),
+        escalus:send(Alice, csi_helper:csi_stanza(<<"invalid">>)),
         Stanza = escalus:wait_for_stanza(Alice),
         escalus:assert(is_error, [<<"modify">>, <<"bad-request">>], Stanza)
     end).
 
 alice_is_inactive_and_no_stanza_arrived(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-        given_client_is_inactive_and_no_messages_arrive(Alice),
-        given_messages_are_sent(Alice, Bob, 1),
-        then_client_does_not_receive_any_message(Alice)
+        csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+        csi_helper:given_messages_are_sent(Alice, Bob, 1),
+        csi_helper:then_client_does_not_receive_any_message(Alice)
     end).
 
 alice_gets_msgs_after_activate(Config) ->
@@ -89,19 +88,19 @@ alice_gets_msgs_after_activate_in_order(Config) ->
 
 alice_gets_msgs_after_activate(Config, N) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-        given_client_is_inactive_and_no_messages_arrive(Alice),
-        Msgs = given_messages_are_sent(Alice, Bob, N),
-        given_client_is_active(Alice),
-        then_client_receives_message(Alice, Msgs)
+        csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+        Msgs = csi_helper:given_messages_are_sent(Alice, Bob, N),
+        csi_helper:given_client_is_active(Alice),
+        csi_helper:then_client_receives_message(Alice, Msgs)
     end).
 
 inactive_twice_does_not_reset_buffer(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-        given_client_is_inactive_and_no_messages_arrive(Alice),
-        Msgs = given_messages_are_sent(Alice, Bob, 2),
-        given_client_is_inactive_and_no_messages_arrive(Alice),
-        given_client_is_active(Alice),
-        then_client_receives_message(Alice, Msgs)
+        csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+        Msgs = csi_helper:given_messages_are_sent(Alice, Bob, 2),
+        csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+        csi_helper:given_client_is_active(Alice),
+        csi_helper:then_client_receives_message(Alice, Msgs)
     end).
 
 alice_gets_buffered_messages_after_reconnection_with_sm(Config) ->
@@ -113,9 +112,9 @@ alice_gets_buffered_messages_after_reconnection_with_sm(Config) ->
     Alice = Alice0#client{jid = JID},
     {ok, Bob, _} = escalus_connection:start(BobSpec),
 
-    given_client_is_inactive_and_no_messages_arrive(Alice),
+    csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
 
-    MsgsToAlice = given_messages_are_sent(Alice, Bob, 5),
+    MsgsToAlice = csi_helper:given_messages_are_sent(Alice, Bob, 5),
 
     %% then Alice disconnects
 
@@ -124,7 +123,7 @@ alice_gets_buffered_messages_after_reconnection_with_sm(Config) ->
     ConnSteps = [start_stream, stream_features, authenticate, bind, session],
     {ok, Alice2, _} = escalus_connection:start(AliceSpec, ConnSteps),
 
-    then_client_receives_message(Alice2, MsgsToAlice),
+    csi_helper:then_client_receives_message(Alice2, MsgsToAlice),
     escalus_connection:stop(Alice2),
     escalus_connection:stop(Bob).
 
@@ -141,9 +140,9 @@ alice_gets_buffered_messages_after_stream_resumption(Config) ->
     escalus:wait_for_stanza(Alice),
     {ok, Bob, _} = escalus_connection:start(BobSpec),
 
-    given_client_is_inactive_and_no_messages_arrive(Alice),
-    MsgsToAlice = given_messages_are_sent(Alice, Bob, 5),
-    then_client_does_not_receive_any_message(Alice),
+    csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+    MsgsToAlice = csi_helper:given_messages_are_sent(Alice, Bob, 5),
+    csi_helper:then_client_does_not_receive_any_message(Alice),
 
     %% then Alice loses connection and resumes it
     escalus_connection:kill(Alice),
@@ -151,7 +150,7 @@ alice_gets_buffered_messages_after_stream_resumption(Config) ->
     ResumeSession = [start_stream, stream_features, authenticate, mk_resume_stream(SMID, 1)],
     {ok, Alice2, _} = escalus_connection:start(AliceSpec, ResumeSession),
 
-    then_client_receives_message(Alice2, MsgsToAlice),
+    csi_helper:then_client_receives_message(Alice2, MsgsToAlice),
     escalus_connection:stop(Alice2),
     escalus_connection:stop(Bob).
 
@@ -170,16 +169,16 @@ mk_resume_stream(SMID, PrevH) ->
 
 alice_gets_message_after_buffer_overflow(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
-        given_client_is_inactive_and_no_messages_arrive(Alice),
-        Msgs = given_messages_are_sent(Alice, Bob, ?CSI_BUFFER_MAX + 5),
+        csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+        Msgs = csi_helper:given_messages_are_sent(Alice, Bob, ?CSI_BUFFER_MAX + 5),
         {Flushed, Awaiting} = lists:split(?CSI_BUFFER_MAX+1, Msgs),
-        then_client_receives_message(Alice, Flushed),
+        csi_helper:then_client_receives_message(Alice, Flushed),
         %% and no other stanza
-        then_client_does_not_receive_any_message(Alice),
+        csi_helper:then_client_does_not_receive_any_message(Alice),
         %% Alice activates
-        given_client_is_active(Alice),
+        csi_helper:given_client_is_active(Alice),
         %% ands gets remaining stanzas
-        then_client_receives_message(Alice, Awaiting)
+        csi_helper:then_client_receives_message(Alice, Awaiting)
     end).
 
 bob_gets_msgs_from_inactive_alice(Config) ->
@@ -190,7 +189,7 @@ bob_gets_msgs_from_inactive_alice(Config) ->
 
 alice_is_inactive_but_sends_sm_req_and_recives_ack(Config) ->
     escalus:fresh_story(Config, [{alice,1}], fun(Alice) ->
-        given_client_is_inactive_and_no_messages_arrive(Alice),
+        csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
         escalus:send(Alice, escalus_stanza:sm_request()),
         escalus:assert(is_sm_ack, escalus:wait_for_stanza(Alice))
 
@@ -198,39 +197,9 @@ alice_is_inactive_but_sends_sm_req_and_recives_ack(Config) ->
 
 given_client_is_inactive_but_sends_messages(Alice, Bob, N) ->
     %%Given
-    given_client_is_inactive_and_no_messages_arrive(Alice),
-    MsgsToAlice = given_messages_are_sent(Alice, Bob, N),
-    MsgsToBob = gen_msgs(<<"Hi, Bob">>, N),
-    send_msgs(Alice, Bob, MsgsToBob),
+    csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+    MsgsToAlice = csi_helper:given_messages_are_sent(Alice, Bob, N),
+    MsgsToBob = csi_helper:gen_msgs(<<"Hi, Bob">>, N),
+    csi_helper:send_msgs(Alice, Bob, MsgsToBob),
     timer:sleep(1),
     {MsgsToAlice, MsgsToBob}.
-
-then_client_does_not_receive_any_message(Alice) ->
-    [] = escalus:wait_for_stanzas(Alice, 1, 100),
-    escalus_assert:has_no_stanzas(Alice).
-
-then_client_receives_message(Alice, Msgs) ->
-    [escalus:assert(is_chat_message, [Msg], escalus:wait_for_stanza(Alice)) ||
-     Msg <- Msgs].
-
-given_messages_are_sent(Alice, Bob, N) ->
-    Msgs = gen_msgs(<<"Hi, Alice">>, N),
-    send_msgs(Bob, Alice, Msgs),
-    Msgs.
-
-send_msgs(From, To, Msgs) ->
-    [escalus:send(From, escalus_stanza:chat_to(To, Msg)) || Msg <- Msgs].
-
-gen_msgs(Prefix, N) ->
-    [<<Prefix/binary, ": ", (integer_to_binary(I))/binary>> || I <- lists:seq(1, N)].
-
-given_client_is_active(Alice) ->
-    escalus:send(Alice, csi_stanza(<<"active">>)).
-
-given_client_is_inactive_and_no_messages_arrive(Alice) ->
-    escalus:send(Alice, csi_stanza(<<"inactive">>)),
-    then_client_does_not_receive_any_message(Alice).
-
-csi_stanza(Name) ->
-    #xmlel{name = Name,
-           attrs = [{<<"xmlns">>, <<"urn:xmpp:csi:0">>}]}.

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -449,12 +449,13 @@ handle_sasl_abort(StateData, SaslAcc, Retries) ->
     handle_sasl_failure(StateData, SaslAcc, Error, Retries).
 
 -spec stream_start_features_before_auth(data()) -> fsm_res().
-stream_start_features_before_auth(#c2s_data{listener_opts = LOpts} = StateData) ->
+stream_start_features_before_auth(#c2s_data{sid = SID, listener_opts = LOpts} = StateData) ->
     send_header(StateData),
-    SaslAcc = mongoose_c2s_sasl:new(StateData),
+    SaslAcc0 = mongoose_c2s_sasl:new(StateData),
+    SaslAcc1 = mongoose_acc:set_permanent(c2s, [{origin_sid, SID}], SaslAcc0),
     StreamFeatures = mongoose_c2s_stanzas:stream_features_before_auth(StateData),
-    SaslAcc1 = send_acc_from_server_jid(StateData, SaslAcc, StreamFeatures),
-    {next_state, {wait_for_feature_before_auth, SaslAcc1, ?AUTH_RETRIES}, StateData, state_timeout(LOpts)}.
+    SaslAcc2 = send_acc_from_server_jid(StateData, SaslAcc1, StreamFeatures),
+    {next_state, {wait_for_feature_before_auth, SaslAcc2, ?AUTH_RETRIES}, StateData, state_timeout(LOpts)}.
 
 -spec stream_start_features_after_auth(data()) -> fsm_res().
 stream_start_features_after_auth(#c2s_data{listener_opts = LOpts} = StateData) ->

--- a/src/mod_bind2.erl
+++ b/src/mod_bind2.erl
@@ -1,12 +1,22 @@
 %% @doc Implement Bind2, allowing the inline specification of:
-%% - Resource binding
-%% - Stream management
+%% resource binding, stream management, carbons and csi.
+%%
+%% There are two steps to this: on sasl2_success, we check if there was a bind2 inline request,
+%% and also, if there was a previous SM resumption that has already succeeded – if resumption
+%% succeeded, bind2 must be entirely skipped.
+%%
+%% If we can proceed with binding, we run a similar algorithm that c2s runs itself: we verify the
+%% user is allowed to start a session, we open the session changing the c2s data, and we finalise
+%% the operation with handle_state_after_packet or maybe_retry_state. But in the case of bind2,
+%% once verifications are successful, we need to modify the c2s data to append for example the csi
+%% state or the carbons tag in the session info, before the session is actually established, so that
+%% session establishment is atomic to changes in the c2s data.
 -module(mod_bind2).
 -xep([{xep, 386}, {version, "0.4.0"}, {status, partial}]).
 
 -include("jlib.hrl").
 
--define(XMLNS_BIND2, {<<"xmlns">>, ?NS_BIND_2}).
+-define(XMLNS_BIND_2, {<<"xmlns">>, ?NS_BIND_2}).
 
 -behaviour(gen_mod).
 
@@ -20,7 +30,7 @@
          sasl2_success/3
         ]).
 
--export([get_bind2_jid/1, get_bind_request/1, append_inline_bound_answer/3]).
+-export([get_bind_request/1, append_inline_bound_answer/3]).
 
 %% gen_mod
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
@@ -48,7 +58,13 @@ supported_features() ->
     [dynamic_domains].
 
 
-%% Hooks
+%% Hook handlers
+-spec sasl2_stream_features(Acc, #{c2s_data := mongoose_c2s:data()}, gen_hook:extra()) ->
+    {ok, Acc} when Acc :: [exml:element()].
+sasl2_stream_features(Acc, #{c2s_data := C2SData}, _) ->
+    Bind2Feature = feature(C2SData),
+    {ok, lists:keystore(feature_name(), #xmlel.name, Acc, Bind2Feature)}.
+
 -spec sasl2_start(SaslAcc, #{stanza := exml:element()}, gen_hook:extra()) ->
     {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
 sasl2_start(SaslAcc, #{stanza := El}, _) ->
@@ -61,22 +77,59 @@ sasl2_start(SaslAcc, #{stanza := El}, _) ->
 
 -spec sasl2_success(SaslAcc, mod_sasl2:c2s_state_data(), gen_hook:extra()) ->
     {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
-sasl2_success(SaslAcc, _, _) ->
+sasl2_success(SaslAcc, _, #{host_type := HostType}) ->
     case mod_sasl2:get_inline_request(SaslAcc, ?MODULE, undefined) of
         undefined ->
             {ok, SaslAcc};
         #{request := BindRequest} ->
             Resource = generate_lresource(BindRequest),
             InlineSm = get_stream_management_resumption_status(SaslAcc),
-            maybe_bind(SaslAcc, Resource, InlineSm)
+            maybe_bind(SaslAcc, Resource, HostType, InlineSm)
     end.
 
--spec sasl2_stream_features(Acc, #{c2s_data := mongoose_c2s:data()}, gen_hook:extra()) ->
-    {ok, Acc} when Acc :: [exml:element()].
-sasl2_stream_features(Acc, #{c2s_data := C2SData}, _) ->
-    Bind2Feature = feature(C2SData),
-    {ok, lists:keystore(feature_name(), #xmlel.name, Acc, Bind2Feature)}.
+-spec maybe_bind(SaslAcc, jid:lresource(), mongooseim:host_type(), undefined | mod_sasl2:inline_request()) ->
+    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
+maybe_bind(SaslAcc, _Resource, _HostType, #{status := success, response := SmResponse}) ->
+    Bound = #xmlel{name = <<"bound">>, attrs = [?XMLNS_BIND_2], children = [SmResponse]},
+    {ok, mod_sasl2:update_inline_request(SaslAcc, ?MODULE, Bound, success)};
+maybe_bind(SaslAcc, Resource, HostType, InlineSm) ->
+    {SaslAcc1, SaslStateData1, HookParams} = build_new_c2sdata_saslstatedata_and_hookparams(SaslAcc, Resource),
+    case mongoose_c2s:verify_user(session_established, HostType, HookParams, SaslAcc1) of
+        {ok, SaslAcc2} ->
+            Bound = create_bind_response(<<"bound">>, InlineSm),
+            SaslAcc3 = mod_sasl2:update_inline_request(SaslAcc2, ?MODULE, Bound, success),
+            SaslAcc4 = mongoose_hooks:bind2_enable_features(HostType, SaslAcc3, SaslStateData1),
+            #{c2s_data := C2SData2} = SaslStateData2 = mod_sasl2:get_state_data(SaslAcc4),
+            {ok, SaslAcc5, C2SData3} = mongoose_c2s:maybe_open_session(session_established, {ok, SaslAcc4}, C2SData2),
+            SaslStateData3 = SaslStateData2#{c2s_data => C2SData3, c2s_state => session_established},
+            SaslAcc6 = mod_sasl2:set_state_data(SaslAcc5, SaslStateData3),
+            {ok, SaslAcc6};
+        {stop, SaslAcc1} ->
+            bind2_failed(SaslAcc1, InlineSm)
+    end.
 
+-spec build_new_c2sdata_saslstatedata_and_hookparams(mongoose_acc:t(), jid:lresource()) ->
+    {mongoose_acc:t(), mod_sasl2:c2s_state_data(), mongoose_c2s_hooks:params()}.
+build_new_c2sdata_saslstatedata_and_hookparams(SaslAcc, Resource) ->
+    SaslStateData1 = mod_sasl2:get_state_data(SaslAcc),
+    #{c2s_data := C2SData1, c2s_state := C2SState1} = SaslStateData1,
+    C2SData2 = mongoose_c2s:replace_resource(C2SData1, Resource),
+    SaslStateData2 = SaslStateData1#{c2s_data => C2SData2},
+    HookParams = mongoose_c2s:hook_arg(C2SData2, C2SState1, internal, bind2, undefined),
+    {mod_sasl2:set_state_data(SaslAcc, SaslStateData2), SaslStateData2, HookParams}.
+
+bind2_failed(SaslAcc, InlineSm) ->
+    %% The XEP does not specify what to do if the resource wasn't bound
+    %% so we just set failed here and move along with SASL2
+    Error = create_bind_response(<<"failed">>, InlineSm),
+    {ok, mod_sasl2:update_inline_request(SaslAcc, ?MODULE, Error, failure)}.
+
+create_bind_response(Answer, InlineSm) ->
+    MaybeSmChild = case InlineSm of
+                       #{status := failure, response := Response} -> [Response];
+                       _ -> []
+                   end,
+    #xmlel{name = Answer, attrs = [?XMLNS_BIND_2], children = MaybeSmChild}.
 
 %% Helpers
 -spec generate_lresource(exml:element()) -> jid:lresource().
@@ -100,50 +153,12 @@ generate_lresource(BindRequest) ->
 get_stream_management_resumption_status(SaslAcc) ->
     mod_sasl2:get_inline_request(SaslAcc, mod_stream_management, undefined).
 
--spec maybe_bind(
-        SaslAcc, jid:lresource(), undefined | mod_sasl2:inline_request()) ->
-    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
-maybe_bind(SaslAcc, _Resource, #{status := success, response := SmResponse}) ->
-    Bound = #xmlel{name = <<"bound">>, attrs = [?XMLNS_BIND2], children = [SmResponse]},
-    {ok, mod_sasl2:update_inline_request(SaslAcc, ?MODULE, Bound, success)};
-maybe_bind(SaslAcc, Resource, InlineSm) ->
-    SaslStateData = mod_sasl2:get_state_data(SaslAcc),
-    MaybeSmChild = case InlineSm of
-                       #{status := failure, response := Response} -> [Response];
-                       _ -> []
-                   end,
-    case do_bind(SaslAcc, SaslStateData, Resource) of
-        {ok, SaslAcc1, C2SData} ->
-            NewJid = mongoose_c2s:get_jid(C2SData),
-            HostType = mongoose_acc:host_type(SaslAcc),
-            Bound = #xmlel{name = <<"bound">>, attrs = [?XMLNS_BIND2], children = MaybeSmChild},
-            NewSaslStateData = SaslStateData#{c2s_data => C2SData, c2s_state => session_established},
-            SaslAcc2 = mod_sasl2:set_state_data(SaslAcc1, NewSaslStateData),
-            SaslAcc3 = mod_sasl2:update_inline_request(SaslAcc2, ?MODULE, Bound, success),
-            SaslAcc4 = mongoose_acc:set(?MODULE, jid, NewJid, SaslAcc3),
-            SaslAcc5 = mongoose_hooks:bind2_enable_features(HostType, SaslAcc4, SaslStateData),
-            {ok, SaslAcc5};
-        {stop, SaslAcc1} ->
-            %% The XEP does not specify what to do if the resource wasn't bound
-            %% so we just set failed here and move along with SASL2
-            Error = #xmlel{name = <<"failed">>, attrs = [?XMLNS_BIND2], children = MaybeSmChild},
-            {ok, mod_sasl2:update_inline_request(SaslAcc1, ?MODULE, Error, failure)}
-    end.
-
--spec do_bind(SaslAcc, mod_sasl2:c2s_state_data(), jid:lresource()) ->
-    {ok, SaslAcc, mongoose_c2s:data()} | {stop, SaslAcc}
-      when SaslAcc :: mongoose_acc:t().
-do_bind(SaslAcc, #{c2s_state := C2SState, c2s_data := C2SData}, Resource) ->
-    C2SData1 = mongoose_c2s:replace_resource(C2SData, Resource),
-    HookParams = mongoose_c2s:hook_arg(C2SData1, C2SState, internal, bind2, undefined),
-    mongoose_c2s:verify_user_and_open_session(HookParams, session_established, SaslAcc).
-
 -spec feature(mongoose_c2s:data()) -> exml:element().
 feature(C2SData) ->
     Inlines = mongoose_hooks:bind2_stream_features(C2SData, []),
     InlineElem = inlines(Inlines),
     #xmlel{name = feature_name(),
-           attrs = [?XMLNS_BIND2],
+           attrs = [?XMLNS_BIND_2],
            children = [InlineElem]}.
 
 -spec inlines([exml:element()]) -> exml:element().
@@ -153,10 +168,6 @@ inlines(Inlines) ->
 -spec feature_name() -> binary().
 feature_name() ->
     <<"bind">>.
-
--spec get_bind2_jid(mongoose_acc:t()) -> jid:jid().
-get_bind2_jid(SaslAcc) ->
-    mongoose_acc:get(?MODULE, jid, SaslAcc).
 
 -spec get_bind_request(mongoose_acc:t()) -> mod_sasl2:inline_request().
 get_bind_request(SaslAcc) ->

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -354,13 +354,13 @@ carbon_copy_children(Acc, ?NS_CC_2, JID, Packet, Direction) ->
 enable(JID, CC, Acc) ->
     ?LOG_INFO(#{what => cc_enable,
                 user => JID#jid.luser, server => JID#jid.lserver}),
-    OriginSid = mongoose_acc:get(c2s, origin_sid, undefined, Acc),
+    OriginSid = mongoose_acc:get(c2s, origin_sid, Acc),
     ejabberd_sm:store_info(JID, OriginSid, ?CC_KEY, cc_ver_to_int(CC)).
 
 disable(JID, Acc) ->
     ?LOG_INFO(#{what => cc_disable,
                 user => JID#jid.luser, server => JID#jid.lserver}),
-    OriginSid = mongoose_acc:get(c2s, origin_sid, undefined, Acc),
+    OriginSid = mongoose_acc:get(c2s, origin_sid, Acc),
     ejabberd_sm:remove_info(JID, OriginSid, ?CC_KEY).
 
 complete_packet(Acc, From, #xmlel{name = <<"message">>, attrs = OrigAttrs} = Packet, sent) ->

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -53,8 +53,8 @@ hooks(HostType) ->
     ].
 
 ensure_metrics(HostType) ->
-    mongoose_metrics:ensure_metric(HostType, [HostType, modCSIInactive], spiral),
-    mongoose_metrics:ensure_metric(HostType, [HostType, modCSIActive], spiral).
+    mongoose_metrics:ensure_metric(HostType, [modCSIInactive], spiral),
+    mongoose_metrics:ensure_metric(HostType, [modCSIActive], spiral).
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -13,6 +13,8 @@
 
 %% Hook handlers
 -export([c2s_stream_features/3,
+         bind2_stream_features/3,
+         bind2_enable_features/3,
          xmpp_presend_element/3,
          user_send_xmlel/3,
          handle_user_stopping/3,
@@ -25,6 +27,7 @@
           buffer_max = 20 :: non_neg_integer()
          }).
 
+-type params() :: #{c2s_data := mongoose_c2s:data(), _ := _}.
 -type state() :: active | inactive.
 -type csi_state() :: #csi_state{}.
 
@@ -39,6 +42,8 @@ stop(_HostType) ->
 hooks(HostType) ->
     [
      {c2s_stream_features, HostType, fun ?MODULE:c2s_stream_features/3, #{}, 60},
+     {bind2_stream_features, HostType, fun ?MODULE:bind2_stream_features/3, #{}, 50},
+     {bind2_enable_features, HostType, fun ?MODULE:bind2_enable_features/3, #{}, 50},
      {xmpp_presend_element, HostType, fun ?MODULE:xmpp_presend_element/3, #{}, 45}, %% just before stream management!
      {user_send_xmlel, HostType, fun ?MODULE:user_send_xmlel/3, #{}, 60},
      {user_stop_request, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
@@ -68,6 +73,27 @@ supported_features() ->
 -spec c2s_stream_features(Acc, map(), gen_hook:extra()) -> {ok, Acc} when Acc :: [exml:element()].
 c2s_stream_features(Acc, _, _) ->
     {ok, lists:keystore(<<"csi">>, #xmlel.name, Acc, csi())}.
+
+-spec bind2_stream_features(Acc, #{c2s_data := mongoose_c2s:data()}, gen_hook:extra()) ->
+    {ok, Acc} when Acc :: [exml:element()].
+bind2_stream_features(Acc, _, _) ->
+    SmFeature = #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_CSI}]},
+    {ok, [SmFeature | Acc]}.
+
+-spec bind2_enable_features(SaslAcc, mod_sasl2:c2s_state_data(), gen_hook:extra()) ->
+    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
+bind2_enable_features(SaslAcc, Params, _) ->
+    #{request := BindRequest} = mod_bind2:get_bind_request(SaslAcc),
+    case exml_query:subelement_with_ns(BindRequest, ?NS_CSI) of
+        undefined ->
+            {ok, SaslAcc};
+        #xmlel{name = <<"active">>} ->
+            SaslAcc1 = handle_active_request(SaslAcc, Params),
+            {ok, SaslAcc1};
+        #xmlel{name = <<"inactive">>} ->
+            SaslAcc1 = handle_inactive_request(SaslAcc, Params),
+            {ok, SaslAcc1}
+    end.
 
 %% The XEP doesn't require any specific server behaviour in response to CSI stanzas,
 %% there are only some suggestions. The implementation in MongooseIM will simply buffer
@@ -153,7 +179,7 @@ handle_csi_request(Acc, _, _) ->
     ErrorAcc = mongoose_acc:update_stanza(#{from_jid => From, to_jid => To, element => Error }, Acc),
     mongoose_c2s_acc:to_acc(Acc, route, ErrorAcc).
 
--spec handle_inactive_request(mongoose_acc:t(), mongoose_c2s_hooks:params()) -> mongoose_acc:t().
+-spec handle_inactive_request(mongoose_acc:t(), params()) -> mongoose_acc:t().
 handle_inactive_request(Acc, #{c2s_data := C2SData} = _Params) ->
     HostType = mongoose_c2s:get_host_type(C2SData),
     mongoose_metrics:update(HostType, modCSIInactive, 1),
@@ -167,7 +193,7 @@ handle_inactive_request(Acc, #{c2s_data := C2SData} = _Params) ->
             mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi})
     end.
 
--spec handle_active_request(mongoose_acc:t(), mongoose_c2s_hooks:params()) -> mongoose_acc:t().
+-spec handle_active_request(mongoose_acc:t(), params()) -> mongoose_acc:t().
 handle_active_request(Acc, #{c2s_data := C2SData}) ->
     HostType = mongoose_c2s:get_host_type(C2SData),
     mongoose_metrics:update(HostType, modCSIActive, 1),

--- a/src/mod_sasl2.erl
+++ b/src/mod_sasl2.erl
@@ -35,7 +35,8 @@
 %% helpers
 -export([get_inline_request/2, get_inline_request/3, put_inline_request/3,
          append_inline_response/3, update_inline_request/4,
-         get_state_data/1, set_state_data/2]).
+         get_state_data/1, set_state_data/2,
+         request_block_future_stream_features/1]).
 
 -type maybe_binary() :: undefined | binary().
 -type status() :: pending | success | failure.
@@ -297,19 +298,33 @@ process_sasl2_success(SaslAcc, OriginalStateData, MaybeServerOut) ->
     mongoose_c2s_acc:pairs().
 build_to_c2s_acc(SaslAcc, C2SData, OriginalStateData, SuccessStanza) ->
     ModState = get_mod_state(SaslAcc),
+    MaybeSocketSendStreamFeatures = maybe_stream_features(SaslAcc, C2SData),
     case is_new_c2s_state_requested(SaslAcc, OriginalStateData) of
+        false ->
+            %% Unless specified by an inline feature, sasl2 would normally put the statem just before bind
+            ToAcc0 = [{actions, [pop_callback_module, mongoose_c2s:state_timeout(C2SData)]},
+                      {state_mod, {?MODULE, ModState#{authenticated := true}}}],
+            MaybeSocketSendStreamFeatures ++
+                [{socket_send_first, SuccessStanza},
+                 {c2s_state, {wait_for_feature_after_auth, ?BIND_RETRIES}} | ToAcc0];
         true ->
             ToAcc0 = [{actions, [pop_callback_module]},
                       {state_mod, {?MODULE, ModState#{authenticated := true}}}],
-            [{socket_send_first, SuccessStanza} | ToAcc0];
+            MaybeSocketSendStreamFeatures ++
+                [{socket_send_first, SuccessStanza} | ToAcc0]
+    end.
+
+-spec request_block_future_stream_features(mongoose_acc:t()) -> mongoose_acc:t().
+request_block_future_stream_features(SaslAcc) ->
+    mongoose_acc:set(?MODULE, stream_features, false, SaslAcc).
+
+-spec maybe_stream_features(mongoose_acc:t(), mongoose_c2s:data()) -> [{socket_send, exml:element()}].
+maybe_stream_features(SaslAcc, C2SData) ->
+    case mongoose_acc:get(?MODULE, stream_features, true, SaslAcc) of
+        true ->
+            [{socket_send, mongoose_c2s_stanzas:stream_features_after_auth(C2SData)}];
         false ->
-            %% Unless specified by an inline feature, sasl2 would normally put the statem just before bind
-            StreamFeaturesStanza = mongoose_c2s_stanzas:stream_features_after_auth(C2SData),
-            ToAcc0 = [{actions, [pop_callback_module, mongoose_c2s:state_timeout(C2SData)]},
-                      {state_mod, {?MODULE, ModState#{authenticated := true}}}],
-            [{socket_send_first, SuccessStanza},
-             {socket_send, StreamFeaturesStanza},
-             {c2s_state, {wait_for_feature_after_auth, ?BIND_RETRIES}} | ToAcc0]
+            []
     end.
 
 -spec is_new_c2s_state_requested(mongoose_acc:t(), c2s_state_data()) -> boolean().

--- a/src/mod_sasl2.erl
+++ b/src/mod_sasl2.erl
@@ -391,7 +391,7 @@ if_provided_then_is_not_invalid_uuid_v4(Binary) ->
         Uuid
     catch
         exit:badarg:_ -> invalid_agent;
-        error:badmatch:_ -> invalid_agent
+        error:{badmatch, false}:_ -> invalid_agent
     end.
 
 -spec feature(mongoose_c2s:data(), [exml:element()]) -> exml:element().

--- a/src/stream_management/mod_stream_management_sasl2.erl
+++ b/src/stream_management/mod_stream_management_sasl2.erl
@@ -1,0 +1,121 @@
+-module(mod_stream_management_sasl2).
+
+-define(SM, mod_stream_management).
+
+-include("jlib.hrl").
+-include("mongoose_ns.hrl").
+
+-export([hooks/1]).
+
+-export([sasl2_stream_features/3,
+         sasl2_start/3,
+         sasl2_success/3,
+         bind2_stream_features/3,
+         bind2_enable_features/3]).
+
+%% Helpers
+-spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
+hooks(HostType) ->
+    [
+     {sasl2_stream_features, HostType, fun ?MODULE:sasl2_stream_features/3, #{}, 50},
+     {sasl2_start, HostType, fun ?MODULE:sasl2_start/3, #{}, 50},
+     {sasl2_success, HostType, fun ?MODULE:sasl2_success/3, #{}, 20},
+     {bind2_stream_features, HostType, fun ?MODULE:bind2_stream_features/3, #{}, 50},
+     {bind2_enable_features, HostType, fun ?MODULE:bind2_enable_features/3, #{}, 50}
+    ].
+
+%% Hook handlers
+-spec sasl2_stream_features(Acc, #{c2s_data := mongoose_c2s:data()}, gen_hook:extra()) ->
+    {ok, Acc} when Acc :: [exml:element()].
+sasl2_stream_features(Acc, _, _) ->
+    Resume = #xmlel{name = <<"resume">>, attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}]},
+    {ok, [Resume | Acc]}.
+
+-spec sasl2_start(SaslAcc, #{stanza := exml:element()}, gen_hook:extra()) ->
+    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
+sasl2_start(SaslAcc, #{stanza := El}, _) ->
+    case exml_query:path(El, [{element_with_ns, <<"resume">>, ?NS_STREAM_MGNT_3}]) of
+        undefined ->
+            {ok, SaslAcc};
+        SmRequest ->
+            {ok, mod_sasl2:put_inline_request(SaslAcc, ?MODULE, SmRequest)}
+    end.
+
+%% If SASL2 inline stream resumption is requested, that MUST be processed FIRST by the server.
+-spec sasl2_success(mongoose_acc:t(), mod_sasl2:c2s_state_data(), gen_hook:extra()) ->
+    mongoose_c2s_hooks:result().
+sasl2_success(SaslAcc, _, _) ->
+    case mod_sasl2:get_inline_request(SaslAcc, ?MODULE, undefined) of
+        undefined ->
+            {ok, SaslAcc};
+        SmRequest ->
+            handle_sasl2_resume(SaslAcc, SmRequest)
+    end.
+
+-spec bind2_stream_features(Acc, #{c2s_data := mongoose_c2s:data()}, gen_hook:extra()) ->
+    {ok, Acc} when Acc :: [exml:element()].
+bind2_stream_features(Acc, _, _) ->
+    SmFeature = #xmlel{name = <<"feature">>, attrs = [{<<"var">>, ?NS_STREAM_MGNT_3}]},
+    {ok, [SmFeature | Acc]}.
+
+-spec bind2_enable_features(SaslAcc, mod_sasl2:c2s_state_data(), gen_hook:extra()) ->
+    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
+bind2_enable_features(SaslAcc, Params, _) ->
+    Inline = #{request := BindRequest} = mod_bind2:get_bind_request(SaslAcc),
+    case exml_query:subelement_with_name_and_ns(BindRequest, <<"enable">>, ?NS_STREAM_MGNT_3) of
+        undefined ->
+            {ok, SaslAcc};
+        El ->
+            handle_bind_enable(SaslAcc, Params, Inline, El)
+    end.
+
+%% If resumption is successful:
+%% - MUST skip resource binding (a resumed session already has a resource bound)
+%% - MUST entirely ignore the potentially inlined <bind/> request
+%% - MUST NOT send stream features in this case (overriding behaviour defined in SASL2)
+-spec handle_sasl2_resume(mongoose_acc:t(), mod_sasl2:inline_request()) ->
+    mongoose_c2s_hooks:result().
+handle_sasl2_resume(SaslAcc, #{request := El}) ->
+    #{c2s_state := C2SState, c2s_data := C2SData} = mod_sasl2:get_state_data(SaslAcc),
+    case mod_stream_management:handle_resume(C2SData, C2SState, El) of
+        {stream_mgmt_error, ErrorStanza} ->
+            {ok, mod_sasl2:update_inline_request(SaslAcc, ?MODULE, ErrorStanza, failure)};
+        {error, _ErrorStanza, _Reason} -> %% This signifies a stream-error, but we discard those here
+            SimpleErrorStanza = mod_stream_management_stanzas:stream_mgmt_failed(<<"bad-request">>),
+            {ok, mod_sasl2:update_inline_request(SaslAcc, ?MODULE, SimpleErrorStanza, failure)};
+        {error, ErrorStanza} ->
+            {ok, mod_sasl2:update_inline_request(SaslAcc, ?MODULE, ErrorStanza, failure)};
+        {ok, #{resumed := Resumed, forward := ToForward} = Ret} ->
+            SaslAcc1 = mod_sasl2:update_inline_request(SaslAcc, ?MODULE, Resumed, success),
+            SaslAcc2 = mod_sasl2:set_state_data(SaslAcc1, Ret),
+            %% We stop here to completely ignore subsequent inlines (for example BIND2)
+            {stop, mongoose_c2s_acc:to_acc(SaslAcc2, socket_send, ToForward)}
+    end.
+
+-spec handle_bind_enable(SaslAcc, mod_sasl2:c2s_state_data(), mod_sasl2:inline_request(), exml:element()) ->
+    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
+handle_bind_enable(SaslAcc, #{c2s_data := C2SData}, Inline, El) ->
+    case mod_stream_management:if_not_already_enabled_create_sm_state(C2SData) of
+        error ->
+            mod_stream_management:stream_error(SaslAcc, C2SData);
+        SmState ->
+            do_handle_bind_enable(SaslAcc, C2SData, SmState, Inline, El)
+    end.
+
+-spec do_handle_bind_enable(SaslAcc, mongoose_c2s:data(), mod_stream_management:sm_state(), mod_sasl2:inline_request(), exml:element()) ->
+    {ok, SaslAcc} when SaslAcc :: mongoose_acc:t().
+do_handle_bind_enable(SaslAcc, C2SData, SmState, Inline, El) ->
+    case exml_query:attr(El, <<"resume">>, false) of
+        false ->
+            Stanza = mod_stream_management_stanzas:stream_mgmt_enabled(),
+            SaslAcc1 = mongoose_c2s_acc:to_acc(SaslAcc, state_mod, {?SM, SmState}),
+            SaslAcc2 = mod_bind2:append_inline_bound_answer(SaslAcc1, Inline, Stanza),
+            {ok, SaslAcc2};
+        Attr when Attr =:= <<"true">>; Attr =:= <<"1">> ->
+            Stanza = mod_stream_management:register_smid_return_enabled_stanza(C2SData),
+            SaslAcc1 = mongoose_c2s_acc:to_acc(SaslAcc, state_mod, {?SM, SmState}),
+            SaslAcc2 = mod_bind2:append_inline_bound_answer(SaslAcc1, Inline, Stanza),
+            {ok, SaslAcc2};
+        _ ->
+            mod_stream_management:stream_error(SaslAcc, C2SData)
+    end.

--- a/src/stream_management/mod_stream_management_sasl2.erl
+++ b/src/stream_management/mod_stream_management_sasl2.erl
@@ -28,7 +28,7 @@ hooks(HostType) ->
 -spec sasl2_stream_features(Acc, #{c2s_data := mongoose_c2s:data()}, gen_hook:extra()) ->
     {ok, Acc} when Acc :: [exml:element()].
 sasl2_stream_features(Acc, _, _) ->
-    Resume = #xmlel{name = <<"resume">>, attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}]},
+    Resume = #xmlel{name = <<"sm">>, attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}]},
     {ok, [Resume | Acc]}.
 
 -spec sasl2_start(SaslAcc, #{stanza := exml:element()}, gen_hook:extra()) ->

--- a/src/stream_management/mod_stream_management_sasl2.erl
+++ b/src/stream_management/mod_stream_management_sasl2.erl
@@ -88,8 +88,9 @@ handle_sasl2_resume(SaslAcc, #{request := El}) ->
         {ok, #{resumed := Resumed, forward := ToForward} = Ret} ->
             SaslAcc1 = mod_sasl2:update_inline_request(SaslAcc, ?MODULE, Resumed, success),
             SaslAcc2 = mod_sasl2:set_state_data(SaslAcc1, Ret),
+            SaslAcc3 = mod_sasl2:request_block_future_stream_features(SaslAcc2),
             %% We stop here to completely ignore subsequent inlines (for example BIND2)
-            {stop, mongoose_c2s_acc:to_acc(SaslAcc2, socket_send, ToForward)}
+            {stop, mongoose_c2s_acc:to_acc(SaslAcc3, socket_send, ToForward)}
     end.
 
 -spec handle_bind_enable(SaslAcc, mod_sasl2:c2s_state_data(), mod_sasl2:inline_request(), exml:element()) ->

--- a/src/stream_management/mod_stream_management_stanzas.erl
+++ b/src/stream_management/mod_stream_management_stanzas.erl
@@ -1,0 +1,68 @@
+-module(mod_stream_management_stanzas).
+
+-include("jlib.hrl").
+-include("mongoose_ns.hrl").
+
+-export([
+         sm/0,
+         stream_mgmt_enabled/0,
+         stream_mgmt_enabled/1,
+         stream_mgmt_resumed/2,
+         stream_mgmt_failed/1,
+         stream_mgmt_failed/2,
+         stream_mgmt_ack/1,
+         stream_mgmt_request/0,
+         sm_handled_count_too_high_stanza/2
+        ]).
+
+-spec sm() -> exml:element().
+sm() ->
+    #xmlel{name = <<"sm">>,
+           attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}]}.
+
+-spec stream_mgmt_enabled() -> exml:element().
+stream_mgmt_enabled() ->
+    stream_mgmt_enabled([]).
+
+-spec stream_mgmt_enabled([exml:attr()]) -> exml:element().
+stream_mgmt_enabled(ExtraAttrs) ->
+    #xmlel{name = <<"enabled">>,
+           attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}] ++ ExtraAttrs}.
+
+-spec stream_mgmt_resumed(mod_stream_management:smid(), mod_stream_management:short()) ->
+    exml:element().
+stream_mgmt_resumed(SMID, Handled) ->
+    #xmlel{name = <<"resumed">>,
+           attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3},
+                    {<<"previd">>, SMID},
+                    {<<"h">>, integer_to_binary(Handled)}]}.
+
+-spec stream_mgmt_failed(binary()) -> exml:element().
+stream_mgmt_failed(Reason) ->
+    stream_mgmt_failed(Reason, []).
+
+-spec stream_mgmt_failed(binary(), [exml:attr()]) -> exml:element().
+stream_mgmt_failed(Reason, Attrs) ->
+    ReasonEl = #xmlel{name = Reason,
+                      attrs = [{<<"xmlns">>, ?NS_STANZAS}]},
+    #xmlel{name = <<"failed">>,
+           attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3} | Attrs],
+           children = [ReasonEl]}.
+
+-spec stream_mgmt_ack(non_neg_integer()) -> exml:element().
+stream_mgmt_ack(NIncoming) ->
+    #xmlel{name = <<"a">>,
+           attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3},
+                    {<<"h">>, integer_to_binary(NIncoming)}]}.
+
+-spec stream_mgmt_request() -> exml:element().
+stream_mgmt_request() ->
+    #xmlel{name = <<"r">>,
+           attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3}]}.
+
+-spec sm_handled_count_too_high_stanza(non_neg_integer(), non_neg_integer()) -> exml:element().
+sm_handled_count_too_high_stanza(Handled, OldAcked) ->
+    #xmlel{name = <<"handled-count-too-high">>,
+           attrs = [{<<"xmlns">>, ?NS_STREAM_MGNT_3},
+                    {<<"h">>, integer_to_binary(Handled)},
+                    {<<"send-count">>, integer_to_binary(OldAcked)}]}.


### PR DESCRIPTION
This PR introduces BIND2 support for carbons, csi, and sm.

As described in
- https://xmpp.org/extensions/xep-0388.html (SASL2 XEP)
- https://xmpp.org/extensions/xep-0386.html (BIND2 XEP)
- https://github.com/xsf/xeps/pull/1215 (changes to the stream-management XEP specifying the interactions with SASL2 and BIND2)

Note that the changes to SM are not accepted yet (at the moment of writing), and for a while they claimed the SM feature inlined into SASL2 should be announced as `resume` but then it was requested it should announce `sm`, as other XMPP servers and clients have already done.