### PR TITLE
If MAM lookup code crashes, user gets an empty result set instead of an error

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -840,11 +840,21 @@ init_per_testcase(C=muc_message_with_stanzaid, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
     escalus:init_per_testcase(C, start_alice_room(Config1));
 init_per_testcase(C=muc_light_failed_to_decode_message_in_database, Config) ->
-    dynamic_modules:ensure_modules(host_type(), required_modules(C, Config)),
-    escalus:init_per_testcase(C, Config);
+    case proplists:get_value(configuration, Config) of
+        elasticsearch ->
+            {skip, "elasticsearch does not support encodings"};
+        _ ->
+            dynamic_modules:ensure_modules(host_type(), required_modules(C, Config)),
+            escalus:init_per_testcase(C, Config)
+    end;
 init_per_testcase(C=pm_failed_to_decode_message_in_database, Config) ->
-    dynamic_modules:ensure_modules(host_type(), required_modules(C, Config)),
-    escalus:init_per_testcase(C, Config);
+    case proplists:get_value(configuration, Config) of
+        elasticsearch ->
+            {skip, "elasticsearch does not support encodings"};
+        _ ->
+            dynamic_modules:ensure_modules(host_type(), required_modules(C, Config)),
+            escalus:init_per_testcase(C, Config)
+    end;
 init_per_testcase(C, Config) when C =:= retract_muc_message;
                                   C =:= retract_muc_message_on_stanza_id;
                                   C =:= retract_wrong_muc_message ->

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -115,6 +115,8 @@
          muc_light_stored_in_pm_if_allowed_to/1,
          muc_light_chat_markers_are_archived_if_enabled/1,
          muc_light_chat_markers_are_not_archived_if_disabled/1,
+         muc_light_failed_to_decode_message_in_database/1,
+         pm_failed_to_decode_message_in_database/1,
          messages_filtered_when_prefs_default_policy_is_always/1,
          messages_filtered_when_prefs_default_policy_is_never/1,
          messages_filtered_when_prefs_default_policy_is_roster/1,
@@ -478,7 +480,8 @@ muc_light_cases() ->
      muc_light_shouldnt_modify_pm_archive,
      muc_light_stored_in_pm_if_allowed_to,
      muc_light_chat_markers_are_archived_if_enabled,
-     muc_light_chat_markers_are_not_archived_if_disabled
+     muc_light_chat_markers_are_not_archived_if_disabled,
+     muc_light_failed_to_decode_message_in_database
     ].
 
 muc_rsm_cases() ->
@@ -538,7 +541,8 @@ prefs_cases() ->
      run_set_and_get_prefs_cases].
 
 impl_specific() ->
-    [check_user_exist].
+    [check_user_exist,
+     pm_failed_to_decode_message_in_database].
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
@@ -835,6 +839,12 @@ init_per_testcase(C=same_stanza_id, Config) ->
 init_per_testcase(C=muc_message_with_stanzaid, Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}, {bob, 1}]),
     escalus:init_per_testcase(C, start_alice_room(Config1));
+init_per_testcase(C=muc_light_failed_to_decode_message_in_database, Config) ->
+    dynamic_modules:ensure_modules(host_type(), required_modules(C, Config)),
+    escalus:init_per_testcase(C, Config);
+init_per_testcase(C=pm_failed_to_decode_message_in_database, Config) ->
+    dynamic_modules:ensure_modules(host_type(), required_modules(C, Config)),
+    escalus:init_per_testcase(C, Config);
 init_per_testcase(C, Config) when C =:= retract_muc_message;
                                   C =:= retract_muc_message_on_stanza_id;
                                   C =:= retract_wrong_muc_message ->
@@ -969,20 +979,6 @@ end_per_testcase(C=muc_no_elements, Config) ->
 end_per_testcase(C=muc_only_stanzaid, Config) ->
     destroy_room(Config),
     escalus:end_per_testcase(C, Config);
-end_per_testcase(C = muc_light_stored_in_pm_if_allowed_to, Config) ->
-    escalus:end_per_testcase(C, Config);
-end_per_testcase(C = retract_message_on_stanza_id, Config) ->
-    escalus:end_per_testcase(C, Config);
-end_per_testcase(C = muc_light_chat_markers_are_archived_if_enabled, Config) ->
-    escalus:end_per_testcase(C, Config);
-end_per_testcase(C = muc_light_chat_markers_are_not_archived_if_disabled, Config) ->
-    escalus:end_per_testcase(C, Config);
-end_per_testcase(C = no_elements, Config) ->
-    escalus:end_per_testcase(C, Config);
-end_per_testcase(C = only_stanzaid, Config) ->
-    escalus:end_per_testcase(C, Config);
-end_per_testcase(C = same_stanza_id, Config) ->
-    escalus:end_per_testcase(C, Config);
 end_per_testcase(CaseName, Config) ->
     escalus:end_per_testcase(CaseName, Config).
 
@@ -999,6 +995,26 @@ required_modules(muc_light_chat_markers_are_archived_if_enabled, Config) ->
 required_modules(muc_no_elements, Config) ->
     Opts = #{muc := MUC} = ?config(mam_meta_opts, Config),
     NewOpts = Opts#{muc := MUC#{no_stanzaid_element => true}},
+    [{mod_mam, NewOpts}];
+required_modules(muc_light_failed_to_decode_message_in_database, Config) ->
+    Opts = #{muc := MUC} = ?config(mam_meta_opts, Config),
+    NewOpts = Opts#{muc := MUC#{db_message_format => mam_message_eterm}},
+    [{mod_mam, NewOpts}];
+required_modules(muc_light_failed_to_decode_message_in_database2, Config) ->
+    %% We apply this preset in the middle of
+    %% muc_light_failed_to_decode_message_in_database test
+    Opts = #{muc := MUC} = ?config(mam_meta_opts, Config),
+    NewOpts = Opts#{muc := MUC#{db_message_format => mam_message_xml}},
+    [{mod_mam, NewOpts}];
+required_modules(pm_failed_to_decode_message_in_database, Config) ->
+    Opts = #{pm := PM} = ?config(mam_meta_opts, Config),
+    NewOpts = Opts#{pm := PM#{db_message_format => mam_message_eterm}},
+    [{mod_mam, NewOpts}];
+required_modules(pm_failed_to_decode_message_in_database2, Config) ->
+    %% We apply this preset in the middle of
+    %% pm_failed_to_decode_message_in_database test
+    Opts = #{pm := PM} = ?config(mam_meta_opts, Config),
+    NewOpts = Opts#{pm := PM#{db_message_format => mam_message_xml}},
     [{mod_mam, NewOpts}];
 required_modules(muc_only_stanzaid, Config) ->
     Opts = ?config(mam_meta_opts, Config),
@@ -1689,6 +1705,35 @@ muc_light_chat_markers_are_not_archived_if_disabled(Config) ->
             when_archive_query_is_sent(Bob, muc_light_helper:room_bin_jid(Room), Config),
             ExpectedResponse = [{create, [{Alice, owner}, {Bob, member}]}],
             then_archive_response_is(Bob, ExpectedResponse, Config)
+        end).
+
+muc_light_failed_to_decode_message_in_database(Config) ->
+    escalus:story(Config, [{alice, 1}], fun(Alice) ->
+            Room = muc_helper:fresh_room_name(),
+            given_muc_light_room(Room, Alice, []),
+
+            M1 = when_muc_light_message_is_sent(Alice, Room,
+                                                <<"Msg 1">>, <<"Id1">>),
+            then_muc_light_message_is_received_by([Alice], M1),
+            mam_helper:wait_for_room_archive_size(muc_light_host(), Room, 2),
+            NewMods = required_modules(muc_light_failed_to_decode_message_in_database2, Config),
+            %% Change the encoding format for messages in the database
+            dynamic_modules:ensure_modules(host_type(), NewMods),
+            when_archive_query_is_sent(Alice, muc_light_helper:room_bin_jid(Room), Config),
+            Err = escalus:wait_for_stanza(Alice),
+            escalus_assert:is_error(Err, <<"wait">>, <<"internal-server-error">>)
+        end).
+
+pm_failed_to_decode_message_in_database(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+            escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi">>)),
+            mam_helper:wait_for_archive_size(Alice, 1),
+            NewMods = required_modules(pm_failed_to_decode_message_in_database2, Config),
+            %% Change the encoding format for messages in the database
+            dynamic_modules:ensure_modules(host_type(), NewMods),
+            when_archive_query_is_sent(Alice, undefined, Config),
+            Err = escalus:wait_for_stanza(Alice),
+            escalus_assert:is_error(Err, <<"wait">>, <<"internal-server-error">>)
         end).
 
 retrieve_form_fields(ConfigIn) ->

--- a/src/mam/mam_decoder.erl
+++ b/src/mam/mam_decoder.erl
@@ -4,6 +4,9 @@
 -export([decode_muc_gdpr_row/2]).
 -export([decode_retraction_info/3]).
 
+-include_lib("kernel/include/logger.hrl").
+-include_lib("exml/include/exml.hrl").
+
 -type ext_mess_id() :: non_neg_integer() | binary().
 -type env_vars() :: mod_mam_rdbms_arch:env_vars().
 -type db_row() :: {ext_mess_id(), ExtSrcJID :: binary(), ExtData :: binary()}.
@@ -51,8 +54,23 @@ decode_jid(ExtJID, #{db_jid_codec := Codec, archive_jid := ArcJID}) ->
 -spec decode_packet(binary(), env_vars()) -> exml:element().
 decode_packet(ExtBin, Env = #{db_message_codec := Codec}) ->
     Bin = unescape_binary(ExtBin, Env),
-    mam_message:decode(Codec, Bin).
+    try
+        mam_message:decode(Codec, Bin)
+    catch Class:Reason:Stacktrace ->
+        ?LOG_ERROR(#{what => mam_failed_to_decode_message,
+                     encoded_message => ExtBin,
+                     class => Class, reason => Reason, stacktrace => Stacktrace}),
+        error_stanza()
+    end.
 
 -spec unescape_binary(binary(), env_vars()) -> binary().
 unescape_binary(Bin, #{host_type := HostType}) ->
     mongoose_rdbms:unescape_binary(HostType, Bin).
+
+error_stanza() ->
+    Text = <<"Failed to decode message in database">>,
+    Err = mongoose_xmpp_errors:internal_server_error(<<"en">>, Text),
+    Body = #xmlel{name = <<"body">>, children = [#xmlcdata{content = Text}]},
+    #xmlel{name = <<"message">>,
+           attrs = [{<<"type">>, <<"error">>}],
+           children = [Err, Body]}.

--- a/src/mam/mam_message.erl
+++ b/src/mam/mam_message.erl
@@ -13,9 +13,27 @@
 
 -export([encode/2, decode/2]).
 
+-include_lib("kernel/include/logger.hrl").
+-include_lib("exml/include/exml.hrl").
+
 -spec encode(module(), exml:element()) -> binary().
 encode(Mod, Packet) -> Mod:encode(Packet).
 
 -spec decode(module(), binary()) -> exml:element().
-decode(Mod, Bin) -> Mod:decode(Bin).
+decode(Mod, Bin) ->
+    try
+        Mod:decode(Bin)
+    catch Class:Reason:Stacktrace ->
+        ?LOG_ERROR(#{what => mam_failed_to_decode_message,
+                     encoded_message => Bin,
+                     class => Class, reason => Reason, stacktrace => Stacktrace}),
+        error_stanza()
+    end.
 
+error_stanza() ->
+    Text = <<"Failed to decode message in database">>,
+    Err = mongoose_xmpp_errors:internal_server_error(<<"en">>, Text),
+    Body = #xmlel{name = <<"body">>, children = [#xmlcdata{content = Text}]},
+    #xmlel{name = <<"message">>,
+           attrs = [{<<"type">>, <<"error">>}],
+           children = [Err, Body]}.

--- a/src/mam/mod_mam_cassandra_arch.erl
+++ b/src/mam/mod_mam_cassandra_arch.erl
@@ -739,12 +739,12 @@ fetch_user_messages_cql() ->
 packet_to_stored_binary(HostType, Packet) ->
     %% Module implementing mam_message behaviour
     Module = db_message_format(HostType),
-    Module:encode(Packet).
+    mam_message:encode(Module, Packet).
 
 stored_binary_to_packet(HostType, Bin) ->
     %% Module implementing mam_message behaviour
     Module = db_message_format(HostType),
-    Module:decode(Bin).
+    mam_message:decode(Module, Bin).
 
 %% ----------------------------------------------------------------------
 %% Params getters

--- a/src/mam/mod_mam_muc_cassandra_arch.erl
+++ b/src/mam/mod_mam_muc_cassandra_arch.erl
@@ -757,12 +757,12 @@ list_message_ids_cql(Filter) ->
 packet_to_stored_binary(HostType, Packet) ->
     %% Module implementing mam_muc_message behaviour
     Module = db_message_format(HostType),
-    Module:encode(Packet).
+    mam_message:encode(Module, Packet).
 
 stored_binary_to_packet(HostType, Bin) ->
     %% Module implementing mam_muc_message behaviour
     Module = db_message_format(HostType),
-    Module:decode(Bin).
+    mam_message:decode(Module, Bin).
 
 %% ----------------------------------------------------------------------
 %% Params getters

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -384,7 +384,11 @@ lookup_messages(_Result, #{owner_jid := ArcJID} = Params, #{host_type := HostTyp
     Env = env_vars(HostType, ArcJID),
     ExdParams = mam_encoder:extend_lookup_params(Params, Env),
     Filter = mam_filter:produce_filter(ExdParams, lookup_fields()),
-    {ok, mam_lookup:lookup(Env, Filter, ExdParams)}.
+    try
+        {ok, mam_lookup:lookup(Env, Filter, ExdParams)}
+    catch error:Reason:Stacktrace ->
+        {error, {Reason, {stacktrace, Stacktrace}}}
+    end.
 
 lookup_query(QueryType, Env, Filters, Order, OffsetLimit) ->
     mam_lookup_sql:lookup_query(QueryType, Env, Filters, Order, OffsetLimit).

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -378,17 +378,11 @@ extract_gdpr_messages(HostType, SenderID) ->
     Acc :: {ok, mod_mam:lookup_result()},
     Params :: mam_iq:lookup_params(),
     Extra :: gen_hook:extra().
-lookup_messages({error, _Reason} = Result, _Params, _Extra) ->
-    {ok, Result};
 lookup_messages(_Result, #{owner_jid := ArcJID} = Params, #{host_type := HostType}) ->
     Env = env_vars(HostType, ArcJID),
     ExdParams = mam_encoder:extend_lookup_params(Params, Env),
     Filter = mam_filter:produce_filter(ExdParams, lookup_fields()),
-    try
-        {ok, mam_lookup:lookup(Env, Filter, ExdParams)}
-    catch error:Reason:Stacktrace ->
-        {error, {Reason, {stacktrace, Stacktrace}}}
-    end.
+    {ok, mam_lookup:lookup(Env, Filter, ExdParams)}.
 
 lookup_query(QueryType, Env, Filters, Order, OffsetLimit) ->
     mam_lookup_sql:lookup_query(QueryType, Env, Filters, Order, OffsetLimit).

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -405,7 +405,11 @@ lookup_messages(_Result, #{owner_jid := ArcJID} = Params, #{host_type := HostTyp
     Env = env_vars(HostType, ArcJID),
     ExdParams = mam_encoder:extend_lookup_params(Params, Env),
     Filter = mam_filter:produce_filter(ExdParams, lookup_fields()),
-    {ok, mam_lookup:lookup(Env, Filter, ExdParams)}.
+    try
+        {ok, mam_lookup:lookup(Env, Filter, ExdParams)}
+    catch error:Reason:Stacktrace ->
+        {error, {Reason, {stacktrace, Stacktrace}}}
+    end.
 
 lookup_query(QueryType, Env, Filters, Order, OffsetLimit) ->
     mam_lookup_sql:lookup_query(QueryType, Env, Filters, Order, OffsetLimit).

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -399,17 +399,11 @@ extract_gdpr_messages(Env, ArcID) ->
     Acc :: {ok, mod_mam:lookup_result()},
     Params :: mam_iq:lookup_params(),
     Extra :: gen_hook:extra().
-lookup_messages({error, _Reason} = Result, _Params, _Extra) ->
-    {ok, Result};
 lookup_messages(_Result, #{owner_jid := ArcJID} = Params, #{host_type := HostType}) ->
     Env = env_vars(HostType, ArcJID),
     ExdParams = mam_encoder:extend_lookup_params(Params, Env),
     Filter = mam_filter:produce_filter(ExdParams, lookup_fields()),
-    try
-        {ok, mam_lookup:lookup(Env, Filter, ExdParams)}
-    catch error:Reason:Stacktrace ->
-        {error, {Reason, {stacktrace, Stacktrace}}}
-    end.
+    {ok, mam_lookup:lookup(Env, Filter, ExdParams)}.
 
 lookup_query(QueryType, Env, Filters, Order, OffsetLimit) ->
     mam_lookup_sql:lookup_query(QueryType, Env, Filters, Order, OffsetLimit).


### PR DESCRIPTION
This PR addresses MIM-2101

Proposed changes include:
* If message fails to be decoded, we return a stanza saying so.
* Each failed message would get such a stanza.
