### PR TITLE
CETS backend for mongoose_cluster_id

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -128,8 +128,9 @@
 %% ct_mongoose_hook will:
 %% * ensure preset & mim_data_dir values are passed to ct Config
 %% * check server's purity after SUITE
+%% ct_sanity_hook would warn if test starts/stops internal databases when not expected.
 {ct_hooks, [ct_groups_summary_hook, ct_tty_hook, ct_mongoose_hook, ct_progress_hook,
-            ct_markdown_errors_hook, ct_mongoose_log_hook]}.
+            ct_markdown_errors_hook, ct_mongoose_log_hook, ct_sanity_hook]}.
 
 %% since test-runner.sh can be executed with the --one-node option,
 %% log collection is enabled by default for host mim1 only.

--- a/big_tests/src/ct_sanity_hook.erl
+++ b/big_tests/src/ct_sanity_hook.erl
@@ -1,0 +1,70 @@
+%% @doc Checks that internal databases are not started accidentally.
+-module(ct_sanity_hook).
+
+%% Callbacks
+-export([id/1]).
+-export([init/2]).
+-export([post_init_per_suite/4,
+         post_init_per_group/4,
+         post_init_per_testcase/4]).
+-export([post_end_per_suite/4,
+         post_end_per_group/4,
+         post_end_per_testcase/4]).
+
+%% @doc Return a unique id for this CTH.
+id(_Opts) ->
+    "ct_sanity_hook_001".
+
+init(_Id, _Opts) ->
+    Nodes = alive_mim_nodes(),
+    {ok, #{
+        alive_mim_nodes => Nodes,
+        running_internal_databases => running_internal_databases(Nodes)
+    }}.
+
+post_init_per_suite(_SuiteName, _Config, Return, State) ->
+    {Return, State}.
+
+post_init_per_group(_GroupName, _Config, Return, State) ->
+    {Return, State}.
+
+post_init_per_testcase(_TC, _Config, Return, State) ->
+    {Return, State}.
+
+post_end_per_suite(_SuiteName, _Config, Return, State) ->
+    Return2 = assert_same_databases(State, Return),
+    {Return2, State}.
+
+post_end_per_group(_GroupName, _Config, Return, State) ->
+    {Return, State}.
+
+post_end_per_testcase(_TC, _Config, Return, State) ->
+    {Return, State}.
+
+running_internal_databases(Nodes) ->
+    [{Node, get_databases(Node)} || Node <- Nodes].
+
+get_databases(Node) ->
+    case rpc:call(Node, mongoose_internal_databases, running_internal_databases, []) of
+        List when is_list(List) ->
+            List;
+        Other ->
+            error({get_databases_failed, Node, Other})
+    end.
+
+alive_mim_nodes() ->
+    [Node || Node <- mim_nodes(), net_adm:ping(Node) =:= pong].
+
+mim_nodes() ->
+    [proplists:get_value(node, Opts) || {_, Opts} <- ct:get_config(hosts)].
+
+assert_same_databases(#{alive_mim_nodes := Nodes, running_internal_databases := Old}, Return) ->
+    New = running_internal_databases(Nodes),
+    case Old of
+        New ->
+            Return;
+        _ ->
+            {fail, #{reason => assert_same_databases_failed,
+                     expected_internal_databases => Old,
+                     running_internal_databases => New}}
+    end.

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -24,20 +24,37 @@ add_node_to_cluster(Config) ->
     Node2 = mim2(),
     add_node_to_cluster(Node2, Config).
 
+has_mnesia(Node) ->
+    DBs = rpc(Node, mongoose_internal_databases, configured_internal_databases, []),
+    lists:member(mnesia, DBs).
+
 add_node_to_cluster(Node, Config) ->
+    case has_mnesia(Node) of
+        true ->
+            add_node_to_mnesia_cluster(Node, Config);
+        false ->
+            ok
+    end,
+    Config.
+
+add_node_to_mnesia_cluster(Node, Config) ->
     ClusterMemberNode = maps:get(node, mim()),
     ok = rpc(Node#{timeout => cluster_op_timeout()},
              mongoose_cluster, join, [ClusterMemberNode]),
-    verify_result(Node, add),
-    Config.
+    verify_result(Node, add).
 
 remove_node_from_cluster(_Config) ->
     Node = mim2(),
     remove_node_from_cluster(Node, _Config).
 
 remove_node_from_cluster(Node, _Config) ->
-    ok = rpc(Node#{timeout => cluster_op_timeout()}, mongoose_cluster, leave, []),
-    verify_result(Node, remove),
+    case has_mnesia(Node) of
+        true ->
+            ok = rpc(Node#{timeout => cluster_op_timeout()}, mongoose_cluster, leave, []),
+            verify_result(Node, remove);
+        false ->
+            ok
+    end,
     ok.
 
 ctl_path(Node, Config) ->

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -25,7 +25,9 @@ add_node_to_cluster(Config) ->
     add_node_to_cluster(Node2, Config).
 
 has_mnesia(Node) ->
-    DBs = rpc(Node, mongoose_internal_databases, configured_internal_databases, []),
+    %% It is shometimes called, when MIM application is stopped,
+    %% so we use running_internal_databases instead of configured_internal_databases.
+    DBs = rpc(Node, mongoose_internal_databases, running_internal_databases, []),
     lists:member(mnesia, DBs).
 
 add_node_to_cluster(Node, Config) ->

--- a/big_tests/tests/mongoose_sanity_checks_SUITE.erl
+++ b/big_tests/tests/mongoose_sanity_checks_SUITE.erl
@@ -1,10 +1,25 @@
 -module(mongoose_sanity_checks_SUITE).
 
 -compile([export_all, nowarn_export_all]).
+-import(distributed_helper, [mim/0, rpc/4]).
+-include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    [is_mongooseim].
+    [is_mongooseim,
+     running_internal_databases_match_the_configured_ones].
 
+
+init_per_suite(Config) ->
+    Config ++ distributed_helper:require_rpc_nodes([mim]).
+
+end_per_suite(_Config) ->
+    ok.
 
 is_mongooseim(Config) ->
     mongooseim = escalus_server:name(Config).
+
+running_internal_databases_match_the_configured_ones(_Config) ->
+    Running = rpc(mim(), mongoose_internal_databases, running_internal_databases, []),
+    Config = rpc(mim(), mongoose_internal_databases, configured_internal_databases, []),
+    ?assert(is_list(Config), {Running, Config}),
+    ?assertMatch(Config, Running).

--- a/rebar.config
+++ b/rebar.config
@@ -80,7 +80,7 @@
   {cache_tab, "1.0.30"},
   {segmented_cache, "0.3.0"},
   {worker_pool, "6.0.1"},
-  {cets, {git, "https://github.com/esl/cets.git", {branch, "main"}}},
+  {cets, {git, "https://github.com/esl/cets.git", {branch, "feature/insert-serial"}}},
 
   %%% HTTP tools
   {graphql, {git, "https://github.com/esl/graphql-erlang.git", {branch, "master"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"def7da28917fe7e21ad2b50d1b9939b1da5046cf"}},
+       {ref,"c7c8124c294b606490dffcef8ef7b1fd66bdc47a"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/src/mongoose_cluster_id.erl
+++ b/src/mongoose_cluster_id.erl
@@ -9,9 +9,9 @@
         ]).
 
 % For testing purposes only
--export([clean_table/0]).
+-export([clean_table/0, clean_cache/0]).
 
--ignore_xref([clean_table/0, get_backend_cluster_id/0]).
+-ignore_xref([clean_table/0, clean_cache/0, get_backend_cluster_id/0]).
 
 -record(mongoose_cluster_id, {key :: atom(), value :: cluster_id()}).
 -type cluster_id() :: binary().
@@ -178,3 +178,9 @@ clean_table(rdbms) ->
             {error, {Class, Reason}}
     end;
 clean_table(_) -> ok.
+
+clean_cache() ->
+    clean_cache(which_volatile_backend_available()).
+
+clean_cache(mnesia) ->
+    mnesia:dirty_delete(mongoose_cluster_id, cluster_id).

--- a/src/mongoose_internal_databases.erl
+++ b/src/mongoose_internal_databases.erl
@@ -1,0 +1,61 @@
+-module(mongoose_internal_databases).
+-export([init/0,
+         configured_internal_databases/0,
+         running_internal_databases/0]).
+
+-ignore_xref([configured_internal_databases/0,
+              running_internal_databases/0]).
+
+init() ->
+    case mongoose_config:lookup_opt([internal_databases, mnesia]) of
+        {ok, _} ->
+            init_mnesia(),
+            mongoose_node_num_mnesia:init();
+        {error, _} ->
+            %% Ensure mnesia is stopped when applying the test presets from the big tests.
+            %% So, we accidentually do not test with mnesia enabled, when starting the
+            %% test cases from the clean test build.
+            mnesia:stop(),
+            ok
+    end.
+
+init_mnesia() ->
+    %% Mnesia should not be running at this point, unless it is started by tests.
+    %% Ensure Mnesia is stopped
+    mnesia:stop(),
+    case mnesia:system_info(extra_db_nodes) of
+        [] ->
+            mnesia:create_schema([node()]);
+        _ ->
+            ok
+    end,
+    application:start(mnesia, permanent),
+    mnesia:wait_for_tables(mnesia:system_info(local_tables), infinity).
+
+configured_internal_databases() ->
+    case mongoose_config:lookup_opt([internal_databases, mnesia]) of
+        {ok, _} ->
+            [mnesia];
+        {error, _} ->
+            []
+    end ++
+    case mongoose_config:lookup_opt([internal_databases, cets]) of
+        {ok, _} ->
+            [cets];
+        {error, _} ->
+            []
+    end.
+
+running_internal_databases() ->
+    case mnesia:system_info(is_running) of
+        yes ->
+            [mnesia];
+        no ->
+            []
+    end ++
+    case is_pid(whereis(mongoose_cets_discovery)) of
+        true ->
+            [cets];
+        false ->
+            []
+    end.

--- a/src/mongoose_mnesia.erl
+++ b/src/mongoose_mnesia.erl
@@ -1,0 +1,46 @@
+-module(mongoose_mnesia).
+-export([create_table/2]).
+
+-include("mongoose.hrl").
+
+%% @doc A wrapper around `mnesia:create_table/2':
+%% - Automatically adds table copies.
+%% - Checks that mnesia is running or fail with an error.
+%% - Checks result of create_table
+-spec create_table(atom(), list()) ->
+    {atomic, ok} | {aborted, {already_exists, atom()}}.
+create_table(Table, Opts) ->
+    case mnesia:system_info(is_running) of
+        no ->
+            report_mnesia_table_error(Table, Opts, mnesia_not_running);
+        yes ->
+            Res = mnesia:create_table(Table, Opts),
+            check_create_table_result(Table, Opts, Res),
+            Res
+    end.
+
+check_create_table_result(_Table, _Opts, {atomic, ok}) ->
+    ok;
+check_create_table_result(Table, Opts, {aborted, {already_exists, Table}}) ->
+    [maybe_add_copies(Table, Opts, Type) || Type <- table_types()],
+    ok;
+check_create_table_result(Table, Opts, Res) ->
+    report_mnesia_table_error(Table, Opts, Res).
+
+table_types() ->
+    [disc_copies, disc_only_copies, ram_copies].
+
+report_mnesia_table_error(Table, Opts, Res) ->
+    ?LOG_CRITICAL(#{what => mnesia_create_table_failed,
+                    table => Table, create_opts => Opts, reason => Res,
+                    schema_nodes => catch mnesia:table_info(schema, disc_copies)}),
+    error({mnesia_create_table_failed, Table, Res}).
+
+maybe_add_copies(Table, Opts, Type) ->
+    case proplists:get_value(Type, Opts) of
+        [_|_] ->
+            mnesia:add_table_copy(Table, node(), Type),
+            ok;
+        _ ->
+            ok
+    end.

--- a/src/offline/mod_offline_mnesia.erl
+++ b/src/offline/mod_offline_mnesia.erl
@@ -42,11 +42,10 @@
 
 -spec init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 init(_HostType, _Opts) ->
-    mnesia:create_table(offline_msg,
+    mongoose_mnesia:create_table(offline_msg,
                         [{disc_only_copies, [node()]},
                          {type, bag},
                          {attributes, record_info(fields, offline_msg)}]),
-    mnesia:add_table_copy(offline_msg, node(), disc_only_copies),
     upgrade_table(),
     ok.
 

--- a/src/privacy/mod_privacy_mnesia.erl
+++ b/src/privacy/mod_privacy_mnesia.erl
@@ -46,9 +46,9 @@
 -include("mod_privacy.hrl").
 
 init(_HostType, _Opts) ->
-    mnesia:create_table(privacy, [{disc_copies, [node()]},
+    mongoose_mnesia:create_table(privacy,
+                                 [{disc_copies, [node()]},
                                   {attributes, record_info(fields, privacy)}]),
-    mnesia:add_table_copy(privacy, node(), disc_copies),
     ok.
 
 get_default_list(_HostType, LUser, LServer) ->


### PR DESCRIPTION
This PR addresses "MIM-2040 System metrics fail with no_client_id"

Proposed changes include:
* CETS backend for mongoose_cluster_id.
* `Added cets:insert_serial/2`. See PR for CETS library: https://github.com/esl/cets/pull/33
* Actually ensure that Mnesia is stopped after applying preset. This requires some fixes in distributed_helper, because some functions assume Mnesia is always running.

