### PR TITLE
Fixing verify ceritificate options on https listeners

### DIFF
--- a/big_tests/tests/ca_certificate_helper.erl
+++ b/big_tests/tests/ca_certificate_helper.erl
@@ -26,11 +26,11 @@ prepare_template_values(User, XMPPAddrsIn) ->
 maybe_prepare_xmpp_addresses(undefined) ->
     "";
 maybe_prepare_xmpp_addresses(Addrs) when is_list(Addrs) ->
-    AddrsWithSeq = lists:zip(Addrs, lists:seq(1, length(Addrs))),
-    Entries = [make_xmpp_addr_entry(Addr, I) || {Addr, I} <- AddrsWithSeq],
+    AddrsWithSeq = lists:enumerate(Addrs),
+    Entries = [make_xmpp_addr_entry(I, Addr) || {I, Addr} <- AddrsWithSeq],
     string:join(Entries, "\n").
 
-make_xmpp_addr_entry(Addr, I) ->
+make_xmpp_addr_entry(I, Addr) ->
     % id-on-xmppAddr OID is specified in the openssl-user.cnf config file
     "otherName." ++ integer_to_list(I) ++ " = id-on-xmppAddr;UTF8:" ++ Addr.
 

--- a/big_tests/tests/ca_certificate_helper.erl
+++ b/big_tests/tests/ca_certificate_helper.erl
@@ -1,0 +1,60 @@
+-module(ca_certificate_helper).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+
+generate_cert(Config, #{cn := User} = CertSpec, BasicTemplateValues) ->
+    ConfigTemplate = filename:join(?config(mim_data_dir, Config), "openssl-user.cnf"),
+    {ok, Template} = file:read_file(ConfigTemplate),
+    XMPPAddrs = maps:get(xmpp_addrs, CertSpec, undefined),
+    TemplateValues = maps:merge(BasicTemplateValues, prepare_template_values(User, XMPPAddrs)),
+    OpenSSLConfig = bbmustache:render(Template, TemplateValues),
+    UserConfig = filename:join(?config(priv_dir, Config), User ++ ".cfg"),
+    ct:log("OpenSSL config: ~ts~n~ts", [UserConfig, OpenSSLConfig]),
+    file:write_file(UserConfig, OpenSSLConfig),
+    UserKey = filename:join(?config(priv_dir, Config), User ++ "_key.pem"),
+    case maps:get(signed, CertSpec, ca) of
+	    ca -> generate_ca_signed_cert(Config, User, UserConfig, UserKey);
+	    self -> generate_self_signed_cert(Config, User, UserConfig, UserKey)
+    end.
+
+prepare_template_values(User, XMPPAddrsIn) ->
+    XMPPAddrs = maybe_prepare_xmpp_addresses(XMPPAddrsIn),
+    #{"cn" => User, "xmppAddrs" => XMPPAddrs}.
+
+maybe_prepare_xmpp_addresses(undefined) ->
+    "";
+maybe_prepare_xmpp_addresses(Addrs) when is_list(Addrs) ->
+    AddrsWithSeq = lists:zip(Addrs, lists:seq(1, length(Addrs))),
+    Entries = [make_xmpp_addr_entry(Addr, I) || {Addr, I} <- AddrsWithSeq],
+    string:join(Entries, "\n").
+
+make_xmpp_addr_entry(Addr, I) ->
+    % id-on-xmppAddr OID is specified in the openssl-user.cnf config file
+    "otherName." ++ integer_to_list(I) ++ " = id-on-xmppAddr;UTF8:" ++ Addr.
+
+
+generate_ca_signed_cert(Config, Filename, ConfigCfg, KeyFilename) ->
+    Csr = filename:join(?config(priv_dir, Config), Filename ++ ".csr"),
+    Cmd = ["openssl req -config ", ConfigCfg, " -newkey rsa:2048 -sha256 -nodes -out ",
+           Csr, " -keyout ", KeyFilename, " -outform PEM"],
+    Out = os:cmd(Cmd),
+    ct:log("generate_ca_signed_cert 1:~nCmd ~p~nOut ~ts", [Cmd, Out]),
+    Cert = filename:join(?config(priv_dir, Config), Filename ++ "_cert.pem"),
+    SignCmd = filename:join(?config(mim_data_dir, Config), "sign_cert.sh"),
+    Cmd2 = [SignCmd, " --req ", Csr, " --out ", Cert],
+    SSLDir = filename:join([path_helper:repo_dir(Config), "tools", "ssl"]),
+    OutLog = os:cmd("cd " ++ SSLDir ++ " && " ++ Cmd2),
+    ct:log("generate_ca_signed_cert 2:~nCmd ~p~nOut ~ts", [Cmd2, OutLog]),
+    #{key => KeyFilename,
+      cert => Cert}.
+
+generate_self_signed_cert(Config, Filename, ConfigCfg, KeyFilename) ->
+    Cert = filename:join(?config(priv_dir, Config), Filename ++ "_self_signed_cert.pem"),
+    Cmd = ["openssl req -config ", ConfigCfg, " -newkey rsa:2048 -sha256 -nodes -out ",
+           Cert, " -keyout ", KeyFilename, " -x509 -outform PEM -extensions client_req_extensions"],
+    OutLog = os:cmd(Cmd),
+    ct:log("generate_self_signed_cert:~nCmd ~p~nOut ~ts", [Cmd, OutLog]),
+    #{key => KeyFilename,
+      cert => Cert}.

--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -210,8 +210,7 @@ tls_connect_domain_admin_no_certificate(Config) ->
     Opts = [{connect_options, [{verify, verify_none}]}],
     Port = get_listener_port(Config, domain_admin_listener_config),
     {ok, Client} = fusco_cp:start_link({"localhost", Port, true}, Opts, 1),
-    Result = fusco_cp:request(Client, <<"/api/graphql">>, <<"POST">>,
-                                    get_headers(), <<>>, 2, 10000),
+    Result = fusco_cp:request(Client, <<"/api/graphql">>, <<"POST">>, headers(), <<>>, 2, 10000),
     fusco_cp:stop(Client),
     ?assertMatch({ok, {{<<"400">>, <<"Bad Request">>}, _, _, _, _}}, Result).
 
@@ -219,8 +218,7 @@ tls_connect_user_no_certificate(Config) ->
     Opts = [{connect_options, [{verify, verify_none}]}],
     Port = get_listener_port(Config, user_listener_config),
     {ok, Client} = fusco_cp:start_link({"localhost", Port, true}, Opts, 1),
-    Result = fusco_cp:request(Client, <<"/api/graphql">>, <<"POST">>,
-                                    get_headers(), <<>>, 2, 10000),
+    Result = fusco_cp:request(Client, <<"/api/graphql">>, <<"POST">>, headers(), <<>>, 2, 10000),
     ?assertMatch(ok, assert_match_result(Result)).
 
 tls_connect_user_unknown_certificate(Config) ->
@@ -245,8 +243,7 @@ tls_connect_admin_no_certificate(Config) ->
     Opts = [{connect_options, [{verify, verify_none}]}],
     Port = get_listener_port(Config, admin_listener_config),
     {ok, Client} = fusco_cp:start_link({"localhost", Port, true}, Opts, 1),
-    Result = fusco_cp:request(Client, <<"/api/graphql">>, <<"POST">>,
-                                    get_headers(), <<>>, 2, 10000),
+    Result = fusco_cp:request(Client, <<"/api/graphql">>, <<"POST">>, headers(), <<>>, 2, 10000),
     ?assertMatch(ok, assert_match_result(Result)).
 
 tls_connect_admin_unknown_certificate(Config) ->
@@ -279,7 +276,7 @@ assert_match_result(_) ->
 send_request_with_cert(Cert, Key, Port) ->
     Opts = [{connect_options, [{verify, verify_none}, {certfile, Cert}, {keyfile, Key}]}],
     {ok, Client} = fusco_cp:start_link({"localhost", Port, true}, Opts, 1),
-    fusco_cp:request(Client, <<"/api/graphql">>, <<"POST">>, get_headers(), <<>>, 2, 10000).
+    fusco_cp:request(Client, <<"/api/graphql">>, <<"POST">>, headers(), <<>>, 2, 10000).
 
 get_listener_port(Config, Listener) ->
     ListenerConfig = ?config(Listener, Config),
@@ -295,7 +292,7 @@ generate_certificate_selfsigned(Config) ->
     Filenames = ca_certificate_helper:generate_cert(Config, CertSpec, #{}),
     [{certificate_selfsigned, Filenames} | Config].
 
-get_headers() ->
+headers() ->
     [{<<"Content-Type">>, <<"application/json">>},
      {<<"Request-Id">>, rest_helper:random_request_id()}].
 

--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -266,6 +266,10 @@ tls_connect_admin_signed_certificate(Config) ->
 
 %% Helpers
 
+% The proper error should be the first one, {error, {tls_alert, {certificate_required, _}}}.
+% Sometimes for unknown reasons, the result is {error, connection_closed}. This test is important
+% to check if the server does not allow the connection when the certificate is not attached.
+%  Therefore, to prevent the creation of a flaky test, the function below was created.
 assert_match_result({error, {tls_alert, {certificate_required, _}}}) ->
     ok;
 assert_match_result({error, connection_closed}) ->

--- a/big_tests/tests/graphql_SUITE_data/openssl-user.cnf
+++ b/big_tests/tests/graphql_SUITE_data/openssl-user.cnf
@@ -1,0 +1,38 @@
+HOME            = .
+RANDFILE        = $ENV::HOME/.rnd
+
+oid_section = xmpp_oids
+
+####################################################################
+[ req ]
+default_bits        = 4096
+distinguished_name  = client_distinguished_name
+req_extensions      = client_req_extensions
+string_mask         = utf8only
+prompt              = no
+
+####################################################################
+[ xmpp_oids ]
+{{{xmppOids}}}
+
+####################################################################
+[ client_distinguished_name ]
+commonName                  = {{cn}}
+
+####################################################################
+[ client_req_extensions ]
+
+subjectKeyIdentifier        = hash
+basicConstraints            = CA:FALSE
+keyUsage                    = digitalSignature, keyEncipherment
+subjectAltName              = @alternate_names
+nsComment                   = "Fake Dev-Only Certificate for GRAPHQL tests"
+
+###############################################################################################################
+## subjectAltName sections, see 'man x509v3_config' for more information
+## example:
+## otherName.1 = id-on-xmppAddr;UTF8:alice@localhost
+###############################################################################################################
+[ alternate_names ]
+{{{xmppAddrs}}}
+email = {{cn}}@mail.domain.com ## this is just to have sth in the section

--- a/big_tests/tests/graphql_SUITE_data/sign_cert.sh
+++ b/big_tests/tests/graphql_SUITE_data/sign_cert.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+function invalid_usage()
+{
+  echo    "invalid input parameters, correct usage:"
+  echo -n "    sign_cert.sh --req <path_to_csr_file> --out <path_to_signed_cert>"
+  exit 1
+}
+
+req_file=
+out_file=
+
+## process input parameters
+[ $# -eq 0 ] && invalid_usage
+while true; do
+  [ "$1" == "--req" ] && [ $# -gt 1 ] && { req_file="$2";  shift 2; continue; }
+  [ "$1" == "--out" ] && [ $# -gt 1 ] && { out_file="$2";  shift 2; continue; }
+  break
+done
+
+openssl ca -config openssl-ca-clients.cnf \
+              -policy signing_policy \
+	      -extensions signing_req \
+              -out $out_file \
+              -in $req_file <<EOF
+y
+y
+EOF
+

--- a/big_tests/tests/graphql_SUITE_data/sign_cert.sh
+++ b/big_tests/tests/graphql_SUITE_data/sign_cert.sh
@@ -19,11 +19,10 @@ while true; do
 done
 
 openssl ca -config openssl-ca-clients.cnf \
-              -policy signing_policy \
-	      -extensions signing_req \
-              -out $out_file \
-              -in $req_file <<EOF
-y
-y
+           -policy signing_policy \
+           -extensions signing_req \
+           -out $out_file \
+           -batch \
+           -in $req_file <<EOF
 EOF
 

--- a/big_tests/tests/sasl_external_SUITE_data/sign_cert.sh
+++ b/big_tests/tests/sasl_external_SUITE_data/sign_cert.sh
@@ -19,11 +19,10 @@ while true; do
 done
 
 openssl ca -config openssl-ca-clients.cnf \
-              -policy signing_policy \
-	      -extensions signing_req \
-              -out $out_file \
-              -in $req_file <<EOF
-y
-y
+           -policy signing_policy \
+           -extensions signing_req \
+           -out $out_file \
+           -batch \
+           -in $req_file <<EOF
 EOF
 

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -163,7 +163,7 @@ do_start_cowboy(Ref, Opts) ->
     end.
 
 start_http_or_https(#{tls := TLSOpts}, Ref, TransportOpts, ProtocolOpts) ->
-    SSLOpts = just_tls:make_ssl_opts(TLSOpts),
+    SSLOpts = just_tls:make_cowboy_ssl_opts(TLSOpts),
     SocketOptsWithSSL = maps:get(socket_opts, TransportOpts) ++ SSLOpts,
     cowboy_start_https(Ref, TransportOpts#{socket_opts := SocketOptsWithSSL}, ProtocolOpts);
 start_http_or_https(#{}, Ref, TransportOpts, ProtocolOpts) ->


### PR DESCRIPTION
The `verify_mode` option had no effect on incoming HTTP connections, and always works as `none`.
In this PR, I've enabled the check and disallowed  connections from untrusted peers with the `peer` mode. 
The option `selfsigned_peer` is supported as well.

The changes in the code consist of adding the option `fail_if_no_peer_cert = true`, whenever the verify_mode is set to `peer` or `selfsigned_peer`. Because the option is desired only in https listeners, not when we are connecting to the database, a separate function was created only for cowboy listener, to allow it to work properly.

In the big_tests the tests are testing all possible scenarios, with graphql handlers: `domain_admin_listener` has verify_mode set to `none`, `user_listener` has verify_mode set to `selfsigned_peer`, and `admin_listener` has veirfy_mode set to `peer`. Certificates needed to perform the tests were signed based on the existing code in `sasl_external_suite`. To prevent code duplication, the new helper, `ca_certificate_helper` has been created. 