### PR TITLE
Cast the postgres timestamp to integer

### DIFF
--- a/src/rdbms/mongoose_rdbms_timestamp.erl
+++ b/src/rdbms/mongoose_rdbms_timestamp.erl
@@ -12,7 +12,7 @@ select_query() ->
        {mysql, _} ->
            <<"SELECT UNIX_TIMESTAMP()">>;
        {pgsql, _} ->
-           <<"SELECT ROUND(extract(epoch from now()))">>;
+           <<"SELECT CAST(extract(epoch from now()) AS integer)">>;
        {odbc, mssql} ->
            <<"SELECT DATEDIFF_BIG(second, '1970-01-01 00:00:00', GETUTCDATE())">>;
        Other ->


### PR DESCRIPTION
ROUND returns a float on Postgres 13.9, resulting in a type error.

