### PR TITLE
Add CETS backend for mod_keystore

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -248,6 +248,7 @@
       {stream_management_backend, cets},
       {muc_online_backend, cets},
       {jingle_sip_backend, cets},
+      {keystore_backend, cets},
       {auth_method, "rdbms"},
       {internal_databases, "[internal_databases.cets]
   cluster_name = \"{{cluster_name}}\""},

--- a/big_tests/tests/graphql_token_SUITE.erl
+++ b/big_tests/tests/graphql_token_SUITE.erl
@@ -82,9 +82,10 @@ end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-required_modules() ->
+required_modules(Config) ->
     KeyOpts = #{keys => #{token_secret => ram,
-                         provision_pre_shared => ram}},
+                         provision_pre_shared => ram},
+                backend => ct_helper:get_preset_var(Config, keystore_backend, mnesia)},
     KeyStoreOpts = config_parser_helper:mod_config(mod_keystore, KeyOpts),
     [{mod_keystore, KeyStoreOpts},
      {mod_auth_token, auth_token_opts()}].
@@ -112,7 +113,7 @@ init_per_group(user, Config) ->
 
 ensure_token_started(Config) ->
     HostType = domain_helper:host_type(),
-    dynamic_modules:ensure_modules(HostType, required_modules()),
+    dynamic_modules:ensure_modules(HostType, required_modules(Config)),
     Config.
 
 ensure_token_stopped(Config) ->

--- a/big_tests/tests/graphql_token_SUITE.erl
+++ b/big_tests/tests/graphql_token_SUITE.erl
@@ -84,7 +84,7 @@ end_per_suite(Config) ->
 
 required_modules(Config) ->
     KeyOpts = #{keys => #{token_secret => ram,
-                         provision_pre_shared => ram},
+                          provision_pre_shared => ram},
                 backend => ct_helper:get_preset_var(Config, keystore_backend, mnesia)},
     KeyStoreOpts = config_parser_helper:mod_config(mod_keystore, KeyOpts),
     [{mod_keystore, KeyStoreOpts},

--- a/big_tests/tests/oauth_SUITE.erl
+++ b/big_tests/tests/oauth_SUITE.erl
@@ -83,7 +83,7 @@ init_per_suite(Config0) ->
         true ->
             HostType = domain_helper:host_type(),
             Config = dynamic_modules:save_modules(HostType, Config0),
-            dynamic_modules:ensure_modules(HostType, required_modules()),
+            dynamic_modules:ensure_modules(HostType, required_modules(Config)),
             escalus:init_per_suite(Config);
         false ->
             {skip, "RDBMS not available"}
@@ -459,8 +459,9 @@ serialize(ServerSideToken) ->
 to_lower(B) when is_binary(B) ->
     list_to_binary(string:to_lower(binary_to_list(B))).
 
-required_modules() ->
-    KeyOpts = #{keys => #{token_secret => ram,
+required_modules(Config) ->
+    KeyOpts = #{backend => ct_helper:get_preset_var(Config, keystore_backend, mnesia),
+                keys => #{token_secret => ram,
                          %% This is a hack for tests! As the name implies,
                          %% a pre-shared key should be read from a file stored
                          %% on disk. This way it can be shared with trusted 3rd

--- a/rebar.config
+++ b/rebar.config
@@ -80,7 +80,7 @@
   {cache_tab, "1.0.30"},
   {segmented_cache, "0.3.0"},
   {worker_pool, "6.0.1"},
-  {cets, {git, "https://github.com/esl/cets.git", {branch, "main"}}},
+  {cets, {git, "https://github.com/esl/cets.git", {branch, "insert-new-or-lookup"}}},
 
   %%% HTTP tools
   {graphql, {git, "https://github.com/esl/graphql-erlang.git", {branch, "master"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -80,7 +80,7 @@
   {cache_tab, "1.0.30"},
   {segmented_cache, "0.3.0"},
   {worker_pool, "6.0.1"},
-  {cets, {git, "https://github.com/esl/cets.git", {branch, "insert-new-or-lookup"}}},
+  {cets, {git, "https://github.com/esl/cets.git", {branch, "main"}}},
 
   %%% HTTP tools
   {graphql, {git, "https://github.com/esl/graphql-erlang.git", {branch, "master"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"72b01d2dd97c193e60365f0e7e53d30d0876ba1b"}},
+       {ref,"f715c4a2e4b2bcb9f5c1dcd5164ee5271aefa0a9"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"e3ad43f3836ea457bcb54e2f8266e9d7c32b014f"}},
+       {ref,"72b01d2dd97c193e60365f0e7e53d30d0876ba1b"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/src/mod_keystore.erl
+++ b/src/mod_keystore.erl
@@ -57,6 +57,7 @@ start(HostType, Opts) ->
 -spec stop(mongooseim:host_type()) -> ok.
 stop(HostType) ->
     clear_keystore_ets(HostType),
+    mod_keystore_backend:stop(HostType),
     ok.
 
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().

--- a/src/mod_keystore_backend.erl
+++ b/src/mod_keystore_backend.erl
@@ -2,11 +2,12 @@
 %% the backend modules (i.e. mod_keystore_mnesia...).
 -module(mod_keystore_backend).
 
--export([init/2, init_ram_key/2, get_key/1]).
+-export([init/2, stop/1, init_ram_key/2, get_key/1]).
 
 -define(MAIN_MODULE, mod_keystore).
 
 -callback init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+-callback stop(mongooseim:host_type()) -> ok.
 
 %% Cluster members race to decide whose key gets stored in the distributed database.
 %% That's why ProposedKey (the key this cluster member tries to propagate to other nodes)
@@ -22,6 +23,11 @@
 init(HostType, Opts) ->
     mongoose_backend:init(HostType, ?MAIN_MODULE, [], Opts),
     Args = [HostType, Opts],
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec stop(mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    Args = [HostType],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
 %% Cluster members race to decide whose key gets stored in the distributed database.

--- a/src/mod_keystore_cets.erl
+++ b/src/mod_keystore_cets.erl
@@ -1,0 +1,63 @@
+-module(mod_keystore_cets).
+-behaviour(mod_keystore_backend).
+
+-export([init/2,
+         init_ram_key/1,
+         get_key/1]).
+
+%% CETS callbacks
+-export([handle_conflict/2]).
+
+-ignore_xref([get_key/1, init/2, init_ram_key/1]).
+
+-include("mod_keystore.hrl").
+-include("mongoose_logger.hrl").
+
+-define(TABLE, cets_keystore).
+
+-spec init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+init(_HostType, _Opts) ->
+    %% There is no logic to remove keys.
+    cets:start(?TABLE, #{handle_conflict => fun ?MODULE:handle_conflict/2}),
+    cets_discovery:add_table(mongoose_cets_discovery, ?TABLE),
+    ok.
+
+%% We need to choose one key consistently.
+handle_conflict(Rec1, Rec2) ->
+    max(Rec1, Rec2).
+
+-spec init_ram_key(ProposedKey) -> Result when
+      ProposedKey :: mod_keystore:key(),
+      Result :: {ok, ActualKey} | {error, init_ram_key_failed},
+      ActualKey :: mod_keystore:key().
+init_ram_key(ProposedKey) ->
+    init_ram_key(ProposedKey, 1, 3).
+
+%% Inserts new key or returns already inserted.
+-spec init_ram_key(Key, TriedTimes, Retries) -> Result when
+      Result :: {ok, Key} | {error, init_ram_key_failed},
+      Key :: mod_keystore:key(),
+      TriedTimes :: non_neg_integer(),
+      Retries :: non_neg_integer().
+init_ram_key(#key{id = Id, key = Key}, _, 0) ->
+    ?LOG_ERROR(#{what => init_ram_key_failed, id => Id, key => Key}),
+    {error, init_ram_key_failed};
+init_ram_key(ProposedKey = #key{id = Id, key = PropKey}, N, Retries) ->
+    case cets:insert_new(?TABLE, {Id, PropKey}) of
+        true ->
+            {ok, ProposedKey};
+        false ->
+            case ets:lookup(?TABLE, Id) of
+                [{Id, Key}] ->
+                    %% Return already inserted key
+                    {ok, #key{id = Id, key = Key}};
+                [] ->
+                    ?LOG_WARNING(#{what => init_ram_key_retry,
+                                   id => Id, key => PropKey, tried_times => N}),
+                    init_ram_key(ProposedKey, N + 1, Retries - 1)
+            end
+   end.
+
+-spec get_key(Id :: mod_keystore:key_id()) -> mod_keystore:key_list().
+get_key(Id) ->
+    ets:lookup(?TABLE, Id).

--- a/src/mod_keystore_mnesia.erl
+++ b/src/mod_keystore_mnesia.erl
@@ -2,6 +2,7 @@
 -behaviour(mod_keystore_backend).
 
 -export([init/2,
+         stop/1,
          init_ram_key/1,
          get_key/1]).
 
@@ -16,6 +17,10 @@ init(_HostType, _Opts) ->
                          {type, set},
                          {attributes, record_info(fields, key)}]),
     mnesia:add_table_copy(key, node(), ram_copies),
+    ok.
+
+-spec stop(mongooseim:host_type()) -> ok.
+stop(_HostType) ->
     ok.
 
 -spec init_ram_key(ProposedKey) -> Result when


### PR DESCRIPTION
This PR addresses "MIM-2051 mod_keystore needs CETS backend"

Proposed changes include:
* Adds mod_keystore
* uses new `cets:insert_new_or_lookup/2` (Please, review https://github.com/esl/cets/pull/36)