### PR TITLE
Pools/per host config

### DIFF
--- a/doc/configuration/Services.md
+++ b/doc/configuration/Services.md
@@ -75,7 +75,7 @@ It is used to synchronise dynamic domains between nodes after starting.
 * **Example:** `db_pool = "my_host_type"`
 
 By default, this service uses the RDBMS connection pool configured with the scope `"global"`.
-You can put a specific host type there to use the pool with the `"host"` or `"single_host"` scope for that particular host type. See the [outgoing connections docs](outgoing-connections.md) for more information about pool scopes.
+You can put a specific host type there to use the `default` pool with the `host_type` scope for that particular host type. See the [outgoing connections docs](outgoing-connections.md) for more information about pool scopes.
 
 ### `services.service_domain_db.event_cleaning_interval`
 

--- a/doc/configuration/host_config.md
+++ b/doc/configuration/host_config.md
@@ -112,6 +112,26 @@ If we wanted to enable `mod_roster`, it would need to be repeated in `host_confi
   [host_config.modules.mod_stream_management]
 ```
 
+### `host_config.outgoing_pools`
+
+This section overrides any pool with the same type and tag that was defined in the top-level [`outgoing_pools`](outgoing-connections.md) section.
+If we wanted to enable a `default` `rdbms` pool only for `"host-type-basic"` for example, we could do so as follows:
+
+```toml
+[general]
+  host_type = ["host-type-basic", "host-type-advanced", "host-type-privacy"]
+
+[[host_config]]
+  host = "host-type-basic"
+
+  [outgoing_pools.rdbms.default]
+    workers = 5
+    [outgoing_pools.rdbms.default.connection]
+    ...
+```
+
+Configuration for such pools is all the same, except that the `scope` key is here disallowed.
+
 ### `host_config.acl`
 
 The access classes defined here are merged with the ones defined in the top-level [`acl`](acl.md) section - when a class is defined in both places, the result is a union of both classes.

--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -15,32 +15,24 @@ This allows you to create multiple dedicated pools of the same type.
 ## General pool options
 
 ### `outgoing_pools.*.*.scope`
-* **Syntax:** string, one of:`"global"`, `"host_type"`, `"single_host_type"`
+* **Syntax:** string, one of:`"global"`, `"host_type"`.
 * **Default:** `"global"`
 * **Example:** `scope = "host_type"`
 
-### `outgoing_pools.*.*.host_type`
-* **Syntax:** string
-* **Default:** no default; required if `"single_host_type"` scope is specified
-* **Example:** `host_type = "basic_host_type"`
-
-### `outgoing_pools.*.*.host`
-* **Syntax:** string
-* **Default:** no default; required if `"single_host"` scope is specified
-* **Example:** `host = "anotherhost.com"`
-
 `scope` can be set to:
 
-* `global` - meaning that the pool will be started once no matter how many XMPP hosts are served by MongooseIM
-* `host_type` - the pool will be started for each XMPP host or host type served by MongooseIM
-* `single_host_type` - the pool will be started for the selected host or host type only (you must provide the name).
+* `global` - meaning that the pool will be started once no matter how many XMPP hosts are served by MongooseIM.
+* `host_type` - the pool will be started for each static XMPP host or host type served by MongooseIM.
 
     !!! Note
         A pool with scope `global` and tag `default` is used by services that are not configured by host_type, like `service_domain_db` or `service_mongoose_system_metrics`, or by modules that don't support dynamic domains, like `mod_pubsub`.
         If a global default pool is not configured, these services will fail.
 
     !!! Note
-        `host` and `single_host` are still supported and behave equivalent to `host_type` and `single_host_type` respectively; however, they are deprecated in favour of the latter.
+        The option `host` is still supported and behaves equivalent to `host_type`; however, it is deprecated in favour of the latter.
+
+    !!! Warning
+        The options `single_host` and `single_host_type` for the scope has been deprecated, in favour of configuring the specified pools within the [`host_config`](host_config.md) section.
 
 ## Worker pool options
 

--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -31,9 +31,6 @@ This allows you to create multiple dedicated pools of the same type.
     !!! Note
         The option `host` is still supported and behaves equivalent to `host_type`; however, it is deprecated in favour of the latter.
 
-    !!! Warning
-        The options `single_host` and `single_host_type` for the scope has been deprecated, in favour of configuring the specified pools within the [`host_config`](host_config.md) section.
-
 ## Worker pool options
 
 All pools are managed by the [inaka/worker_pool](https://github.com/inaka/worker_pool) library.

--- a/doc/migrations/6.2.0_x.x.x.md
+++ b/doc/migrations/6.2.0_x.x.x.md
@@ -12,4 +12,6 @@ There is a new column in the `mam_message` table in the database, which is used 
 
 ## Outgoing pools
 
-Pools now take `host_type` and `single_host_type` instead of `host` and `single_host` in their scope, see [outgoing pools](../configuration/outgoing-connections.md) for more information.
+The outgoing connections option `host` is now named `host_type`, see [outgoing pools](../configuration/outgoing-connections.md) for more information.
+
+The option `single_host` for the scope has been deprecated, in favour of configuring the specified pools within the [`host_config`](../configuration/host_config.md) section.

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -494,7 +494,7 @@ outgoing_pool_extra(host_config, Type) ->
              process = fun ?MODULE:process_host_config_pool/2
             };
 outgoing_pool_extra(global_config, Type) ->
-    Scopes = [global, host_type, single_host_type, host, single_host], %% TODO deprecated
+    Scopes = [global, host_type, host], %% TODO deprecated
     #section{items = #{<<"scope">> => #option{type = atom,
                                               validate = {enum, Scopes}},
                        <<"host_type">> => #option{type = binary,
@@ -1115,14 +1115,6 @@ process_host_config_pool([Tag, Type, _Pools, {host, HT} | _], AllOpts = #{connec
       opts => maps:remove(connection, AllOpts),
       conn_opts => Connection}.
 
-pool_scope(single_host_type, none) ->
-    error(#{what => pool_single_host_type_not_specified,
-            text => <<"\"host_type\" option is required if \"single_host_type\" is used.">>});
-pool_scope(single_host, none) ->
-    error(#{what => pool_single_host_not_specified,
-            text => <<"\"host\" option is required if \"single_host\" is used.">>});
-pool_scope(single_host_type, HostType) -> HostType;
-pool_scope(single_host, Host) -> Host;
 pool_scope(host, none) -> host_type;
 pool_scope(host_type, none) -> host_type;
 pool_scope(global, none) -> global.

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -475,10 +475,9 @@ wpool(ExtraDefaults) ->
                                      <<"call_timeout">> => 5000}, ExtraDefaults)}.
 
 outgoing_pool_extra(Type) ->
+    Scopes = [global, host_type, single_host_type, host, single_host], %% TODO deprecated
     #section{items = #{<<"scope">> => #option{type = atom,
-                                              validate = {enum, [global,
-                                                                 host_type, single_host_type,
-                                                                 host, single_host]}}, %% TODO deprecated
+                                              validate = {enum, Scopes}},
                        <<"host_type">> => #option{type = binary,
                                                   validate = non_empty},
                        <<"host">> => #option{type = binary, %% TODO deprecated

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -236,10 +236,10 @@ domain_cert() ->
 
 %% path: listen
 listen() ->
-    Keys = [c2s, s2s, service, http],
+    ListenerTypes = [<<"c2s">>, <<"s2s">>, <<"service">>, <<"http">>],
     #section{
-       items = maps:from_list([{atom_to_binary(Key), #list{items = listener(Key), wrap = none}}
-                               || Key <- Keys]),
+       items = maps:from_list([{Listener, #list{items = listener(Listener), wrap = none}}
+                               || Listener <- ListenerTypes]),
        process = fun mongoose_listener_config:verify_unique_listeners/1,
        wrap = global_config,
        format_items = list
@@ -264,7 +264,7 @@ listener_common() ->
              process = fun ?MODULE:process_listener/2
             }.
 
-listener_extra(http) ->
+listener_extra(<<"http">>) ->
     %% tls options passed to ranch_ssl (with verify_mode translated to verify_fun)
     #section{items = #{<<"tls">> => tls([server], [just_tls]),
                        <<"transport">> => http_transport(),
@@ -292,7 +292,7 @@ xmpp_listener_common() ->
                           <<"num_acceptors">> => 100}
             }.
 
-xmpp_listener_extra(c2s) ->
+xmpp_listener_extra(<<"c2s">>) ->
     #section{items = #{<<"access">> => #option{type = atom,
                                                validate = non_empty},
                        <<"shaper">> => #option{type = atom,
@@ -315,14 +315,14 @@ xmpp_listener_extra(c2s) ->
                           <<"reuse_port">> => false,
                           <<"backwards_compatible_session">> => true}
             };
-xmpp_listener_extra(s2s) ->
+xmpp_listener_extra(<<"s2s">>) ->
     TLSSection = tls([server], [fast_tls]),
     #section{items = #{<<"shaper">> => #option{type = atom,
                                                validate = non_empty},
                        <<"tls">> => TLSSection#section{include = always}},
              defaults = #{<<"shaper">> => none}
             };
-xmpp_listener_extra(service) ->
+xmpp_listener_extra(<<"service">>) ->
     #section{items = #{<<"access">> => #option{type = atom,
                                                validate = non_empty},
                        <<"shaper_rule">> => #option{type = atom,

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -27,9 +27,7 @@
          get_pool_settings/3, get_pools/0, stats/3]).
 
 -export([start_sup_pool/3]).
--export([start_configured_pools/0]).
--export([start_configured_pools/1]).
--export([start_configured_pools/2]).
+-export([start_configured_pools/0, start_configured_pools/1, start_configured_pools/2]).
 -export([is_configured/1]).
 -export([make_pool_name/3]).
 -export([call_start_callback/2]).
@@ -43,14 +41,13 @@
               start/5, start_configured_pools/1, start_configured_pools/2, stats/3,
               stop/1, stop/2]).
 
--type pool_type() :: redis | http | rdbms | cassandra | elastic | generic
-                     | rabbit | ldap.
+-type pool_type() :: redis | http | rdbms | cassandra | elastic | generic | rabbit | ldap.
 
 %% Config scope
 -type scope() :: global | host_type | mongooseim:host_type().
 -type host_type_or_global() :: mongooseim:host_type_or_global().
-
 -type tag() :: atom().
+
 %% Name of a process
 -type proc_name() :: atom().
 
@@ -80,13 +77,7 @@
 -type start_result() :: {ok, pid()} | {error, term()}.
 -type stop_result() :: ok | term().
 
--export_type([pool_type/0]).
--export_type([tag/0]).
--export_type([scope/0]).
--export_type([proc_name/0]).
--export_type([pool_name/0]).
--export_type([pool_opts/0]).
--export_type([conn_opts/0]).
+-export_type([pool_type/0, tag/0, scope/0, proc_name/0, pool_name/0, pool_opts/0, conn_opts/0]).
 
 -type callback_fun() :: init | start | is_supported_strategy | stop.
 

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -118,7 +118,7 @@ start_configured_pools(PoolsIn, HostTypes) ->
 
 start_configured_pools(PoolsIn, HostTypeSpecific, HostTypes) ->
     Pools = expand_pools(PoolsIn, HostTypeSpecific, HostTypes),
-    [call_callback(init, PoolType, []) || PoolType <- get_unique_types(PoolsIn)],
+    [call_callback(init, PoolType, []) || PoolType <- get_unique_types(PoolsIn, HostTypeSpecific)],
     [start(Pool) || Pool <- Pools].
 
 -spec start(pool_map()) -> start_result().
@@ -379,9 +379,9 @@ prepare_pool_map(Pool = #{scope := HT, opts := Opts}) ->
     Pool1 = maps:remove(scope, Pool),
     Pool1#{host_type => HT, opts => maps:to_list(Opts)}.
 
--spec get_unique_types([pool_map_in()]) -> [pool_type()].
-get_unique_types(Pools) ->
-    lists:usort([maps:get(type, Pool) || Pool <- Pools]).
+-spec get_unique_types([pool_map_in()], [pool_map_in()]) -> [pool_type()].
+get_unique_types(Pools, HostTypeSpecific) ->
+    lists:usort([maps:get(type, Pool) || Pool <- Pools ++ HostTypeSpecific]).
 
 -spec get_pool(pool_type(), host_type_or_global(), tag()) -> pool_record_result().
 get_pool(PoolType, HostType, Tag) ->

--- a/src/wpool/mongoose_wpool.erl
+++ b/src/wpool/mongoose_wpool.erl
@@ -112,8 +112,8 @@ start_configured_pools(PoolsIn) ->
     start_configured_pools(PoolsIn, ?ALL_HOST_TYPES).
 
 start_configured_pools(PoolsIn, HostTypes) ->
-    [call_callback(init, PoolType, []) || PoolType <- get_unique_types(PoolsIn)],
     Pools = expand_pools(PoolsIn, HostTypes),
+    [call_callback(init, PoolType, []) || PoolType <- get_unique_types(PoolsIn)],
     [start(Pool) || Pool <- Pools].
 
 -spec start(pool_map()) -> start_result().

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -77,7 +77,7 @@ init_per_suite(Config) ->
               % This would be started via outgoing_pools in normal case
               Pool = config([outgoing_pools, http, auth], pool_opts()),
               HostTypes = [?HOST_TYPE, <<"another host type">>],
-              mongoose_wpool:start_configured_pools([Pool], HostTypes),
+              mongoose_wpool:start_configured_pools([Pool], [], HostTypes),
               mongoose_wpool_http:init(),
               ejabberd_auth_http:start(?HOST_TYPE)
       end),

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -261,9 +261,8 @@ options("mongooseim-pgsql") ->
      {component_backend, mnesia},
      {s2s_backend, mnesia},
      {{outgoing_pools, <<"anonymous.localhost">>},
-      lists:map(
-        fun host_pool_config/1,
-        [#{tag => special,
+      [host_pool_config(
+         #{tag => special,
            scope => <<"anonymous.localhost">>,
            type => rdbms,
            opts => #{workers => 5},
@@ -274,7 +273,7 @@ options("mongooseim-pgsql") ->
                                    server_name_indication => #{enabled => false}}
                          }
           }
-        ])},
+        )]},
      {{auth, <<"anonymous.localhost">>},
       (default_auth())#{anonymous => #{backend => mnesia,
                                        allow_multiple_connections => true,
@@ -299,10 +298,9 @@ options("mongooseim-pgsql") ->
      {{replaced_wait_timeout, <<"localhost">>}, 2000},
      {{replaced_wait_timeout, <<"localhost.bis">>}, 2000},
      {{outgoing_pools, <<"localhost">>},
-      lists:map(
-        fun host_pool_config/1,
-        [#{type => redis, scope => <<"localhost">>, tag => global_distrib,
-           opts => #{workers => 10}, conn_opts => #{}}])},
+      [host_pool_config(
+         #{type => redis, scope => <<"localhost">>, tag => global_distrib,
+           opts => #{workers => 10}, conn_opts => #{}})]},
      {{s2s, <<"anonymous.localhost">>}, pgsql_s2s()},
      {{s2s, <<"localhost">>}, pgsql_s2s()},
      {{s2s, <<"localhost.bis">>}, pgsql_s2s()},
@@ -370,10 +368,9 @@ options("outgoing_pools") ->
      {routing_modules, mongoose_router:default_routing_modules()},
      {services, #{}},
      {{outgoing_pools, <<"localhost">>},
-      lists:map(
-        fun host_pool_config/1,
-        [#{type => redis, scope => <<"localhost">>, tag => global_distrib,
-           opts => #{workers => 10}, conn_opts => #{}}])},
+      [host_pool_config(
+         #{type => redis, scope => <<"localhost">>, tag => global_distrib,
+           opts => #{workers => 10}, conn_opts => #{}})]},
      {{s2s, <<"anonymous.localhost">>}, default_s2s()},
      {{s2s, <<"localhost">>}, default_s2s()},
      {{s2s, <<"localhost.bis">>}, default_s2s()},

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -248,9 +248,7 @@ options("mongooseim-pgsql") ->
                                    cacertfile => "priv/ca.pem",
                                    server_name_indication => #{enabled => false}}
                          }
-          },
-         #{type => redis, scope => <<"localhost">>, tag => global_distrib,
-           opts => #{workers => 10}, conn_opts => #{}}
+          }
         ])},
      {rdbms_server_type, generic},
      {registration_timeout, infinity},
@@ -365,15 +363,13 @@ options("outgoing_pools") ->
                                    cacertfile => "priv/ca.pem",
                                    server_name_indication => #{enabled => false}}
                          }
-          },
-         #{type => redis, scope => <<"localhost">>, tag => global_distrib,
-           opts => #{workers => 10}, conn_opts => #{}}
+          }
         ])},
      {rdbms_server_type, generic},
      {registration_timeout, 600},
      {routing_modules, mongoose_router:default_routing_modules()},
      {services, #{}},
-     {{outgoing_pools, <<"localhost.bis">>},
+     {{outgoing_pools, <<"localhost">>},
       lists:map(
         fun host_pool_config/1,
         [#{type => redis, scope => <<"localhost">>, tag => global_distrib,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -877,6 +877,8 @@ pool_basics(_Config) ->
     Required = #{<<"connection">> => #{<<"host">> => <<"http://localhost">>}},
     ?cfg(P ++ [type], http, pool_raw(<<"http">>, <<"default">>, Required)),
     ?cfg(P ++ [tag], default, pool_raw(<<"http">>, <<"default">>, Required)),
+    ?cfg(host_opts([{P ++ [tag], default}]),
+         host_config(pool_raw(<<"http">>, <<"default">>, Required))),
     ?err(pool_raw(<<"swimming_pool">>, <<"default">>, Required)),
     ?err(pool_raw(<<"http">>, 1000, Required)).
 
@@ -886,9 +888,8 @@ pool_scope(_Config) ->
     T = fun(Opts) -> pool_raw(<<"http">>, <<"default">>, maps:merge(Required, Opts)) end,
     ?cfg(P, host_type, T(#{<<"scope">> => <<"host">>})),
     ?cfg(P, host_type, T(#{<<"scope">> => <<"host_type">>})),
-    ?err(T(#{<<"host">> => <<"localhost">>})), % missing scope
-    ?err(T(#{<<"host_type">> => <<"localhost">>})), % missing scope
-    ?err(T(#{<<"scope">> => <<"whatever">>})).
+    ?err(T(#{<<"scope">> => <<"whatever">>})),
+    ?err(host_config(T(#{<<"scope">> => <<"global">>}))). %% scope is not allowed in host_config
 
 pool_rdbms(_Config) ->
     test_pool_opts(rdbms, #{<<"connection">> => raw_sql_opts(pgsql)}).

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -886,12 +886,8 @@ pool_scope(_Config) ->
     T = fun(Opts) -> pool_raw(<<"http">>, <<"default">>, maps:merge(Required, Opts)) end,
     ?cfg(P, host_type, T(#{<<"scope">> => <<"host">>})),
     ?cfg(P, host_type, T(#{<<"scope">> => <<"host_type">>})),
-    ?cfg(P, <<"localhost">>, T(#{<<"scope">> => <<"single_host">>, <<"host">> => <<"localhost">>})),
-    ?cfg(P, <<"localhost">>, T(#{<<"scope">> => <<"single_host_type">>, <<"host_type">> => <<"localhost">>})),
     ?err(T(#{<<"host">> => <<"localhost">>})), % missing scope
     ?err(T(#{<<"host_type">> => <<"localhost">>})), % missing scope
-    ?err(T(#{<<"scope">> => <<"single_host">>})), % missing host
-    ?err(T(#{<<"scope">> => <<"single_host_type">>})), % missing host type
     ?err(T(#{<<"scope">> => <<"whatever">>})).
 
 pool_rdbms(_Config) ->

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -131,11 +131,6 @@
 
   [auth.rdbms]
 
-[outgoing_pools.redis.global_distrib]
-  scope = "single_host"
-  host = "localhost"
-  workers = 10
-
 [outgoing_pools.rdbms.default]
   scope = "global"
   workers = 5
@@ -304,6 +299,11 @@
   [[s2s.address]]
     host = "fed1"
     ip_address = "127.0.0.1"
+
+[[host_config]]
+  host = "localhost"
+  [host_config.outgoing_pools.redis.global_distrib]
+    workers = 10
 
 [[host_config]]
   host = "anonymous.localhost"

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -307,7 +307,16 @@
 
 [[host_config]]
   host = "anonymous.localhost"
-
   [host_config.auth.anonymous]
     allow_multiple_connections = true
     protocol = "both"
+  [host_config.outgoing_pools.rdbms.special]
+    workers = 5
+    connection.driver = "pgsql"
+    connection.host = "localhost"
+    connection.database = "mongooseim"
+    connection.username = "mongooseim"
+    connection.password = "mongooseim_secret"
+    connection.tls.required = true
+    connection.tls.cacertfile = "priv/ca.pem"
+    connection.tls.server_name_indication.enabled = false

--- a/test/config_parser_SUITE_data/outgoing_pools.toml
+++ b/test/config_parser_SUITE_data/outgoing_pools.toml
@@ -69,3 +69,8 @@
     servers = ["ldap-server.example.com"]
     root_dn = "cn=admin,dc=example,dc=com"
     password = "ldap-admin-password"
+
+[[host_config]]
+  host = "localhost.bis"
+  [host_config.outgoing_pools.redis.global_distrib]
+    workers = 10

--- a/test/config_parser_SUITE_data/outgoing_pools.toml
+++ b/test/config_parser_SUITE_data/outgoing_pools.toml
@@ -6,11 +6,6 @@
   ]
   default_server_domain = "localhost"
 
-[outgoing_pools.redis.global_distrib]
-  scope = "single_host_type"
-  host = "localhost"
-  workers = 10
-
 [outgoing_pools.rdbms.default]
   scope = "global"
   workers = 5
@@ -71,6 +66,6 @@
     password = "ldap-admin-password"
 
 [[host_config]]
-  host = "localhost.bis"
+  host = "localhost"
   [host_config.outgoing_pools.redis.global_distrib]
     workers = 10

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -78,7 +78,7 @@ init_redis_group(true, Config) ->
                   mongoose_wpool:ensure_started(),
                   % This would be started via outgoing_pools in normal case
                   Pool = default_config([outgoing_pools, redis, default]),
-                  mongoose_wpool:start_configured_pools([Pool], []),
+                  mongoose_wpool:start_configured_pools([Pool], [], []),
                   Self ! ready,
                   receive stop -> ok end
           end),

--- a/test/http_client_SUITE.erl
+++ b/test/http_client_SUITE.erl
@@ -57,7 +57,7 @@ end_per_suite(_Config) ->
 
 init_per_testcase(TC, Config) ->
     Pool = config([outgoing_pools, http, pool()], pool_opts(TC)),
-    mongoose_wpool:start_configured_pools([Pool], [<<"a.com">>]),
+    mongoose_wpool:start_configured_pools([Pool], [], [<<"a.com">>]),
     Config.
 
 pool_opts(request_timeout_test) ->


### PR DESCRIPTION
What I wanted to have was to allow to have a default global pool, and another default for a single_host_type for example. But the current TOML config doesn’t let me have two pools tagged default. Allow for this.