### PR TITLE
Put xep list as JSON in the online docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ certs: maybe_clean_certs
 
 xeplist:
 	$(XEP_TOOL)/xep_tool.escript doap doc/mongooseim.doap
+	$(XEP_TOOL)/xep_tool.escript json doc/supported-xeps.json
 	$(XEP_TOOL)/xep_tool.escript markdown doc/user-guide/Supported-XEPs.md
 
 install: configure.out rel


### PR DESCRIPTION
It can be consumed by MongooseKeeper and any future services. JSON is chosen as it is easily human- and machine-readable.

Tested manually - format of `doc/supported-xeps.json` after `make xeplist`:

```
[
  {
    "url" : "https://xmpp.org/extensions/xep-0004.html",
    "xep" : "0004",
    "modules" : [
      "mongoose_data_forms"
    ],
    "version" : "2.13.1",
    "status" : "complete",
    "name" : "Data Forms"
  },
  {
    "url" : "https://xmpp.org/extensions/xep-0012.html",
    "xep" : "0012",
    "modules" : [
      "mod_last"
    ],
    "version" : "2.0",
    "status" : "complete",
    "name" : "Last Activity"
  },
  (...)
]
```

Also tested for a proto-xep (we could add such annotations in a separate PR):

```
  {
    "url" : "https://xmpp.org/extensions/inbox/muc-light.html",
    "xep" : "muc-light",
    "modules" : [
      "mod_muc_light"
    ],
    "version" : "0.0.1",
    "status" : "complete",
    "name" : "Multi-User Chat Light"
  }
]
```