### PR TITLE
Remove '--rebase' option for 'mike deploy'

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -478,7 +478,7 @@ jobs:
                   ssh-keyscan github.com >> ~/.ssh/known_hosts
                   git fetch git@github.com:esl/MongooseDocs.git gh-pages:gh-pages
                   pip3 install mike
-                  mike deploy $DOCS_TAG --remote git@github.com:esl/MongooseDocs.git --branch gh-pages --push --rebase
+                  mike deploy $DOCS_TAG --remote git@github.com:esl/MongooseDocs.git --branch gh-pages --push
 
   build_in_docker:
     executor: << parameters.executor >>


### PR DESCRIPTION
This option is not supported in [Mike 2.0](https://github.com/jimporter/mike/releases/tag/v2.0.0), which led to doc build failures in `master`.
It is unlikely that the repo will need to be rebased anyway, because it has just been fetched.

I tested the command manually with a SSH job in CircleCI, and it deploys the docs correctly.

