### PR TITLE
Fix muc_light_rooms.id key deifinition on MariaDB

### DIFF
--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -322,7 +322,7 @@ CREATE TABLE muc_light_rooms(
     lserver VARCHAR(250)    NOT NULL,
     version VARCHAR(20)     NOT NULL,
     PRIMARY KEY (lserver, luser),
-    UNIQUE KEY k_id USING HASH (id)
+    UNIQUE KEY uk_muc_light_rooms_id USING BTREE (id)
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
 


### PR DESCRIPTION
Fixes error with MariaDB:


This PR addresses:

```
ERROR 1901 (HY000) at line 319: Function or expression 'AUTO_INCREMENT' cannot be used in the USING HASH
```

Proposed changes include:
* Use btree instead of hash.
