### PR TITLE
updating setup-beam GH action and OTP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ## the full list of supported (prebuilt) OTP versions for ubuntu-22.04 runners
+        ## can be found here:
+        ##     https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
         otp: [ '25.3.2.6', '26.1.2' ]
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '24.3.4', '25.2' ]
+        otp: [ '25.3.2.6', '26.1.2' ]
     runs-on: ubuntu-22.04
     env:
       PRESET: 'small_tests'
     steps:
       - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@v1.16.0
         with:
           otp-version: ${{ matrix.otp }}
       - uses: actions/cache@v3
@@ -61,17 +61,17 @@ jobs:
       matrix:
         preset: [internal_mnesia, pgsql_mnesia, mysql_redis, odbc_mssql_mnesia,
                  ldap_mnesia, elasticsearch_and_cassandra_mnesia]
-        otp: [ '25.2' ]
+        otp: [ '26.1.2' ]
         include:
           - test-spec: "default.spec"
           - preset: elasticsearch_and_cassandra_mnesia
             test-spec: "mam.spec"
           - preset: ldap_mnesia
             test-spec: "default.spec"
-            otp: '24.3.4'
+            otp: '25.3.2.6'
           - preset: pgsql_mnesia
             test-spec: "default.spec"
-            otp: '24.3.4'
+            otp: '25.3.2.6'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -94,11 +94,11 @@ jobs:
       fail-fast: false
       matrix:
         preset: [pgsql_mnesia, mysql_redis, odbc_mssql_mnesia]
-        otp: [ '25.2' ]
+        otp: [ '26.1.2' ]
         test-spec: ["dynamic_domains.spec"]
         include:
           - preset: pgsql_mnesia
-            otp: '24.3.4'
+            otp: '25.3.2.6'
             test-spec: "dynamic_domains.spec"
     runs-on: ubuntu-22.04
     steps:
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@v1.16.0
         with:
           otp-version: ${{matrix.otp}}
       - run: tools/test.sh -p dialyzer_only
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@v1.16.0
         with:
           otp-version: ${{matrix.otp}}
       - run: tools/test.sh -p xref_only
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@v1.16.0
         with:
           otp-version: ${{matrix.otp}}
       - run: tools/test.sh -p edoc_only


### PR DESCRIPTION
GH Actions build - https://github.com/esl/MongooseIM/actions/runs/6555138169

The latest `setup-beam` GH Action (`v1.16.0` as of 18/10/2023) states that only versions up to OTP 25 are supported for ubuntu-22.04 runners (see [this page](https://github.com/marketplace/actions/setup-erlang-otp-with-optional-elixir-and-mix-and-or-rebar3?version=v1.16.0#compatibility-between-operating-system-and-erlangotp) for more details).

However, for all Linux runners, the `setup-beam` GH Action uses prebuilt OTP releases stored at [builds.hex.pm](https://builds.hex.pm/). Those builds are prepared by [Bob the builder](https://github.com/hexpm/bob#erlang-builds), and the actual list of the prebuilt OTP versions for ubuntu-22.04 runners can be found [here](https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt).

For more details, check the implementation of [getOTPVersions()](https://github.com/erlef/setup-beam/blob/v1.16.0/dist/index.js#L10120) and [installOTP()](https://github.com/erlef/setup-beam/blob/v1.16.0/dist/index.js#L9721) functions of `setup-beam` GH Action.