### PR TITLE
Stop the test-runner process if any of parallel subtasks fail

### DIFF
--- a/tools/parallel.sh
+++ b/tools/parallel.sh
@@ -8,6 +8,7 @@ PARALLEL_ENABLED=${PARALLEL_ENABLED-true}
 # Add prefix to all lines of the output
 function exec_with_prefix
 {
+  set -eo pipefail
   NAME="$1"
   shift
   if [ "$NAME" = "false" ]; then
@@ -38,10 +39,13 @@ function init_parallel
   fi
 }
 
+PARALLEL_PIDS=""
+
 function parallel
 {
   if [ "$PARALLEL_ENABLED" = "true" ]; then
     exec_with_prefix $@ &
+    PARALLEL_PIDS="$PARALLEL_PIDS $!"
   else
     shift # ignore an argument with a prefix
     $@
@@ -51,7 +55,25 @@ function parallel
 function wait_for_parallel
 {
   if [ "$PARALLEL_ENABLED" = "true" ]; then
-    wait
-    echo "Done $1"
+    # https://stackoverflow.com/questions/49513335/bash-wait-exit-on-error-code
+    set -e
+    werr=0
+    err=0
+    for pid in $PARALLEL_PIDS; do
+      wait $pid || werr=$?
+      ! [ $werr = 127 ] || break
+      err=$werr
+      ## To handle *as soon as* first failure happens uncomment this:
+      [ $err = 0 ] || break
+    done
+    ## If you want to still wait for children to finish before exiting
+    ## parent (even if you handle the failed child early) uncomment this:
+    #trap 'wait || :' EXIT
+    if [ $err = 0 ]; then
+      echo "Done $1"
+    else
+      echo "Failed $1"
+      exit $err
+    fi
   fi
 }


### PR DESCRIPTION
This PR addresses "If there is a compilation error, test runner keeps going".

Proposed changes include:
* Gather a list of pids to wait.
* Wait for the pids and handle the exit code.

