### PR TITLE
Update OTP versions

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 references:
-  - &OTP25 mongooseim/cimg-erlang:25.3.2.6
-  - &OTP26 mongooseim/cimg-erlang:26.1.2
+  - &OTP25 mongooseim/cimg-erlang:25.3.2.9
+  - &OTP26 mongooseim/cimg-erlang:26.2.2
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         ## the full list of supported (prebuilt) OTP versions for ubuntu-22.04 runners
         ## can be found here:
         ##     https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
-        otp: [ '25.3.2.6', '26.1.2' ]
+        otp: [ '25.3.2.9', '26.2.2' ]
     runs-on: ubuntu-22.04
     env:
       PRESET: 'small_tests'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # MongooseIM platform
 
 [![GitHub release](https://img.shields.io/github/release/esl/MongooseIM.svg)](https://github.com/esl/MongooseIM/releases)
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/esl/MongooseIM/tree/rel-6.1.svg?style=shield)](https://app.circleci.com/pipelines/github/esl/MongooseIM?branch=rel-6.1)
-[![Codecov](https://codecov.io/gh/esl/MongooseIM/branch/rel-6.1/graph/badge.svg)](https://app.codecov.io/gh/esl/MongooseIM/tree/rel-6.1)
-[![GitHub Actions](https://github.com/esl/MongooseIM/workflows/CI/badge.svg?branch=rel-6.1)](https://github.com/esl/MongooseIM/actions/workflows/ci.yml?query=branch%3Arel-6.1)
-[![Coveralls](https://coveralls.io/repos/github/esl/MongooseIM/badge.svg?branch=rel-6.1)](https://coveralls.io/github/esl/MongooseIM?branch=rel-6.1)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/esl/MongooseIM/tree/rel-6.2.svg?style=shield)](https://app.circleci.com/pipelines/github/esl/MongooseIM?branch=rel-6.2)
+[![Codecov](https://codecov.io/gh/esl/MongooseIM/branch/rel-6.2/graph/badge.svg)](https://app.codecov.io/gh/esl/MongooseIM/tree/rel-6.2)
+[![GitHub Actions](https://github.com/esl/MongooseIM/workflows/CI/badge.svg?branch=rel-6.2)](https://github.com/esl/MongooseIM/actions/workflows/ci.yml?query=branch%3Arel-6.2)
+[![Coveralls](https://coveralls.io/repos/github/esl/MongooseIM/badge.svg?branch=rel-6.2)](https://coveralls.io/github/esl/MongooseIM?branch=rel-6.2)
 
 * [Getting started](https://esl.github.io/MongooseDocs/latest/getting-started/Installation/)
 * [Developer's guide](https://esl.github.io/MongooseDocs/latest/developers-guide/Testing-MongooseIM/)


### PR DESCRIPTION
Update versions of Erlang/OTP used in CircleCI and GH Actions.
Also: update the release branch in buttons.

See commits for details.