### PR TITLE
Custom epmd module - simple solution

### DIFF
--- a/big_tests/tests/cets_disco_SUITE.erl
+++ b/big_tests/tests/cets_disco_SUITE.erl
@@ -30,7 +30,8 @@ rdbms_cases() ->
      no_ip_in_db,
      cannot_connect_to_epmd,
      address_please,
-     address_please_returns_ip].
+     address_please_returns_ip,
+     address_please_returns_ip_fallbacks_to_resolve].
 
 suite() ->
     distributed_helper:require_rpc_nodes([mim, mim2]).
@@ -58,44 +59,21 @@ end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(address_please_returns_ip, Config) ->
-    case rpc(mim(), erlang, whereis, [mongoose_cets_discovery]) of
-        undefined ->
-            mock_epmd(mim()),
-            {ok, _} = rpc(mim(), supervisor, start_child, [ejabberd_sup, cets_disco_spec(<<"testmim1@localhost">>, <<"127.0.0.2">>)]),
-            {ok, _} = rpc(mim2(), supervisor, start_child, [ejabberd_sup, cets_disco_spec(<<"testmim2@localhost">>, <<"127.0.0.5">>)]),
-            %% Force nodes to see each other
-            rpc(mim2(), erlang, send, [mongoose_cets_discovery, check]),
-            ok = rpc(mim2(), cets_discovery, wait_for_get_nodes, [mongoose_cets_discovery, 5000]),
-            rpc(mim(), erlang, send, [mongoose_cets_discovery, check]),
-            Config;
-        _ ->
-            {skip, cets_disco_already_running}
-    end;
+    start_cets_discovery(Config, true);
+init_per_testcase(address_please_returns_ip_fallbacks_to_resolve, Config) ->
+    start_cets_discovery(Config, false);
 init_per_testcase(_CaseName, Config) -> Config.
 
 end_per_testcase(address_please_returns_ip, Config) ->
-    ok = rpc(mim(), supervisor, terminate_child, [ejabberd_sup, cets_discovery]),
-    ok = rpc(mim2(), supervisor, terminate_child, [ejabberd_sup, cets_discovery]),
+    stop_cets_discovery(),
     unmock_epmd(mim()),
+    Config;
+end_per_testcase(address_please_returns_ip_fallbacks_to_resolve, Config) ->
+    stop_cets_discovery(),
     Config;
 end_per_testcase(_CaseName, Config) ->
     unmock(mim()),
     unmock(mim2()).
-
-cets_disco_spec(Node, IP) ->
-    DiscoOpts = #{
-        backend_module => mongoose_cets_discovery_rdbms,
-        cluster_name => <<"mim">>,
-        node_name_to_insert => Node,
-        node_ip_binary => IP,
-        name => mongoose_cets_discovery},
-     #{
-        id => cets_discovery,
-        start => {mongoose_cets_discovery, start_link, [DiscoOpts]},
-        restart => temporary,
-        type => worker,
-        shutdown => infinity,
-        modules => [cets_discovery]}.
 
 %%--------------------------------------------------------------------
 %% Test cases
@@ -254,7 +232,13 @@ address_please_returns_ip(Config) ->
     Res = rpc(mim(), mongoose_epmd, address_please, ["testmim2", "localhost", inet]),
     Info = rpc(mim(), cets_discovery, system_info, [mongoose_cets_discovery]),
     ct:log("system_info ~p", [Info]),
-    {ok, {127, 0, 0, 5}} = Res.
+    {ok, {192, 168, 115, 112}} = Res.
+
+address_please_returns_ip_fallbacks_to_resolve(Config) ->
+    Res = rpc(mim(), mongoose_epmd, address_please, ["testmim2", "localhost", inet]),
+    Info = rpc(mim(), cets_discovery, system_info, [mongoose_cets_discovery]),
+    ct:log("system_info ~p", [Info]),
+    {ok, {127, 0, 0, 1}} = Res.
 
 %%--------------------------------------------------------------------
 %% Helpers
@@ -348,3 +332,42 @@ start_node_address_server(Node) ->
 
 stop_node_address_server(Node) ->
     rpc(Node, supervisor, terminate_child, [ejabberd_sup, mongoose_node_address]).
+
+start_cets_discovery(Config, MockEpmd) ->
+    case rpc(mim(), erlang, whereis, [mongoose_cets_discovery]) of
+        undefined ->
+            case MockEpmd of
+                true ->
+                    mock_epmd(mim());
+                false ->
+                    ok
+            end,
+            {ok, _} = rpc(mim(), supervisor, start_child, [ejabberd_sup, cets_disco_spec(<<"testmim1@localhost">>, <<"192.168.115.111">>)]),
+            {ok, _} = rpc(mim2(), supervisor, start_child, [ejabberd_sup, cets_disco_spec(<<"testmim2@localhost">>, <<"192.168.115.112">>)]),
+            %% Force nodes to see each other
+            rpc(mim2(), erlang, send, [mongoose_cets_discovery, check]),
+            ok = rpc(mim2(), cets_discovery, wait_for_get_nodes, [mongoose_cets_discovery, 5000]),
+            rpc(mim(), erlang, send, [mongoose_cets_discovery, check]),
+            Config;
+        _ ->
+            {skip, cets_disco_already_running}
+    end.
+
+stop_cets_discovery() ->
+    ok = rpc(mim(), supervisor, terminate_child, [ejabberd_sup, cets_discovery]),
+    ok = rpc(mim2(), supervisor, terminate_child, [ejabberd_sup, cets_discovery]).
+
+cets_disco_spec(Node, IP) ->
+    DiscoOpts = #{
+        backend_module => mongoose_cets_discovery_rdbms,
+        cluster_name => <<"mim">>,
+        node_name_to_insert => Node,
+        node_ip_binary => IP,
+        name => mongoose_cets_discovery},
+     #{
+        id => cets_discovery,
+        start => {mongoose_cets_discovery, start_link, [DiscoOpts]},
+        restart => temporary,
+        type => worker,
+        shutdown => infinity,
+        modules => [cets_discovery]}.

--- a/big_tests/tests/graphql_cets_SUITE.erl
+++ b/big_tests/tests/graphql_cets_SUITE.erl
@@ -206,16 +206,17 @@ register_bad_node() ->
     ClusterName = <<"mim">>,
     Node = <<"badnode@localhost">>,
     Num = 100,
+    Address = <<>>,
     Timestamp = rpc(mim(), mongoose_rdbms_timestamp, select, []),
-    InsertArgs = [ClusterName, Node, Num, Timestamp],
-    {updated, 1} = rpc(mim(), mongoose_rdbms, execute, [global, cets_disco_insert_new, InsertArgs]).
+    InsertArgs = [ClusterName, Node, Num, Address, Timestamp],
+    {updated, 1} = rpc(mim(), mongoose_cets_discovery_rdbms, insert_new, InsertArgs).
 
 ensure_bad_node_unregistered() ->
     ClusterName = <<"mim">>,
     Node = <<"badnode@localhost">>,
     DeleteArgs = [ClusterName, Node],
     %% Ensure the node is removed
-    {updated, _} = rpc(mim(), mongoose_rdbms, execute, [global, cets_delete_node_from_db, DeleteArgs]).
+    {updated, _} = rpc(mim(), mongoose_cets_discovery_rdbms, delete_node_from_db, DeleteArgs).
 
 force_check() ->
     Pid = rpc(mim(), erlang, whereis, [mongoose_cets_discovery]),

--- a/doc/configuration/release-options.md
+++ b/doc/configuration/release-options.md
@@ -33,6 +33,17 @@ These options are inserted into the `rel/files/vm.args` template.
 * **Syntax:** command-line arguments
 * **Example:** `{highload_vm_args, "+P 10000000 -env ERL_MAX_PORTS 250000"}.`
 
+### epmd_module
+
+Allows to set EPMD module to `mongoose_epmd` in case CETS is used with RDBMS backend
+to enable getting IP addresses of the remote nodes using RDBMS instead of the default
+resolver.
+
+* **Type:** parameter
+* **Option:** value of `-epmd_module` in [vm.args](configuration-files.md#vmargs)
+* **Syntax:** Erlang module name: `mongoose_epmd`
+* **Example:** `{epmd_module, "mongoose_epmd"}.`
+
 ## TOML Options
 
 These options are inserted into the `rel/files/mongooseim.toml` template.

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -754,10 +754,10 @@ CREATE TABLE domain_events (
 CREATE INDEX i_domain_events_domain ON domain_events(domain);
 
 CREATE TABLE discovery_nodes (
-    cluster_name varchar(250),
-    node_name varchar(250),
+    cluster_name varchar(250) NOT NULL,
+    node_name varchar(250) NOT NULL,
     node_num INT NOT NULL,
-    address varchar(250),
+    address varchar(250) NOT NULL DEFAULT '', -- empty means we should ask DNS
     updated_timestamp BIGINT NOT NULL, -- in seconds
     PRIMARY KEY (cluster_name, node_name)
 );

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -754,10 +754,11 @@ CREATE TABLE domain_events (
 CREATE INDEX i_domain_events_domain ON domain_events(domain);
 
 CREATE TABLE discovery_nodes (
-    node_name varchar(250),
     cluster_name varchar(250),
-    updated_timestamp BIGINT NOT NULL, -- in seconds
+    node_name varchar(250),
     node_num INT NOT NULL,
+    address varchar(250),
+    updated_timestamp BIGINT NOT NULL, -- in seconds
     PRIMARY KEY (cluster_name, node_name)
 );
 CREATE UNIQUE INDEX i_discovery_nodes_node_num ON discovery_nodes(cluster_name, node_num);

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -546,10 +546,10 @@ CREATE TABLE domain_events (
 CREATE INDEX i_domain_events_domain ON domain_events(domain);
 
 CREATE TABLE discovery_nodes (
-    cluster_name varchar(250),
-    node_name varchar(250),
+    cluster_name varchar(250) NOT NULL,
+    node_name varchar(250) NOT NULL,
     node_num INT UNSIGNED NOT NULL,
-    address varchar(250),
+    address varchar(250) NOT NULL DEFAULT '', -- empty means we should ask DNS
     updated_timestamp BIGINT NOT NULL, -- in seconds
     PRIMARY KEY (cluster_name, node_name)
 );

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -546,10 +546,11 @@ CREATE TABLE domain_events (
 CREATE INDEX i_domain_events_domain ON domain_events(domain);
 
 CREATE TABLE discovery_nodes (
-    node_name varchar(250),
     cluster_name varchar(250),
-    updated_timestamp BIGINT NOT NULL, -- in seconds
+    node_name varchar(250),
     node_num INT UNSIGNED NOT NULL,
+    address varchar(250),
+    updated_timestamp BIGINT NOT NULL, -- in seconds
     PRIMARY KEY (cluster_name, node_name)
 );
 CREATE UNIQUE INDEX i_discovery_nodes_node_num USING BTREE ON discovery_nodes(cluster_name, node_num);

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -506,10 +506,10 @@ CREATE TABLE domain_events (
 CREATE INDEX i_domain_events_domain ON domain_events(domain);
 
 CREATE TABLE discovery_nodes (
-    cluster_name varchar(250),
-    node_name varchar(250),
+    cluster_name varchar(250) NOT NULL,
+    node_name varchar(250) NOT NULL,
     node_num INT NOT NULL,
-    address varchar(250),
+    address varchar(250) NOT NULL DEFAULT '', -- empty means we should ask DNS
     updated_timestamp BIGINT NOT NULL, -- in seconds
     PRIMARY KEY (cluster_name, node_name)
 );

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -506,10 +506,11 @@ CREATE TABLE domain_events (
 CREATE INDEX i_domain_events_domain ON domain_events(domain);
 
 CREATE TABLE discovery_nodes (
-    node_name varchar(250),
     cluster_name varchar(250),
-    updated_timestamp BIGINT NOT NULL, -- in seconds
+    node_name varchar(250),
     node_num INT NOT NULL,
+    address varchar(250),
+    updated_timestamp BIGINT NOT NULL, -- in seconds
     PRIMARY KEY (cluster_name, node_name)
 );
 CREATE UNIQUE INDEX i_discovery_nodes_node_num ON discovery_nodes USING BTREE(cluster_name, node_num);

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"2ca31058bf616392ed91e4eb8642cc5af872902e"}},
+       {ref,"4ef4a347f8dd9b5e798499705e290b8e1cce5523"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"ce92a1bf821b5cf7d4241f2d49f656171875cafe"}},
+       {ref,"9c5b2c9269daeb4ee6830f7cd1538e0a4218e281"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"4ef4a347f8dd9b5e798499705e290b8e1cce5523"}},
+       {ref,"ce92a1bf821b5cf7d4241f2d49f656171875cafe"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -21,4 +21,6 @@
 ## Tweak GC to run more often
 -env ERL_FULLSWEEP_AFTER 2
 
-{{epmd_vm_args}}
+{{#epmd_module}}
+-epmd_module {{{epmd_module}}}
+{{/epmd_module}}

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -20,3 +20,5 @@
 
 ## Tweak GC to run more often
 -env ERL_FULLSWEEP_AFTER 2
+
+{{epmd_vm_args}}

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -1,5 +1,6 @@
 %% vm.args
 {node_name, "mongooseim3@localhost"}.
+{epmd_vm_args, "-epmd_module mongoose_epmd"}.
 
 %% mongooseim.toml
 {c2s_port, 5262}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -1,6 +1,6 @@
 %% vm.args
 {node_name, "mongooseim3@localhost"}.
-{epmd_vm_args, "-epmd_module mongoose_epmd"}.
+{epmd_module, "mongoose_epmd"}.
 
 %% mongooseim.toml
 {c2s_port, 5262}.

--- a/src/mongoose_cets_discovery.erl
+++ b/src/mongoose_cets_discovery.erl
@@ -35,10 +35,13 @@ supervisor_specs(#{backend := DiscoBackend, cluster_name := ClusterName} = Opts)
         node_name_to_insert => atom_to_binary(node(), latin1),
         node_ip_binary => get_node_ip_binary(),
         name => mongoose_cets_discovery, disco_file => DiscoFile},
-    CetsDisco =
-        {cets_discovery,
-          {?MODULE, start_link, [DiscoOpts]},
-          permanent, infinity, supervisor, [cets_discovery]},
+    CetsDisco = #{
+        id => cets_discovery,
+        start => {?MODULE, start_link, [DiscoOpts]},
+        restart => permanent,
+        type => worker,
+        shutdown => infinity,
+        modules => [cets_discovery]},
     [CetsDisco].
 
 disco_backend_to_module(rdbms) -> mongoose_cets_discovery_rdbms;

--- a/src/mongoose_cets_discovery.erl
+++ b/src/mongoose_cets_discovery.erl
@@ -33,6 +33,7 @@ supervisor_specs(#{backend := DiscoBackend, cluster_name := ClusterName} = Opts)
         backend_module => disco_backend_to_module(DiscoBackend),
         cluster_name => atom_to_binary(ClusterName),
         node_name_to_insert => atom_to_binary(node(), latin1),
+        node_ip_binary => get_node_ip_binary(),
         name => mongoose_cets_discovery, disco_file => DiscoFile},
     CetsDisco =
         {cets_discovery,
@@ -42,3 +43,6 @@ supervisor_specs(#{backend := DiscoBackend, cluster_name := ClusterName} = Opts)
 
 disco_backend_to_module(rdbms) -> mongoose_cets_discovery_rdbms;
 disco_backend_to_module(file) -> cets_discovery_file.
+
+get_node_ip_binary() ->
+    list_to_binary(os:getenv("MIM_NODE_IP", "")).

--- a/src/mongoose_cets_discovery_rdbms.erl
+++ b/src/mongoose_cets_discovery_rdbms.erl
@@ -4,8 +4,8 @@
 -export([init/1, get_nodes/1]).
 
 %% these functions are exported for testing purposes only.
--export([select/1, insert_new/4, update_existing/3, delete_node_from_db/2]).
--ignore_xref([select/1, insert_new/4, update_existing/3, delete_node_from_db/2]).
+-export([select/1, insert_new/5, update_existing/4, delete_node_from_db/2]).
+-ignore_xref([select/1, insert_new/5, update_existing/4, delete_node_from_db/2]).
 
 -include("mongoose_logger.hrl").
 
@@ -59,19 +59,21 @@ try_register(ClusterName, Node, State) when is_binary(Node), is_binary(ClusterNa
     prepare(),
     Timestamp = timestamp(),
     {selected, Rows} = select(ClusterName),
-    {Nodes, Nums, _Timestamps} = lists:unzip3(Rows),
+    Nodes = [element(1, Row) || Row <- Rows],
+    Nums = [element(2, Row) || Row <- Rows],
     AlreadyRegistered = lists:member(Node, Nodes),
+    Address = os:getenv("MIM_NODE_IP", ""),
     NodeNum =
         case AlreadyRegistered of
             true ->
-                 update_existing(ClusterName, Node, Timestamp),
-                 {value, {_, Num, _TS}} = lists:keysearch(Node, 1, Rows),
+                 update_existing(ClusterName, Node, Address, Timestamp),
+                 {value, {_, Num, _Addr, _TS}} = lists:keysearch(Node, 1, Rows),
                  Num;
             false ->
                  Num = first_free_num(lists:usort(Nums)),
                  %% Could fail with duplicate node_num reason.
                  %% In this case just wait for the next get_nodes call.
-                 case insert_new(ClusterName, Node, Timestamp, Num) of
+                 case insert_new(ClusterName, Node, Num, Address, Timestamp) of
                      {error, _} -> 0; %% return default node num
                      {updated, 1} -> Num
                  end
@@ -79,6 +81,7 @@ try_register(ClusterName, Node, State) when is_binary(Node), is_binary(ClusterNa
     RunCleaningResult = run_cleaning(ClusterName, Timestamp, Rows, State),
     %% This could be used for debugging
     Info = #{already_registered => AlreadyRegistered, timestamp => Timestamp,
+             address => Address,
              node_num => Num, last_rows => Rows, run_cleaning_result => RunCleaningResult},
     {NodeNum, skip_expired_nodes(Nodes, RunCleaningResult), Info}.
 
@@ -87,7 +90,7 @@ skip_expired_nodes(Nodes, {removed, ExpiredNodes}) ->
 
 run_cleaning(ClusterName, Timestamp, Rows, State) ->
     #{expire_time := ExpireTime, node_name_to_insert := CurrentNode} = State,
-    ExpiredNodes = [DbNode || {DbNode, _Num, DbTS} <- Rows,
+    ExpiredNodes = [DbNode || {DbNode, _Num, _Addr, DbTS} <- Rows,
                               is_expired(DbTS, Timestamp, ExpireTime),
                               DbNode =/= CurrentNode],
     [delete_node_from_db(ClusterName, DbNode) || DbNode <- ExpiredNodes],
@@ -110,30 +113,31 @@ prepare() ->
     mongoose_rdbms_timestamp:prepare(),
     mongoose_rdbms:prepare(cets_disco_select, T, [cluster_name], select()),
     mongoose_rdbms:prepare(cets_disco_insert_new, T,
-                           [cluster_name, node_name, node_num, updated_timestamp], insert_new()),
+                           [cluster_name, node_name, node_num, address, updated_timestamp], insert_new()),
     mongoose_rdbms:prepare(cets_disco_update_existing, T,
-                           [updated_timestamp, cluster_name, node_name], update_existing()),
+                           [updated_timestamp, address, cluster_name, node_name], update_existing()),
     mongoose_rdbms:prepare(cets_delete_node_from_db, T,
                            [cluster_name, node_name], delete_node_from_db()).
 
 select() ->
-    <<"SELECT node_name, node_num, updated_timestamp FROM discovery_nodes WHERE cluster_name = ?">>.
+    <<"SELECT node_name, node_num, address, updated_timestamp FROM discovery_nodes WHERE cluster_name = ?">>.
 
 select(ClusterName) ->
     mongoose_rdbms:execute_successfully(global, cets_disco_select, [ClusterName]).
 
 insert_new() ->
-    <<"INSERT INTO discovery_nodes (cluster_name, node_name, node_num, updated_timestamp)"
-      " VALUES (?, ?, ?, ?)">>.
+    <<"INSERT INTO discovery_nodes (cluster_name, node_name, node_num, address, updated_timestamp)"
+      " VALUES (?, ?, ?, ?, ?)">>.
 
-insert_new(ClusterName, Node, Timestamp, Num) ->
-    mongoose_rdbms:execute(global, cets_disco_insert_new, [ClusterName, Node, Num, Timestamp]).
+insert_new(ClusterName, NodeName, NodeNum, Address, UpdatedTimestamp) ->
+    mongoose_rdbms:execute(global, cets_disco_insert_new,
+                           [ClusterName, NodeName, NodeNum, Address, UpdatedTimestamp]).
 
 update_existing() ->
-    <<"UPDATE discovery_nodes SET updated_timestamp = ? WHERE cluster_name = ? AND node_name = ?">>.
+    <<"UPDATE discovery_nodes SET updated_timestamp = ?, address = ? WHERE cluster_name = ? AND node_name = ?">>.
 
-update_existing(ClusterName, Node, Timestamp) ->
-    mongoose_rdbms:execute(global, cets_disco_update_existing, [Timestamp, ClusterName, Node]).
+update_existing(ClusterName, NodeName, Address, UpdatedTimestamp) ->
+    mongoose_rdbms:execute(global, cets_disco_update_existing, [UpdatedTimestamp, Address, ClusterName, NodeName]).
 
 delete_node_from_db() ->
     <<"DELETE FROM discovery_nodes WHERE cluster_name = ? AND node_name = ?">>.

--- a/src/mongoose_epmd.erl
+++ b/src/mongoose_epmd.erl
@@ -1,3 +1,5 @@
+%% EPMD implementation which redefines how name lookups work
+%% There is no behaviour for erl_epmd
 -module(mongoose_epmd).
 -export([
     start/0,
@@ -11,6 +13,29 @@
     open/0, open/1, open/2
 ]).
 -include_lib("kernel/include/logger.hrl").
+
+%% For debugging
+-export([lookup_ip/1]).
+-export([match_node_name/2]).
+
+-type lookup_error() ::
+    {no_ip_in_db, node()}
+  | {cannot_connect_to_epmd, node(), inet:ip_address()}
+  | {no_record_for_node, node()}
+  | mongoose_node_address_ets_table_not_found.
+
+-ignore_xref([
+    start/0,
+    start_link/0,
+    stop/0,
+    port_please/2, port_please/3,
+    listen_port_please/2,
+    names/0, names/1,
+    register_node/2, register_node/3,
+    address_please/3,
+    open/0, open/1, open/2,
+    lookup_ip/1, match_node_name/2
+]).
 
 start() -> erl_epmd:start().
 start_link() -> erl_epmd:start_link().
@@ -27,11 +52,72 @@ open(A) -> erl_epmd:open(A).
 open(A, B) -> erl_epmd:open(A, B).
 
 address_please(Name, Host, AddressFamily) ->
-    Node = list_to_atom(Name ++ "@" ++ Host),
-    case mongoose_node_address:lookup(Node) of
+    Node = list_to_binary(Name ++ "@" ++ Host),
+    case lookup_ip(Node) of
         {ok, _IP} = Res ->
             Res;
         _ ->
             %% Fallback to the default behaviour
             inet:getaddr(Host, AddressFamily)
     end.
+
+%% This function waits for the IP address to appear.
+%% It only works well in case net_kernel does not contact a lot of
+%% dead nodes.
+%% Generally, we only expect calls for nodes that are alive
+%% and the connect is issued by CETS (but CETS checks that node is
+%% reachable first) or by connect_all feature in the global module of OTP.
+-spec lookup_ip(binary()) -> {ok, inet:ip_address()} | {error, lookup_error()}.
+lookup_ip(Node) ->
+    try
+        cets_discovery:wait_for_get_nodes(mongoose_cets_discovery, 3000),
+        cets_discovery:system_info(mongoose_cets_discovery)
+    of
+        #{backend_state := BackendState} ->
+            match_node_name(BackendState, Node)
+    catch _:_ ->
+        {error, failed_to_get_disco_state}
+    end.
+
+match_node_name(#{address_pairs := Pairs}, Node) ->
+    case Pairs of
+        #{Node := <<>>} ->
+            %% The caller should try DNS.
+            {error, {no_ip_in_db, Node}};
+        #{Node := Bin} ->
+            {ok, IP} = inet:parse_address(binary_to_list(Bin)),
+            case can_connect(IP) of
+                true ->
+                    {ok, IP};
+                false ->
+                    {error, {cannot_connect_to_epmd, Node, IP}}
+            end;
+        #{} ->
+            {error, {no_record_for_node, Node}}
+    end.
+
+-spec can_connect(inet:ip_address()) -> boolean().
+can_connect(IP) ->
+    Timeout = 1000,
+    case try_open(IP, Timeout) of
+        {ok, Socket} ->
+            gen_tcp:close(Socket),
+            true;
+        _ ->
+            false
+    end.
+
+-spec get_epmd_port() -> inet:port_number().
+get_epmd_port() ->
+    case init:get_argument(epmd_port) of
+        {ok, [[PortStr|_]|_]} when is_list(PortStr) ->
+            list_to_integer(PortStr);
+        error ->
+            4369
+    end.
+
+try_open({_, _, _, _} = IP, Timeout) ->
+    %% That would block
+    gen_tcp:connect(IP, get_epmd_port(), [inet], Timeout);
+try_open({_, _, _, _, _, _, _, _} = IP, Timeout) ->
+    gen_tcp:connect(IP, get_epmd_port(), [inet6], Timeout).

--- a/src/mongoose_epmd.erl
+++ b/src/mongoose_epmd.erl
@@ -1,0 +1,37 @@
+-module(mongoose_epmd).
+-export([
+    start/0,
+    start_link/0,
+    stop/0,
+    port_please/2, port_please/3,
+    listen_port_please/2,
+    names/0, names/1,
+    register_node/2, register_node/3,
+    address_please/3,
+    open/0, open/1, open/2
+]).
+-include_lib("kernel/include/logger.hrl").
+
+start() -> erl_epmd:start().
+start_link() -> erl_epmd:start_link().
+stop() -> erl_epmd:stop().
+port_please(A, B) -> erl_epmd:port_please(A, B).
+port_please(A, B, C) -> erl_epmd:port_please(A, B, C).
+listen_port_please(A, B) -> erl_epmd:listen_port_please(A, B).
+names() -> erl_epmd:names().
+names(A) -> erl_epmd:names(A).
+register_node(A, B) -> erl_epmd:register_node(A, B).
+register_node(A, B, C) -> erl_epmd:register_node(A, B, C).
+open() -> erl_epmd:open().
+open(A) -> erl_epmd:open(A).
+open(A, B) -> erl_epmd:open(A, B).
+
+address_please(Name, Host, AddressFamily) ->
+    Node = list_to_atom(Name ++ "@" ++ Host),
+    case mongoose_node_address:lookup(Node) of
+        {ok, _IP} = Res ->
+            Res;
+        _ ->
+            %% Fallback to the default behaviour
+            inet:getaddr(Host, AddressFamily)
+    end.


### PR DESCRIPTION
This PR addresses "previous PR https://github.com/esl/MongooseIM/pull/4174, but with simplified".

Sometimes, it could take 30 seconds for DNS record to become resolvable in k8s.
In this time, a node could try establishing outgoing erlang distribution connections but could not accept incoming erlang distribution connections. But, global tries to maintain a fully connected mesh between nodes. This means that

    new node connects to the cluster
    other nodes try to connect to that new node (coordinated by global)
    they get nxdomain error inside net_kernel and global gets pang
    global gets pang (and nodedown), asks other nodes to disconnect from this new node:

```
 when=2023-11-02T14:06:42.939527+00:00 level=warning pid=<0.59.0> at=: unstructured_log="'global' at node 'mongooseim@mongooseim-5.mongooseim.default.svc.cluster.local' disconnected node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' in order to prevent overlapping partitions"
when=2023-11-02T14:06:42.936864+00:00 level=warning pid=<0.1310.0> at=: unstructured_log="'global' at 'mongooseim@mongooseim-5.mongooseim.default.svc.cluster.local' failed to connect to 'mongooseim@mongooseim-4.mongooseim.default.svc.cluster.local'\
```

Proposed changes include:
* mongoose_node_address module and gen_server are gone.
* No retries. We wait for get_nodes call to finish instead.
* No extra ETS table - get value from the disco state instead (disco is only blocking for get_nodes call. Join/ping calls are async. So should be safe).
* No connect.

Requires https://github.com/esl/cets/pull/42 (merged)
Requires https://github.com/esl/cets/pull/43 (merged)