### PR TITLE
Fix flaky `sm_SUITE:ping_timeout` test

### DIFF
--- a/big_tests/tests/sm_helper.erl
+++ b/big_tests/tests/sm_helper.erl
@@ -28,6 +28,7 @@
          wait_until_resume_session/1,
          process_initial_stanza/1,
          kill_and_connect_resume/1,
+         kill_client_and_wait_for_termination/1,
          monitor_session/1]).
 
 %% Stanza helpers


### PR DESCRIPTION
This PR addresses the flaky `sm_SUITE:ping_timeout` test.

The test was failing sporadically due to the client receiving ping stanzas at inappropriate moments, such as during stream resumption configuration or while attempting to close the connection. Additionally, the client's connection was sometimes closed earlier than expected while it was still receiving information from the server.

These issues were resolved by ignoring ping stanzas during critical moments and retrieving necessary information earlier in the test process.

The test was run 1000 times on CI to confirm that the issue has been resolved.