### PR TITLE
Prepare log_helper for parallel tests

### DIFF
--- a/test/common/ets_helper.erl
+++ b/test/common/ets_helper.erl
@@ -1,0 +1,33 @@
+%% Helper module for an ETS table with an owner process
+
+-module(ets_helper).
+
+-compile([export_all, nowarn_export_all]).
+
+%% API
+
+new(Name) ->
+    new(Name, []).
+
+new(Name, ExtraOpts) ->
+    TabOwner = spawn(?MODULE, init_tab, [self(), Name, ExtraOpts]),
+    receive
+        table_created -> ok
+    after
+        5000 ->
+            exit(TabOwner, kill),
+            error("Table owner did not respond")
+    end.
+
+delete(Name) ->
+    TabOwner = ets:info(Name, owner),
+    ets:delete(Name),
+    TabOwner ! stop,
+    ok.
+
+%% Helpers
+
+init_tab(Caller, Name, ExtraOpts) ->
+    ets:new(Name, [named_table, public | ExtraOpts]),
+    Caller ! table_created,
+    receive stop -> ok end.

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -251,24 +251,28 @@ init_per_group(dynamic_domains, Config) ->
     meck:expect(ejabberd_auth_http, supported_features, fun() -> [] end),
     meck:expect(mod_test, supported_features, fun() -> [] end),
     Config;
+init_per_group(logs, _Config) ->
+    log_helper:set_up();
 init_per_group(_, Config) ->
     Config.
 
 end_per_group(dynamic_domains, _Config) ->
     meck:unload();
+end_per_group(logs, _Config) ->
+    log_helper:tear_down();
 end_per_group(_, _Config) ->
     ok.
 
 init_per_testcase(CaseName, Config) ->
     case lists:member(CaseName, log_cases()) of
-        true -> log_helper:set_up();
+        true -> log_helper:subscribe();
         false -> ok
     end,
     Config.
 
 end_per_testcase(CaseName, _Config) ->
     case lists:member(CaseName, log_cases()) of
-        true -> log_helper:tear_down();
+        true -> log_helper:unsubscribe();
         false -> ok
     end.
 

--- a/test/log_helper.erl
+++ b/test/log_helper.erl
@@ -4,17 +4,32 @@
 -module(log_helper).
 -compile([export_all, nowarn_export_all]).
 
-%% Call in init_per_testcase
+%% Call in init_per_suite/group
 set_up() ->
-    logger:add_handler(handler_id(), ?MODULE, #{receiver => self()}).
+    ets_helper:new(?MODULE),
+    ok = logger:add_handler(?MODULE, ?MODULE, #{}).
+
+%% Call in init_per_testcase
+subscribe() ->
+    subscribe(self()).
+
+subscribe(Pid) ->
+    ets:insert(?MODULE, {Pid}),
+    ok.
 
 %% Call in end_per_testcase
+unsubscribe() ->
+    unsubscribe(self()).
+
+unsubscribe(Pid) ->
+    ets:delete(?MODULE, Pid),
+    ok.
+
+%% Call in end_per_suite/group
 tear_down() ->
-    logger:remove_handler(handler_id()).
+    logger:remove_handler(?MODULE),
+    ets_helper:delete(?MODULE).
 
 %% Logger callback
-log(Event, #{receiver := Receiver}) ->
-    Receiver ! {log, Event}.
-
-handler_id() ->
-    list_to_atom(pid_to_list(self())).
+log(Event, #{}) ->
+    [Receiver ! {log, Event} || {Receiver} <- ets:tab2list(?MODULE)].


### PR DESCRIPTION
This PR prepares `log_helper` for being used in parallel tests.

Logger does adding/removing handlers asynchronously, which leads to race conditions, and some handlers may fail to get registered.

This is why `log_helper` is now reimplemented with only one log handler, and an ETS table for receiver Pids.

Additionally, `ets_helper` is added, which is currently used only once, but in `feature/instrument` it will be used again.