### PR TITLE
  Test with CETS logging features [DO NOT MERGE] - net_adm:ping without disconnect_node

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -80,7 +80,7 @@
   {cache_tab, "1.0.30"},
   {segmented_cache, "0.3.0"},
   {worker_pool, "6.0.1"},
-  {cets, {git, "https://github.com/esl/cets.git", {branch, "main"}}},
+  {cets, {git, "https://github.com/esl/cets.git", {branch, "test-2023-01"}}},
 
   %%% HTTP tools
   {graphql, {git, "https://github.com/esl/graphql-erlang.git", {branch, "master"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"7d1d076aaaec1953f5c694eda71294560254280f"}},
+       {ref,"81a8269f1929df0bbca9c3b14be596977398a1f9"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"f715c4a2e4b2bcb9f5c1dcd5164ee5271aefa0a9"}},
+       {ref,"7d1d076aaaec1953f5c694eda71294560254280f"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/src/ejabberd_sm_cets.erl
+++ b/src/ejabberd_sm_cets.erl
@@ -76,7 +76,7 @@ cleanup(Node) ->
     KeyPattern = {'_', '_', '_', {'_', '$1'}},
     Guard = {'==', {node, '$1'}, Node},
     R = {KeyPattern, '_', '_'},
-    cets:sync(?TABLE),
+    cets:ping_all(?TABLE),
     %% This is a full table scan, but cleanup is rare.
     Tuples = ets:select(?TABLE, [{R, [Guard], ['$_']}]),
     lists:foreach(fun({_Key, _, _} = Tuple) ->

--- a/src/mod_bosh_cets.erl
+++ b/src/mod_bosh_cets.erl
@@ -41,7 +41,7 @@ get_sessions() ->
 node_cleanup(Node) ->
     Guard = {'==', {node, '$1'}, Node},
     R = {'_', '_', '$1'},
-    cets:sync(?TABLE),
+    cets:ping_all(?TABLE),
     %% We don't need to replicate deletes
     %% We remove the local content here
     ets:select_delete(?TABLE, [{R, [Guard], [true]}]),


### PR DESCRIPTION
This is the same as https://github.com/esl/MongooseIM/pull/4156 
`+` net_adm:ping without disconnect_node
`+` random delay in global:trans (but it is not really super useful for our debugging)

Why 2 PRs - so I can switch between two builds easily.

Please, ignore the PR.

