### PR TITLE
Revert dist blocker

### DIFF
--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -38,7 +38,6 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    DistBlocker = worker_spec(cets_dist_blocker),
     Hooks = worker_spec(gen_hook),
     Cleaner = worker_spec(mongoose_cleaner),
     Router = worker_spec(ejabberd_router),
@@ -65,8 +64,7 @@ init([]) ->
     IQSupervisor =
         ejabberd_tmp_sup_spec(ejabberd_iq_sup, [ejabberd_iq_sup, mongoose_iq_worker]),
     {ok, {{one_for_one, 10, 1},
-          [DistBlocker,
-           StartIdServer,
+          [StartIdServer,
            PG,
            Hooks,
            Cleaner,

--- a/src/mongoose_cleaner.erl
+++ b/src/mongoose_cleaner.erl
@@ -34,7 +34,6 @@ start_link() ->
 %%%===================================================================
 
 init([]) ->
-    cets_dist_blocker:add_cleaner(self()),
     case net_kernel:monitor_nodes(true) of
         ok ->
             {ok, #state{}};
@@ -57,7 +56,6 @@ handle_info({nodedown, Node}, State) ->
                    text => <<"mongoose_cleaner received nodenown event">>,
                    down_node => Node}),
     cleanup_modules(Node),
-    cets_dist_blocker:cleaning_done(self(), Node),
     {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -97,7 +97,7 @@ opts() ->
       {modules, ?HOST} => #{}}.
 
 meck_mods() ->
-    [exometer, mod_bosh_socket, cets_dist_blocker, mongoose_bin, ejabberd_sm, ejabberd_local].
+    [exometer, mod_bosh_socket, mongoose_bin, ejabberd_sm, ejabberd_local].
 
 required_modules(muc, Config) ->
     required_module(mod_muc, #{online_backend => ?config(backend, Config), backend => mnesia});
@@ -291,11 +291,7 @@ setup_meck(mongoose_bin) ->
     meck:expect(mongoose_bin, gen_from_crypto, fun() -> <<"123456">> end);
 setup_meck(mod_bosh_socket) ->
     meck:new(mod_bosh_socket, [passthrough, no_link]),
-    meck:expect(mod_bosh_socket, start_supervisor, fun() -> {ok, self()} end);
-setup_meck(cets_dist_blocker) ->
-    meck:new(cets_dist_blocker, [passthrough, no_link]),
-    meck:expect(cets_dist_blocker, add_cleaner, fun(_Pid) -> ok end),
-    meck:expect(cets_dist_blocker, cleaning_done, fun(_Pid, _Node) -> ok end).
+    meck:expect(mod_bosh_socket, start_supervisor, fun() -> {ok, self()} end).
 
 unload_meck(Module) ->
     meck:validate(Module),


### PR DESCRIPTION
The `dist_blocker` feature was introduced to protect a disconnected node from reconnecting before other nodes finished the cleanup to avoid issues with inconsistent CETS tables. The solution was to change the cookie value on `nodeup` (sic!) for the particular node until the cleanup for that node is finished.

There are following issues with that solution:
- Sometimes there is a delay before `nodedown` is received, and cleanup is started. However, when the node comes back online, `nodedown` would be received, followed by `nodeup`. The problem is that `dist_blocker` is preventing the node from connecting, which might delay reconnection. In [MongooseHelm tests](https://github.com/esl/MongooseHelm/blob/master/test/mim_kind_SUITE.erl#L97) this was causing a 15-second delay before reconnection, but it could be more in some configurations. There is even potential for a deadlock, but I couldn't trigger it in tests.
- When `dist_blocker` kicks in, multiple error messages would appear on several nodes, informing about the blocked connections. These unwanted and surprising logs could confuse the user.
- Changing cookies looks like a very radical solution to me, and the recent improvement of cleanup makes it avoidable.

Because of these concerns, `dist_blocker` is disabled in this PR. It is enough to disable it in MIM, because CETS does not enable it by default.

The MongooseHelm tests have shown that after https://github.com/esl/MongooseIM/pull/4250 it is difficult to reproduce the issue - it occurred only once in about 50 tests, which try to quickly restart MIM to trigger the issue. Keep in mind, that with `dist_blocker` it has also [failed](https://app.circleci.com/pipelines/github/esl/MongooseHelm/221/workflows/148fd51f-52db-49f7-a5df-a4c2274e6cdc/jobs/298) at least twice on CI.

We can prevent the issues in different ways, and we can do so in separate PR's.