### PR TITLE
Refactor/presences

### DIFF
--- a/big_tests/tests/disco_and_caps_SUITE.erl
+++ b/big_tests/tests/disco_and_caps_SUITE.erl
@@ -167,7 +167,6 @@ user_can_query_server_features(Config) ->
         escalus:assert(has_identity, [<<"server">>, <<"im">>], Stanza),
         escalus:assert(has_feature, [<<"iq">>], Stanza),
         escalus:assert(has_feature, [<<"presence">>], Stanza),
-        escalus:assert(has_feature, [<<"presence-invisible">>], Stanza),
         escalus:assert(is_stanza_from, [domain()], Stanza)
     end).
 

--- a/big_tests/tests/presence_SUITE.erl
+++ b/big_tests/tests/presence_SUITE.erl
@@ -47,7 +47,8 @@ groups() ->
                              available_direct_then_unavailable,
                              become_unavailable,
                              available_direct_then_disconnect,
-                             additions
+                             additions,
+                             invalid_presence
                             ]},
      {presence_priority, [parallel], [negative_priority_presence]},
      {roster, [parallel], [get_roster,
@@ -210,6 +211,14 @@ additions(Config) ->
         escalus:assert(is_presence_with_priority, [<<"1">>], Received)
 
         end).
+
+invalid_presence(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        Presence = escalus_stanza:presence(<<"invalid-type">>),
+        escalus:send(Alice, Presence),
+        Received = escalus:wait_for_stanza(Alice),
+        escalus_assert:is_error(Received, <<"modify">>, <<"bad-request">>)
+    end).
 
 negative_priority_presence(Config) ->
     escalus:fresh_story(Config, [{alice, 2}, {bob, 1}], fun(Alice1, Alice2, Bob) ->

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -245,7 +245,7 @@ disco_sm_items(Acc, _, _) ->
     Params :: map(),
     Extra :: map().
 disco_local_features(Acc = #{node := <<>>}, _, _) ->
-    {ok, mongoose_disco:add_features([<<"iq">>, <<"presence">>, <<"presence-invisible">>], Acc)};
+    {ok, mongoose_disco:add_features([<<"iq">>, <<"presence">>], Acc)};
 disco_local_features(Acc, _, _) ->
     {ok, Acc}.
 

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -7,7 +7,7 @@
 -behavior(gen_mod).
 
 -type jid_set() :: gb_sets:set(jid:jid()).
--type priority() :: -128..128.
+-type priority() :: -128..127.
 -type maybe_priority() :: priority() | undefined.
 -record(presences_state, {
           %% We have _subscription to_ these users' presence status;
@@ -643,7 +643,7 @@ get_mod_state(StateData) ->
 get_priority_from_presence(PresencePacket) ->
     MaybePriority = exml_query:path(PresencePacket, [{element, <<"priority">>}, cdata], undefined),
     case catch binary_to_integer(MaybePriority) of
-        P when is_integer(P), -128 =< P, P =< 128 -> P;
+        P when is_integer(P), -128 =< P, P =< 127 -> P;
         _ -> 0
     end.
 

--- a/src/privacy/mod_privacy.erl
+++ b/src/privacy/mod_privacy.erl
@@ -149,7 +149,6 @@ user_receive_presence(Acc, #{c2s_data := StateData}, _Extra) ->
     case mongoose_acc:stanza_type(Acc) of
         <<"error">> -> {ok, Acc};
         <<"probe">> -> {ok, Acc};
-        <<"invisible">> -> {ok, Acc};
         _ -> do_privacy_check_receive(Acc, StateData, ignore)
     end.
 

--- a/src/privacy/mod_privacy.erl
+++ b/src/privacy/mod_privacy.erl
@@ -271,8 +271,8 @@ maybe_update_presence(Acc, StateData, OldList, NewList) ->
     % Our own jid is added to pres_f, even though we're not a "contact", so for
     % the purposes of this check we don't want it:
     SelfJID = jid:to_bare(Jid),
-    FromsExceptSelf = gb_sets:del_element(SelfJID, FromS),
-    gb_sets:fold(
+    FromsExceptSelf = sets:del_element(SelfJID, FromS),
+    sets:fold(
       fun(T, Ac) ->
               send_unavail_if_newly_blocked(Ac, Jid, T, OldList, NewList, StateData)
       end, Acc, FromsExceptSelf).

--- a/src/privacy/mod_privacy.erl
+++ b/src/privacy/mod_privacy.erl
@@ -271,9 +271,9 @@ maybe_update_presence(Acc, StateData, OldList, NewList) ->
     % Our own jid is added to pres_f, even though we're not a "contact", so for
     % the purposes of this check we don't want it:
     SelfJID = jid:to_bare(Jid),
-    FromsExceptSelf = sets:del_element(SelfJID, FromS),
-    sets:fold(
-      fun(T, Ac) ->
+    FromsExceptSelf = maps:remove(SelfJID, FromS),
+    maps:fold(
+      fun(T, _, Ac) ->
               send_unavail_if_newly_blocked(Ac, Jid, T, OldList, NewList, StateData)
       end, Acc, FromsExceptSelf).
 


### PR DESCRIPTION
The main points are

* 39c81f2b4c5e0fbd654d326fc3337df279394865
>  Unify sets in the presence state record
The idea is to keep track of a smaller set of data, I'm assuming that jids that
would fall both on pres_f and pres_t are common, so we can keep track of them
only once instead of duplicating. This way we also give a meaning to the values
of the map underlying the implementation of sets.
Note too that this set is rarely updated: it is build once upon user starting a
presence session, and it is updated only on roster changes.

* 3a06929fe056bbac1120b07229999bd7f08f3be1
> This is functionality that was deprecated from XMPP already back in 2003 (!),
and we still have code for it that has been surviving different XEP
advertisement updates as well as shuffling of presences code.
Note that this is not related to the https://xmpp.org/extensions/xep-0126.html
XEP, as this one achieves the same by usage of privacy lists specific for the
purpose, thereby establishing only a client-based protocal that is transparent
for the server.

* 79547ea805ba92aa59c79be0cf090f87f0058f35
> ttps://www.rfc-editor.org/rfc/rfc6121.html#section-4.7.1 defines a strict list of valid types.

This should all make code more readable and hopefully have some minimal performance improvements.