### PR TITLE
Update CETS version with fixes for unknown/missing tables in the status API

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"f715c4a2e4b2bcb9f5c1dcd5164ee5271aefa0a9"}},
+       {ref,"2ca31058bf616392ed91e4eb8642cc5af872902e"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/src/ejabberd_sm_cets.erl
+++ b/src/ejabberd_sm_cets.erl
@@ -76,7 +76,7 @@ cleanup(Node) ->
     KeyPattern = {'_', '_', '_', {'_', '$1'}},
     Guard = {'==', {node, '$1'}, Node},
     R = {KeyPattern, '_', '_'},
-    cets:sync(?TABLE),
+    cets:ping_all(?TABLE),
     %% This is a full table scan, but cleanup is rare.
     Tuples = ets:select(?TABLE, [{R, [Guard], ['$_']}]),
     lists:foreach(fun({_Key, _, _} = Tuple) ->

--- a/src/mod_bosh_cets.erl
+++ b/src/mod_bosh_cets.erl
@@ -41,7 +41,7 @@ get_sessions() ->
 node_cleanup(Node) ->
     Guard = {'==', {node, '$1'}, Node},
     R = {'_', '_', '$1'},
-    cets:sync(?TABLE),
+    cets:ping_all(?TABLE),
     %% We don't need to replicate deletes
     %% We remove the local content here
     ets:select_delete(?TABLE, [{R, [Guard], [true]}]),


### PR DESCRIPTION
This PR applies this fix https://github.com/esl/cets/pull/40

Proposed changes include:
* Correct remoteUnknownTables/remoteMissingTables in "cets systemInfo" API.
* Also includes https://github.com/esl/MongooseIM/pull/4161 :

* * Includes **Log error once in nested long calls** https://github.com/esl/cets/pull/38 
* * Includes **Fix never returning gen_server:call(Server, sync) call** https://github.com/esl/cets/pull/37 
* * Use ping_all instead of cets:sync (it has been renamed)


