### PR TITLE
Correctly handle the case when TLS is disabled

### DIFF
--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -163,8 +163,8 @@ Same syntax as for `auth.methods` option.
 
 ## TLS options for C2S
 
-By default the C2S listener does not use TLS.
-To use TLS, you need to add a TOML subsection called `tls` to the listener options.
+To enable TLS, a TOML subsection called `tls` has to be present in the listener options.
+To disable TLS, make sure that the section is not present, and no TLS options are set.
 You can set the following options in this section:
 
 ### `listen.c2s.tls.mode`

--- a/src/c2s/mongoose_c2s_stanzas.erl
+++ b/src/c2s/mongoose_c2s_stanzas.erl
@@ -8,6 +8,7 @@
          stream_header/1,
          stream_features_before_auth/1,
          tls_proceed/0,
+         tls_failure/0,
          stream_features_after_auth/1,
          sasl_success_stanza/1,
          sasl_failure_stanza/1,
@@ -89,6 +90,11 @@ starttls_stanza(TLSRequired) when TLSRequired =:= required; TLSRequired =:= opti
 -spec tls_proceed() -> exml:element().
 tls_proceed() ->
     #xmlel{name = <<"proceed">>,
+           attrs = [{<<"xmlns">>, ?NS_TLS}]}.
+
+-spec tls_failure() -> exml:element().
+tls_failure() ->
+    #xmlel{name = <<"failure">>,
            attrs = [{<<"xmlns">>, ?NS_TLS}]}.
 
 -spec stream_features_after_auth(mongoose_c2s:data()) -> exml:element().

--- a/src/c2s/mongoose_c2s_stanzas.erl
+++ b/src/c2s/mongoose_c2s_stanzas.erl
@@ -57,12 +57,12 @@ stream_features_before_auth(StateData) ->
 %% http://xmpp.org/rfcs/rfc6120.html#tls-rules-mtn
 determine_features(_, _, _, #{tls := #{mode := starttls_required}}, false) ->
     [starttls_stanza(required)];
-determine_features(StateData, HostType, LServer, _, true) ->
-    InitialFeatures = maybe_sasl_mechanisms(StateData),
+determine_features(StateData, HostType, LServer, #{tls := #{mode := starttls}}, false) ->
+    InitialFeatures = [starttls_stanza(optional) | maybe_sasl_mechanisms(StateData)],
     StreamFeaturesParams = #{c2s_data => StateData, lserver => LServer},
     mongoose_hooks:c2s_stream_features(HostType, StreamFeaturesParams, InitialFeatures);
 determine_features(StateData, HostType, LServer, _, _) ->
-    InitialFeatures = [starttls_stanza(optional) | maybe_sasl_mechanisms(StateData)],
+    InitialFeatures = maybe_sasl_mechanisms(StateData),
     StreamFeaturesParams = #{c2s_data => StateData, lserver => LServer},
     mongoose_hooks:c2s_stream_features(HostType, StreamFeaturesParams, InitialFeatures).
 


### PR DESCRIPTION
When the TLS section is missing, then according to the [documentation](https://esl.github.io/MongooseDocs/latest/configuration/listen/#tls-options-for-c2s) STARTTLS should be rejected. This was not the case: the feature was advertised, and a TLS upgrade performed by a client (who was informed about the support) resulted in a crash.

This PR fixes these issues:
- STARTTLS is only advertised when enabled.
- Upgrade attempt results in a correct failure element, as described in [RFC 6120](https://datatracker.ietf.org/doc/html/rfc6120#section-5.4.2.2)

The tests are updated to check these conditions, and to correctly verify the features for optional and required STARTTLS as well.

The bugs were discovered accidentally when checking https://github.com/esl/mongooseim-docker/issues/42. The statement about TLS disabled by default is changed in the docs, because it most likely confused the reporter of that issue.

