### PR TITLE
Increase idle_timeout for SSE connections

### DIFF
--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -1471,7 +1471,7 @@ verify_server_name_in_header(Server, ExpectedName) ->
 config_to_muc_host(Config) ->
     ?config(muc_light_host, Config).
 
-get_client_api_listner() ->
+get_client_api_listener() ->
     Handler = #{module => mongoose_client_api},
     ListenerOpts = #{handlers => [Handler]},
     [Listener] = mongoose_helper:get_listeners(distributed_helper:mim(), ListenerOpts),

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -39,7 +39,7 @@ all() ->
      {group, messages_with_props},
      {group, messages_with_thread},
      {group, security},
-     {group, sse}].
+     {group, sse_timeout}].
 
 groups() ->
     [{messages_with_props, [parallel], message_with_props_test_cases()},
@@ -50,7 +50,7 @@ groups() ->
      {muc_disabled, [parallel], muc_disabled_cases()},
      {roster, [parallel], roster_test_cases()},
      {security, [], security_test_cases()},
-     {sse, [], [sse_should_not_get_timeout]}].
+     {sse_timeout, [], [sse_should_not_get_timeout]}].
 
 message_test_cases() ->
     [msg_is_sent_and_delivered_over_xmpp,
@@ -154,9 +154,9 @@ init_per_group(muc_disabled = GN, Config) ->
     Config1 = dynamic_modules:save_modules(HostType, Config),
     dynamic_modules:ensure_modules(HostType, required_modules(GN)),
     Config1;
-init_per_group(sse, Config) ->
+init_per_group(sse_timeout, Config) ->
     % Change the default idle_timeout for the listener to 1s to test if sse will override it
-    Listener = get_client_api_listner(),
+    Listener = get_client_api_listener(),
     mongoose_helper:change_listener_idle_timeout(Listener, 1000),
     Config;
 init_per_group(_GN, Config) ->
@@ -164,8 +164,8 @@ init_per_group(_GN, Config) ->
 
 end_per_group(muc_disabled, Config) ->
     dynamic_modules:restore_modules(Config);
-end_per_group(sse, _Config) ->
-    Listener = get_client_api_listner(),
+end_per_group(sse_timeout, _Config) ->
+    Listener = get_client_api_listener(),
     mongoose_helper:restart_listener(distributed_helper:mim(), Listener);
 end_per_group(_GN, _Config) ->
     ok.

--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -548,6 +548,14 @@ When set, enables authentication for the admin API, otherwise it is disabled. Re
 By default, when the option is not included, all GraphQL categories are enabled, so you don't need to add this option.
 When this option is added, only listed GraphQL categories will be processed. For others, the error "category disabled" will be returned.
 
+#### `listen.http.handlers.mongoose_graphql_handler.sse_idle_timeout`
+* **Syntax:** positive integer or the string `"infinity"`
+* **Default:** 3600000
+* **Example:** `schema_endpoint = "admin"`
+
+This option specifies the time in milliseconds after which the sse connection is closed when idle.
+The default value is 1 hour.
+
 ### Handler types: REST API - Admin - `mongoose_admin_api`
 
 The recommended configuration is shown in [Example 5](#example-5-admin-rest-api) below.

--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -553,7 +553,7 @@ When this option is added, only listed GraphQL categories will be processed. For
 * **Default:** 3600000
 * **Example:** `schema_endpoint = "admin"`
 
-This option specifies the time in milliseconds after which the sse connection is closed when idle.
+This option specifies the time in milliseconds after which the SSE connection is closed when idle.
 The default value is 1 hour.
 
 ### Handler types: REST API - Admin - `mongoose_admin_api`

--- a/doc/rest-api/Client-frontend_swagger.yml
+++ b/doc/rest-api/Client-frontend_swagger.yml
@@ -378,6 +378,7 @@ paths:
               "affiliation":"member"}
              ```
         For more details please refer to the [rooms API specifications](#/Rooms)
+        Note: The SSE connection will be closed after 1 hour of idle time.
       tags:
         - "Server Sent Events"
       produces:

--- a/src/graphql/mongoose_graphql_handler.erl
+++ b/src/graphql/mongoose_graphql_handler.erl
@@ -45,13 +45,16 @@
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
     #section{
-       items = #{<<"username">> => #option{type = binary},
-                 <<"password">> => #option{type = binary},
-                 <<"schema_endpoint">> => #option{type = atom,
-                                                  validate = {enum, [admin, domain_admin, user]}},
-                 <<"allowed_categories">> => #list{items = #option{type = binary,
-                                                                   validate = {enum, allowed_categories()}},
-                                                   validate = unique_non_empty}},
+        items = #{<<"username">> => #option{type = binary},
+                  <<"password">> => #option{type = binary},
+                  <<"schema_endpoint">> => #option{type = atom,
+                                                   validate = {enum, [admin, domain_admin, user]}},
+                  <<"allowed_categories">> => #list{items = #option{type = binary,
+                                                                    validate = {enum, allowed_categories()}},
+                                                    validate = unique_non_empty},
+                  <<"sse_idle_timeout">> => #option{type = int_or_infinity,
+                                                    validate = positive}},
+        defaults = #{<<"sse_idle_timeout">> => 3600000}, % 1h
         format_items = map,
         required = [<<"schema_endpoint">>],
         process = fun ?MODULE:process_config/1}.

--- a/src/graphql/mongoose_graphql_sse_handler.erl
+++ b/src/graphql/mongoose_graphql_sse_handler.erl
@@ -26,6 +26,10 @@
           {shutdown, cowboy:http_status(), cowboy:http_headers(), iodata(), req(), state()}.
 init(State, _LastEvtId, Req) ->
     process_flag(trap_exit, true), % needed for 'terminate' to be called
+    % set 1h timeout to prevent from frequent client disconections
+    cowboy_req:cast({set_options, #{
+        idle_timeout => 3600000
+    }}, Req),
     case cowboy_req:method(Req) of
         <<"GET">> ->
             case mongoose_graphql_handler:check_auth_header(Req, State) of

--- a/src/graphql/mongoose_graphql_sse_handler.erl
+++ b/src/graphql/mongoose_graphql_sse_handler.erl
@@ -24,11 +24,10 @@
 -spec init(state(), any(), cowboy_req:req()) ->
           {ok, req(), state()} |
           {shutdown, cowboy:http_status(), cowboy:http_headers(), iodata(), req(), state()}.
-init(State, _LastEvtId, Req) ->
+init(#{sse_idle_timeout := Timeout} = State, _LastEvtId, Req) ->
     process_flag(trap_exit, true), % needed for 'terminate' to be called
-    % set 1h timeout to prevent from frequent client disconections
     cowboy_req:cast({set_options, #{
-        idle_timeout => 3600000
+        idle_timeout => Timeout
     }}, Req),
     case cowboy_req:method(Req) of
         <<"GET">> ->

--- a/src/mongoose_client_api/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api/mongoose_client_api_sse.erl
@@ -21,7 +21,7 @@ init(_InitArgs, _LastEvtId, Req) ->
     ?LOG_DEBUG(#{what => client_api_sse_init, req => Req}),
     {cowboy_rest, Req1, State0} = mongoose_client_api:init(Req, []),
     {Authorization, Req2, State} = mongoose_client_api:is_authorized(Req1, State0),
-    % set 1h timeout to prevent from frequent client disconections
+    % set 1h timeout to prevent client from frequent disconnections
     cowboy_req:cast({set_options, #{
         idle_timeout => 3600000
     }}, Req),

--- a/src/mongoose_client_api/mongoose_client_api_sse.erl
+++ b/src/mongoose_client_api/mongoose_client_api_sse.erl
@@ -21,6 +21,10 @@ init(_InitArgs, _LastEvtId, Req) ->
     ?LOG_DEBUG(#{what => client_api_sse_init, req => Req}),
     {cowboy_rest, Req1, State0} = mongoose_client_api:init(Req, []),
     {Authorization, Req2, State} = mongoose_client_api:is_authorized(Req1, State0),
+    % set 1h timeout to prevent from frequent client disconections
+    cowboy_req:cast({set_options, #{
+        idle_timeout => 3600000
+    }}, Req),
     maybe_init(Authorization, Req2, State#{id => 1}).
 
 maybe_init(true, Req, #{jid := JID} = State) ->

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -1083,7 +1083,8 @@ default_config([listen, http, handlers, mongoose_client_api]) ->
       module => mongoose_client_api};
 default_config([listen, http, handlers, mongoose_graphql_handler]) ->
     #{module => mongoose_graphql_handler,
-      schema_endpoint => admin};
+      schema_endpoint => admin,
+      sse_idle_timeout => 3600000};
 default_config([listen, http, handlers, Module]) ->
     #{module => Module};
 default_config([listen, http, transport]) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -616,8 +616,10 @@ listen_http_handlers_graphql(_Config) ->
     test_listen_http_handler_creds(P, T),
     ?cfg(P ++ [allowed_categories], [<<"muc">>, <<"inbox">>],
          T(#{<<"allowed_categories">> => [<<"muc">>, <<"inbox">>]})),
+    ?cfg(P ++ [sse_idle_timeout], 3600000, T(#{})),
     ?err(T(#{<<"allowed_categories">> => [<<"invalid">>]})),
     ?err(T(#{<<"schema_endpoint">> => <<"wrong_endpoint">>})),
+    ?err(T(#{<<"sse_idle_timeout">> => 0})),
     ?err(http_handler_raw(mongoose_graphql_handler, #{})).
 
 test_listen_http_handler_creds(P, T) ->


### PR DESCRIPTION
This PR addresses [Issue # 2754](https://github.com/esl/MongooseIM/issues/2754) (MIM-2100).

It increases `idle_timeout` in cowboy's requests options for all SSE connections (both REST and GraphQL) to 1 hour. This will ensure that client connections are not closed after 1 minute.