### PR TITLE
Use the latest version of mongooseim-docker

### DIFF
--- a/tools/circleci-prepare-mongooseim-docker.sh
+++ b/tools/circleci-prepare-mongooseim-docker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 set -e
-# From https://github.com/esl/mongooseim-docker/pull/49
-MIM_DOCKER_VERSION=6b62e9cf26c523e35fe78c57cbae2e8832f555d2
+# master from 2023-11-10
+MIM_DOCKER_VERSION=e46784fd44c5ec170d07adeead39755af9395d53
 
 # We use output of generate_vsn, because it does not contain illegal characters, returns
 # git tag when building from tag itself, and is unique in any other case


### PR DESCRIPTION
This new version allows overriding `NODE_HOST`, making it possible to use an IP address (or other host name) for the host part of the node name.