### PR TITLE
Update CETS with pause-on-all nodes fix

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"0e3f83ed3ef2e75f833e068f9c53610b72ad75e7"}},
+       {ref,"7eca9e949c83e759a8d5aeae4135ff738a89899a"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},


### PR DESCRIPTION
This PR addresses MIM-2137.
Uses https://github.com/esl/cets/pull/46.



To avoid race conditions we have to pause on all nodes.

The issue:

    if join coordinator node looses connection with one of the nodes during join, that node gets unpaused.
    when unpaused, the node would start sending remote ops and check_server requests.
    there is a chance that other nodes in cluster would receive the messages before send_dump.

I've tried to show the errors in tests.

Solution:

    we could delay the messages by unpausing only when all nodes receive DOWN from the cets_join process.



