### PR TITLE
Update XEP-0215: External Service Discovery

### DIFF
--- a/doc/modules/mod_extdisco.md
+++ b/doc/modules/mod_extdisco.md
@@ -34,9 +34,9 @@ Service type, common values are `"stun"`, `"turn"`, `"ftp"`.
 Hostname or an IP address where the service is hosted.
 
 #### `modules.mod_extdisco.service.port`
-* **Syntax:** string
+* **Syntax:** integer, between 0 and 65535, non-inclusive
 * **Default:** none, this option is recommended
-* **Example:** `port = "3478"`
+* **Example:** `port = 3478`
 
 The communications port to be used at the host.
 

--- a/src/mod_extdisco.erl
+++ b/src/mod_extdisco.erl
@@ -16,7 +16,7 @@
 -module (mod_extdisco).
 -author('jan.ciesla@erlang-solutions.com').
 
--xep([{xep, 215}, {version, "0.7"}]).
+-xep([{xep, 215}, {version, "1.0.0"}]).
 -behaviour(gen_mod).
 
 %% gen_mod callbacks.


### PR DESCRIPTION
This PR addresses MIM-2038.

Changes in the newest XEP included:
- XML schema was fixed to allow more than a single `<service/>` in `<services/>`. We’re not restricting services in `mod_extdisco:process_iq/5` nor in `mod_extdisco:get_external_services/1`. No change is required.
- `port` in XML schema is now restricted to `xs:unsignedShort` but optional. It already reflected in `mod_extdisco:service_config_spec/0`. No change is required.

Additionally I fixed documentation about the service port. It was saying that port should be a string while an example of the whole config had an integer there. Also, I tested that when you put a string in such config then MongooseIM crashes during start.