### PR TITLE
Pools/list

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -236,7 +236,8 @@
     {internal_mnesia,
      %% dbs variable is used by ./tools/test_runner/presets_to_dbs.sh script
      [{dbs, [redis, minio]},
-      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+      {outgoing_pools, "[[outgoing_pools.redis]]
+  tag = \"global_distrib\"
   scope = \"global\"
   workers = 10"}]},
     {pgsql_cets,
@@ -250,10 +251,12 @@
       {auth_method, "rdbms"},
       {internal_databases, "[internal_databases.cets]
   cluster_name = \"{{cluster_name}}\""},
-      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+      {outgoing_pools, "[[outgoing_pools.redis]]
+  tag = \"global_distrib\"
   scope = \"global\"
   workers = 10
-[outgoing_pools.rdbms.default]
+[[outgoing_pools.rdbms]]
+  tag = \"default\"
   scope = \"global\"
   workers = 5
   connection.driver = \"pgsql\"
@@ -271,10 +274,12 @@
     {pgsql_mnesia,
      [{dbs, [redis, pgsql]},
       {auth_method, "rdbms"},
-      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+      {outgoing_pools, "[[outgoing_pools.redis]]
+  tag = \"global_distrib\"
   scope = \"global\"
   workers = 10
-[outgoing_pools.rdbms.default]
+[[outgoing_pools.rdbms]]
+  tag = \"default\"
   scope = \"global\"
   workers = 5
   connection.driver = \"pgsql\"
@@ -293,10 +298,12 @@
      [{dbs, [redis, mssql]},
       {auth_method, "rdbms"},
       {rdbms_server_type, "\"mssql\""},
-      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+      {outgoing_pools, "[[outgoing_pools.redis]]
+  tag = \"global_distrib\"
   scope = \"global\"
   workers = 10
-[outgoing_pools.rdbms.default]
+[[outgoing_pools.rdbms]]
+  tag = \"default\"
   scope = \"global\"
   workers = 5
   connection.driver = \"odbc\"
@@ -309,14 +316,17 @@
      [{dbs, [redis, mysql, rmq]},
       {sm_backend, "\"redis\""},
       {auth_method, "rdbms"},
-      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+      {outgoing_pools, "[[outgoing_pools.redis]]
+  tag = \"global_distrib\"
   scope = \"global\"
   workers = 10
-[outgoing_pools.redis.default]
+[[outgoing_pools.redis]]
+  tag = \"default\"
   scope = \"global\"
   workers = 10
   strategy = \"random_worker\"
-[outgoing_pools.rdbms.default]
+[[outgoing_pools.rdbms]]
+  tag = \"default\"
   scope = \"global\"
   workers = 5
   connection.driver = \"mysql\"
@@ -333,10 +343,12 @@
     {ldap_mnesia,
      [{dbs, [redis, ldap]},
       {auth_method, "ldap"},
-      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+      {outgoing_pools, "[[outgoing_pools.redis]]
+  tag = \"global_distrib\"
   scope = \"global\"
   workers = 10
-[outgoing_pools.ldap.default]
+[[outgoing_pools.ldap]]
+  tag = \"default\"
   scope = \"global\"
   workers = 5
   connection.port = 3636
@@ -346,7 +358,8 @@
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
   connection.tls.certfile = \"priv/ssl/fake_cert.pem\"
   connection.tls.keyfile = \"priv/ssl/fake_key.pem\"
-[outgoing_pools.ldap.bind]
+[[outgoing_pools.ldap]]
+  tag = \"bind\"
   scope = \"global\"
   workers = 5
   connection.port = 3636
@@ -363,15 +376,18 @@
   ldap.filter = \"(objectClass=inetOrgPerson)\"\n"}]},
     {elasticsearch_and_cassandra_mnesia,
      [{dbs, [redis, elasticsearch, cassandra]},
-      {outgoing_pools, "[outgoing_pools.redis.global_distrib]
+      {outgoing_pools, "[[outgoing_pools.redis]]
+  tag = \"global_distrib\"
   scope = \"global\"
   workers = 10
-[outgoing_pools.cassandra.default]
+[[outgoing_pools.cassandra]]
+  tag = \"default\"
   scope = \"global\"
   workers = 20
   connection.servers = [{host = \"localhost\", port = 9142}]
   connection.tls.cacertfile = \"priv/ssl/cacert.pem\"
-[outgoing_pools.elastic.default]
+[[outgoing_pools.elastic]]
+  tag = \"default\"
   scope = \"global\""}
      ]}
    ]}

--- a/big_tests/tests/mod_event_pusher_http_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_http_SUITE.erl
@@ -170,7 +170,7 @@ get_prefix(Config) ->
 start_pool() ->
     PoolOpts = #{strategy => available_worker, workers => 5},
     ConnOpts = #{host => http_notifications_host(), request_timeout => 2000},
-    Pool = config([outgoing_pools, http, http_pool], #{opts => PoolOpts, conn_opts => ConnOpts}),
+    Pool = config([aoutgoing_pools, http], #{tag => http_pool, opts => PoolOpts, conn_opts => ConnOpts}),
     [{ok, _Pid}] = rpc(mim(), mongoose_wpool, start_configured_pools, [[Pool]]).
 
 stop_pool() ->

--- a/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
@@ -44,7 +44,7 @@
 -define(CHAT_MSG_RECV_TOPIC, <<"custom_chat_msg_recv_topic">>).
 -define(GROUP_CHAT_MSG_SENT_TOPIC, <<"custom_group_chat_msg_sent_topic">>).
 -define(GROUP_CHAT_MSG_RECV_TOPIC, <<"custom_group_chat_msg_recv_topic">>).
--define(WPOOL_CFG, #{scope => host_type,
+-define(WPOOL_CFG, #{tag => event_pusher, scope => host_type,
                      opts => #{workers => 20, strategy => best_worker, call_timeout => 5000}}).
 -define(IF_EXCHANGE_EXISTS_RETRIES, 30).
 -define(WAIT_FOR_EXCHANGE_INTERVAL, 100). % ms
@@ -614,7 +614,7 @@ start_rabbit_wpool(Host) ->
 
 start_rabbit_wpool(Host, WpoolConfig) ->
     rpc(mim(), mongoose_wpool, ensure_started, []),
-    Pool = config([outgoing_pools, rabbit, event_pusher], WpoolConfig),
+    Pool = config([outgoing_pools, rabbit], WpoolConfig),
     [{ok, _Pid}] = rpc(mim(), mongoose_wpool, start_configured_pools, [[Pool], [Host]]).
 
 stop_rabbit_wpool({Pool, Host, Tag}) ->

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -378,8 +378,8 @@ init_per_group(G, Config) when G =:= http_auth_no_server;
     PoolOpts = #{strategy => available_worker, workers => 5},
     ConnOpts = #{host => "http://localhost:8080", path_prefix => <<"/muc/auth/">>,
                  request_timeout => 2000},
-    Pool = config([outgoing_pools, http, muc_http_auth_test],
-                  #{opts => PoolOpts, conn_opts => ConnOpts}),
+    Pool = config([outgoing_pools, http],
+                  #{tag => muc_http_auth_test, opts => PoolOpts, conn_opts => ConnOpts}),
     [{ok, _Pid}] = rpc(mim(), mongoose_wpool, start_configured_pools, [[Pool]]),
     case G of
         http_auth -> http_helper:start(8080, "/muc/auth/check_password", fun handle_http_auth/1);

--- a/big_tests/tests/push_http_SUITE.erl
+++ b/big_tests/tests/push_http_SUITE.erl
@@ -170,8 +170,8 @@ check_default_format(From, To, Body, Msg) ->
 start_pool() ->
     PoolOpts = #{strategy => random_worker, call_timeout => 5000, workers => 10},
     ConnOpts = #{host => http_notifications_host(), request_timeout => 5000},
-    Pool = config([outgoing_pools, http, http_pool],
-                  #{scope => host_type, opts => PoolOpts, conn_opts => ConnOpts}),
+    Pool = config([outgoing_pools, http],
+                  #{tag => http_pool, scope => host_type, opts => PoolOpts, conn_opts => ConnOpts}),
     [{ok, _Pid}] = rpc(mongoose_wpool, start_configured_pools, [[Pool], [<<"localhost">>]]).
 
 stop_pool() ->

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -135,7 +135,7 @@ init_per_suite(Config) ->
     PoolOpts = #{strategy => available_worker, workers => 20},
     ConnOpts = #{host => "https://localhost:" ++ integer_to_list(Port), request_timeout => 2000,
                  tls => #{verify_mode => none}},
-    Pool = config([outgoing_pools, http, mongoose_push_http], #{opts => PoolOpts, conn_opts => ConnOpts}),
+    Pool = config([outgoing_pools, http], #{tag => mongoose_push_http, opts => PoolOpts, conn_opts => ConnOpts}),
     [{ok, _Pid}] = rpc(?RPC_SPEC, mongoose_wpool, start_configured_pools, [[Pool]]),
     ConfigWithModules = dynamic_modules:save_modules(domain(), Config),
     escalus:init_per_suite(ConfigWithModules).

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -78,8 +78,8 @@ init_per_testcase(CaseName, Config) ->
     PoolOpts = #{strategy => available_worker, workers => 20},
     ConnOpts = #{host => "http://localhost:" ++ integer_to_list(MongoosePushMockPort),
                  request_timeout => 2000},
-    Pool = config([outgoing_pools, http, mongoose_push_http],
-                  #{opts => PoolOpts, conn_opts => ConnOpts}),
+    Pool = config([outgoing_pools, http],
+                  #{tag => mongoose_push_http, opts => PoolOpts, conn_opts => ConnOpts}),
     [{ok, _Pid}] = rpc(mongoose_wpool, start_configured_pools, [[Pool]]),
     escalus:init_per_testcase(CaseName, Config).
 

--- a/doc/migrations/6.2.0_x.x.x.md
+++ b/doc/migrations/6.2.0_x.x.x.md
@@ -13,3 +13,16 @@ There is a new column in the `mam_message` table in the database, which is used 
 ## Outgoing pools
 
 Pools now take `host_type` and `single_host_type` instead of `host` and `single_host` in their scope, see [outgoing pools](../configuration/outgoing-connections.md) for more information.
+
+Furthermore, pools are now configured as a list, where the pool tag is no longer a key in the TOML path but a KV-pair in the pool table. This way, for example, more than one pool with tag `default` can be configured for different scopes, for example a `global` `default` pool and a `single_host_type` `default` pool too.
+
+```toml
+[outgoing_pools.type.some_tag]
+```
+now becomes
+```toml
+[[outgoing_pools.type]]
+  tag = "tag"
+```
+
+Please update your config file accordingly.

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -174,11 +174,11 @@
 {{{outgoing_pools}}}
 {{/outgoing_pools}}
 {{^outgoing_pools}}
-#[outgoing_pools.rdbms.default]
+#[[outgoing_pools.rdbms]]
+#  tag = "default"
 #  scope = "global"
 #  workers = 5
-#
-#  [outgoing_pools.rdbms.default.connection]
+#  [outgoing_pools.rdbms.connection]
 #    driver = "pgsql"
 #    host = "localhost"
 #    database = "mongooseim"

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -475,10 +475,9 @@ wpool(ExtraDefaults) ->
                                      <<"call_timeout">> => 5000}, ExtraDefaults)}.
 
 outgoing_pool_extra(Type) ->
+    Scopes = [global, host_type, single_host_type, host, single_host], %% TODO deprecated
     #section{items = #{<<"scope">> => #option{type = atom,
-                                              validate = {enum, [global,
-                                                                 host_type, single_host_type,
-                                                                 host, single_host]}}, %% TODO deprecated
+                                              validate = {enum, Scopes}},
                        <<"host_type">> => #option{type = binary,
                                                   validate = non_empty},
                        <<"host">> => #option{type = binary, %% TODO deprecated

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -236,10 +236,10 @@ domain_cert() ->
 
 %% path: listen
 listen() ->
-    Keys = [c2s, s2s, service, http],
+    ListenerTypes = [<<"c2s">>, <<"s2s">>, <<"service">>, <<"http">>],
     #section{
-       items = maps:from_list([{atom_to_binary(Key), #list{items = listener(Key), wrap = none}}
-                               || Key <- Keys]),
+       items = maps:from_list([{Listener, #list{items = listener(Listener), wrap = none}}
+                               || Listener <- ListenerTypes]),
        process = fun mongoose_listener_config:verify_unique_listeners/1,
        wrap = global_config,
        format_items = list
@@ -264,7 +264,7 @@ listener_common() ->
              process = fun ?MODULE:process_listener/2
             }.
 
-listener_extra(http) ->
+listener_extra(<<"http">>) ->
     %% tls options passed to ranch_ssl (with verify_mode translated to verify_fun)
     #section{items = #{<<"tls">> => tls([server], [just_tls]),
                        <<"transport">> => http_transport(),
@@ -292,7 +292,7 @@ xmpp_listener_common() ->
                           <<"num_acceptors">> => 100}
             }.
 
-xmpp_listener_extra(c2s) ->
+xmpp_listener_extra(<<"c2s">>) ->
     #section{items = #{<<"access">> => #option{type = atom,
                                                validate = non_empty},
                        <<"shaper">> => #option{type = atom,
@@ -315,14 +315,14 @@ xmpp_listener_extra(c2s) ->
                           <<"reuse_port">> => false,
                           <<"backwards_compatible_session">> => true}
             };
-xmpp_listener_extra(s2s) ->
+xmpp_listener_extra(<<"s2s">>) ->
     TLSSection = tls([server], [fast_tls]),
     #section{items = #{<<"shaper">> => #option{type = atom,
                                                validate = non_empty},
                        <<"tls">> => TLSSection#section{include = always}},
              defaults = #{<<"shaper">> => none}
             };
-xmpp_listener_extra(service) ->
+xmpp_listener_extra(<<"service">>) ->
     #section{items = #{<<"access">> => #option{type = atom,
                                                validate = non_empty},
                        <<"shaper_rule">> => #option{type = atom,

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -27,9 +27,7 @@
          get_pool_settings/3, get_pools/0, stats/3]).
 
 -export([start_sup_pool/3]).
--export([start_configured_pools/0]).
--export([start_configured_pools/1]).
--export([start_configured_pools/2]).
+-export([start_configured_pools/0, start_configured_pools/1, start_configured_pools/2]).
 -export([is_configured/1]).
 -export([make_pool_name/3]).
 -export([call_start_callback/2]).
@@ -43,14 +41,13 @@
               start/5, start_configured_pools/1, start_configured_pools/2, stats/3,
               stop/1, stop/2]).
 
--type pool_type() :: redis | http | rdbms | cassandra | elastic | generic
-                     | rabbit | ldap.
+-type pool_type() :: redis | http | rdbms | cassandra | elastic | generic | rabbit | ldap.
 
 %% Config scope
 -type scope() :: global | host_type | mongooseim:host_type().
 -type host_type_or_global() :: mongooseim:host_type_or_global().
-
 -type tag() :: atom().
+
 %% Name of a process
 -type proc_name() :: atom().
 
@@ -80,13 +77,7 @@
 -type start_result() :: {ok, pid()} | {error, term()}.
 -type stop_result() :: ok | term().
 
--export_type([pool_type/0]).
--export_type([tag/0]).
--export_type([scope/0]).
--export_type([proc_name/0]).
--export_type([pool_name/0]).
--export_type([pool_opts/0]).
--export_type([conn_opts/0]).
+-export_type([pool_type/0, tag/0, scope/0, proc_name/0, pool_name/0, pool_opts/0, conn_opts/0]).
 
 -type callback_fun() :: init | start | is_supported_strategy | stop.
 

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -240,7 +240,8 @@ options("mongooseim-pgsql") ->
      {outgoing_pools,
       lists:map(
         fun pool_config/1,
-        [#{type => rdbms,
+        [#{tag => default,
+           type => rdbms,
            opts => #{workers => 5},
            conn_opts => #{driver => pgsql, host => "localhost", port => 5432, database => "mongooseim",
                           username => "mongooseim", password => "mongooseim_secret",
@@ -249,7 +250,7 @@ options("mongooseim-pgsql") ->
                                    server_name_indication => #{enabled => false}}
                          }
           },
-         #{type => redis, scope => <<"localhost">>, tag => global_distrib,
+         #{tag => global_distrib, type => redis, scope => <<"localhost">>,
            opts => #{workers => 10}, conn_opts => #{}}
         ])},
      {rdbms_server_type, generic},
@@ -769,7 +770,7 @@ pgsql_access() ->
       s2s_shaper => [#{acl => all, value => fast}]}.
 
 pool_config(PoolIn = #{type := Type}) ->
-    config([outgoing_pools, Type, maps:get(tag, PoolIn, default)], PoolIn).
+    config([outgoing_pools, Type], PoolIn).
 
 default_pool_wpool_opts(cassandra) ->
     #{workers => 20,
@@ -783,7 +784,7 @@ default_pool_wpool_opts(_) ->
     default_wpool_opts().
 
 default_wpool_opts() ->
-     #{workers => 10,
+    #{workers => 10,
       strategy => best_worker,
       call_timeout => 5000}.
 
@@ -1243,20 +1244,20 @@ default_config([modules, mod_vcard, ldap]) -> % included when backend => ldap
                           {<<"Organization Unit">>, <<"ORGUNIT">>}],
       search_operator => 'and',
       binary_search_fields => []};
-default_config([outgoing_pools, Type, Tag] = P) ->
+default_config([outgoing_pools, Type] = P) ->
     #{type => Type,
-      tag => Tag,
+      tag => default,
       scope => global,
       opts => default_config(P ++ [opts]),
       conn_opts => default_config(P ++ [conn_opts])};
-default_config([outgoing_pools, Type, _Tag, opts]) ->
+default_config([outgoing_pools, Type, opts]) ->
     default_pool_wpool_opts(Type);
-default_config([outgoing_pools, Type, _Tag, conn_opts]) ->
+default_config([outgoing_pools, Type, conn_opts]) ->
     default_pool_conn_opts(Type);
-default_config([outgoing_pools, _Type, _Tag, conn_opts, tls] = P) ->
+default_config([outgoing_pools, _Type, conn_opts, tls] = P) ->
     #{verify_mode => peer,
       server_name_indication => default_config(P ++ [server_name_indication])};
-default_config([outgoing_pools, _Type, _Tag, conn_opts, tls, server_name_indication]) ->
+default_config([outgoing_pools, _Type, conn_opts, tls, server_name_indication]) ->
     #{enabled => true, protocol => default};
 default_config([services, service_domain_db]) ->
     #{event_cleaning_interval => 1800,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -902,7 +902,7 @@ pool_rdbms_connection_odbc(_Config) ->
     Required = #{<<"driver">> => <<"odbc">>, <<"settings">> => <<"DSN=mydb">>},
     T = fun(Opts) -> pool_conn_raw(<<"rdbms">>, Opts) end,
     test_pool_rdbms_connection_common_opts(P, T, Required),
-    ?cfg(P, config([outgoing_pools, rdbms, default, conn_opts],
+    ?cfg(P, config([outgoing_pools, rdbms, conn_opts],
                    #{driver => odbc, settings => "DSN=mydb"}), T(Required)),
     ?err(T(Required#{<<"settings">> => true})),
     [?err(T(maps:remove(K, Required))) || K <- maps:keys(Required)].
@@ -919,7 +919,7 @@ pool_rdbms_connection_tls_pgsql(_Config) ->
     Required = raw_sql_opts(pgsql),
     T = fun(Opts) -> pool_conn_raw(<<"rdbms">>, Required#{<<"tls">> => Opts}) end,
     M = tls_ca_raw(),
-    ?cfg(P, config([outgoing_pools, rdbms, default, conn_opts, tls], (tls_ca())#{required => false}),
+    ?cfg(P, config([outgoing_pools, rdbms, conn_opts, tls], (tls_ca())#{required => false}),
          T(M)),
     ?cfg(P ++ [required], true, T(M#{<<"required">> => true})),
     ?err(T(M#{<<"required">> => <<"maybe">>})),
@@ -937,12 +937,12 @@ pool_rdbms_connection_tls_mysql(_Config) ->
     Required = raw_sql_opts(mysql),
     T = fun(Opts) -> pool_conn_raw(<<"rdbms">>, Required#{<<"tls">> => Opts}) end,
     M = tls_ca_raw(),
-    ?cfg(P, config([outgoing_pools, rdbms, default, conn_opts, tls], tls_ca()), T(M)),
+    ?cfg(P, config([outgoing_pools, rdbms, conn_opts, tls], tls_ca()), T(M)),
     ?err(T(M#{<<"required">> => true})), % only for pgsql
     test_just_tls_client(P, T).
 
 test_pool_rdbms_connection_sql_opts(P, T, Required, Expected) ->
-    ?cfg(P, config([outgoing_pools, rdbms, default, conn_opts], Expected), T(Required)),
+    ?cfg(P, config([outgoing_pools, rdbms, conn_opts], Expected), T(Required)),
     ?cfg(P ++ [port], 1234, T(Required#{<<"port">> => 1234})),
     ?err(T(Required#{<<"host">> => <<>>})),
     ?err(T(Required#{<<"port">> => -1})),
@@ -981,7 +981,7 @@ pool_http_connection(_Config) ->
     P = [outgoing_pools, 1, conn_opts],
     T = fun(Opts) -> pool_conn_raw(<<"http">>, Opts) end,
     Required = #{<<"host">> => <<"https://localhost:8443">>},
-    ?cfg(P, config([outgoing_pools, http, default, conn_opts], #{host => "https://localhost:8443"}),
+    ?cfg(P, config([outgoing_pools, http, conn_opts], #{host => "https://localhost:8443"}),
          T(Required)),
     ?cfg(P ++ [path_prefix], <<"/my_path/">>, T(Required#{<<"path_prefix">> => <<"/my_path/">>})),
     ?cfg(P ++ [request_timeout], 999, T(Required#{<<"request_timeout">> => 999})),
@@ -994,7 +994,7 @@ pool_http_connection_tls(_Config) ->
     P = [outgoing_pools, 1, conn_opts, tls],
     T = fun(Opts) -> pool_conn_raw(<<"http">>, #{<<"host">> => <<"http://localhost">>,
                                                  <<"tls">> => Opts}) end,
-    ?cfg(P, config([outgoing_pools, http, default, conn_opts, tls], tls_ca()), T(tls_ca_raw())),
+    ?cfg(P, config([outgoing_pools, http, conn_opts, tls], tls_ca()), T(tls_ca_raw())),
     test_just_tls_client(P, T).
 
 pool_redis(_Config) ->
@@ -1003,7 +1003,7 @@ pool_redis(_Config) ->
 pool_redis_connection(_Config) ->
     P = [outgoing_pools, 1, conn_opts],
     T = fun(Opts) -> pool_conn_raw(<<"redis">>, Opts) end,
-    ?cfg(P, default_config([outgoing_pools, redis, default, conn_opts]), T(#{})),
+    ?cfg(P, default_config([outgoing_pools, redis, conn_opts]), T(#{})),
     ?cfg(P ++ [host], "my_host", T(#{<<"host">> => <<"my_host">>})),
     ?cfg(P ++ [port], 9999, T(#{<<"port">> => 9999})),
     ?cfg(P ++ [database], 1, T(#{<<"database">> => 1})),
@@ -1019,7 +1019,7 @@ pool_cassandra(_Config) ->
 pool_cassandra_connection(_Config) ->
     P = [outgoing_pools, 1, conn_opts],
     T = fun(Opts) -> pool_conn_raw(<<"cassandra">>, Opts) end,
-    ?cfg(P, default_config([outgoing_pools, cassandra, default, conn_opts]), T(#{})),
+    ?cfg(P, default_config([outgoing_pools, cassandra, conn_opts]), T(#{})),
     ?cfg(P ++ [keyspace], big_mongooseim, T(#{<<"keyspace">> => <<"big_mongooseim">>})),
     ?err(T(#{<<"keyspace">> => <<>>})).
 
@@ -1045,7 +1045,7 @@ pool_cassandra_connection_servers(_Config) ->
 pool_cassandra_connection_tls(_Config) ->
     P = [outgoing_pools, 1, conn_opts, tls],
     T = fun(Opts) -> pool_conn_raw(<<"cassandra">>, #{<<"tls">> => Opts}) end,
-    ?cfg(P, config([outgoing_pools, cassandra, default, conn_opts, tls], tls_ca()), T(tls_ca_raw())),
+    ?cfg(P, config([outgoing_pools, cassandra, conn_opts, tls], tls_ca()), T(tls_ca_raw())),
     test_just_tls_client(P, T).
 
 pool_elastic(_Config) ->
@@ -1054,7 +1054,7 @@ pool_elastic(_Config) ->
 pool_elastic_connection(_Config) ->
     P = [outgoing_pools, 1, conn_opts],
     T = fun(Opts) -> pool_conn_raw(<<"elastic">>, Opts) end,
-    ?cfg(P, default_config([outgoing_pools, elastic, default, conn_opts]), T(#{})),
+    ?cfg(P, default_config([outgoing_pools, elastic, conn_opts]), T(#{})),
     ?cfg(P ++ [host], <<"my_host">>, T(#{<<"host">> => <<"my_host">>})),
     ?cfg(P ++ [port], 9999, T(#{<<"port">> => 9999})),
     ?err(T(#{<<"host">> => <<>>})),
@@ -1066,7 +1066,7 @@ pool_rabbit(_Config) ->
 pool_rabbit_connection(_Config) ->
     P = [outgoing_pools, 1, conn_opts],
     T = fun(Opts) -> pool_conn_raw(<<"rabbit">>, Opts) end,
-    ?cfg(P, default_config([outgoing_pools, rabbit, default, conn_opts]), T(#{})),
+    ?cfg(P, default_config([outgoing_pools, rabbit, conn_opts]), T(#{})),
     ?cfg(P ++ [host], "my_host", T(#{<<"host">> => <<"my_host">>})),
     ?cfg(P ++ [port], 9999, T(#{<<"port">> => 9999})),
     ?cfg(P ++ [username], <<"user">>, T(#{<<"username">> => <<"user">>})),
@@ -1086,7 +1086,7 @@ pool_ldap(_Config) ->
 pool_ldap_connection(_Config) ->
     P = [outgoing_pools, 1, conn_opts],
     T = fun(Opts) -> pool_conn_raw(<<"ldap">>, Opts) end,
-    ?cfg(P, default_config([outgoing_pools, ldap, default, conn_opts]), T(#{})),
+    ?cfg(P, default_config([outgoing_pools, ldap, conn_opts]), T(#{})),
     ?cfg(P ++ [servers], ["server1.example.com", "server2.example.com"],
          T(#{<<"servers">> => [<<"server1.example.com">>, <<"server2.example.com">>]})),
     ?cfg(P ++ [port], 999, T(#{<<"port">> => 999})),
@@ -1104,13 +1104,13 @@ pool_ldap_connection(_Config) ->
 pool_ldap_connection_tls(_Config) ->
     P = [outgoing_pools, 1, conn_opts, tls],
     T = fun(Opts) -> pool_conn_raw(<<"ldap">>, #{<<"tls">> => Opts}) end,
-    ?cfg(P, config([outgoing_pools, ldap, default, conn_opts, tls], tls_ca()), T(tls_ca_raw())),
+    ?cfg(P, config([outgoing_pools, ldap, conn_opts, tls], tls_ca()), T(tls_ca_raw())),
     test_just_tls_client(P, T).
 
 test_pool_opts(Type, Required) ->
     P = [outgoing_pools, 1, opts],
-    T = fun(Opts) -> pool_raw(atom_to_binary(Type), <<"default">>, Opts) end,
-    ?cfg(P, default_config([outgoing_pools, Type, default, opts]), T(Required)),
+    T = fun(Opts) -> pool_raw(atom_to_binary(Type), Opts) end,
+    ?cfg(P, default_config([outgoing_pools, Type, opts]), T(Required)),
     ?cfg(P ++ [workers], 11, T(Required#{<<"workers">> => 11})),
     ?cfg(P ++ [strategy], random_worker, T(Required#{<<"strategy">> => <<"random_worker">>})),
     ?cfg(P ++ [call_timeout], 999, T(Required#{<<"call_timeout">> => 999})),
@@ -3032,11 +3032,14 @@ auth_raw(Method, Opts) ->
 
 %% helpers for 'pool' tests
 
+pool_raw(Type, Opts) ->
+    #{<<"outgoing_pools">> => #{Type => [Opts]}}.
+
 pool_raw(Type, Tag, Opts) ->
-    #{<<"outgoing_pools">> => #{Type => #{Tag => Opts}}}.
+    #{<<"outgoing_pools">> => #{Type => [Opts#{<<"tag">> => Tag}]}}.
 
 pool_conn_raw(Type, Opts) ->
-    #{<<"outgoing_pools">> => #{Type => #{<<"default">> => #{<<"connection">> => Opts}}}}.
+    #{<<"outgoing_pools">> => #{Type => [#{<<"tag">> => <<"default">>, <<"connection">> => Opts}]}}.
 
 %% helpers for 'access' tests
 

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -131,16 +131,17 @@
 
   [auth.rdbms]
 
-[outgoing_pools.redis.global_distrib]
+[[outgoing_pools.redis]]
+  tag = "global_distrib"
   scope = "single_host"
   host = "localhost"
   workers = 10
 
-[outgoing_pools.rdbms.default]
+[[outgoing_pools.rdbms]]
+  tag = "default"
   scope = "global"
   workers = 5
-
-  [outgoing_pools.rdbms.default.connection]
+  [outgoing_pools.rdbms.connection]
     driver = "pgsql"
     host = "localhost"
     database = "mongooseim"

--- a/test/config_parser_SUITE_data/outgoing_pools.toml
+++ b/test/config_parser_SUITE_data/outgoing_pools.toml
@@ -6,16 +6,17 @@
   ]
   default_server_domain = "localhost"
 
-[outgoing_pools.redis.global_distrib]
+[[outgoing_pools.redis]]
+  tag = "global_distrib"
   scope = "single_host_type"
   host = "localhost"
   workers = 10
 
-[outgoing_pools.rdbms.default]
+[[outgoing_pools.rdbms]]
+  tag = "default"
   scope = "global"
   workers = 5
-
-  [outgoing_pools.rdbms.default.connection]
+  [outgoing_pools.rdbms.connection]
     driver = "pgsql"
     host = "localhost"
     database = "mongooseim"
@@ -26,34 +27,35 @@
     tls.cacertfile = "priv/ca.pem"
     tls.server_name_indication.enabled = false
 
-[outgoing_pools.http.mongoose_push_http]
+[[outgoing_pools.http]]
+  tag = "mongoose_push_http"
   scope = "global"
   workers = 50
-
-  [outgoing_pools.http.mongoose_push_http.connection]
+  [outgoing_pools.http.connection]
     host = "https://localhost:8443"
     path_prefix = "/"
     request_timeout = 2000
 
-[outgoing_pools.cassandra.default]
+[[outgoing_pools.cassandra]]
+  tag = "default"
   scope = "global"
-
-  [outgoing_pools.cassandra.default.connection]
+  [outgoing_pools.cassandra.connection]
     servers = [
       {host = "cassandra_server1.example.com", port = 9042},
       {host = "cassandra_server2.example.com", port = 9042}
     ]
     keyspace = "big_mongooseim"
 
-[outgoing_pools.elastic.default]
+[[outgoing_pools.elastic]]
+  tag = "default"
   scope = "global"
   connection.host = "localhost"
 
-[outgoing_pools.rabbit.event_pusher]
+[[outgoing_pools.rabbit]]
+  tag = "event_pusher"
   scope = "host_type"
   workers = 20
-
-  [outgoing_pools.rabbit.event_pusher.connection]
+  [outgoing_pools.rabbit.connection]
     host = "localhost"
     port = 5672
     username = "guest"
@@ -61,11 +63,11 @@
     confirms_enabled = true
     max_worker_queue_len = 100
 
-[outgoing_pools.ldap.default]
+[[outgoing_pools.ldap]]
+  tag = "default"
   scope = "host_type"
   workers = 5
-
-  [outgoing_pools.ldap.default.connection]
+  [outgoing_pools.ldap.connection]
     servers = ["ldap-server.example.com"]
     root_dn = "cn=admin,dc=example,dc=com"
     password = "ldap-admin-password"


### PR DESCRIPTION
The main idea is that now pools are configured as a list, where the pool tag is no longer a key in the TOML path but a KV-pair in the pool table. This way, for example, more than one pool with tag `default` can be configured for different scopes, for example a `global` `default` pool and a `single_host_type` `default` pool too.