### PR TITLE
Cets/prevent crash on upgrade

### DIFF
--- a/big_tests/tests/cets_disco_SUITE.erl
+++ b/big_tests/tests/cets_disco_SUITE.erl
@@ -23,6 +23,7 @@ file_cases() ->
 rdbms_cases() ->
     [rdbms_backend,
      rdbms_backend_supports_cluster_change,
+     rdbms_backend_cluster_name_contains_cets_version,
      rdbms_backend_supports_auto_cleaning,
      rdbms_backend_node_doesnt_remove_itself,
      rdbms_backend_db_queries,
@@ -119,6 +120,13 @@ rdbms_backend_supports_cluster_change(_Config) ->
     %% Node test2 moves to CN2, and the nodes are connected again
     init_and_get_nodes(mim2(), Opts2#{cluster_name := CN2}, [test1]),
     get_nodes(mim(), NewState1A, [test1, test2]).
+
+rdbms_backend_cluster_name_contains_cets_version(_Config) ->
+    CN = random_cluster_name(?FUNCTION_NAME),
+    Opts = #{cluster_name => CN, node_name_to_insert => <<"test1">>},
+    #{cluster_name := CNWithVsn} = init_and_get_nodes(mim(), Opts, []),
+    [<<>>, Vsn] = binary:split(CNWithVsn, CN),
+    ?assertMatch({match, _}, re:run(Vsn, "-[0-9]+\\.[0-9]+")).
 
 rdbms_backend_supports_auto_cleaning(_Config) ->
     Timestamp = month_ago(),

--- a/big_tests/tests/graphql_cets_SUITE.erl
+++ b/big_tests/tests/graphql_cets_SUITE.erl
@@ -242,7 +242,7 @@ add_bad_node() ->
     wait_for_has_bad_node().
 
 register_bad_node() ->
-    ClusterName = <<"mim">>,
+    ClusterName = rpc(mim(), mongoose_cets_discovery_rdbms, cluster_name_with_vsn, [<<"mim">>]),
     Node = <<"badnode@localhost">>,
     Num = 100,
     Address = <<>>,

--- a/src/mongoose_cets_discovery_rdbms.erl
+++ b/src/mongoose_cets_discovery_rdbms.erl
@@ -25,8 +25,14 @@
 -spec init(opts()) -> state().
 init(Opts = #{cluster_name := ClusterName, node_name_to_insert := Node})
        when is_binary(ClusterName), is_binary(Node) ->
-    Keys = [cluster_name, node_name_to_insert, last_query_info, expire_time, node_ip_binary],
-    maps:with(Keys, maps:merge(defaults(), Opts)).
+    Keys = [node_name_to_insert, expire_time, last_query_info, node_ip_binary],
+    StateOpts = maps:merge(defaults(), maps:with(Keys, Opts)),
+    StateOpts#{cluster_name => cluster_name_with_vsn(ClusterName)}.
+
+cluster_name_with_vsn(ClusterName) ->
+    {ok, CetsVsn} = application:get_key(cets, vsn),
+    [MajorVsn, MinorVsn | _] = string:tokens(CetsVsn, "."),
+    iolist_to_binary([ClusterName, $-, MajorVsn, $., MinorVsn]).
 
 defaults() ->
     #{expire_time => 60 * 60 * 1, %% 1 hour in seconds

--- a/src/mongoose_cets_discovery_rdbms.erl
+++ b/src/mongoose_cets_discovery_rdbms.erl
@@ -4,8 +4,10 @@
 -export([init/1, get_nodes/1]).
 
 %% these functions are exported for testing purposes only.
--export([select/1, insert_new/5, update_existing/3, delete_node_from_db/1]).
--ignore_xref([select/1, insert_new/5, update_existing/3, delete_node_from_db/1]).
+-export([select/1, insert_new/5, update_existing/3, delete_node_from_db/1,
+         cluster_name_with_vsn/1]).
+-ignore_xref([select/1, insert_new/5, update_existing/3, delete_node_from_db/1,
+              cluster_name_with_vsn/1]).
 
 -include("mongoose_logger.hrl").
 


### PR DESCRIPTION
Add CETS `major.minor` version as a suffix to cluster name in the `discovery_nodes` table, preventing CETS from crashing if a rolling upgrade is performed, and the CETS versions are incompatible.

This would occur when upgrading MIM from `6.2.0` to the upcoming `6.2.1`, which translates to CETS upgrade from `0.1.0` to `0.2.0`. If only the patch version of CETS is changed, e.g. `0.2.0` to `0.2.1`, they are still considered compatible. From now on, we only need to ensure that CETS versions are marked accordingly before MIM releases.

This change was tested manually by upgrading from `6.2.0` to this PR. The test was performed twice:
1. In local environment: 3-node cluster created with `test-helper`,
2. With `helm upgrade`.

**Note:** The version is not a separate DB column, because the nodes running version 6.2.0 would still try to connect to the upgraded nodes. Extending the name seems like a sane option, and similar solutions are used in well-known tools and platforms like k8s.

