### PR TITLE
Fix "Unable to restart VM after applying CETS preset"

### DIFF
--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -215,6 +215,9 @@
 {{{mod_last}}}
 {{/mod_last}}
 [modules.mod_stream_management]
+  {{#stream_management_backend}}
+  backend = "{{{stream_management_backend}}}"
+  {{/stream_management_backend}}
 
 {{#mod_offline}}
 [modules.mod_offline]

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -67,9 +67,11 @@
 -spec start(mongooseim:host_type()) -> ok.
 start(HostType) ->
     %% TODO: Check cluster mode
-    mongoose_mnesia:create_table(anonymous,
+    %% TODO: Add CETS backend, use mongoose_mnesia
+    mnesia:create_table(anonymous,
         [{ram_copies, [node()]}, {type, bag},
          {attributes, record_info(fields, anonymous)}]),
+    mnesia:add_table_copy(anonymous, node(), ram_copies),
     %% The hooks are needed to add / remove users from the anonymous tables
     gen_hook:add_handlers(hooks(HostType)),
     ok.

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -51,10 +51,12 @@
 start(HostType, #{iqdisc := IQDisc}) ->
     [gen_iq_handler:add_iq_handler_for_domain(HostType, ?NS_REGISTER, Component, Fn, #{}, IQDisc) ||
         {Component, Fn} <- iq_handlers()],
-    mongoose_mnesia:create_table(mod_register_ip,
+    %% TODO Add CETS backend, use mongoose_mnesia
+    mnesia:create_table(mod_register_ip,
         [{ram_copies, [node()]},
          {local_content, true},
          {attributes, [key, value]}]),
+    mnesia:add_table_copy(mod_register_ip, node(), ram_copies),
     ok.
 
 -spec stop(mongooseim:host_type()) -> ok.


### PR DESCRIPTION
This PR addresses "MIM-2071 Unable to restart VM after applying CETS preset"

Proposed changes include:
* Disable strict check that mnesia is running for mod_register and ejabberd_auth_anon (they are still not supported by CETS though).
* Configure mod_stream_management with the proper backend in the templates.