### PR TITLE
Anonymous auth supports mnesia and cets backends

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -249,6 +249,7 @@
       {muc_online_backend, cets},
       {jingle_sip_backend, cets},
       {keystore_backend, cets},
+      {auth_anonymous_backend, cets},
       {auth_method, "rdbms"},
       {internal_databases, "[internal_databases.cets]
   cluster_name = \"{{cluster_name}}\""},

--- a/doc/authentication-methods/anonymous.md
+++ b/doc/authentication-methods/anonymous.md
@@ -22,6 +22,13 @@ Specifies the SASL mechanisms supported by the `anonymous` authentication method
 * `login_anon` - support the non-anonymous mechanisms (`PLAIN`, `DIGEST-MD5`, `SCRAM-*`),
 * `both` - support both types of mechanisms.
 
+### `auth.anonymous.backend`
+* **Syntax:** string, one of `mnesia`, `cets`
+* **Default:** `mnesia`
+* **Example:** `backend = cets`
+
+Sets the backend where anonymous sessions will be stored in-memory. See [internal databases](../configuration/internal-databases.md)
+
 ### Example
 
 ```toml

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -30,6 +30,9 @@
   [host_config.auth.anonymous]
     allow_multiple_connections = true
     protocol = \"both\"
+    {{#auth_anonymous_backend}}
+    backend = \"{{{auth_anonymous_backend}}}\"
+    {{/auth_anonymous_backend}}
 
 [[host_config]]
   host_type = \"anonymous\"

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -54,6 +54,16 @@
 
 {host_config,
   "[[host_config]]
+  host = \"anonymous.localhost\"
+
+  [host_config.auth.anonymous]
+    allow_multiple_connections = true
+    protocol = \"both\"
+    {{#auth_anonymous_backend}}
+    backend = \"{{{auth_anonymous_backend}}}\"
+    {{/auth_anonymous_backend}}
+
+  [[host_config]]
   host_type = \"dummy auth\"
   [host_config.modules.mod_presence]
   [host_config.auth.dummy]"}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -47,5 +47,16 @@
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 
+{host_config,
+  "[[host_config]]
+  host = \"anonymous.localhost\"
+
+  [host_config.auth.anonymous]
+    allow_multiple_connections = true
+    protocol = \"both\"
+    {{#auth_anonymous_backend}}
+    backend = \"{{{auth_anonymous_backend}}}\"
+    {{/auth_anonymous_backend}}
+  "}.
 %% Include common vars shared by all profiles
 "./vars-toml.config".

--- a/src/auth/ejabberd_auth_anonymous_backend.erl
+++ b/src/auth/ejabberd_auth_anonymous_backend.erl
@@ -1,0 +1,41 @@
+-module(ejabberd_auth_anonymous_backend).
+
+-export([init/1, stop/1, does_anonymous_user_exist/2, remove_connection/3, add_connection/3]).
+
+-define(MAIN_MODULE, ejabberd_auth_anonymous).
+
+-callback init(mongooseim:host_type()) -> ok.
+
+-callback stop(mongooseim:host_type()) -> ok.
+
+-callback does_anonymous_user_exist(mongooseim:host_type(), jid:simple_bare_jid()) -> boolean().
+
+-callback remove_connection(mongooseim:host_type(), ejabberd_sm:sid(), jid:simple_bare_jid()) -> ok.
+
+-callback add_connection(mongooseim:host_type(), ejabberd_sm:sid(), jid:simple_bare_jid()) -> ok.
+
+-spec init(mongooseim:host_type()) -> ok.
+init(HostType) ->
+    TrackedFuns = [does_anonymous_user_exist],
+    Backend = mongoose_config:get_opt([{auth, HostType}, anonymous, backend]),
+    mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, #{backend => Backend}),
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, [HostType]).
+
+-spec stop(mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, [HostType]).
+
+-spec does_anonymous_user_exist(mongooseim:host_type(), jid:simple_bare_jid()) -> boolean().
+does_anonymous_user_exist(HostType, US) ->
+    Args = [HostType, US],
+    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec add_connection(mongooseim:host_type(), ejabberd_sm:sid(), jid:simple_bare_jid()) -> ok.
+add_connection(HostType, SID, US) ->
+    Args = [HostType, SID, US],
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec remove_connection(mongooseim:host_type(), ejabberd_sm:sid(), jid:simple_bare_jid()) -> ok.
+remove_connection(HostType, SID, US) ->
+    Args = [HostType, SID, US],
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/auth/ejabberd_auth_anonymous_cets.erl
+++ b/src/auth/ejabberd_auth_anonymous_cets.erl
@@ -1,0 +1,37 @@
+-module(ejabberd_auth_anonymous_cets).
+
+-behaviour(ejabberd_auth_anonymous_backend).
+
+-export([init/1, stop/1, does_anonymous_user_exist/2, add_connection/3, remove_connection/3]).
+
+-spec init(mongooseim:host_type()) -> ok.
+init(HostType) ->
+    Tab = table_name(HostType),
+    cets:start(Tab, #{type => bag}),
+    cets_discovery:add_table(mongoose_cets_discovery, Tab),
+    ok.
+
+-spec does_anonymous_user_exist(mongooseim:host_type(), jid:simple_bare_jid()) -> boolean().
+does_anonymous_user_exist(HostType, US) ->
+    Tab = table_name(HostType),
+    [] =/= ets:lookup(Tab, US).
+
+-spec add_connection(mongooseim:host_type(), ejabberd_sm:sid(), jid:simple_bare_jid()) -> ok.
+add_connection(HostType, SID, US) ->
+    Tab = table_name(HostType),
+    cets:insert(Tab, {US, SID}).
+
+-spec remove_connection(mongooseim:host_type(), ejabberd_sm:sid(), jid:simple_bare_jid()) -> ok.
+remove_connection(HostType, SID, US) ->
+    Tab = table_name(HostType),
+    cets:delete_object(Tab, {US, SID}).
+
+-spec stop(mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    Tab = table_name(HostType),
+    cets_discovery:delete_table(mongoose_cets_discovery, Tab),
+    cets:stop(Tab),
+    ok.
+
+table_name(HostType) ->
+    binary_to_atom(<<"cets_auth_anonymous_", HostType/binary>>).

--- a/src/auth/ejabberd_auth_anonymous_mnesia.erl
+++ b/src/auth/ejabberd_auth_anonymous_mnesia.erl
@@ -1,0 +1,32 @@
+-module(ejabberd_auth_anonymous_mnesia).
+
+-behaviour(ejabberd_auth_anonymous_backend).
+
+-export([init/1, stop/1, does_anonymous_user_exist/2, add_connection/3, remove_connection/3]).
+
+-record(anonymous, {us  :: jid:simple_bare_jid(), sid :: ejabberd_sm:sid()}).
+
+-spec init(mongooseim:host_type()) -> ok.
+init(_HostType) ->
+    mnesia:create_table(anonymous,
+                        [{ram_copies, [node()]}, {type, bag},
+                         {attributes, record_info(fields, anonymous)}]),
+    mnesia:add_table_copy(anonymous, node(), ram_copies),
+    ok.
+
+-spec does_anonymous_user_exist(mongooseim:host_type(), jid:simple_bare_jid()) -> boolean().
+does_anonymous_user_exist(_HostType, US) ->
+    [] =/= catch mnesia:dirty_read({anonymous, US}).
+
+-spec add_connection(mongooseim:host_type(), ejabberd_sm:sid(), jid:simple_bare_jid()) -> ok.
+add_connection(_HostType, SID, US) ->
+    mnesia:sync_dirty(fun() -> mnesia:write(#anonymous{us = US, sid = SID}) end).
+
+-spec remove_connection(mongooseim:host_type(), ejabberd_sm:sid(), jid:simple_bare_jid()) -> ok.
+remove_connection(_HostType, SID, US) ->
+    mnesia:transaction(fun() -> mnesia:delete_object({anonymous, US, SID}) end),
+    ok.
+
+-spec stop(mongooseim:host_type()) -> ok.
+stop(_HostType) ->
+    ok.

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -270,7 +270,8 @@ options("mongooseim-pgsql") ->
      {component_backend, mnesia},
      {s2s_backend, mnesia},
      {{auth, <<"anonymous.localhost">>},
-      (default_auth())#{anonymous => #{allow_multiple_connections => true,
+      (default_auth())#{anonymous => #{backend => mnesia,
+                                       allow_multiple_connections => true,
                                        protocol => both},
                         methods => [anonymous]}},
      {{auth, <<"localhost">>},
@@ -690,7 +691,8 @@ custom_auth() ->
     maps:merge(default_auth(), extra_auth()).
 
 extra_auth() ->
-    #{anonymous => #{allow_multiple_connections => true,
+    #{anonymous => #{backend => mnesia,
+                     allow_multiple_connections => true,
                      protocol => sasl_anon},
       http => #{basic_auth => "admin:admin"},
       external => #{instances => 1,

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -121,6 +121,7 @@ opts() ->
       host_types => [],
       all_metrics_are_global => false,
       s2s_backend => mnesia,
+      {auth, ?HOST} => config_parser_helper:extra_auth(),
       {modules, ?HOST} => #{}}.
 
 meck_mods(bosh) -> [exometer, mod_bosh_socket];


### PR DESCRIPTION
MIM-2066
`ejabberd_auth_anonymous` has now two backends, mnesia and cets, which can be configured.