### PR TITLE
Upgrade CircleCI OTP to 26.1.2

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 references:
   - &OTP25 mongooseim/cimg-erlang:25.3.2.6
-  - &OTP26 mongooseim/cimg-erlang:26.0.2
+  - &OTP26 mongooseim/cimg-erlang:26.1.2
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3


### PR DESCRIPTION
There was an issue in 26.1 were big modules were taking too long to compile and CI was failing, that was fixed in 26.1.1 already. Upgrading to the latest OTP here.