### PR TITLE
Require 'cacertfile' for just_tls when verify_mode = 'peer'

### DIFF
--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -193,7 +193,7 @@ By default the TLS library used for C2S connections is `fast_tls`, which uses Op
 Specifies the way client certificate verification works:
 
 * `peer` - makes sure the client certificate is valid and signed by a trusted CA. Requires a valid `cacertfile`.
-* `selfsigned_peer` - makes sure the client certificate is valid, but allows self-signed certificates; supported only by `just_tls`.
+* `selfsigned_peer` - makes sure the client certificate is valid, but allows self-signed certificates; supported only by `just_tls`. Requires a valid `cacertfile`.
 * `none` - client certificate is not checked.
 
 ### `listen.c2s.tls.certfile`

--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -373,8 +373,11 @@ TLS options for a given pool type/tag pair are defined in a subsection starting 
 * **Default:** `"peer"`
 * **Example:** `tls.verify_mode = "none"`
 
-The default value, `"peer"`, enforces verification of the server certificate, and requires a valid `cacertfile` to do so.
-You can set it to `"selfsigned_peer"` to accept self-signed certificates or to `"none"` to skip certificate verification altogether.
+Specifies the way server certificate verification works:
+
+* `peer` - makes sure the server certificate is valid and signed by a trusted CA. Requires a valid `cacertfile`.
+* `selfsigned_peer` - makes sure the server certificate is valid, but allows self-signed certificates. Requires a valid `cacertfile`.
+* `none` - server certificate is not checked.
 
 ### `outgoing_pools.*.*.connection.tls.certfile`
 * **Syntax:** string, path in the file system

--- a/doc/migrations/6.1.0_6.2.0.md
+++ b/doc/migrations/6.1.0_6.2.0.md
@@ -5,6 +5,20 @@ Now there is an option to use [CETS](https://github.com/esl/cets/) instead.
 Mnesia is still used by default, so you don't need to change your configuration file.
 If you want to switch to CETS, see [`internal_databases`](../configuration/internal-databases.md).
 
-# Transition to New CLI Commands
+## Validation of TLS options
+
+Erlang/OTP 26 has more strict checking of the TLS options, as described in [release highlights](https://www.erlang.org/blog/otp-26-highlights/#ssl-improved-checking-of-options).
+MongooseIM follows the same rules now, preventing runtime crashes if TLS is misconfigured.
+
+By default `verify_mode` is set to `"peer"` for each `tls` section in the configuration, and this requires `cacertfile` - otherwise the server will refuse to start. This was already documented, but not enforced. The option `"selfsigned_peer"` also requires `cacertfile` now.
+
+This change affects the following configuration sections:
+
+* [Listeners](../configuration/listen.md). Currently it only affects [`http`](../configuration/listen.md#http-based-services-listenhttp) and [`c2s`](../configuration/listen.md#client-to-server-c2s-listenc2s) with [`tls.module`](../configuration/listen.md#listenc2stlsmodule) set to `"just_tls"`, but we recommend fixing it for all listeners already, because in future releases all listeners would have this validation.
+* [Outgoing connections](../configuration/outgoing-connections.md).
+
+For each of the affected sections, if there is any `tls` option present, **make sure** that either `tls.cacertfile` is provided or `tls.verify_mode` is set to `"none"`.
+
+## Transition to New CLI Commands
 
 Legacy CLI commands previously marked as deprecated have now been removed. The users are encouraged to explore the new GraphQL-based CLI. It is recommended to transition to the new CLI commands **prior to the next system upgrade**. The configuration options `general.mongooseimctl_access_commands` and `services.service_admin_extra` related to the legacy CLI were also removed. **You need to remove them** from your configuration file unless you have already done so.

--- a/doc/tutorials/client-certificate.md
+++ b/doc/tutorials/client-certificate.md
@@ -64,6 +64,7 @@ In order to tell MongooseIM to accept self-signed certs, the `listen.c2s.tls.ver
 [listen.c2s]
   tls.verify_mode = "selfsigned_peer"
   tls.disconnect_on_failure = false
+  tls.cacertfile = "ca.pem"
 ```
 
 where the `tls.disconnect_on_failure` is a boolean with the following meaning only for `just_tls`:
@@ -81,6 +82,7 @@ In order to accept self-signed certs for WS or BOSH connections, the `tls` optio
 ```toml
 [listen.http]
   tls.verify_mode = "selfsigned_peer"
+  tls.cacertfile = "ca.pem"
 ```
 
 ### Examples

--- a/src/config/mongoose_config_utils.erl
+++ b/src/config/mongoose_config_utils.erl
@@ -2,7 +2,7 @@
 %% This stuff can be pure, but most likely not.
 %% It's for generic functions.
 -module(mongoose_config_utils).
--export([exit_or_halt/1, section_to_defaults/1, merge_sections/2, section_with_keys/2]).
+-export([exit_or_halt/1, section_to_defaults/1, merge_sections/2]).
 
 -ignore_xref([section_to_defaults/1]).
 
@@ -40,10 +40,3 @@ merge_process_functions(Process1, Process2) ->
             V1 = mongoose_config_parser_toml:process(Path, V, Process1),
             mongoose_config_parser_toml:process(Path, V1, Process2)
     end.
-
-section_with_keys(Keys, Section) ->
-    BinKeys = [atom_to_binary(Key) || Key <- Keys],
-    #section{items = Items, defaults = Defaults, required = Required} = Section,
-    Section#section{items = maps:with(BinKeys, Items),
-                    defaults = maps:with(BinKeys, Defaults),
-                    required = Required -- (Required -- BinKeys)}.

--- a/src/global_distrib/mod_global_distrib.erl
+++ b/src/global_distrib/mod_global_distrib.erl
@@ -128,8 +128,7 @@ endpoint_spec() ->
     }.
 
 tls_spec() ->
-    TLSSection = mongoose_config_spec:tls([client, server], [fast_tls]),
-    TLSSection#section{process = fun mongoose_config_spec:process_fast_tls/1}.
+    mongoose_config_spec:tls([client, server], [fast_tls]).
 
 redis_spec() ->
     #section{

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -180,7 +180,8 @@ options("mongooseim-pgsql") ->
                               username => <<"ala">>, password => <<"makotaipsa">>})
                     ],
                 transport => #{num_acceptors => 10, max_connections => 1024},
-                tls => #{certfile => "priv/cert.pem", keyfile => "priv/dc1.pem", password => ""}
+                tls => #{certfile => "priv/cert.pem", keyfile => "priv/dc1.pem", password => "",
+                         verify_mode => none}
                }),
        config([listen, http],
               #{ip_address => "127.0.0.1",
@@ -198,7 +199,8 @@ options("mongooseim-pgsql") ->
                             #{host => '_', path => "/api"})],
                 protocol => #{compress => true},
                 transport => #{num_acceptors => 10, max_connections => 1024},
-                tls => #{certfile => "priv/cert.pem", keyfile => "priv/dc1.pem", password => ""}
+                tls => #{certfile => "priv/cert.pem", keyfile => "priv/dc1.pem", password => "",
+                         verify_mode => none}
                }),
        config([listen, s2s],
               #{port => 5269,

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -36,6 +36,7 @@
   tls.certfile = "priv/cert.pem"
   tls.keyfile = "priv/dc1.pem"
   tls.password = ""
+  tls.verify_mode = "none"
 
   [[listen.http.handlers.mongoose_admin_api]]
     host = "localhost"
@@ -72,6 +73,7 @@
   tls.certfile = "priv/cert.pem"
   tls.keyfile = "priv/dc1.pem"
   tls.password = ""
+  tls.verify_mode = "none"
 
   [[listen.http.handlers.mongoose_client_api]]
     host = "_"


### PR DESCRIPTION
Require `cacertfile` for `just_tls` when `verify_mode` is set to `peer` or `selfsigned_peer`.  

This validation prevents runtime crashes in Erlang 26 resulting from more strict checking of TLS options.

The requirement was already stated in the docs.

**Notes:**
- As `peer` is the default `verify_mode`, all tests for TLS options in `just_tls` need `cacertfile` or verify_mode` se to `none`.
- TLS option spec is reworked to avoid unnecessary manipulations of sections generated with the `tls/2` helper.
- Reorganized some functions, e.g. `tls_defaults` were c2s-specific

**Excluded from this PR:**
- Requirement of `cacertfile` for `fast_tls`, because `s2s.tls` section is always included, and it has no `cacertfile`, so all default configurations would become invalid. I think that `s2s` TLS options should be reworked separately after the release.