### PR TITLE
Test instrumentation for dropped MAM messages

### DIFF
--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1377,6 +1377,9 @@ assert_dropped_iq_event(Config, BinJid) ->
 assert_event_with_jid(EventName, BinJid) ->
     assert_event(EventName, fun(#{count := 1, jid := Jid}) -> eq_bjid(Jid, BinJid) end).
 
+assert_dropped_msg_event(EventName) ->
+    assert_event(EventName, fun(#{count := 1}) -> true end).
+
 assert_event(EventName, F) ->
     instrument_helper:assert(EventName, #{host_type => host_type()}, F).
 

--- a/src/mam/mod_mam_cassandra_arch.erl
+++ b/src/mam/mod_mam_cassandra_arch.erl
@@ -140,10 +140,10 @@ archive_message(_Result, Params, #{host_type := HostType}) ->
     try
         {ok, archive_message2(Params, HostType)}
     catch _Type:Reason:StackTrace ->
-        ?LOG_ERROR(#{what => archive_message_failed,
-                    host_type => HostType, mam_params => Params,
-                    reason => Reason, stacktrace => StackTrace}),
         mongoose_instrument:execute(mod_mam_pm_dropped, #{host_type => HostType}, #{count => 1}),
+        ?LOG_ERROR(#{what => archive_message_failed,
+                     host_type => HostType, mam_params => Params,
+                     reason => Reason, stacktrace => StackTrace}),
         {ok, {error, Reason}}
     end.
 

--- a/src/mam/mod_mam_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_elasticsearch_arch.erl
@@ -94,10 +94,10 @@ archive_message(_Result,
         {ok, _} ->
             {ok, ok};
         {error, Reason} = Err ->
+            mongoose_instrument:execute(mod_mam_pm_dropped, #{host_type => Host}, #{count => 1}),
             ?LOG_ERROR(#{what => archive_message_failed,
                          user => Owner, server => Host, remote => Remote,
                          message_id => MessageId, reason => Reason}),
-            mongoose_instrument:execute(mod_mam_pm_dropped, #{host_type => Host}, #{count => 1}),
             {ok, Err}
     end.
 

--- a/src/mam/mod_mam_muc_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_muc_elasticsearch_arch.erl
@@ -93,11 +93,11 @@ archive_message(_Result, Params, #{host_type := HostType}) ->
         {ok, _} ->
             {ok, ok};
         {error, Reason} = Err ->
+            mongoose_instrument:execute(mod_mam_muc_dropped, #{host_type => HostType}, #{count => 1}),
             ?LOG_ERROR(maps:merge(Params,
                        #{what => archive_muc_message_failed, reason => Reason,
                          server => HostType, room => Room, source => SourceBinJid,
                          message_id => MessageId})),
-            mongoose_instrument:execute(mod_mam_dropped, #{host_type => HostType}, #{count => 1}),
             {ok, Err}
     end.
 

--- a/src/mam/mod_mam_muc_rdbms_arch.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch.erl
@@ -243,9 +243,10 @@ archive_message(_Result, #{local_jid := ArcJID} = Params0, #{host_type := HostTy
         retract_message(HostType, Params, Env),
         {ok, ok}
     catch error:Reason:StackTrace ->
+        mongoose_instrument:execute(mod_mam_muc_dropped, #{host_type => HostType}, #{count => 1}),
         ?LOG_ERROR(#{what => archive_message_failed,
-                    host_type => HostType, mam_params => Params0,
-                    reason => Reason, stacktrace => StackTrace}),
+                     host_type => HostType, mam_params => Params0,
+                     reason => Reason, stacktrace => StackTrace}),
         erlang:raise(error, Reason, StackTrace)
     end.
 

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -283,6 +283,7 @@ archive_message(_Result, #{local_jid := ArcJID} = Params, #{host_type := HostTyp
         ?LOG_ERROR(#{what => archive_message_failed,
                     host_type => HostType, mam_params => Params,
                     reason => Reason, stacktrace => StackTrace}),
+        mongoose_instrument:execute(mod_mam_pm_dropped, #{host_type => HostType}, #{count => 1}),
         erlang:raise(error, Reason, StackTrace)
     end.
 

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -280,10 +280,10 @@ archive_message(_Result, #{local_jid := ArcJID} = Params, #{host_type := HostTyp
         retract_message(HostType, Params, Env),
         {ok, ok}
     catch error:Reason:StackTrace ->
-        ?LOG_ERROR(#{what => archive_message_failed,
-                    host_type => HostType, mam_params => Params,
-                    reason => Reason, stacktrace => StackTrace}),
         mongoose_instrument:execute(mod_mam_pm_dropped, #{host_type => HostType}, #{count => 1}),
+        ?LOG_ERROR(#{what => archive_message_failed,
+                     host_type => HostType, mam_params => Params,
+                     reason => Reason, stacktrace => StackTrace}),
         erlang:raise(error, Reason, StackTrace)
     end.
 


### PR DESCRIPTION
This PR adds tests for `mod_mam_pm_dropped` and `mod_mam_muc_dropped` events to verify that they occur after a message fails to be saved to the database. It also extends logging to regular writers, rather than only logging such events for `async` writers.