### PR TITLE
Dialyzer extra checks

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,8 @@
             {d, xml_nif},
             {d, namespaced_types},
             {platform_define, "^(20)", fun_stacktrace},
-            {platform_define, "^(25)", gen_server_request_id}]}.
+            {platform_define, "^(25)", gen_server_request_id},
+            {platform_define, "^(26)", dialyzer_has_missing_return_attribute}]}.
 
 %% For behaviour info
 {erl_first_files, [

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,3 +1,4 @@
+% vim: syntax=erlang
 os:putenv("EXOMETER_PACKAGES", "(minimal)"),
 
 MaybeReadFromConfig =

--- a/src/auth/ejabberd_auth_external.erl
+++ b/src/auth/ejabberd_auth_external.erl
@@ -132,7 +132,7 @@ check_password(HostType, LUser, LServer, Password, _Digest, _DigestGen) ->
 -spec set_password(HostType :: mongooseim:host_type(),
                    LUser :: jid:luser(),
                    LServer :: jid:lserver(),
-                   Password :: binary()) -> ok | {error, not_allowed}.
+                   Password :: binary()) -> ok | {error, not_allowed} | {error, unknown_problem}.
 set_password(HostType, LUser, LServer, Password) ->
     case extauth:set_password(HostType, LUser, LServer, Password) of
         true ->

--- a/src/auth/mongoose_gen_auth.erl
+++ b/src/auth/mongoose_gen_auth.erl
@@ -79,7 +79,7 @@
                        User :: jid:luser(),
                        Server :: jid:lserver(),
                        Password :: binary()) ->
-    ok | {error, not_allowed | invalid_jid | user_not_found}.
+    ok | {error, not_allowed | invalid_jid | user_not_found | unknown_problem}.
 
 -callback remove_user(HostType :: mongooseim:host_type(),
                       User :: jid:luser(),
@@ -204,7 +204,7 @@ get_password_s(Mod, HostType, LUser, LServer) ->
 
 -spec set_password(ejabberd_auth:authmodule(), mongooseim:host_type(),
                    jid:luser(), jid:lserver(), binary()) ->
-          ok | {error, not_allowed | invalid_jid}.
+          ok | {error, not_allowed | invalid_jid | unknown_problem}.
 set_password(Mod, HostType, LUser, LServer, Password) ->
     case is_exported(Mod, set_password, 4) of
         true -> Mod:set_password(HostType, LUser, LServer, Password);

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -857,17 +857,19 @@ reroute_one(#c2s_data{sid = Sid}, Acc) ->
     Acc2 = patch_acc_for_reroute(Acc, Sid),
     ejabberd_router:route(From, To, Acc2).
 
--spec reroute_buffer(data(), [mongoose_acc:t()]) -> term().
+-spec reroute_buffer(data(), [mongoose_acc:t()]) -> ok.
 reroute_buffer(StateData = #c2s_data{host_type = HostType, jid = Jid}, Buffer) ->
     OrderedBuffer = lists:reverse(Buffer),
     FilteredBuffer = mongoose_hooks:filter_unacknowledged_messages(HostType, Jid, OrderedBuffer),
-    [reroute_one(StateData, BufferedAcc) || BufferedAcc <- FilteredBuffer].
+    [reroute_one(StateData, BufferedAcc) || BufferedAcc <- FilteredBuffer],
+    ok.
 
--spec reroute_buffer_to_pid(data(), pid(), [mongoose_acc:t()]) -> term().
+-spec reroute_buffer_to_pid(data(), pid(), [mongoose_acc:t()]) -> ok.
 reroute_buffer_to_pid(StateData = #c2s_data{host_type = HostType, jid = Jid}, Pid, Buffer) ->
     OrderedBuffer = lists:reverse(Buffer),
     FilteredBuffer = mongoose_hooks:filter_unacknowledged_messages(HostType, Jid, OrderedBuffer),
-    [reroute_one_to_pid(StateData, Pid, BufferedAcc) || BufferedAcc <- FilteredBuffer].
+    [reroute_one_to_pid(StateData, Pid, BufferedAcc) || BufferedAcc <- FilteredBuffer],
+    ok.
 
 -spec reroute_one_to_pid(data(), pid(), mongoose_acc:t()) -> {route, mongoose_acc:t()}.
 reroute_one_to_pid(#c2s_data{sid = Sid}, Pid, Acc) ->

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -30,7 +30,8 @@
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, _Opts) ->
-    ensure_metrics(HostType).
+    ensure_metrics(HostType),
+    ok.
 
 -spec stop(mongooseim:host_type()) -> ok.
 stop(_HostType) ->

--- a/src/s2s/mongoose_s2s_info.erl
+++ b/src/s2s/mongoose_s2s_info.erl
@@ -22,10 +22,11 @@ get_connections(Type) ->
 type_to_supervisor(in) -> ejabberd_s2s_in_sup;
 type_to_supervisor(out) -> ejabberd_s2s_out_sup.
 
+%% temporary supervisors do not allow Pid to be undefined or restarting.
 -spec child_to_pid(supervisor_child_spec()) -> pid().
-child_to_pid({_, Pid, _, _}) -> Pid.
+child_to_pid({_, Pid, _, _}) when is_pid(Pid) -> Pid.
 
--spec get_state_info(pid()) -> [connection_info()].
+-spec get_state_info(pid() | undefined | restarting) -> [connection_info()].
 get_state_info(Pid) when is_pid(Pid) ->
     case gen_fsm_compat:sync_send_all_state_event(Pid, get_state_info) of
         Info when is_map(Info) ->

--- a/src/smart_markers/mod_smart_markers.erl
+++ b/src/smart_markers/mod_smart_markers.erl
@@ -335,7 +335,7 @@ extract_chat_markers(Acc, From, To, Packet) ->
 -spec get_thread(exml:element()) -> maybe_thread().
 get_thread(El) ->
     case exml_query:path(El, [{element, <<"thread">>}, cdata]) of
-        Thread when Thread =/= <<>> -> Thread;
+        Thread when Thread =/= <<>>, is_binary(Thread) -> Thread;
         _ -> undefined
     end.
 

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -93,9 +93,12 @@ tracking_id_section() ->
 
 -spec start_link(mongoose_service:options()) -> {ok, pid()}.
 start_link(Opts) ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, Opts, []).
+    Res = gen_server:start_link({local, ?MODULE}, ?MODULE, Opts, []),
+    check_start_link_result(Res).
 
--spec init(mongoose_service:options()) -> {ok, system_metrics_state()}.
+check_start_link_result(Res = {ok, Pid}) when is_pid(Pid) -> Res.
+
+-spec init(mongoose_service:options()) -> {ok, system_metrics_state()} | ignore.
 init(Opts) ->
     case report_transparency(Opts) of
         skip -> ignore;

--- a/src/vcard/mod_vcard_api.erl
+++ b/src/vcard/mod_vcard_api.erl
@@ -13,7 +13,7 @@
          get_vcard/1]).
 
 -spec set_vcard(jid:jid(), vcard_map()) ->
-     {ok, vcard_map()} | {user_not_found, string()} | {internal, string()} | {vcard_not_found, string()}.
+     {ok, vcard_map()} | {user_not_found, binary()} | {internal, string()} | {vcard_not_found, string()}.
 set_vcard(#jid{luser = LUser, lserver = LServer} = UserJID, Vcard) ->
     case check_user(UserJID) of
         {ok, HostType} ->
@@ -28,7 +28,7 @@ set_vcard(#jid{luser = LUser, lserver = LServer} = UserJID, Vcard) ->
     end.
 
 -spec get_vcard(jid:jid()) ->
-     {ok, vcard_map()} | {user_not_found, string()} | {internal, string()} | {vcard_not_found, string()}
+     {ok, vcard_map()} | {user_not_found, binary()} | {internal, string()} | {vcard_not_found, string()}
    | {vcard_not_configured_error, string()}.
 get_vcard(#jid{luser = LUser, lserver = LServer} = UserJID) ->
     % check if mod_vcard is loaded is needed in user's get_vcard command, when user variable is not passed

--- a/src/vcard/mod_vcard_ldap.erl
+++ b/src/vcard/mod_vcard_ldap.erl
@@ -157,7 +157,7 @@ set_vcard(_HostType, _User, _LServer, _VCard, _VCardSearch) ->
     {error, mongoose_xmpp_errors:not_allowed()}.
 
 -spec search(mongooseim:host_type(), jid:lserver(), [{binary(), [binary()]}]) ->
-          [[mongoose_data_forms:field()]].
+          [[mongoose_data_forms:field()]] | error.
 search(HostType, LServer, Data) ->
     State = get_state(HostType, LServer),
     search_internal(State, Data).

--- a/src/wpool/mongoose_wpool_rabbit.erl
+++ b/src/wpool/mongoose_wpool_rabbit.erl
@@ -5,9 +5,10 @@
 -export([start/4]).
 -export([stop/2]).
 
--spec init() -> ok | {error, any()}.
+-spec init() -> ok.
 init() ->
-    application:ensure_all_started(amqp_client).
+    application:ensure_all_started(amqp_client),
+    ok.
 
 -spec start(mongooseim:host_type_or_global(), mongoose_wpool:tag(),
             mongoose_wpool:pool_opts(), mongoose_wpool:conn_opts()) -> {ok, pid()} | {error, any()}.


### PR DESCRIPTION
This PR addresses "PoC for more dialyzer checks".

Proposed changes include:
* The bug like that https://github.com/esl/MongooseIM/pull/4122 could be easily avoided if we had `missing_return` option enabled for dialyzer.
* Except, enabling it would produce 200 warnings.
* Enabling `extra_return` would make 200 more warnings.
* OTP 25 had no support to disable warnings for functions (it had nowarn attribute, but not per function per check).
* OTP 26 adds extra attributes we use in this PR.

Proposed idea allows to enable missing checks per module basis.
This PR enables the checks for `mod_stream_management`.
The idea is to enable the checks gradually for more and more modules, till we enable the checks for all modules.
After that we could remove the attributes, enable the check for all modules in rebar.config and benifit from proper static type analysis.

These attributes are only supported by OTP 26, so no CI yet (we could add a job for Circle CI though without waiting for all tests to pass on OTP 26).

missing_return would catch the errors like:
- we said we return binary() in spec but we return a string() instead.
- we said we return `{ok, Type}` in spec, but we return `Type` instead.
- sadly, if we use some generic API like mongoose_config, we have to disable the check for that specific function (but it is kinda ok, we usually have getter functions to get options which do not contain any logic. So, disabling the check per function would say dialyzer "yes, trust me, it is that type").

unmatched_returns would force us to write `_ = function_call()`, if the function makes some complex result like `ok | {error, _}` and we silently ignore the result (so, reader would know that the place could require some branching logic).

