### PR TITLE
Enable coverage report for eunit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ct:
 		else $(RUN) $(REBAR) ct $(REBAR_CT_EXTRA_ARGS); fi)
 
 eunit:
-	@$(RUN) $(REBAR) eunit
+	@$(RUN) $(REBAR) eunit $(REBAR_EUNIT_EXTRA_ARGS)
 
 rel: certs configure.out rel/configure.vars.config
 	. ./configure.out && $(REBAR) as prod release

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -100,6 +100,9 @@ run_small_tests() {
 run_eunit_tests() {
   tools/print-dots.sh start
   tools/print-dots.sh monitor $$
+  if [ "$COVER_ENABLED" = true ]; then
+    export REBAR_EUNIT_EXTRA_ARGS="-c"
+  fi
   make eunit
   RESULT="$?"
   tools/print-dots.sh stop


### PR DESCRIPTION
Coverage was not reported for `eunit`, resulting in false reports for uncovered lines.