### PR TITLE
Fix invalid username in scram authentication

### DIFF
--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -92,7 +92,8 @@ all_tests() ->
     [log_one,
      log_non_existent_plain,
      log_one_scram_sha1,
-     log_non_existent_scram
+     log_non_existent_scram,
+     log_bad_user_fails
     ].
 
 access_tests() ->
@@ -377,6 +378,14 @@ log_non_existent_digest(Config) ->
 log_non_existent_scram(Config) ->
     R = log_non_existent([{escalus_auth_method, <<"SCRAM-SHA-1">>} | Config]),
     {expected_challenge, _, _} = R.
+
+log_bad_user_fails(Config) ->
+    Config1 = [{escalus_auth_method, <<"SCRAM-SHA-1">>} | Config],
+    [{kate, UserSpec}] = escalus_users:get_users([kate]),
+    UserSpec1 = lists:keyreplace(username, 1, UserSpec, {username, <<" kate">>}),
+    {error, {connection_step_failed, _, R}} = escalus_client:start(Config1, UserSpec1, <<"res">>),
+    {expected_challenge, got, Xmlel} = R,
+    #xmlel{name = <<"failure">>} = Xmlel.
 
 log_non_existent(Config) ->
     [{kate, UserSpec}] = escalus_users:get_users([kate]),

--- a/src/sasl/cyrsasl_scram.erl
+++ b/src/sasl/cyrsasl_scram.erl
@@ -8,6 +8,7 @@
 -export([mech_new/3, mech_step/2]).
 
 -include("mongoose.hrl").
+-include("jlib.hrl").
 
 -behaviour(cyrsasl).
 
@@ -24,31 +25,39 @@ mech_new(LServer, Creds, #{sha := Sha,
                            auth_mech := AuthMech,
                            scram_plus := ScramPlus}) ->
     ChannelBinding = calculate_channel_binding(Socket, ScramPlus, Sha, AuthMech),
-    Fun = fun(Username, St0) ->
-                  JID = jid:make_bare(Username, LServer),
-                  HostType = mongoose_credentials:host_type(Creds),
-                  case get_scram_attributes(HostType, JID, Sha) of
-                      {AuthModule, {StoredKey, ServerKey, Salt, ItCount}} ->
-                          Creds1 = fast_scram:mech_get(creds, St0, Creds),
-                          R = [{username, Username}, {auth_module, AuthModule}],
-                          Creds2 = mongoose_credentials:extend(Creds1, R),
-                          St1 = fast_scram:mech_set(creds, Creds2, St0),
-                          ExtraConfig = #{it_count => ItCount, salt => Salt,
-                                          auth_data => #{stored_key => StoredKey,
-                                                         server_key => ServerKey}},
-                          {St1, ExtraConfig};
-                      {error, Reason, User} ->
-                          {error, {Reason, User}}
-                  end
-          end,
     {ok, St0} = fast_scram:mech_new(
                         #{entity => server,
                           hash_method => Sha,
-                          retrieve_mechanism => Fun,
+                          retrieve_mechanism => retrieve_mechanism_fun(LServer, Creds, Sha),
                           nonce_size => ?NONCE_LENGTH,
                           channel_binding => ChannelBinding}),
     St1 = fast_scram:mech_set(creds, Creds, St0),
     {ok, St1}.
+
+retrieve_mechanism_fun(LServer, Creds, Sha) ->
+    fun(Username, St0) ->
+            case jid:make_bare(Username, LServer) of
+                error -> {error, {invalid_username, Username}};
+                JID ->
+                    retrieve_mechanism_continue(JID, Creds, Sha, St0)
+            end
+    end.
+
+retrieve_mechanism_continue(#jid{luser = Username} = JID, Creds, Sha, St0) ->
+    HostType = mongoose_credentials:host_type(Creds),
+    case get_scram_attributes(HostType, JID, Sha) of
+        {AuthModule, {StoredKey, ServerKey, Salt, ItCount}} ->
+            Creds1 = fast_scram:mech_get(creds, St0, Creds),
+            R = [{username, Username}, {auth_module, AuthModule}],
+            Creds2 = mongoose_credentials:extend(Creds1, R),
+            St1 = fast_scram:mech_set(creds, Creds2, St0),
+            ExtraConfig = #{it_count => ItCount, salt => Salt,
+                            auth_data => #{stored_key => StoredKey,
+                                           server_key => ServerKey}},
+            {St1, ExtraConfig};
+        {error, Reason, User} ->
+            {error, {Reason, User}}
+    end.
 
 mech_step(State, ClientIn) ->
     case fast_scram:mech_step(State, ClientIn) of


### PR DESCRIPTION
Addresses MIM-2035

When the connecting user starts SASL authentication with SCRAM, e.g.
```
<auth mechanism="SCRAM-SHA-512">biwsbj0gYm9iLHI9NGVLZkZBLzVjbWp2N3FGR1FNY1V4dz09</auth>
```

which decodes to
```
n,,n= bob,r=4eKfFA/5cmjv7qFGQMcUxw==
```

MongooseIM has the following error in the logs:
```
when=2023-09-07T08:52:53.097286+00:00 level=error reason="{error,function_clause,[{ejabberd_auth,get_passterm_with_authmodule,[<<\"advanced\">>,error],[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/auth/ejabberd_auth.erl\"},{line,295}]},{cyrsasl_scram,get_scram_attributes,3,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl_scram.erl\"},{line,69}]},{cyrsasl_scram,'-mech_new/3-fun-0-',5,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl_scram.erl\"},{line,30}]},{fast_scram,apply_fun,2,[{file,\"fast_scram.erl\"},{line,165}]},{fast_scram,mech_step,2,[{file,\"fast_scram.erl\"},{line,106}]},{cyrsasl_scram,mech_step,2,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl_scram.erl\"},{line,54}]},{cyrsasl,server_step,2,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl.erl\"},{line,130}]},{mongoose_c2s,do_handle_auth_start,4,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/c2s/mongoose_c2s.erl\"},{line,400}]}]}" pid=<0.19732.0> at=gen_statem:error_info/7:2617 state_enter=false timeouts={1,[{state_timeout,state_timeout_termination}]} postponed= callback_mode=handle_event_function client_info=undefined modules=[mongoose_c2s] queue="[{internal,{xmlel,<<\"auth\">>,[{<<\"mechanism\">>,<<\"SCRAM-SHA-512\">>},{<<\"xmlns\">>,<<\"urn:ietf:params:xml:ns:xmpp-sasl\">>}],[{xmlcdata,<<\"biwsbj0gYm9iLHI9NGVLZkZBLzVjbWp2N3FGR1FNY1V4dz09\">>}]}}]" state="{{wait_for_feature_before_auth,{sasl_state,<<\"jabber\">>,<<\"test-erlang-solutions1693992338.trymongoose.im\">>,<<\"advanced\">>,<<>>,undefined,undefined,{mongoose_credentials,<<\"test-erlang-solutions1693992338.trymongoose.im\">>,<<\"advanced\">>,[],[],[ejabberd_auth_rdbms]}},3},{c2s_data,<<\"advanced\">>,<<\"test-erlang-solutions1693992338.trymongoose.im\">>,<<\"en\">>,{1694076773095334,<0.19732.0>},<<\"7db3caad6170885d\">>,undefined,{c2s_socket,mod_websockets,{websocket,<0.19730.0>,{{127,0,0,1},55613},undefined}},{parser,#Ref<0.1133472776.1103495169.169242>,[]},none,#{access => all,port => 5280,shaper => none,hibernate_after => 0,max_stanza_size => 0,ip_tuple => {0,0,0,0},c2s_state_timeout => 5000,backwards_compatible_session => true,proto => tcp,xml_socket => true},#{},#{}}}" log= name=<0.19732.0> label={gen_statem,terminate}
when=2023-09-07T08:52:53.099650+00:00 level=error pid=<0.19732.0> at=proc_lib:crash_report/4:584 report="[[{initial_call,{mongoose_c2s,init,['Argument__1']}},{pid,<0.19732.0>},{registered_name,[]},{error_info,{error,function_clause,[{ejabberd_auth,get_passterm_with_authmodule,[<<\"advanced\">>,error],[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/auth/ejabberd_auth.erl\"},{line,295}]},{cyrsasl_scram,get_scram_attributes,3,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl_scram.erl\"},{line,69}]},{cyrsasl_scram,'-mech_new/3-fun-0-',5,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl_scram.erl\"},{line,30}]},{fast_scram,apply_fun,2,[{file,\"fast_scram.erl\"},{line,165}]},{fast_scram,mech_step,2,[{file,\"fast_scram.erl\"},{line,106}]},{cyrsasl_scram,mech_step,2,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl_scram.erl\"},{line,54}]},{cyrsasl,server_step,2,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl.erl\"},{line,130}]},{mongoose_c2s,do_handle_auth_start,4,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/c2s/mongoose_c2s.erl\"},{line,400}]}]}},{ancestors,[mongoose_c2s_sup,ejabberd_sup,<0.340.0>]},{message_queue_len,0},{messages,[]},{links,[<0.619.0>]},{dictionary,[]},{trap_exit,false},{status,running},{heap_size,10958},{stack_size,28},{reductions,76483}],[]]" label={proc_lib,crash}
when=2023-09-07T08:52:53.101167+00:00 level=error pid=<0.619.0> at=supervisor:do_restart/3:757 report="[{supervisor,{local,mongoose_c2s_sup}},{errorContext,child_terminated},{reason,{function_clause,[{ejabberd_auth,get_passterm_with_authmodule,[<<\"advanced\">>,error],[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/auth/ejabberd_auth.erl\"},{line,295}]},{cyrsasl_scram,get_scram_attributes,3,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl_scram.erl\"},{line,69}]},{cyrsasl_scram,'-mech_new/3-fun-0-',5,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl_scram.erl\"},{line,30}]},{fast_scram,apply_fun,2,[{file,\"fast_scram.erl\"},{line,165}]},{fast_scram,mech_step,2,[{file,\"fast_scram.erl\"},{line,106}]},{cyrsasl_scram,mech_step,2,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl_scram.erl\"},{line,54}]},{cyrsasl,server_step,2,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/sasl/cyrsasl.erl\"},{line,130}]},{mongoose_c2s,do_handle_auth_start,4,[{file,\"/Users/pawelchrzaszcz/dev/mongoose/src/c2s/mongoose_c2s.erl\"},{line,400}]}]}},{offender,[{pid,<0.19732.0>},{id,undefined},{mfargs,{mongoose_c2s,start_link,undefined}},{restart_type,temporary},{significant,false},{shutdown,brutal_kill},{child_type,worker}]}]" label={supervisor,child_terminated}
10:52:53.098 [error] gen_statem <0.19732.0> in state {wait_for_feature_before_auth,{sasl_state,<<106,97,98,98,101,114>>,<<116,101,115,116,45,101,114,108,97,110,103,45,115,111,108,117,116,105,111,110,115,49,54,57,51,57,57,50,51,51,56,46,116,114,121,109,111,110,103,111,111,115,101,46,105,109>>,<<97,100,118,97,110,99,101,100>>,<<>>,undefined,undefined,{mongoose_credentials,<<116,101,115,116,45,101,114,108,97,110,103,45,115,111,108,117,116,105,111,110,115,49,54,57,51,57,57,50,51,51,56,46,116,114,121,109,111,110,103,111,111,115,101,46,105,109>>,<<97,100,118,97,110,99,101,100>>,[],[],[ejabberd_auth_rdbms]}},3} terminated with reason: {function_clause,handle_event_function}
10:52:53.099 [error] CRASH REPORT Process <0.19732.0> with 0 neighbours crashed with reason: no function clause matching ejabberd_auth:get_passterm_with_authmodule(<<"advanced">>, error) line 295
10:52:53.101 [error] Supervisor mongoose_c2s_sup had child undefined started with {mongoose_c2s,start_link,undefined} at <0.19732.0> exit with reason no function clause matching ejabberd_auth:get_passterm_with_authmodule(<<"advanced">>, error) line 295 in context child_terminated
```

This is all because the user name starts with a space, and string-prepping results with an error atom, which is then passed to the following functions - and this shouldn’t take place.

MongooseIM should return with a proper authentication error instead.