### PR TITLE
CETS backend for mongoose_cluster_id (minimal logic)

### DIFF
--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -24,20 +24,37 @@ add_node_to_cluster(Config) ->
     Node2 = mim2(),
     add_node_to_cluster(Node2, Config).
 
+has_mnesia(Node) ->
+    DBs = rpc(Node, mongoose_internal_databases, configured_internal_databases, []),
+    lists:member(mnesia, DBs).
+
 add_node_to_cluster(Node, Config) ->
+    case has_mnesia(Node) of
+        true ->
+            add_node_to_mnesia_cluster(Node, Config);
+        false ->
+            ok
+    end,
+    Config.
+
+add_node_to_mnesia_cluster(Node, Config) ->
     ClusterMemberNode = maps:get(node, mim()),
     ok = rpc(Node#{timeout => cluster_op_timeout()},
              mongoose_cluster, join, [ClusterMemberNode]),
-    verify_result(Node, add),
-    Config.
+    verify_result(Node, add).
 
 remove_node_from_cluster(_Config) ->
     Node = mim2(),
     remove_node_from_cluster(Node, _Config).
 
 remove_node_from_cluster(Node, _Config) ->
-    ok = rpc(Node#{timeout => cluster_op_timeout()}, mongoose_cluster, leave, []),
-    verify_result(Node, remove),
+    case has_mnesia(Node) of
+        true ->
+            ok = rpc(Node#{timeout => cluster_op_timeout()}, mongoose_cluster, leave, []),
+            verify_result(Node, remove);
+        false ->
+            ok
+    end,
     ok.
 
 ctl_path(Node, Config) ->

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -25,7 +25,9 @@ add_node_to_cluster(Config) ->
     add_node_to_cluster(Node2, Config).
 
 has_mnesia(Node) ->
-    DBs = rpc(Node, mongoose_internal_databases, configured_internal_databases, []),
+    %% It is shometimes called, when MIM application is stopped,
+    %% so we use running_internal_databases instead of configured_internal_databases.
+    DBs = rpc(Node, mongoose_internal_databases, running_internal_databases, []),
     lists:member(mnesia, DBs).
 
 add_node_to_cluster(Node, Config) ->

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -25,10 +25,10 @@ add_node_to_cluster(Config) ->
     add_node_to_cluster(Node2, Config).
 
 has_mnesia(Node) ->
-    %% It is shometimes called, when MIM application is stopped,
-    %% so we use running_internal_databases instead of configured_internal_databases.
-    DBs = rpc(Node, mongoose_internal_databases, running_internal_databases, []),
-    lists:member(mnesia, DBs).
+    %% TODO We should check that Mnesia is configured here instead of is_running.
+    %% But it would require the issue fixed first:
+    %% "MIM-2067 Actually disable mnesia from starting in tests in pgsql_cets"
+    rpc(Node, mnesia, system_info, [is_running]) =:= yes.
 
 add_node_to_cluster(Node, Config) ->
     case has_mnesia(Node) of

--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -71,8 +71,13 @@ end_per_group(GroupName, Config) ->
     metrics_helper:finalise_by_all_metrics_are_global(Config, GroupName =:= all_metrics_are_global).
 
 init_per_testcase(cluster_size = CN, Config) ->
-    Config1 = ensure_nodes_not_clustered(Config),
-    escalus:init_per_testcase(CN, Config1);
+    case distributed_helper:has_mnesia(mim()) of
+        true ->
+            Config1 = ensure_nodes_not_clustered(Config),
+            escalus:init_per_testcase(CN, Config1);
+        false ->
+            {skip, "Requires Mnesia"}
+    end;
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -153,7 +153,7 @@ Metrics specific to an extension, e.g. Message Archive Management, are described
 | `[global, uniqueSessionCount]` | value | A number of unique users connected to a MongooseIM cluster (e.g. 3 sessions of the same user will be counted as 1 in this metric). |
 | `[global, cache, unique_sessions_number]` | gauge | A cached value of `uniqueSessionCount`. It is automatically updated when a unique session count is calculated. |
 | `[global, nodeUpTime]` | value | Node uptime. |
-| `[global, clusterSize]` | value | A number of nodes in a MongooseIM cluster seen by a given MongooseIM node. |
+| `[global, clusterSize]` | value | A number of nodes in a MongooseIM cluster seen by a given MongooseIM node (based on Mnesia). For CETS use `global.cets.system.joined_nodes` instead. |
 | `[global, tcpPortsUsed]` | value | A number of open tcp connections. This should relate to the number of connected sessions and databases, as well as federations and http requests, in order to detect connection leaks. |
 | `[global, processQueueLengths]` | probe | The number of queued messages in the internal message queue of every erlang process, and the internal queue of every fsm (ejabberd\_c2s). This is sampled every 30 seconds asynchronously. It is a good indicator of an overloaded system: if too many messages are queued at the same time, the system is not able to process the data at the rate it was designed for. |
 

--- a/rebar.config
+++ b/rebar.config
@@ -80,7 +80,7 @@
   {cache_tab, "1.0.30"},
   {segmented_cache, "0.3.0"},
   {worker_pool, "6.0.1"},
-  {cets, {git, "https://github.com/esl/cets.git", {branch, "feature/insert-serial"}}},
+  {cets, {git, "https://github.com/esl/cets.git", {branch, "main"}}},
 
   %%% HTTP tools
   {graphql, {git, "https://github.com/esl/graphql-erlang.git", {branch, "master"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -80,7 +80,7 @@
   {cache_tab, "1.0.30"},
   {segmented_cache, "0.3.0"},
   {worker_pool, "6.0.1"},
-  {cets, {git, "https://github.com/esl/cets.git", {branch, "main"}}},
+  {cets, {git, "https://github.com/esl/cets.git", {branch, "feature/insert-serial"}}},
 
   %%% HTTP tools
   {graphql, {git, "https://github.com/esl/graphql-erlang.git", {branch, "master"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"c7c8124c294b606490dffcef8ef7b1fd66bdc47a"}},
+       {ref,"e3ad43f3836ea457bcb54e2f8266e9d7c32b014f"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"def7da28917fe7e21ad2b50d1b9939b1da5046cf"}},
+       {ref,"c7c8124c294b606490dffcef8ef7b1fd66bdc47a"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/src/mongoose_cluster_id.erl
+++ b/src/mongoose_cluster_id.erl
@@ -9,9 +9,9 @@
         ]).
 
 % For testing purposes only
--export([clean_table/0]).
+-export([clean_table/0, clean_cache/0]).
 
--ignore_xref([clean_table/0, get_backend_cluster_id/0]).
+-ignore_xref([clean_table/0, clean_cache/0, get_backend_cluster_id/0]).
 
 -record(mongoose_cluster_id, {key :: atom(), value :: cluster_id()}).
 -type cluster_id() :: binary().
@@ -178,3 +178,9 @@ clean_table(rdbms) ->
             {error, {Class, Reason}}
     end;
 clean_table(_) -> ok.
+
+clean_cache() ->
+    clean_cache(which_volatile_backend_available()).
+
+clean_cache(mnesia) ->
+    mnesia:dirty_delete(mongoose_cluster_id, cluster_id).

--- a/src/mongoose_internal_databases.erl
+++ b/src/mongoose_internal_databases.erl
@@ -1,10 +1,5 @@
 -module(mongoose_internal_databases).
--export([init/0,
-         configured_internal_databases/0,
-         running_internal_databases/0]).
-
--ignore_xref([configured_internal_databases/0,
-              running_internal_databases/0]).
+-export([init/0]).
 
 init() ->
     case mongoose_config:lookup_opt([internal_databases, mnesia]) of
@@ -32,31 +27,3 @@ init_mnesia() ->
     end,
     application:start(mnesia, permanent),
     mnesia:wait_for_tables(mnesia:system_info(local_tables), infinity).
-
-configured_internal_databases() ->
-    case mongoose_config:lookup_opt([internal_databases, mnesia]) of
-        {ok, _} ->
-            [mnesia];
-        {error, _} ->
-            []
-    end ++
-    case mongoose_config:lookup_opt([internal_databases, cets]) of
-        {ok, _} ->
-            [cets];
-        {error, _} ->
-            []
-    end.
-
-running_internal_databases() ->
-    case mnesia:system_info(is_running) of
-        yes ->
-            [mnesia];
-        no ->
-            []
-    end ++
-    case is_pid(whereis(mongoose_cets_discovery)) of
-        true ->
-            [cets];
-        false ->
-            []
-    end.

--- a/src/mongoose_internal_databases.erl
+++ b/src/mongoose_internal_databases.erl
@@ -15,7 +15,8 @@ init() ->
             %% Ensure mnesia is stopped when applying the test presets from the big tests.
             %% So, we accidentually do not test with mnesia enabled, when starting the
             %% test cases from the clean test build.
-            mnesia:stop(),
+            %% TODO Stopping here would break a lot of tests, stop here once tests are fixed.
+            % mnesia:stop(),
             ok
     end.
 

--- a/src/mongoose_internal_databases.erl
+++ b/src/mongoose_internal_databases.erl
@@ -1,0 +1,61 @@
+-module(mongoose_internal_databases).
+-export([init/0,
+         configured_internal_databases/0,
+         running_internal_databases/0]).
+
+-ignore_xref([configured_internal_databases/0,
+              running_internal_databases/0]).
+
+init() ->
+    case mongoose_config:lookup_opt([internal_databases, mnesia]) of
+        {ok, _} ->
+            init_mnesia(),
+            mongoose_node_num_mnesia:init();
+        {error, _} ->
+            %% Ensure mnesia is stopped when applying the test presets from the big tests.
+            %% So, we accidentually do not test with mnesia enabled, when starting the
+            %% test cases from the clean test build.
+            mnesia:stop(),
+            ok
+    end.
+
+init_mnesia() ->
+    %% Mnesia should not be running at this point, unless it is started by tests.
+    %% Ensure Mnesia is stopped
+    mnesia:stop(),
+    case mnesia:system_info(extra_db_nodes) of
+        [] ->
+            mnesia:create_schema([node()]);
+        _ ->
+            ok
+    end,
+    application:start(mnesia, permanent),
+    mnesia:wait_for_tables(mnesia:system_info(local_tables), infinity).
+
+configured_internal_databases() ->
+    case mongoose_config:lookup_opt([internal_databases, mnesia]) of
+        {ok, _} ->
+            [mnesia];
+        {error, _} ->
+            []
+    end ++
+    case mongoose_config:lookup_opt([internal_databases, cets]) of
+        {ok, _} ->
+            [cets];
+        {error, _} ->
+            []
+    end.
+
+running_internal_databases() ->
+    case mnesia:system_info(is_running) of
+        yes ->
+            [mnesia];
+        no ->
+            []
+    end ++
+    case is_pid(whereis(mongoose_cets_discovery)) of
+        true ->
+            [cets];
+        false ->
+            []
+    end.


### PR DESCRIPTION
This PR addresses "MIM-2040 System metrics fail with no_client_id".

This is a copy of https://github.com/esl/MongooseIM/pull/4135 but the difference is that this branch does not try to fix all the tests, that still assume Mnesia is started.

Proposed changes include:
* CETS backend for mongoose_cluster_id.
* `Added cets:insert_serial/2`. See PR for CETS library: https://github.com/esl/cets/pull/33
* _Actually ensure that Mnesia is stopped after applying preset. This requires some fixes in distributed_helper, because some functions assume Mnesia is always running._  - update: we have the code but we disable this ensuring check for now, because it breaks a lot of tests. We will try to fix tests suite-by-suite and enable this check..

