### PR TITLE
Fix error on ping timeout with stream management

### DIFF
--- a/big_tests/tests/mod_ping_SUITE.erl
+++ b/big_tests/tests/mod_ping_SUITE.erl
@@ -56,7 +56,8 @@ all_tests() ->
      active,
      active_keep_alive,
      server_ping_pong,
-     server_ping_pang
+     server_ping_pang,
+     service_unavailable_response
     ].
 
 suite() ->
@@ -182,6 +183,26 @@ wrong_ping(Config) ->
 
             PingResp = escalus_client:wait_for_stanza(Alice),
             escalus:assert(is_iq_error, [PingReq], PingResp)
+        end).
+
+service_unavailable_response(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+        fun(Alice) ->
+            PingReq = wait_for_ping_req(Alice),
+            PingId = exml_query:attr(PingReq, <<"id">>),
+
+            ErrorStanzaBody = [#xmlel{name = <<"ping">>, attrs = [{<<"xmlns">>, ?NS_PING}]},
+                               #xmlel{name = <<"error">>, attrs = [{<<"type">>, <<"cancel">>}],
+                               children = [#xmlel{name = <<"service-unavailable">>,
+                                                  attrs = [{<<"xmlns">>, ?NS_STANZA_ERRORS}]}]}],
+            ErrorStanza = escalus_stanza:set_id(
+                            escalus_stanza:iq(domain(), <<"error">>, ErrorStanzaBody), PingId),
+            escalus_client:send(Alice, ErrorStanza),
+
+            ct:sleep(timer:seconds(1)),
+            TimeoutAction = ?config(timeout_action, Config),
+            check_connection(TimeoutAction, Alice),
+            escalus_client:kill_connection(Config, Alice)
         end).
 
 active(ConfigIn) ->

--- a/big_tests/tests/mod_ping_SUITE.erl
+++ b/big_tests/tests/mod_ping_SUITE.erl
@@ -199,7 +199,6 @@ service_unavailable_response(Config) ->
                             escalus_stanza:iq(domain(), <<"error">>, ErrorStanzaBody), PingId),
             escalus_client:send(Alice, ErrorStanza),
 
-            ct:sleep(timer:seconds(1)),
             TimeoutAction = ?config(timeout_action, Config),
             check_connection(TimeoutAction, Alice),
             escalus_client:kill_connection(Config, Alice)
@@ -286,7 +285,7 @@ wait_ping_interval(Ration) ->
     ct:sleep(WaitTime).
 
 check_connection(kill, Client) ->
-    false = escalus_connection:is_connected(Client);
+    mongoose_helper:wait_until(fun() -> escalus_connection:is_connected(Client) end, false);
 check_connection(_, Client) ->
     true = escalus_connection:is_connected(Client).
 

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -638,7 +638,10 @@ ping_timeout(Config) ->
     send_initial_presence(NewAlice),
 
     %% check if the error stanza was handled by mod_ping
-    ?assertEqual(1, length(get_stanzas_filtered_by_mod_ping())),
+    [Stanza] = get_stanzas_filtered_by_mod_ping(),
+    escalus:assert(is_iq_error, Stanza),
+    ?assertNotEqual(undefined,
+        exml_query:subelement_with_name_and_ns(Stanza, <<"ping">>, <<"urn:xmpp:ping">>)),
 
     %% stop the connection
     escalus_connection:stop(NewAlice).


### PR DESCRIPTION
This PR addresses an issue arising when both `mod_ping` (with `timeout_action = "kill”`) and `mod_stream_management` are enabled. Previously, error stanzas were routed back to the server after the ping and resume timeouts passed, leading to the resending of unacknowledged messages. Due to the lack of appropriate stanza handling in `mod_ping`, they were processed by `ejabberd_local`, resulting in ID-related errors.

The stanza arrives with the same ID in case of an error, but it doesn't require further processing since the ping timeout handling has already been invoked.

`mod_ping` likely skips using `ejabberd_local:route_iq` with a callback to avoid another laver of indirection. Handling ping responses directly in the module makes the process more straightforward and easier to understand.