### PR TITLE
Update CETS: Do not log pause_owner_crashed when the pause owner exits normally

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"7eca9e949c83e759a8d5aeae4135ff738a89899a"}},
+       {ref,"0321fa355d6bfb0f28ff244e34b22deec707dbee"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},


### PR DESCRIPTION
This PR addresses MIM-2144

Proposed changes include:
* Do not log pause_owner_crashed when the pause owner exits normally in CETS

