### PR TITLE
Fully test and annotate MAM preferences

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -573,7 +573,6 @@ init_per_group(muc_prefs_cases, Config) ->
         {error, _} -> 
             {skip, "Database not supported"};
         MamPrefsBackendModule ->
-            io:format("module: ~p", [MamPrefsBackendModule]),
             Config1 = dynamic_modules:save_modules(host_type(), Config),
             dynamic_modules:restart(host_type(), MamPrefsBackendModule, #{muc => true, pm => true}),
             Config1
@@ -3418,7 +3417,6 @@ muc_query_get_request(ConfigIn) ->
              {element, <<"field">>},
              {element, <<"value">>},
               cdata]),
-        io:format("~p", [ResponseXmlns]),
         ?assert_equal(QueryXmlns, ResponseXmlns)
         end,
     RoomOpts = [{persistent, true}],

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -3570,7 +3570,6 @@ run_prefs_cases(DefaultPolicy, ConfigIn) ->
     escalus_fresh:story_with_config(ConfigIn, [{alice, 1}, {bob, 1}, {kate, 1}], F).
 
 muc_run_prefs_cases(DefaultPolicy, ConfigIn) ->
-    P = ?config(props, ConfigIn),
     F = fun(Config, Alice, Bob, Kate) ->
         %% Just send messages for each prefs configuration
         Namespace = mam_ns_binary_v04(),

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -573,6 +573,7 @@ init_per_group(muc_prefs_cases, Config) ->
         {error, _} -> 
             {skip, "Database not supported"};
         MamPrefsBackendModule ->
+            io:format("module: ~p", [MamPrefsBackendModule]),
             Config1 = dynamic_modules:save_modules(host_type(), Config),
             dynamic_modules:restart(host_type(), MamPrefsBackendModule, #{muc => true, pm => true}),
             Config1
@@ -672,7 +673,7 @@ maybe_set_wait(C, Types, Config) when C =:= rdbms_async_pool;
 maybe_set_wait(_C, _, Config) ->
     Config.
 
-mam_prefs_backend_module(rdbms, _) ->
+mam_prefs_backend_module(rdbms, rdbms) ->
     mod_mam_rdbms_prefs;
 mam_prefs_backend_module(cassandra, cassandra) ->
     mod_mam_cassandra_prefs;

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -109,7 +109,6 @@
          stanza_metadata_request/0,
          assert_archive_message_event/2,
          assert_lookup_event/2,
-         assert_dropped_msg_event/1,
          assert_flushed_event_if_async/2,
          assert_dropped_iq_event/2,
          assert_event_with_jid/2
@@ -240,8 +239,6 @@ basic_groups() ->
             {nostore, [parallel], nostore_cases()},
             {archived, [parallel], archived_cases()},
             {configurable_archiveid, [], configurable_archiveid_cases()},
-            % Due to the mocking of the DB, the message_dropped test cannot be run in parallel
-            {drop_msg, [], [message_dropped]},
             {rsm_all, [], %% not parallel, because we want to limit concurrency
              [
               %% Functions mod_mam_utils:make_fin_element_v03/5 and make_fin_element/5
@@ -260,7 +257,7 @@ basic_groups() ->
             {muc06, [parallel], muc_cases() ++ muc_stanzaid_cases() ++ muc_retract_cases()
                                 ++ muc_metadata_cases() ++ muc_fetch_specific_msgs_cases()},
             {muc_configurable_archiveid, [], muc_configurable_archiveid_cases()},
-            {muc_drop_msg, [], [muc_message_dropped]},
+            {muc_prefs_cases, [parallel], muc_prefs_cases()},
             {muc_rsm_all, [parallel],
              [{muc_rsm04, [parallel], muc_rsm_cases()}]}]},
      {muc_light,        [], muc_light_cases()},
@@ -491,6 +488,12 @@ prefs_cases() ->
      messages_filtered_when_prefs_default_policy_is_roster,
      run_set_and_get_prefs_cases].
 
+muc_prefs_cases() ->
+    [muc_prefs_set_request,
+     muc_prefs_set_request_not_an_owner,
+     muc_prefs_set_cdata_request,
+     muc_query_get_request].
+
 impl_specific() ->
     [check_user_exist,
      pm_failed_to_decode_message_in_database].
@@ -499,8 +502,6 @@ suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 init_per_suite(Config) ->
-    %% Inject module for mocking with unnamed functions
-    mongoose_helper:inject_module(?MODULE, reload),
     instrument_helper:start(instrument_helper:declared_events(instrumented_modules())),
     muc_helper:load_muc(),
     mam_helper:prepare_for_suite(
@@ -559,16 +560,14 @@ init_per_group(rsm04_comp, Config) ->
     [{props, mam04_props()}|Config];
 init_per_group(with_rsm04, Config) ->
     [{props, mam04_props()}, {with_rsm, true}|Config];
-
+    
+init_per_group(muc_prefs_cases, Config) ->
+    Config;
 init_per_group(nostore, Config) ->
     Config;
 init_per_group(archived, Config) ->
     Config;
 init_per_group(mam_metrics, Config) ->
-    Config;
-init_per_group(G, Config) when G =:= drop_msg;
-                               G =:= muc_drop_msg ->
-    setup_meck(G, ?config(configuration, Config)),
     Config;
 init_per_group(muc04, Config) ->
     [{props, mam04_props()}, {with_rsm, true}|Config];
@@ -609,14 +608,12 @@ do_init_per_group(C, ConfigIn) ->
             Config0
     end.
 
+end_per_group(muc_prefs_cases, Config) ->
+    Config;
 end_per_group(G, Config) when G == rsm_all; G == nostore;
     G == mam04; G == rsm04; G == with_rsm04; G == muc04; G == muc_rsm04; G == rsm04_comp;
     G == muc06; G == mam06; G == archived; G == mam_metrics ->
       Config;
-end_per_group(G, Config) when G == drop_msg;
-                              G == muc_drop_msg ->
-    teardown_meck(),
-    Config;
 end_per_group(muc_configurable_archiveid, Config) ->
     dynamic_modules:restore_modules(Config),
     Config;
@@ -731,51 +728,6 @@ init_per_testcase(CaseName, Config) ->
         {skip, Msg} ->
             {skip, Msg}
     end.
-
-setup_meck(_, elasticsearch) ->
-    ok = rpc(mim(), meck, expect,
-             [mongoose_elasticsearch, insert_document, 4, {error, simulated}]);
-setup_meck(_, cassandra) ->
-    ok = rpc(mim(), meck, expect,
-             [mongoose_cassandra, cql_write_async, 5, {error, simulated}]);
-setup_meck(drop_msg, Config) when Config =:= rdbms_async_pool;
-                                  Config =:= rdbms_async_cache ->
-    ok = rpc(mim(), meck, new, [mongoose_rdbms, [no_link, passthrough]]),
-    ok = rpc(mim(), meck, expect,
-             [mongoose_rdbms, execute,
-              fun (_HostType, insert_mam_message, _Parameters) ->
-                      {error, simulated};
-                  (HostType, Name, Parameters) ->
-                      meck:passthrough([HostType, Name, Parameters])
-              end]);
-setup_meck(muc_drop_msg, Config) when Config =:= rdbms_async_pool;
-                                      Config =:= rdbms_async_cache ->
-    ok = rpc(mim(), meck, new, [mongoose_rdbms, [no_link, passthrough]]),
-    ok = rpc(mim(), meck, expect,
-             [mongoose_rdbms, execute,
-              fun (_HostType, insert_mam_muc_message, _Parameters) ->
-                      {error, simulated};
-                  (HostType, Name, Parameters) ->
-                      meck:passthrough([HostType, Name, Parameters])
-              end]);
-setup_meck(drop_msg, _) ->
-    ok = rpc(mim(), meck, new, [mongoose_rdbms, [no_link, passthrough]]),
-    ok = rpc(mim(), meck, expect,
-             [mongoose_rdbms, execute_successfully,
-              fun (_HostType, insert_mam_message, _Parameters) ->
-                      error(#{what => simulated_error});
-                  (HostType, Name, Parameters) ->
-                      meck:passthrough([HostType, Name, Parameters])
-              end]);
-setup_meck(muc_drop_msg, _) ->
-    ok = rpc(mim(), meck, new, [mongoose_rdbms, [no_link, passthrough]]),
-    ok = rpc(mim(), meck, expect,
-             [mongoose_rdbms, execute_successfully,
-              fun (_HostType, insert_mam_muc_message, _Parameters) ->
-                      error(#{what => simulated_error});
-                  (HostType, Name, Parameters) ->
-                      meck:passthrough([HostType, Name, Parameters])
-              end]).
 
 init_steps() ->
     [fun init_users/2, fun init_archive/2, fun start_room/2, fun init_metrics/2,
@@ -894,9 +846,6 @@ end_per_testcase(CaseName, Config) ->
     maybe_destroy_room(CaseName, Config),
     escalus:end_per_testcase(CaseName, Config).
 
-teardown_meck() ->
-    rpc(mim(), meck, unload, []).
-
 maybe_destroy_room(CaseName, Config) ->
     case lists:member(CaseName, all_cases_with_room()) of
         true -> destroy_room(Config);
@@ -905,8 +854,7 @@ maybe_destroy_room(CaseName, Config) ->
 
 all_cases_with_room() ->
     muc_cases_with_room() ++ muc_fetch_specific_msgs_cases() ++ muc_configurable_archiveid_cases() ++
-        muc_stanzaid_cases() ++ muc_retract_cases() ++ muc_metadata_cases() ++
-        muc_text_search_cases() ++ [muc_message_dropped].
+        muc_stanzaid_cases() ++ muc_retract_cases() ++ muc_metadata_cases() ++ muc_text_search_cases().
 
 %% Module configuration per testcase
 
@@ -1126,19 +1074,6 @@ archive_is_instrumented(Config) ->
         {S, U} = {escalus_utils:get_server(Alice), escalus_utils:get_username(Alice)},
         mam_helper:delete_archive(S, U),
         assert_event_with_jid(mod_mam_pm_remove_archive, escalus_utils:get_short_jid(Alice))
-        end,
-    escalus_fresh:story(Config, [{alice, 1}, {bob, 1}], F).
-
-message_dropped(Config) ->
-    P = ?config(props, Config),
-    F = fun(Alice, Bob) ->
-        escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"OH, HAI!">>)),
-        maybe_wait_for_archive(Config),
-        escalus:send(Alice, stanza_archive_request(P, <<"q1">>)),
-        Res = wait_archive_respond(Alice),
-        assert_respond_size(0, Res),
-        assert_dropped_msg_event(mod_mam_pm_dropped),
-        ok
         end,
     escalus_fresh:story(Config, [{alice, 1}, {bob, 1}], F).
 
@@ -1697,30 +1632,6 @@ muc_querying_for_all_messages_with_jid(Config) ->
             ok
         end,
     escalus:story(Config, [{alice, 1}], F).
-
-muc_message_dropped(Config) ->
-    P = ?config(props, Config),
-    F = fun(Alice, Bob) ->
-        Room = ?config(room, Config),
-        RoomAddr = room_address(Room),
-        Text = <<"OH, HAI!">>,
-        escalus:send(Alice, stanza_muc_enter_room(Room, nick(Alice))),
-        escalus:send(Bob, stanza_muc_enter_room(Room, nick(Bob))),
-        escalus:wait_for_stanzas(Bob, 3),
-        escalus:wait_for_stanzas(Alice, 3),
-
-        escalus:send(Alice, escalus_stanza:groupchat_to(RoomAddr, Text)),
-        escalus:wait_for_stanza(Alice),
-        escalus:wait_for_stanza(Bob),
-        maybe_wait_for_archive(Config),
-
-        Stanza = stanza_archive_request(P, <<"q1">>),
-        escalus:send(Alice, stanza_to_room(Stanza, Room)),
-        assert_respond_size(0, wait_archive_respond(Alice)),
-        assert_dropped_msg_event(mod_mam_muc_dropped),
-        ok
-    end,
-    escalus:story(Config, [{alice, 1}, {bob, 1}], F).
 
 muc_light_service_discovery_stored_in_pm(Config) ->
     F = fun(Alice) ->
@@ -3419,6 +3330,115 @@ prefs_set_cdata_request(Config) ->
         ok
         end,
     escalus_fresh:story(Config, [{alice, 1}], F).
+
+muc_prefs_set_request(ConfigIn) ->
+    F = fun(Config, Alice, _Bob) ->
+        %% Send
+        %%
+        %% <iq type='set' id='juliet2' to='room-alice'>
+        %%   <prefs xmlns='urn:xmpp:mam:1' default='roster'>
+        %%     <always>
+        %%       <jid>romeo@montague.net</jid>
+        %%     </always>
+        %%     <never>
+        %%       <jid>montague@montague.net</jid>
+        %%     </never>
+        %%   </prefs>
+        %% </iq>
+        
+        Room = ?config(room, Config),
+        RoomAddr = room_address(Room),
+        escalus:send(Alice, stanza_to_room(stanza_prefs_set_request(<<"roster">>,
+                                                                    [<<"romeo@montague.net">>],
+                                                                    [<<"montague@montague.net">>],
+                                                                    mam_ns_binary()), Room)),
+        ReplySet = escalus:wait_for_stanza(Alice),
+        assert_event_with_jid(mod_mam_muc_set_prefs, RoomAddr),
+
+        escalus:send(Alice, stanza_to_room(stanza_prefs_get_request(mam_ns_binary()), Room)),
+        ReplyGet = escalus:wait_for_stanza(Alice),
+        assert_event_with_jid(mod_mam_muc_get_prefs, RoomAddr),
+
+        ResultIQ1 = parse_prefs_result_iq(ReplySet),
+        ResultIQ2 = parse_prefs_result_iq(ReplyGet),
+        ?assert_equal(ResultIQ1, ResultIQ2),
+        ok
+        end,
+    RoomOpts = [{persistent, true}],
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    muc_helper:story_with_room(ConfigIn, RoomOpts, UserSpecs, F).
+
+muc_prefs_set_request_not_an_owner(ConfigIn) ->
+    F = fun(Config, _Alice, Bob) ->
+        Room = ?config(room, Config),
+        escalus:send(Bob, stanza_to_room(stanza_prefs_set_request(<<"roster">>,
+                                                                    [<<"romeo@montague.net">>],
+                                                                    [<<"montague@montague.net">>],
+                                                                    mam_ns_binary()), Room)),
+        escalus:assert(is_error, [<<"cancel">>, <<"not-allowed">>], escalus:wait_for_stanza(Bob))
+    end,
+    RoomOpts = [{persistent, true}],
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    muc_helper:story_with_room(ConfigIn, RoomOpts, UserSpecs, F).
+
+muc_query_get_request(ConfigIn) ->
+    F = fun(Config, Alice) ->
+        Room = ?config(room, Config),
+        QueryXmlns = mam_ns_binary_v04(),
+        escalus:send(Alice, stanza_to_room(stanza_query_get_request(QueryXmlns), Room)),
+        ReplyFields = escalus:wait_for_stanza(Alice),
+        ResponseXmlns = exml_query:path(ReplyFields,
+            [{element, <<"query">>},
+             {element, <<"x">>},
+             {element, <<"field">>},
+             {element, <<"value">>},
+              cdata]),
+        io:format("~p", [ResponseXmlns]),
+        ?assert_equal(QueryXmlns, ResponseXmlns)
+        end,
+    RoomOpts = [{persistent, true}],
+    UserSpecs = [{alice, 1}],
+    muc_helper:story_with_room(ConfigIn, RoomOpts, UserSpecs, F).
+
+%% Test reproducing https://github.com/esl/MongooseIM/issues/263
+%% The idea is this: in a "perfect" world jid elements are put together
+%% without whitespaces. In the real world it is not true.
+%% Put "\n" between two jid elements.
+muc_prefs_set_cdata_request(ConfigIn) ->
+    F = fun(Config, Alice) ->
+        %% Send
+        %%
+        %% <iq type='set' id='juliet2' to='room-alice'>
+        %%   <prefs xmlns='urn:xmpp:mam:1' default='roster'>
+        %%     <always>
+        %%       <jid>romeo@montague.net</jid>
+        %%       <jid>montague@montague.net</jid>
+        %%     </always>
+        %%     <never>
+        %%       <jid>montague@montague.net</jid>
+        %%     </never>
+        %%   </prefs>
+        %% </iq>
+
+        Room = ?config(room, Config),
+        escalus:send(Alice, stanza_to_room(stanza_prefs_set_request(<<"roster">>,
+                                                                    [<<"romeo@montague.net">>,
+                                                                     {xmlcdata, <<"\n">>}, %% Put as it is
+                                                                     <<"montague@montague.net">>], [],
+                                                                    mam_ns_binary_v04()), Room)),
+        ReplySet = escalus:wait_for_stanza(Alice),
+
+        escalus:send(Alice, stanza_to_room(stanza_prefs_get_request(mam_ns_binary_v04()), Room)),
+        ReplyGet = escalus:wait_for_stanza(Alice),
+
+        ResultIQ1 = parse_prefs_result_iq(ReplySet),
+        ResultIQ2 = parse_prefs_result_iq(ReplyGet),
+        ?assert_equal(ResultIQ1, ResultIQ2),
+        ok
+        end,
+    RoomOpts = [{persistent, true}],
+    UserSpecs = [{alice, 1}],
+    muc_helper:story_with_room(ConfigIn, RoomOpts, UserSpecs, F).
 
 mam_service_discovery(Config) ->
     F = fun(Alice) ->

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1169,6 +1169,36 @@ prefs_cases2() ->
      {{always, [], [bob, kate]},     [false, false, false, false]}
     ].
 
+prefs_cases2_muc() ->
+    [
+     {{roster, [], []},              [true, true, true, true]},
+     {{roster, [bob], []},           [true, true, true, true]},
+     {{roster, [kate], []},          [true, true, true, true]},
+     {{roster, [kate, bob], []},     [true, true, true, true]},
+
+     {{roster, [], [bob]},           [false, true, true, true]},
+     {{roster, [], [kate]},          [true, true, false, true]},
+     {{roster, [], [bob, kate]},     [false, true, false, true]},
+
+     {{never, [], []},              [false, false, false, false]},
+     {{never, [bob], []},           [true, false, false, false]},
+     {{never, [kate], []},          [false, false, true, false]},
+     {{never, [kate, bob], []},     [true, false, true, false]},
+
+     {{never, [], [bob]},           [false, false, false, false]},
+     {{never, [], [kate]},          [false, false, false, false]},
+     {{never, [], [bob, kate]},     [false, false, false, false]},
+
+     {{always, [], []},              [true, true, true, true]},
+     {{always, [bob], []},           [true, true, true, true]},
+     {{always, [kate], []},          [true, true, true, true]},
+     {{always, [kate, bob], []},     [true, true, true, true]},
+
+     {{always, [], [bob]},           [false, true, true, true]},
+     {{always, [], [kate]},          [true, true, false, true]},
+     {{always, [], [bob, kate]},     [false, true, false, true]}
+    ].
+
 default_policy({{Default, _, _}, _}) -> Default.
 
 make_alice_and_bob_friends(Alice, Bob) ->
@@ -1228,6 +1258,44 @@ run_prefs_case({PrefsState, ExpectedMessageStates}, Namespace, Alice, Bob, Kate,
                                alice_receives => [M3, M4]})
     end.
 
+muc_run_prefs_case({PrefsState, ExpectedMessageStates}, Namespace, Alice, Bob, Kate, Config) ->
+    Room = ?config(room, Config),
+    RoomAddr = room_address(Room),
+    escalus:send(Alice, stanza_muc_enter_room(Room, nick(Alice))),
+    escalus:send(Bob, stanza_muc_enter_room(Room, nick(Bob))),
+    escalus:send(Kate, stanza_muc_enter_room(Room, nick(Kate))),
+    escalus:wait_for_stanzas(Alice, 4),
+
+    {DefaultMode, AlwaysUsers, NeverUsers} = PrefsState,
+    IqSet = stanza_prefs_set_request_muc({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, Config),
+    escalus:send(Alice, stanza_to_room(IqSet, Room)),
+    _ReplySet = escalus:wait_for_stanza(Alice),
+
+    Messages = [iolist_to_binary(io_lib:format("n=~p, prefs=~p, now=~p",
+                                               [N, PrefsState, os:timestamp()]))
+                || N <- [1, 2, 3, 4]],
+
+    escalus:send(Bob, escalus_stanza:groupchat_to(RoomAddr, lists:nth(1,Messages))),
+    escalus:wait_for_stanza(Alice),
+
+    escalus:send(Alice, escalus_stanza:groupchat_to(RoomAddr, lists:nth(2,Messages))),
+    escalus:wait_for_stanza(Alice),
+
+    escalus:send(Kate, escalus_stanza:groupchat_to(RoomAddr, lists:nth(3,Messages))),
+    escalus:wait_for_stanza(Alice),
+
+    escalus:send(Alice, escalus_stanza:groupchat_to(RoomAddr, lists:nth(4,Messages))),
+    escalus:wait_for_stanza(Alice),
+
+    %% Delay check
+    fun(Bodies) ->
+        ActualMessageStates = [lists:member(M, Bodies) || M <- Messages],
+        Debug = make_debug_prefs(ExpectedMessageStates, ActualMessageStates),
+        ?_assert_equal_extra(ExpectedMessageStates, ActualMessageStates,
+                             #{prefs_state => PrefsState,
+                               debug => Debug})
+    end.
+
 make_debug_prefs(ExpectedMessageStates, ActualMessageStates) ->
     Zipped = lists:zip(prefs_checks_descriptions(),
                        lists:zip(ExpectedMessageStates, ActualMessageStates)),
@@ -1266,6 +1334,16 @@ stanza_prefs_set_request({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, Conf
     AlwaysJIDs = users_to_jids(AlwaysUsers, Config),
     NeverJIDs  = users_to_jids(NeverUsers, Config),
     stanza_prefs_set_request(DefaultModeBin, AlwaysJIDs, NeverJIDs, Namespace).
+
+stanza_prefs_set_request_muc({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, Config) ->
+    DefaultModeBin = atom_to_binary(DefaultMode, utf8),
+    AlwaysJIDs = users_to_nick(AlwaysUsers, Config),
+    NeverJIDs  = users_to_nick(NeverUsers, Config),
+    stanza_prefs_set_request(DefaultModeBin, AlwaysJIDs, NeverJIDs, Namespace).
+
+users_to_nick(Users, Config) ->
+    Room = ?config(room, Config),
+    [muc_helper:room_address(Room, nick(escalus_users:get_jid(Config, User))) || User <- Users].
 
 users_to_jids(Users, Config) ->
     [escalus_users:get_jid(Config, User) || User <- Users].

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1343,7 +1343,7 @@ stanza_prefs_set_request_muc({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, 
 
 users_to_nick(Users, Config) ->
     Room = ?config(room, Config),
-    [muc_helper:room_address(Room, nick(escalus_users:get_jid(Config, User))) || User <- Users].
+    [muc_helper:room_address(Room, string:lowercase(nick(escalus_users:get_jid(Config, User)))) || User <- Users].
 
 users_to_jids(Users, Config) ->
     [escalus_users:get_jid(Config, User) || User <- Users].

--- a/src/mam/ejabberd_gen_mam_prefs.erl
+++ b/src/mam/ejabberd_gen_mam_prefs.erl
@@ -1,12 +1,14 @@
 -module(ejabberd_gen_mam_prefs).
 
 -type set_prefs_params() :: #{archive_id := undefined | mod_mam:archive_id(),
+                              room => jid:jid(),
                               owner := jid:jid(),
                               default_mode := mod_mam:archive_behaviour(),
                               always_jids := [jid:literal_jid()],
                               never_jids := [jid:literal_jid()]}.
 
 -type get_prefs_params() :: #{archive_id := undefined | mod_mam:archive_id(),
+                              room => jid:jid(),
                               owner := jid:jid()}.
 
 -type get_behaviour_params() :: #{archive_id := undefined | mod_mam:archive_id(),

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -18,6 +18,7 @@
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).
 -xep([{xep, 313}, {version, "1.1.0"}, {legacy_versions, ["0.5"]}]).
+-xep([{xep, 441}, {version, "0.2.0"}]).
 -xep([{xep, 424}, {version, "0.3.0"}]).
 
 -include("mod_mam.hrl").

--- a/src/mam/mod_mam_cassandra_prefs.erl
+++ b/src/mam/mod_mam_cassandra_prefs.erl
@@ -35,7 +35,6 @@
 
 -spec start(host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, Opts) ->
-    ?LOG_DEBUG(#{what => cassandra_prefs_starting}),
     gen_hook:add_handlers(hooks(HostType, Opts)).
 
 -spec stop(host_type()) -> ok.
@@ -47,7 +46,6 @@ stop(HostType) ->
 %% Hooks
 
 hooks(HostType, Opts) ->
-    ?LOG_DEBUG(#{what => cassandra_prefs_starting}),
     lists:flatmap(fun(Type) -> hooks(HostType, Type, Opts) end, [pm, muc]).
 
 hooks(HostType, pm, #{pm := true}) ->

--- a/src/mam/mod_mam_mnesia_prefs.erl
+++ b/src/mam/mod_mam_mnesia_prefs.erl
@@ -41,7 +41,6 @@
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, Opts) ->
-    ?LOG_ERROR(#{what => mnesia_prefs_starting}),
     mongoose_mnesia:create_table(mam_prefs,
         [{disc_copies, [node()]},
          {attributes, record_info(fields, mam_prefs)}]),
@@ -68,7 +67,6 @@ hooks(HostType, pm, #{pm := true}) ->
      {mam_set_prefs, HostType, fun ?MODULE:set_prefs/3, #{}, 50},
      {mam_remove_archive, HostType, fun ?MODULE:remove_archive/3, #{}, 50}];
 hooks(HostType, muc, #{muc := true}) ->
-    ?LOG_ERROR(#{what => mnesia_prefs_starting_muc}),
     [{mam_muc_get_behaviour, HostType, fun ?MODULE:get_behaviour/3, #{}, 50},
      {mam_muc_get_prefs, HostType, fun ?MODULE:get_prefs/3, #{}, 50},
      {mam_muc_set_prefs, HostType, fun ?MODULE:set_prefs/3, #{}, 50},

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -285,7 +285,7 @@ check_room_action_allowed_by_default(HostType, Acc, Action, From, To) ->
                     UserJid :: jid:jid(),
                     RoomJid :: jid:jid()) -> boolean().
 is_room_owner(HostType, Acc, UserJid, RoomJid) ->
-    mongoose_hooks:is_muc_room_owner(HostType, Acc, UserJid, RoomJid).
+    mongoose_hooks:is_muc_room_owner(HostType, Acc, RoomJid, UserJid).
 
 %% @doc Return true if user element should be removed from results
 -spec is_user_identity_hidden(HostType :: host_type(),

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -325,17 +325,12 @@ handle_mam_iq(HostType, Action, From, To, IQ) ->
 handle_set_prefs(HostType, ArcJID = #jid{},
                  IQ = #iq{sub_el = PrefsEl}) ->
     {DefaultMode, AlwaysJIDs, NeverJIDs} = mod_mam_utils:parse_prefs(PrefsEl),
-    % In MUC, preference elements resemble JID structures formatted as <room@service/nick>.
-    % Since nicknames are restricted to lowercase characters, storing preferences with 
-    % uppercase nicknames in the database would be incorrect.
-    AlwaysList = lists:map(fun(Element) -> binary_to_lowercase(Element) end, AlwaysJIDs),
-    NeverList = lists:map(fun(Element) -> binary_to_lowercase(Element) end, NeverJIDs),
     ?LOG_DEBUG(#{what => mam_muc_set_prefs, archive_jid => ArcJID,
                  default_mode => DefaultMode,
-                 always_jids => AlwaysList, never_jids => NeverList, iq => IQ}),
+                 always_jids => AlwaysJIDs, never_jids => NeverJIDs, iq => IQ}),
     ArcID = archive_id_int(HostType, ArcJID),
-    Res = set_prefs(HostType, ArcID, ArcJID, DefaultMode, AlwaysList, NeverList),
-    handle_set_prefs_result(Res, DefaultMode, AlwaysList, NeverList, IQ).
+    Res = set_prefs(HostType, ArcID, ArcJID, DefaultMode, AlwaysJIDs, NeverJIDs),
+    handle_set_prefs_result(Res, DefaultMode, AlwaysJIDs, NeverJIDs, IQ).
 
 handle_set_prefs_result(ok, DefaultMode, AlwaysJIDs, NeverJIDs, IQ) ->
     ResultPrefsEl = mod_mam_utils:result_prefs(DefaultMode, AlwaysJIDs, NeverJIDs, IQ#iq.xmlns),
@@ -564,10 +559,6 @@ archive_message(HostType, Params) ->
 
 %% ----------------------------------------------------------------------
 %% Helpers
-
--spec binary_to_lowercase(binary()) -> binary().
-binary_to_lowercase(Binary) ->
-    binary:list_to_bin(string:to_lower(binary:bin_to_list(Binary))).
 
 -spec message_row_to_xml(binary(), jid:jid(), boolean(), boolean(), row(), binary() | undefined) ->
                                 exml:element().


### PR DESCRIPTION
Testing and fixing any issues with muc_mam_prefs. The code was not tested before, so I've made some cosmetic changes. I've also changed the handle_set_prefs function, to prevent saving unusable entries to the database. 