### PR TITLE
Introduce pool names to mongoose_rdbms

### DIFF
--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -31,8 +31,8 @@ This allows you to create multiple dedicated pools of the same type.
 * `single_host` - the pool will be started for the selected host or host type only (you must provide the name).
 
     !!! Note
-        A global pool with name `default` is used by services that are not configured by host_type, like `service_domain_db` or `service_mongoose_system_metrics`, or by modules that don't support dynamic domains, like `mod_pubsub`.
-        If a global pool is not configured, these services will fail.
+        A pool with scope `global` and tag `default` is used by services that are not configured by host_type, like `service_domain_db` or `service_mongoose_system_metrics`, or by modules that don't support dynamic domains, like `mod_pubsub`.
+        If a global default pool is not configured, these services will fail.
 
 ## Worker pool options
 

--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -30,6 +30,10 @@ This allows you to create multiple dedicated pools of the same type.
 * `host` - the pool will be started for each XMPP host or host type served by MongooseIM
 * `single_host` - the pool will be started for the selected host or host type only (you must provide the name).
 
+    !!! Note
+        A global pool with name `default` is used by services that are not configured by host_type, like `service_domain_db` or `service_mongoose_system_metrics`, or by modules that don't support dynamic domains, like `mod_pubsub`.
+        If a global pool is not configured, these services will fail.
+
 ## Worker pool options
 
 All pools are managed by the [inaka/worker_pool](https://github.com/inaka/worker_pool) library.

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -158,7 +158,7 @@
                }).
 -type state() :: #state{}.
 
--define(DEFAULT_POOL, default).
+-define(DEFAULT_POOL_NAME, default).
 -define(STATE_KEY, mongoose_rdbms_state).
 -define(MAX_TRANSACTION_RESTARTS, 10).
 -define(TRANSACTION_TIMEOUT, 60000). % milliseconds
@@ -240,7 +240,7 @@ prepared(Name) ->
 -spec execute(HostType :: server(), Name :: atom(), Parameters :: [term()]) ->
                      query_result().
 execute(HostType, Name, Parameters) ->
-    execute(HostType, ?DEFAULT_POOL, Name, Parameters).
+    execute(HostType, ?DEFAULT_POOL_NAME, Name, Parameters).
 
 -spec execute(HostType :: server(), PoolName :: atom(), Name :: atom(), Parameters :: [term()]) ->
     query_result().
@@ -250,7 +250,7 @@ execute(HostType, PoolName, Name, Parameters) when is_atom(PoolName), is_atom(Na
 -spec execute_cast(HostType :: server(), Name :: atom(), Parameters :: [term()]) ->
     query_result().
 execute_cast(HostType, Name, Parameters) ->
-    execute_cast(HostType, ?DEFAULT_POOL, Name, Parameters).
+    execute_cast(HostType, ?DEFAULT_POOL_NAME, Name, Parameters).
 
 -spec execute_cast(HostType :: server(), PoolName :: atom(), Name :: atom(), Parameters :: [term()]) ->
     query_result().
@@ -260,7 +260,7 @@ execute_cast(HostType, PoolName, Name, Parameters) when is_atom(PoolName), is_at
 -spec execute_request(HostType :: server(), Name :: atom(), Parameters :: [term()]) ->
     request_id().
 execute_request(HostType, Name, Parameters) when is_atom(Name), is_list(Parameters) ->
-    execute_request(HostType, ?DEFAULT_POOL, Name, Parameters).
+    execute_request(HostType, ?DEFAULT_POOL_NAME, Name, Parameters).
 
 -spec execute_request(HostType :: server(), PoolName :: atom(), Name :: atom(), Parameters :: [term()]) ->
     request_id().
@@ -273,7 +273,7 @@ execute_request(HostType, PoolName, Name, Parameters) when is_atom(PoolName), is
     Parameters :: [term()],
     Wrapper :: request_wrapper()) -> request_id().
 execute_wrapped_request(HostType, Name, Parameters, Wrapper) ->
-    execute_wrapped_request(HostType, ?DEFAULT_POOL, Name, Parameters, Wrapper).
+    execute_wrapped_request(HostType, ?DEFAULT_POOL_NAME, Name, Parameters, Wrapper).
 
 -spec execute_wrapped_request(
     HostType :: server(),
@@ -289,7 +289,7 @@ execute_wrapped_request(HostType, PoolName, Name, Parameters, Wrapper)
 -spec execute_successfully(HostType :: server(), Name :: atom(), Parameters :: [term()]) ->
     query_result().
 execute_successfully(HostType, Name, Parameters) ->
-    execute_successfully(HostType, ?DEFAULT_POOL, Name, Parameters).
+    execute_successfully(HostType, ?DEFAULT_POOL_NAME, Name, Parameters).
 
 -spec execute_successfully(HostType :: server(), PoolName :: atom(), Name :: atom(), Parameters :: [term()]) ->
     query_result().
@@ -324,7 +324,7 @@ query_name_to_string(Name) ->
 
 -spec sql_query(HostType :: server(), Query :: any()) -> query_result().
 sql_query(HostType, Query) ->
-    sql_query(HostType, ?DEFAULT_POOL, Query).
+    sql_query(HostType, ?DEFAULT_POOL_NAME, Query).
 
 -spec sql_query(HostType :: server(), PoolName :: atom(), Query :: any()) -> query_result().
 sql_query(HostType, PoolName, Query) ->
@@ -332,7 +332,7 @@ sql_query(HostType, PoolName, Query) ->
 
 -spec sql_query_request(HostType :: server(), Query :: any()) -> request_id().
 sql_query_request(HostType, Query) ->
-    sql_query_request(HostType, ?DEFAULT_POOL, Query).
+    sql_query_request(HostType, ?DEFAULT_POOL_NAME, Query).
 
 -spec sql_query_request(HostType :: server(), PoolName :: atom(), Query :: any()) -> request_id().
 sql_query_request(HostType, PoolName, Query) ->
@@ -340,7 +340,7 @@ sql_query_request(HostType, PoolName, Query) ->
 
 -spec sql_query_cast(HostType :: server(), Query :: any()) -> query_result().
 sql_query_cast(HostType, Query) ->
-    sql_query_cast(HostType, ?DEFAULT_POOL, Query).
+    sql_query_cast(HostType, ?DEFAULT_POOL_NAME, Query).
 
 -spec sql_query_cast(HostType :: server(), PoolName :: atom(), Query :: any()) -> query_result().
 sql_query_cast(HostType, PoolName, Query) ->
@@ -349,7 +349,7 @@ sql_query_cast(HostType, PoolName, Query) ->
 %% @doc SQL transaction based on a list of queries
 -spec sql_transaction(server(), fun() | maybe_improper_list()) -> transaction_result().
 sql_transaction(HostType, Msg) ->
-    sql_transaction(HostType, ?DEFAULT_POOL, Msg).
+    sql_transaction(HostType, ?DEFAULT_POOL_NAME, Msg).
 
 -spec sql_transaction(server(), atom(), fun() | maybe_improper_list()) -> transaction_result().
 sql_transaction(HostType, PoolName, Queries) when is_atom(PoolName), is_list(Queries) ->
@@ -362,7 +362,7 @@ sql_transaction(HostType, PoolName, F) when is_atom(PoolName), is_function(F) ->
 %% @doc SQL transaction based on a list of queries
 -spec sql_transaction_request(server(), fun() | maybe_improper_list()) -> request_id().
 sql_transaction_request(HostType, Queries) ->
-    sql_transaction_request(HostType, ?DEFAULT_POOL, Queries).
+    sql_transaction_request(HostType, ?DEFAULT_POOL_NAME, Queries).
 
 -spec sql_transaction_request(server(), atom(), fun() | maybe_improper_list()) -> request_id().
 sql_transaction_request(HostType, PoolName, Queries) when is_atom(PoolName), is_list(Queries) ->
@@ -400,7 +400,7 @@ do_transaction_with_delayed_retry(HostType, F, Retries, Delay, Info) ->
 
 -spec sql_dirty(server(), fun()) -> any() | no_return().
 sql_dirty(HostType, F) ->
-    sql_dirty(HostType, ?DEFAULT_POOL, F).
+    sql_dirty(HostType, ?DEFAULT_POOL_NAME, F).
 
 -spec sql_dirty(server(), atom(), fun()) -> any() | no_return().
 sql_dirty(HostType, PoolName, F) when is_function(F) ->

--- a/src/rdbms/mongoose_rdbms_timestamp.erl
+++ b/src/rdbms/mongoose_rdbms_timestamp.erl
@@ -21,10 +21,10 @@ select_query() ->
            error({prepare_timestamp_query_failed, Other})
    end.
 
--spec select(mongooseim:host_type_or_global(), atom()) -> integer().
+-spec select(mongooseim:host_type_or_global(), mongoose_wpool:tag()) -> integer().
 select() ->
     select(global, default).
 
-select(HostType, PoolName) ->
-    Res = mongoose_rdbms:execute_successfully(HostType, PoolName, mim_timestamp, []),
+select(HostType, PoolTag) ->
+    Res = mongoose_rdbms:execute_successfully(HostType, PoolTag, mim_timestamp, []),
     mongoose_rdbms:selected_to_integer(Res). %% ensure it is an integer

--- a/src/rdbms/mongoose_rdbms_timestamp.erl
+++ b/src/rdbms/mongoose_rdbms_timestamp.erl
@@ -1,6 +1,8 @@
 -module(mongoose_rdbms_timestamp).
 -export([prepare/0,
-         select/0]).
+         select/0,
+         select/2]).
+-ignore_xref([select/2]).
 
 -spec prepare() -> ok.
 prepare() ->
@@ -19,7 +21,10 @@ select_query() ->
            error({prepare_timestamp_query_failed, Other})
    end.
 
--spec select() -> integer().
+-spec select(mongooseim:host_type_or_global(), atom()) -> integer().
 select() ->
-    Res = mongoose_rdbms:execute_successfully(global, mim_timestamp, []),
+    select(global, default).
+
+select(HostType, PoolName) ->
+    Res = mongoose_rdbms:execute_successfully(HostType, PoolName, mim_timestamp, []),
     mongoose_rdbms:selected_to_integer(Res). %% ensure it is an integer

--- a/src/rdbms/rdbms_queries.erl
+++ b/src/rdbms/rdbms_queries.erl
@@ -43,11 +43,12 @@
 -export([join/2,
          prepare_upsert/6,
          prepare_upsert/7,
-         execute_upsert/5,
+         execute_upsert/5, execute_upsert/6,
          request_upsert/5]).
 
 -ignore_xref([
-    count_records_where/3, get_db_specific_limits/1, get_db_specific_offset/2, get_db_type/0
+    execute_upsert/6, count_records_where/3,
+    get_db_specific_limits/1, get_db_specific_offset/2, get_db_type/0
 ]).
 
 %% We have only two compile time options for db queries:
@@ -88,13 +89,22 @@ get_db_type() ->
                      UpdateParams :: [any()],
                      UniqueKeyValues :: [any()]) -> mongoose_rdbms:query_result().
 execute_upsert(Host, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
+    execute_upsert(Host, default, Name, InsertParams, UpdateParams, UniqueKeyValues).
+
+-spec execute_upsert(Host :: mongoose_rdbms:server(),
+                     PoolName :: atom(),
+                     Name :: atom(),
+                     InsertParams :: [any()],
+                     UpdateParams :: [any()],
+                     UniqueKeyValues :: [any()]) -> mongoose_rdbms:query_result().
+execute_upsert(Host, PoolName, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
     case {mongoose_rdbms:db_engine(Host), mongoose_rdbms:db_type()} of
         {mysql, _} ->
-            mongoose_rdbms:execute(Host, Name, InsertParams ++ UpdateParams);
+            mongoose_rdbms:execute(Host, PoolName, Name, InsertParams ++ UpdateParams);
         {pgsql, _} ->
-            mongoose_rdbms:execute(Host, Name, InsertParams ++ UpdateParams);
+            mongoose_rdbms:execute(Host, PoolName, Name, InsertParams ++ UpdateParams);
         {odbc, mssql} ->
-            mongoose_rdbms:execute(Host, Name, UniqueKeyValues ++ InsertParams ++ UpdateParams);
+            mongoose_rdbms:execute(Host, PoolName, Name, UniqueKeyValues ++ InsertParams ++ UpdateParams);
         NotSupported -> erlang:error({rdbms_not_supported, NotSupported})
     end.
 

--- a/src/rdbms/rdbms_queries.erl
+++ b/src/rdbms/rdbms_queries.erl
@@ -83,70 +83,70 @@ join([H|T], Sep) ->
 get_db_type() ->
     ?RDBMS_TYPE.
 
--spec execute_upsert(Host :: mongoose_rdbms:server(),
+-spec execute_upsert(HostType :: mongooseim:host_type_or_global(),
                      Name :: atom(),
                      InsertParams :: [any()],
                      UpdateParams :: [any()],
                      UniqueKeyValues :: [any()]) -> mongoose_rdbms:query_result().
-execute_upsert(Host, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
-    execute_upsert(Host, default, Name, InsertParams, UpdateParams, UniqueKeyValues).
+execute_upsert(HostType, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
+    execute_upsert(HostType, default, Name, InsertParams, UpdateParams, UniqueKeyValues).
 
--spec execute_upsert(Host :: mongoose_rdbms:server(),
-                     PoolName :: atom(),
+-spec execute_upsert(HostType :: mongooseim:host_type_or_global(),
+                     PoolTag :: mongoose_wpool:tag(),
                      Name :: atom(),
                      InsertParams :: [any()],
                      UpdateParams :: [any()],
                      UniqueKeyValues :: [any()]) -> mongoose_rdbms:query_result().
-execute_upsert(Host, PoolName, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
-    case {mongoose_rdbms:db_engine(Host), mongoose_rdbms:db_type()} of
+execute_upsert(HostType, PoolTag, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
+    case {mongoose_rdbms:db_engine(HostType), mongoose_rdbms:db_type()} of
         {mysql, _} ->
-            mongoose_rdbms:execute(Host, PoolName, Name, InsertParams ++ UpdateParams);
+            mongoose_rdbms:execute(HostType, PoolTag, Name, InsertParams ++ UpdateParams);
         {pgsql, _} ->
-            mongoose_rdbms:execute(Host, PoolName, Name, InsertParams ++ UpdateParams);
+            mongoose_rdbms:execute(HostType, PoolTag, Name, InsertParams ++ UpdateParams);
         {odbc, mssql} ->
-            mongoose_rdbms:execute(Host, PoolName, Name, UniqueKeyValues ++ InsertParams ++ UpdateParams);
+            mongoose_rdbms:execute(HostType, PoolTag, Name, UniqueKeyValues ++ InsertParams ++ UpdateParams);
         NotSupported -> erlang:error({rdbms_not_supported, NotSupported})
     end.
 
--spec request_upsert(Host :: mongoose_rdbms:server(),
+-spec request_upsert(HostType :: mongooseim:host_type_or_global(),
                      Name :: atom(),
                      InsertParams :: [any()],
                      UpdateParams :: [any()],
                      UniqueKeyValues :: [any()]) -> request_id().
-request_upsert(Host, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
-    case {mongoose_rdbms:db_engine(Host), mongoose_rdbms:db_type()} of
+request_upsert(HostType, Name, InsertParams, UpdateParams, UniqueKeyValues) ->
+    case {mongoose_rdbms:db_engine(HostType), mongoose_rdbms:db_type()} of
         {mysql, _} ->
-            mongoose_rdbms:execute_request(Host, Name, InsertParams ++ UpdateParams);
+            mongoose_rdbms:execute_request(HostType, Name, InsertParams ++ UpdateParams);
         {pgsql, _} ->
-            mongoose_rdbms:execute_request(Host, Name, InsertParams ++ UpdateParams);
+            mongoose_rdbms:execute_request(HostType, Name, InsertParams ++ UpdateParams);
         {odbc, mssql} ->
-            mongoose_rdbms:execute_request(Host, Name, UniqueKeyValues ++ InsertParams ++ UpdateParams);
+            mongoose_rdbms:execute_request(HostType, Name, UniqueKeyValues ++ InsertParams ++ UpdateParams);
         NotSupported -> erlang:error({rdbms_not_supported, NotSupported})
     end.
 
 %% @doc
 %% This functions prepares query for inserting a row or updating it if already exists
 %% Updates can be either fields or literal expressions like "column = tab.column + 1"
--spec prepare_upsert(Host :: mongoose_rdbms:server(),
-                     QueryName :: atom(),
+-spec prepare_upsert(HostType :: mongooseim:host_type_or_global(),
+                     QueryName :: mongoose_rdbms:query_name(),
                      TableName :: atom(),
                      InsertFields :: [binary()],
                      Updates :: [binary() | {assignment | expression, binary(), binary()}],
                      UniqueKeyFields :: [binary()]) ->
-    {ok, QueryName :: atom()} | {error, already_exists}.
-prepare_upsert(Host, Name, Table, InsertFields, Updates, UniqueKeyFields) ->
-    prepare_upsert(Host, Name, Table, InsertFields, Updates, UniqueKeyFields, none).
+    {ok, QueryName :: mongoose_rdbms:query_name()} | {error, already_exists}.
+prepare_upsert(HostType, Name, Table, InsertFields, Updates, UniqueKeyFields) ->
+    prepare_upsert(HostType, Name, Table, InsertFields, Updates, UniqueKeyFields, none).
 
--spec prepare_upsert(Host :: mongoose_rdbms:server(),
-                     QueryName :: atom(),
+-spec prepare_upsert(HostType :: mongooseim:host_type_or_global(),
+                     QueryName :: mongoose_rdbms:query_name(),
                      TableName :: atom(),
                      InsertFields :: [ColumnName :: binary()],
                      Updates :: [binary() | {assignment | expression, binary(), binary()}],
                      UniqueKeyFields :: [binary()],
                      IncrementalField :: none | binary()) ->
-    {ok, QueryName :: atom()} | {error, already_exists}.
-prepare_upsert(Host, Name, Table, InsertFields, Updates, UniqueKeyFields, IncrementalField) ->
-    SQL = upsert_query(Host, Table, InsertFields, Updates, UniqueKeyFields, IncrementalField),
+    {ok, QueryName :: mongoose_rdbms:query_name()} | {error, already_exists}.
+prepare_upsert(HostType, Name, Table, InsertFields, Updates, UniqueKeyFields, IncrementalField) ->
+    SQL = upsert_query(HostType, Table, InsertFields, Updates, UniqueKeyFields, IncrementalField),
     Query = iolist_to_binary(SQL),
     ?LOG_DEBUG(#{what => rdbms_upsert_query, name => Name, query => Query}),
     Fields = prepared_upsert_fields(InsertFields, Updates, UniqueKeyFields),
@@ -160,8 +160,8 @@ prepared_upsert_fields(InsertFields, Updates, UniqueKeyFields) ->
         _ -> InsertFields ++ UpdateFields
     end.
 
-upsert_query(Host, Table, InsertFields, Updates, UniqueKeyFields, IncrementalField) ->
-    case {mongoose_rdbms:db_engine(Host), mongoose_rdbms:db_type()} of
+upsert_query(HostType, Table, InsertFields, Updates, UniqueKeyFields, IncrementalField) ->
+    case {mongoose_rdbms:db_engine(HostType), mongoose_rdbms:db_type()} of
         {mysql, _} ->
             upsert_mysql_query(Table, InsertFields, Updates, UniqueKeyFields, IncrementalField);
         {pgsql, _} ->

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -38,7 +38,7 @@
 -export([expand_pools/2]).
 
 -ignore_xref([call/2, cast/2, cast/3, expand_pools/2, get_worker/2,
-              send_request/2, send_request/4, send_request/5,
+              send_request/2, send_request/3, send_request/4, send_request/5,
               is_configured/2, is_configured/1, is_configured/1, start/2, start/3,
               start/5, start_configured_pools/1, start_configured_pools/2, stats/3,
               stop/1, stop/2]).


### PR DESCRIPTION
Solves MIM-2182

Currently the API for mongoose_rdbms allows only for providing the host-type, but not the pool tag. Change all APIs to look approximately like the following:

```
function(HostType, Name, Parameters) ->
    function(HostType, ?DEFAULT_POOL_NAME, Name, Parameters).

-spec function(HostType :: server(), PoolName :: atom(), Name :: atom(), Parameters :: term()) ->
    result().
function(HostType, PoolName, Name, Parameters) when is_atom(PoolName), is_atom(Name) ->
    sql_cast(HostType, PoolName, {sql_execute, Name, Parameters}).
```