### PR TITLE
Require pgsql_cets_26 for successful build

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -961,6 +961,7 @@ workflows:
 
             - small_tests_26
             - internal_mnesia_26
+            - pgsql_cets_26
             - pgsql_mnesia_26
             - mysql_redis_26
             - mssql_mnesia_26


### PR DESCRIPTION
`pgsql_cets_26` was missing from the list of required jobs for successful build of the Docker container.
