### PR TITLE
Make CETS node cleanup consistent

### DIFF
--- a/src/component/mongoose_component_cets.erl
+++ b/src/component/mongoose_component_cets.erl
@@ -17,8 +17,8 @@ init(_) ->
     cets_discovery:add_table(mongoose_cets_discovery, ?TABLE).
 
 node_cleanup(Node) ->
-    ets:match_delete(?TABLE, #external_component{node = Node, _ = '_'}),
-    ok.
+    Components = ets:match_object(?TABLE, #external_component{node = Node, _ = '_'}),
+    unregister_components(Components).
 
 register_components(Components) ->
     cets:insert_many(?TABLE, Components),

--- a/src/ejabberd_sm_cets.erl
+++ b/src/ejabberd_sm_cets.erl
@@ -79,13 +79,11 @@ cleanup(Node) ->
     cets:ping_all(?TABLE),
     %% This is a full table scan, but cleanup is rare.
     Tuples = ets:select(?TABLE, [{R, [Guard], ['$_']}]),
-    lists:foreach(fun({_Key, _, _} = Tuple) ->
+    cets:delete_many(?TABLE, [Key || {Key, _, _} <- Tuples]),
+    lists:foreach(fun(Tuple) ->
                           Session = tuple_to_session(Tuple),
                           ejabberd_sm:run_session_cleanup_hook(Session)
-                  end, Tuples),
-    %% We don't need to replicate deletes
-    %% We remove the local content here
-    ets:select_delete(?TABLE, [{R, [Guard], [true]}]).
+                  end, Tuples).
 
 -spec total_count() -> integer().
 total_count() ->

--- a/src/mod_bosh_cets.erl
+++ b/src/mod_bosh_cets.erl
@@ -39,10 +39,8 @@ get_sessions() ->
 
 -spec node_cleanup(atom()) -> any().
 node_cleanup(Node) ->
-    Guard = {'==', {node, '$1'}, Node},
-    R = {'_', '_', '$1'},
+    Guard = {'==', {node, '$2'}, Node},
+    R = {'_', '$1', '$2'},
     cets:ping_all(?TABLE),
-    %% We don't need to replicate deletes
-    %% We remove the local content here
-    ets:select_delete(?TABLE, [{R, [Guard], [true]}]),
-    ok.
+    Keys = ets:select(?TABLE, [{R, [Guard], ['$1']}]),
+    cets:delete_many(?TABLE, Keys).

--- a/src/muc/mod_muc_online_cets.erl
+++ b/src/muc/mod_muc_online_cets.erl
@@ -105,10 +105,10 @@ get_online_rooms(HostType, MucHost) ->
 -spec node_cleanup(mongooseim:host_type(), node()) -> ok.
 node_cleanup(HostType, Node) ->
     Tab = table_name(HostType),
-    Pattern = {'_', '$1'},
-    Guard = {'==', {node, '$1'}, Node},
-    ets:select_delete(Tab, [{Pattern, [Guard], [true]}]),
-    ok.
+    Pattern = {'$1', '$2'},
+    Guard = {'==', {node, '$2'}, Node},
+    Keys = ets:select(Tab, [{Pattern, [Guard], ['$1']}]),
+    cets:delete_many(Tab, Keys).
 
 %% Clear table for tests
 -spec clear_table(mongooseim:host_type()) -> ok.

--- a/src/s2s/mongoose_s2s_cets.erl
+++ b/src/s2s/mongoose_s2s_cets.erl
@@ -13,8 +13,6 @@
 %% Internal usage (export so the callback would survive multiple code reloads)
 -export([handle_secret_conflict/2]).
 
--include("mongoose_logger.hrl").
-
 -define(TABLE, cets_s2s_session).
 -define(SECRET_TABLE, cets_s2s_secret).
 
@@ -74,8 +72,8 @@ node_cleanup(Node) ->
     KeyPattern = {'_', '$1'},
     R = {KeyPattern},
     Guard = {'==', {node, '$1'}, Node},
-    ets:select_delete(?TABLE, [{R, [Guard], [true]}]),
-    ok.
+    Objects = ets:select(?TABLE, [{R, [Guard], ['$_']}]),
+    cets:delete_objects(?TABLE, Objects).
 
 %% Secrets
 -spec register_secret(HostType :: mongooseim:host_type(),


### PR DESCRIPTION
Previously, during node cleanup for CETS:
- Some modules removed only local content
- Others performed cluster-wide CETS operations

It is not possible to always remove local content because of `session_cleanup` and the need for insertions - see e.g. stream management. Meanwhile, Mnesia cleanup consistently removes all content across the cluster.

After this change, CETS does the same. An immediate benefit is that after the first `global:trans/2` finishes in `mongoose_cleaner:run_node_cleanup/1`, cluster state is consistent. Previously, cleanup would need to succeed on all nodes (sequentially), and before that the cluster would be in an inconsistent state.

Also:
- Refactor cleanup tests to make them more maintainable.
- Improve test coverage for CETS cleanup.