### PR TITLE
Cets/mod register

### DIFF
--- a/src/global_distrib/mod_global_distrib_utils.erl
+++ b/src/global_distrib/mod_global_distrib_utils.erl
@@ -111,14 +111,7 @@ create_ets(Names) ->
 create_ets(Names, Type) when is_list(Names) ->
     [create_ets(Name, Type) || Name <- Names];
 create_ets(Name, Type) ->
-    Self = self(),
-    Heir = case whereis(ejabberd_sup) of
-               undefined -> {heir, none};
-               Self -> {heir, none};
-               Pid -> {heir, Pid, testing}
-           end,
-
-    ets:new(Name, [named_table, public, Type, {read_concurrency, true}, Heir]).
+    ejabberd_sup:create_ets_table(Name, [named_table, public, Type, {read_concurrency, true}]).
 
 -spec resolve_endpoints([{inet:ip_address() | string(), inet:port_number()}]) -> [endpoint()].
 resolve_endpoints(Endpoints) when is_list(Endpoints) ->

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -52,7 +52,11 @@
 start(HostType, #{iqdisc := IQDisc}) ->
     [gen_iq_handler:add_iq_handler_for_domain(HostType, ?NS_REGISTER, Component, Fn, #{}, IQDisc) ||
         {Component, Fn} <- iq_handlers()],
-    ejabberd_sup:create_ets_table(?TABLE, [named_table, public, {read_concurrency, true}]).
+    Concurrency = case IQDisc of
+                      one_queue -> [];
+                      _ -> [{read_concurrency, true}]
+                  end,
+    ejabberd_sup:create_ets_table(?TABLE, [named_table, public | Concurrency]).
 
 -spec stop(mongooseim:host_type()) -> ok.
 stop(HostType) ->
@@ -61,7 +65,8 @@ stop(HostType) ->
     ok.
 
 iq_handlers() ->
-    [{ejabberd_local, fun ?MODULE:process_iq/5}, {ejabberd_sm, fun ?MODULE:process_iq/5}].
+    [{ejabberd_local, fun ?MODULE:process_iq/5},
+     {ejabberd_sm, fun ?MODULE:process_iq/5}].
 
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
@@ -433,40 +438,24 @@ check_timeout(Source) ->
     Timeout = mongoose_config:get_opt(registration_timeout),
     case is_integer(Timeout) of
         true ->
-            Priority = -(erlang:system_time(second)),
-            CleanPriority = Priority + Timeout,
-            check_and_store_ip_entry(Source, Priority, CleanPriority);
+            TS = erlang:system_time(second),
+            clean_ets(TS - Timeout),
+            check_and_store_ip_entry(Source, TS);
         false ->
             true
     end.
 
-check_and_store_ip_entry(Source, Priority, CleanPriority) ->
-    Treap = case ets:lookup(?TABLE, treap) of
-                [] -> treap:empty();
-                [{treap, T}] -> T
-            end,
-    Treap1 = clean_treap(Treap, CleanPriority),
-    case treap:lookup(Source, Treap1) of
-        error ->
-            Treap2 = treap:insert(Source, Priority, [], Treap1),
-            ets:insert(?TABLE, {treap, Treap2}),
+check_and_store_ip_entry(Source, Timestamp) ->
+    case ets:member(?TABLE, Source) of
+        false ->
+            ets:insert(?TABLE, {Source, Timestamp}),
             true;
-        {ok, _, _} ->
-            ets:insert(?TABLE, {treap, Treap1}),
+        true ->
             false
     end.
 
-clean_treap(Treap, CleanPriority) ->
-    case treap:is_empty(Treap) of
-        true ->
-            Treap;
-        false ->
-            {_Key, Priority, _Value} = treap:get_root(Treap),
-            case Priority > CleanPriority of
-                true -> clean_treap(treap:delete_root(Treap), CleanPriority);
-                false -> Treap
-            end
-    end.
+clean_ets(CleanTimestamp) ->
+    ets:select_delete(?TABLE, [{ {'_', '$1'}, [{'<', '$1', CleanTimestamp}], [true]}]).
 
 ip_to_string(Source) when is_tuple(Source) -> inet_parse:ntoa(Source);
 ip_to_string(undefined) -> "undefined";

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -106,17 +106,12 @@ ensure_started() ->
         _ ->
             ok
     end,
-
-    case ets:info(?MODULE) of
-        undefined ->
-            % we set heir here because the whole thing may be started by an ephemeral process
-            ets:new(?MODULE, [named_table, public,
-                {read_concurrency, true},
-                {keypos, #mongoose_wpool.name},
-                {heir, whereis(mongoose_wpool_sup), undefined}]);
-        _ ->
-            ok
-    end.
+    ejabberd_sup:create_ets_table(
+      ?MODULE,
+      [named_table, public,
+       {read_concurrency, true},
+       {keypos, #mongoose_wpool.name},
+       {heir, whereis(mongoose_wpool_sup), undefined}]).
 
 start_configured_pools() ->
     Pools = mongoose_config:get_opt(outgoing_pools),

--- a/src/wpool/mongoose_wpool_http.erl
+++ b/src/wpool/mongoose_wpool_http.erl
@@ -20,18 +20,7 @@
 %% mongoose_wpool callbacks
 -spec init() -> ok.
 init() ->
-    case ets:info(?MODULE) of
-        undefined ->
-            Heir = case whereis(ejabberd_sup) of
-                       undefined -> [];
-                       Pid -> [{heir, Pid, undefined}]
-                   end,
-            ets:new(?MODULE,
-                    [named_table, public, {read_concurrency, true} | Heir]),
-            ok;
-        _ ->
-            ok
-    end.
+    ejabberd_sup:create_ets_table(?MODULE, [named_table, public, {read_concurrency, true}]).
 
 -spec start(mongooseim:host_type_or_global(), mongoose_wpool:tag(),
             mongoose_wpool:pool_opts(), mongoose_wpool:conn_opts()) -> {ok, pid()} | {error, any()}.

--- a/src/wpool/mongoose_wpool_rdbms.erl
+++ b/src/wpool/mongoose_wpool_rdbms.erl
@@ -9,18 +9,8 @@
 %% mongoose_wpool callbacks
 -spec init() -> ok.
 init() ->
-    case ets:info(prepared_statements) of
-        undefined ->
-            Heir = case whereis(ejabberd_sup) of
-                       undefined -> [];
-                       Pid -> [{heir, Pid, undefined}]
-                   end,
-            ets:new(prepared_statements,
-                    [named_table, public, {read_concurrency, true} | Heir]),
-            ok;
-        _ ->
-            ok
-    end.
+    ejabberd_sup:create_ets_table(
+      prepared_statements, [named_table, public, {read_concurrency, true}]).
 
 -spec start(mongooseim:host_type_or_global(), mongoose_wpool:tag(),
             mongoose_wpool:pool_opts(), mongoose_wpool:conn_opts()) -> {ok, pid()} | {error, any()}.


### PR DESCRIPTION
MIM-2072

This removes mnesia usage from mod_register, which really wasn't really needed, it was using mnesia with `local_content` only.

Couldn't resist also simplifying the logic behind what was stored in that ets table, see removing `treap` from it.