### PR TITLE
Fix flaky `init_per_group` in the MUC suite

### DIFF
--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -341,7 +341,6 @@ end_per_suite(Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config).
 
-
 init_per_group(room_registration_race_condition, Config) ->
     escalus_fresh:create_users(Config, [{alice, 1}]);
 


### PR DESCRIPTION
This PR fixes a problem where tests might fail if an HTTP listener has already been started in the `init_per_group` function of the MUC suite.

Sometimes, if other tests that need an HTTP listener don't work right, they can leave the listener running. This causes a problem when trying to start it again in the `init_per_group`.