### PR TITLE
Add new helper function to enable cets/mnesia in big_tests

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -246,9 +246,6 @@
       {component_backend, "\"cets\""},
       {s2s_backend, "\"cets\""},
       {stream_management_backend, cets},
-      {muc_online_backend, cets},
-      {jingle_sip_backend, cets},
-      {keystore_backend, cets},
       {auth_anonymous_backend, cets},
       {auth_method, "rdbms"},
       {internal_databases, "[internal_databases.cets]

--- a/big_tests/tests/carboncopy_SUITE.erl
+++ b/big_tests/tests/carboncopy_SUITE.erl
@@ -50,7 +50,7 @@ end_per_suite(C) ->
     escalus:end_per_suite(C).
 
 init_per_group(muc, Config) ->
-    muc_helper:load_muc(Config),
+    muc_helper:load_muc(),
     Config;
 init_per_group(_GroupName, Config) ->
     Config.

--- a/big_tests/tests/ct_helper.erl
+++ b/big_tests/tests/ct_helper.erl
@@ -5,7 +5,8 @@
          repeat_all_until_any_fail/1,
          repeat_all_until_any_fail/2,
          groups_to_all/1,
-         get_preset_var/3]).
+         get_preset_var/3,
+         get_internal_database/0]).
 
 -type group_name() :: atom().
 
@@ -118,9 +119,15 @@ groups_to_all(Groups) ->
 
 get_preset_var(Config, Opt, Def) ->
     case proplists:get_value(preset, Config, undefined) of
+        undefined ->
+            Def;
         Preset ->
             PresetAtom = list_to_existing_atom(Preset),
-            ct:get_config({presets, toml, PresetAtom, Opt}, Def);
-        _ ->
-            Def
+            ct:get_config({presets, toml, PresetAtom, Opt}, Def)
+    end.
+
+get_internal_database() ->
+    case distributed_helper:lookup_config_opt([internal_databases, cets]) of
+        {ok, _} -> cets;
+        {error, not_found} -> mnesia
     end.

--- a/big_tests/tests/distributed_helper.erl
+++ b/big_tests/tests/distributed_helper.erl
@@ -202,3 +202,6 @@ mongooseim_script(Node, Cmd, Args, Config) ->
 
 subhost_pattern(SubhostTemplate) ->
     rpc(mim(), mongoose_subdomain_utils, make_subdomain_pattern, [SubhostTemplate]).
+
+lookup_config_opt(Key) ->
+    rpc(mim(), mongoose_config, lookup_opt, [Key]).

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -162,7 +162,7 @@ is_internal_or_rdbms() ->
 %%%===================================================================
 
 init_per_testcase(muc_removal, Config) ->
-    muc_helper:load_muc(Config),
+    muc_helper:load_muc(),
     mongoose_helper:ensure_muc_clean(),
     escalus:init_per_testcase(muc_removal, Config);
 init_per_testcase(roster_removal, ConfigIn) ->

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -180,7 +180,7 @@ all_mam_testcases() ->
 init_per_suite(Config) ->
     #{node := MimNode} = distributed_helper:mim(),
     Config1 = [{{ejabberd_cwd, MimNode}, get_mim_cwd()} | dynamic_modules:save_modules(host_type(), Config)],
-    muc_helper:load_muc(Config),
+    muc_helper:load_muc(),
     escalus:init_per_suite(Config1).
 
 end_per_suite(Config) ->
@@ -243,7 +243,7 @@ init_per_testcase(CN, Config) when
     Config1;
 init_per_testcase(CN, Config) when CN =:= retrieve_inbox_muc;
                                    CN =:= remove_inbox_muc ->
-    muc_helper:load_muc(Config),
+    muc_helper:load_muc(),
     Config0 = init_inbox(CN, Config, muc),
     Config0;
 

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -237,20 +237,20 @@ init_per_group(admin_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
 init_per_group(domain_admin_muc, Config) ->
     maybe_enable_mam(),
-    ensure_muc_started(Config),
+    ensure_muc_started(),
     graphql_helper:init_domain_admin_handler(Config);
 init_per_group(user, Config) ->
     graphql_helper:init_user(Config);
 init_per_group(Group, Config) when Group =:= admin_muc_configured;
                                    Group =:= user_muc_configured ->
     disable_mam(),
-    ensure_muc_started(Config),
+    ensure_muc_started(),
     Config;
 init_per_group(Group, Config) when Group =:= admin_muc_and_mam_configured;
                                    Group =:= user_muc_and_mam_configured ->
     case maybe_enable_mam() of
         true ->
-            ensure_muc_started(Config),
+            ensure_muc_started(),
             ensure_muc_light_started(Config);
         false ->
             {skip, "No MAM backend available"}
@@ -277,10 +277,10 @@ maybe_enable_mam() ->
             true
     end.
 
-ensure_muc_started(Config) ->
+ensure_muc_started() ->
     SecondaryHostType = domain_helper:secondary_host_type(),
-    muc_helper:load_muc(Config),
-    muc_helper:load_muc(Config, SecondaryHostType),
+    muc_helper:load_muc(),
+    muc_helper:load_muc(SecondaryHostType),
     mongoose_helper:ensure_muc_clean().
 
 ensure_muc_stopped() ->

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -237,7 +237,7 @@ init_per_group(Group, Config) when Group =:= user_muc_light_with_mam;
                                    Group =:= domain_admin_muc_light_with_mam ->
     case maybe_enable_mam() of
         true ->
-            ensure_muc_started(Config),
+            ensure_muc_started(),
             ensure_muc_light_started(Config);
         false ->
             {skip, "No MAM backend available"}
@@ -281,8 +281,8 @@ ensure_muc_light_stopped(Config) ->
     dynamic_modules:ensure_modules(SecondaryHostType, [{mod_muc_light, stopped}]),
     [{muc_light_host, <<"NON_EXISTING">>} | Config].
 
-ensure_muc_started(Config) ->
-    muc_helper:load_muc(Config),
+ensure_muc_started() ->
+    muc_helper:load_muc(),
     mongoose_helper:ensure_muc_clean().
 
 ensure_muc_stopped() ->

--- a/big_tests/tests/graphql_token_SUITE.erl
+++ b/big_tests/tests/graphql_token_SUITE.erl
@@ -82,10 +82,10 @@ end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-required_modules(Config) ->
+required_modules() ->
     KeyOpts = #{keys => #{token_secret => ram,
                           provision_pre_shared => ram},
-                backend => ct_helper:get_preset_var(Config, keystore_backend, mnesia)},
+                backend => ct_helper:get_internal_database()},
     KeyStoreOpts = config_parser_helper:mod_config(mod_keystore, KeyOpts),
     [{mod_keystore, KeyStoreOpts},
      {mod_auth_token, auth_token_opts()}].
@@ -113,7 +113,7 @@ init_per_group(user, Config) ->
 
 ensure_token_started(Config) ->
     HostType = domain_helper:host_type(),
-    dynamic_modules:ensure_modules(HostType, required_modules(Config)),
+    dynamic_modules:ensure_modules(HostType, required_modules()),
     Config.
 
 ensure_token_stopped(Config) ->

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -188,7 +188,7 @@ init_per_group(muclight_config, Config) ->
     Config1 = inbox_helper:reload_inbox_option(Config, groupchat, [muclight]),
     escalus:create_users(Config1, escalus:get_users([alice, alice_bis, bob, kate, mike]));
 init_per_group(muc, Config) ->
-    muc_helper:load_muc(Config),
+    muc_helper:load_muc(),
     inbox_helper:reload_inbox_option(Config, groupchat, [muc]);
 init_per_group(limit_result, Config) ->
     OptKey = [{modules, domain_helper:host_type()}, mod_inbox, max_result_limit],

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -539,7 +539,7 @@ suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 init_per_suite(Config) ->
-    muc_helper:load_muc(Config),
+    muc_helper:load_muc(),
     mam_helper:prepare_for_suite(
       increase_limits(
         delete_users([{escalus_user_db, {module, escalus_ejabberd}}

--- a/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
@@ -110,7 +110,7 @@ init_per_suite(Config) ->
         true ->
             start_rabbit_wpool(domain()),
             {ok, _} = application:ensure_all_started(amqp_client),
-            muc_helper:load_muc(Config),
+            muc_helper:load_muc(),
             escalus:init_per_suite(Config);
         false ->
             {skip, "RabbitMQ server is not available on default port."}

--- a/big_tests/tests/mod_event_pusher_sns_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_sns_SUITE.erl
@@ -60,7 +60,7 @@ init_per_suite(Config) ->
             %% For mocking with unnamed functions
             mongoose_helper:inject_module(?MODULE),
 
-            muc_helper:load_muc(Config),
+            muc_helper:load_muc(),
             escalus:init_per_suite(Config);
         {error, _} ->
             {skip, "erlcloud dependency is not enabled"}

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -254,7 +254,7 @@ init_per_testcase(CaseName, Config)
     {_, EuropeHost, _} = lists:keyfind(europe_node1, 1, get_hosts()),
     trigger_rebalance(asia_node, EuropeHost),
     %% Load muc on mim node
-    muc_helper:load_muc(Config),
+    muc_helper:load_muc(),
     RegNode = ct:get_config({hosts, reg, node}),
     %% Wait for muc.localhost to become visible from reg node
     wait_for_domain(RegNode, muc_helper:muc_host()),

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -329,7 +329,7 @@ init_per_suite(Config) ->
     Config2 = escalus:init_per_suite(Config),
     Config3 = dynamic_modules:save_modules(host_type(), Config2),
     dynamic_modules:restart(host_type(), mod_disco, default_mod_config(mod_disco)),
-    muc_helper:load_muc(Config),
+    muc_helper:load_muc(),
     mongoose_helper:ensure_muc_clean(),
     Config3.
 

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -52,15 +52,15 @@ foreach_recipient(Users, VerifyFun) ->
               VerifyFun(escalus:wait_for_stanza(Recipient))
       end, Users).
 
-load_muc(Config) ->
-    load_muc(Config, domain_helper:host_type()).
+load_muc() ->
+    load_muc(domain_helper:host_type()).
 
-load_muc(Config, HostType) ->
+load_muc(HostType) ->
     Backend = muc_backend(),
     MucHostPattern = ct:get_config({hosts, mim, muc_service_pattern}),
     ct:log("Starting MUC for ~p", [HostType]),
     Opts = #{host => subhost_pattern(MucHostPattern), backend => Backend,
-             online_backend => muc_online_backend(Config),
+             online_backend => muc_online_backend(),
              hibernate_timeout => 2000,
              hibernated_room_check_interval => 1000,
              hibernated_room_timeout => 2000,
@@ -87,8 +87,8 @@ muc_host_pattern() ->
 muc_backend() ->
     mongoose_helper:mnesia_or_rdbms_backend().
 
-muc_online_backend(Config) when is_list(Config) ->
-    ct_helper:get_preset_var(Config, muc_online_backend, mnesia).
+muc_online_backend() ->
+    ct_helper:get_internal_database().
 
 start_room(Config, User, Room, Nick, Opts) ->
     From = generate_rpc_jid(User),

--- a/big_tests/tests/muc_http_api_SUITE.erl
+++ b/big_tests/tests/muc_http_api_SUITE.erl
@@ -66,7 +66,7 @@ failure_response() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    muc_helper:load_muc(Config),
+    muc_helper:load_muc(),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->

--- a/big_tests/tests/oauth_SUITE.erl
+++ b/big_tests/tests/oauth_SUITE.erl
@@ -83,7 +83,7 @@ init_per_suite(Config0) ->
         true ->
             HostType = domain_helper:host_type(),
             Config = dynamic_modules:save_modules(HostType, Config0),
-            dynamic_modules:ensure_modules(HostType, required_modules(Config)),
+            dynamic_modules:ensure_modules(HostType, required_modules()),
             escalus:init_per_suite(Config);
         false ->
             {skip, "RDBMS not available"}
@@ -459,8 +459,8 @@ serialize(ServerSideToken) ->
 to_lower(B) when is_binary(B) ->
     list_to_binary(string:to_lower(binary_to_list(B))).
 
-required_modules(Config) ->
-    KeyOpts = #{backend => ct_helper:get_preset_var(Config, keystore_backend, mnesia),
+required_modules() ->
+    KeyOpts = #{backend => ct_helper:get_internal_database(),
                 keys => #{token_secret => ram,
                          %% This is a hack for tests! As the name implies,
                          %% a pre-shared key should be read from a file stored


### PR DESCRIPTION
This PR addresses MIM-2081.
It introduces new helper function `ct_helper:get_internal_database/0` and replaces calls `ct_helper:get_preset_var(Config, keystore_backend, mnesia)}` with it. New function does not depend on test config but on configuration of MIM nodes under tests. Former approach was not developer friendly, i.e. it didn't work while: 
- Using the `--rerun-big-tests` option of `test-runner.sh`
- Using `make quicktest`
- Running them directly from the test shell with `make console`

Also, I fixed existing `ct_helper:get_preset_var/3` implementation - 2nd clause of `case` instruction could never match, so instead of returning `Default` it raised an `bad_arg` error during `list_to_existing_atom/1` call.