### PR TITLE
Instrument/metric improvements

### DIFF
--- a/big_tests/tests/mongoose_instrument_event_table.erl
+++ b/big_tests/tests/mongoose_instrument_event_table.erl
@@ -6,20 +6,16 @@
 -define(TABLE, ?MODULE).
 
 %% API
--export([start/1, stop/0, get_events/2]).
+-export([get_events/2, all_keys/0]).
 
 %% mongoose_instrument callbacks
--export([set_up/3, handle_event/4]).
+-export([start/0, stop/0, set_up/3, handle_event/4]).
 
-start(DeclaredEvents) ->
-    ets_helper:new(?TABLE, [bag]), % repeating measurements are stored only once
-    mongoose_instrument:add_handler(event_table, #{declared_events => DeclaredEvents}).
+start() ->
+    ets_helper:new(?TABLE, [bag]). % repeating measurements are stored only once
 
 stop() ->
-    mongoose_instrument:remove_handler(event_table),
-    Logged = all_keys(?TABLE),
-    ets_helper:delete(?TABLE),
-    {ok, Logged}.
+    ets_helper:delete(?TABLE).
 
 set_up(EventName, Labels, _Config) ->
     DeclaredEvents = mongoose_config:get_opt([instrumentation, event_table, declared_events]),
@@ -30,6 +26,9 @@ handle_event(EventName, Labels, _Config, Measurements) ->
 
 get_events(EventName, Labels) ->
     ets:lookup(?TABLE, {EventName, Labels}).
+
+all_keys() ->
+    all_keys(?TABLE).
 
 all_keys(Tab) ->
     all_keys(Tab, ets:first(Tab), []).

--- a/src/instrument/mongoose_instrument.erl
+++ b/src/instrument/mongoose_instrument.erl
@@ -23,7 +23,11 @@
 
 -type event_name() :: atom().
 -type labels() :: #{host_type => mongooseim:host_type()}. % to be extended
--type metrics() :: #{atom() => spiral | histogram}. % to be extended
+-type label_key() :: host_type. % to be extended
+-type label_value() :: mongooseim:host_type(). % to be extended
+-type metrics() :: #{metric_name() => metric_type()}.
+-type metric_name() :: atom().
+-type metric_type() :: spiral | histogram. % to be extended
 -type measurements() :: #{atom() => term()}.
 -type spec() :: {event_name(), labels(), config()}.
 -type config() :: #{metrics => metrics()}. % to be extended
@@ -41,7 +45,8 @@
 
 -optional_callbacks([config_spec/0, start/0, stop/0]).
 
--export_type([event_name/0, labels/0, config/0, measurements/0, spec/0, handlers/0]).
+-export_type([event_name/0, labels/0, label_key/0, label_value/0, config/0, measurements/0,
+              spec/0, handlers/0, metric_name/0, metric_type/0]).
 
 %% API
 

--- a/src/instrument/mongoose_instrument_prometheus.erl
+++ b/src/instrument/mongoose_instrument_prometheus.erl
@@ -4,12 +4,16 @@
 
 -export([set_up/3, handle_event/4]).
 
+%% Define Prometheus metric-related types, because the library has no type specs
+-type spec() :: proplists:proplist().
+-type name() :: string().
+-type help() :: string().
+
 -spec set_up(mongoose_instrument:event_name(), mongoose_instrument:labels(),
-            mongoose_instrument:config()) -> boolean().
+             mongoose_instrument:config()) -> boolean().
 set_up(EventName, Labels, #{metrics := Metrics}) ->
-    LabelKeys = labels_to_keys(Labels),
     maps:foreach(fun(MetricName, MetricType) ->
-                         set_up_metric(EventName, LabelKeys, MetricName, MetricType)
+                         set_up_metric(EventName, Labels, MetricName, MetricType)
                  end, Metrics),
     true;
 set_up(_EventName, _Labels, #{}) ->
@@ -23,20 +27,41 @@ handle_event(EventName, Labels, #{metrics := Metrics}, Measurements) ->
                          handle_metric_event(EventName, LabelValues, MetricName, MetricType, Measurements)
                  end, Metrics).
 
-set_up_metric(EventName, LabelKeys, MetricName, MetricType) ->
+-spec set_up_metric(mongoose_instrument:event_name(), mongoose_instrument:labels(),
+                    mongoose_instrument:metric_name(), mongoose_instrument:metric_type()) ->
+          ok.
+set_up_metric(EventName, Labels, MetricName, MetricType) ->
+    LabelKeys = labels_to_keys(Labels),
+    LabelValues = labels_to_values(Labels),
     MetricSpec = metric_spec(EventName, LabelKeys, MetricName),
-    declare_metric(MetricSpec, MetricType).
+    case declare_metric(MetricSpec, MetricType) of
+        true -> ok;
+        false -> reset_metric(proplists:get_value(name, MetricSpec), LabelValues, MetricType)
+    end.
 
+-spec declare_metric(proplists:proplist(), mongoose_instrument:metric_type()) -> boolean().
 declare_metric(MetricSpec, spiral) ->
     prometheus_counter:declare(MetricSpec);
 declare_metric(MetricSpec, histogram) ->
     prometheus_histogram:declare([{buckets, histogram_buckets()} | MetricSpec]).
 
+-spec reset_metric(name(), [mongoose_instrument:label_value()],
+                   mongoose_instrument:metric_type()) -> ok.
+reset_metric(Name, LabelValues, spiral) ->
+    prometheus_counter:reset(Name, LabelValues),
+    prometheus_counter:inc(Name, LabelValues, 0);
+reset_metric(Name, LabelValues, histogram) ->
+    prometheus_histogram:reset(Name, LabelValues),
+    ok.
+
+-spec metric_spec(mongoose_instrument:event_name(), [mongoose_instrument:label_key()],
+                  mongoose_instrument:metric_name()) -> spec().
 metric_spec(EventName, LabelKeys, MetricName) ->
     [{name, full_metric_name(EventName, MetricName)},
      {help, metric_help(EventName, MetricName)},
      {labels, LabelKeys}].
 
+-spec histogram_buckets() -> [integer()].
 histogram_buckets() ->
     histogram_buckets([], 1 bsl 30). % ~1.07 * 10^9
 
@@ -45,6 +70,9 @@ histogram_buckets(AccBuckets, Val) when Val > 0 ->
 histogram_buckets(AccBuckets, _Val) ->
     AccBuckets.
 
+-spec handle_metric_event(mongoose_instrument:event_name(), [mongoose_instrument:label_value()],
+                          mongoose_instrument:metric_name(), mongoose_instrument:metric_type(),
+                          mongoose_instrument:measurements()) -> ok.
 handle_metric_event(EventName, LabelValues, MetricName, MetricType, Measurements) ->
     case Measurements of
         #{MetricName := MetricValue} ->
@@ -54,19 +82,26 @@ handle_metric_event(EventName, LabelValues, MetricName, MetricType, Measurements
             ok
     end.
 
+-spec metric_help(mongoose_instrument:event_name(), mongoose_instrument:metric_name()) -> help().
 metric_help(EventName, MetricName) ->
     lists:flatten(io_lib:format("Event: ~p, Metric: ~p", [EventName, MetricName])).
 
+-spec full_metric_name(mongoose_instrument:event_name(), mongoose_instrument:metric_name()) ->
+          name().
 full_metric_name(EventName, MetricName) ->
-    list_to_atom(atom_to_list(EventName) ++ "_" ++ atom_to_list(MetricName)).
+    atom_to_list(EventName) ++ "_" ++ atom_to_list(MetricName).
 
+-spec labels_to_keys(mongoose_instrument:labels()) -> [mongoose_instrument:label_key()].
 labels_to_keys(Labels) ->
     lists:sort(maps:keys(Labels)).
 
+-spec labels_to_values(mongoose_instrument:labels()) -> [mongoose_instrument:label_value()].
 labels_to_values(Labels) ->
     [V || {_K, V} <- lists:keysort(1, maps:to_list(Labels))].
 
+-spec update_metric(name(), [mongoose_instrument:label_value()],
+                    mongoose_instrument:metric_type(), integer()) -> ok.
 update_metric(Name, Labels, spiral, Value) when is_integer(Value), Value >= 0 ->
-    prometheus_counter:inc(Name, Labels, Value);
+    ok = prometheus_counter:inc(Name, Labels, Value);
 update_metric(Name, Labels, histogram, Value) when is_integer(Value) ->
-    prometheus_histogram:observe(Name, Labels, Value).
+    ok = prometheus_histogram:observe(Name, Labels, Value).

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -42,8 +42,7 @@
          get_mnesia_running_db_nodes_count/0,
          remove_host_type_metrics/1,
          remove_all_metrics/0,
-         get_report_interval/0,
-         get_host_type_prefix/1
+         get_report_interval/0
         ]).
 
 -ignore_xref([get_dist_data_stats/0, get_mnesia_running_db_nodes_count/0,

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -94,7 +94,7 @@ options("miscellaneous") ->
                                               secret => "Secret"
                                              }}}},
      {instrumentation, #{prometheus => #{},
-                         exometer => #{},
+                         exometer => #{all_metrics_are_global => true},
                          log => #{level => info}}},
      {{s2s, <<"anonymous.localhost">>}, default_s2s()},
      {{s2s, <<"localhost">>}, default_s2s()},
@@ -265,7 +265,7 @@ options("mongooseim-pgsql") ->
      {sm_backend, mnesia},
      {component_backend, mnesia},
      {s2s_backend, mnesia},
-     {instrumentation, #{exometer => #{},
+     {instrumentation, #{exometer => default_config([instrumentation, exometer]),
                          log => default_config([instrumentation, log])}},
      {{outgoing_pools, <<"anonymous.localhost">>},
       [host_pool_config(
@@ -1104,6 +1104,8 @@ extra_service_listener_config() ->
 
 default_config([instrumentation, log]) ->
     #{level => debug};
+default_config([instrumentation, exometer]) ->
+    #{all_metrics_are_global => false};
 default_config([instrumentation, _]) ->
     #{};
 default_config([listen, http]) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -236,6 +236,7 @@ groups() ->
      {services, [parallel], [service_domain_db,
                              service_mongoose_system_metrics]},
      {instrumentation, [parallel], [instrumentation,
+                                    instrumentation_exometer,
                                     instrumentation_log]},
      {logs, [], log_cases()}
     ].
@@ -2935,7 +2936,6 @@ instrumentation(_Config) ->
     T = fun(Opts) -> #{<<"instrumentation">> => Opts} end,
     ?cfg(P, #{}, T(#{})),
     ?cfg(P, #{prometheus => #{}}, T(#{<<"prometheus">> => #{}})),
-    ?cfg(P, #{exometer => #{}}, T(#{<<"exometer">> => #{}})),
     ?err(T(#{<<"prometheus">> => #{<<"fire">> => 1}})),
     ?err(T(#{<<"bad_module">> => #{}})).
 
@@ -2945,6 +2945,13 @@ instrumentation_log(_Config) ->
     ?cfg(P, default_config(P), T(#{})),
     ?cfg(P ++ [level], info, T(#{<<"level">> => <<"info">>})),
     ?err(T(#{<<"level">> => <<"insane">>})).
+
+instrumentation_exometer(_Config) ->
+    P = [instrumentation, exometer],
+    T = fun(Opts) -> #{<<"instrumentation">> => #{<<"exometer">> => Opts}} end,
+    ?cfg(P, default_config(P), T(#{})),
+    ?cfg(P ++ [all_metrics_are_global], true, T(#{<<"all_metrics_are_global">> => true})),
+    ?err(T(#{<<"all_metrics_are_global">> => "yes"})).
 
 %% Logs
 

--- a/test/config_parser_SUITE_data/miscellaneous.toml
+++ b/test/config_parser_SUITE_data/miscellaneous.toml
@@ -83,6 +83,7 @@
 [instrumentation.prometheus]
 
 [instrumentation.exometer]
+  all_metrics_are_global = true
 
 [instrumentation.log]
   level = "info"


### PR DESCRIPTION
This PR groups several improvements of metric handling in `mongoose_instrument`.

Changes:
- Added support for the `all_metrics_are_global` option in `instrumentation.exometer`.
- Event handler failures are now caught and logged to isolate them from the instrumented code.
- Already existing metrics are reset in `set_up`.
- Prometheus counters are initialised with zero to avoid the issue with initial rate calculation in metric graphs.
  - Histograms are not initialised like this,  because if there is no data, quantiles cannot be calculated, and zeroes would be technically incorrect.
- Optional `start/0` and `stop/0` in the `mongoose_instrument` behaviour.
- Prometheus metrics use string for keys to avoid `list_to_atom`.
- Removed dependency on `mongoose_metrics`.