### PR TITLE
Upgrade cets to the latest main version

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -8,7 +8,7 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"2.9.0">>},1},
  {<<"cets">>,
   {git,"https://github.com/esl/cets.git",
-       {ref,"0f69ec9eaed6e9567337b845661045d2ce04ad20"}},
+       {ref,"059078dac14bf5074bb6287852f19a54a4dda619"}},
   0},
  {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.9.0">>},0},
  {<<"cowboy_swagger">>,{pkg,<<"cowboy_swagger">>,<<"2.5.1">>},0},


### PR DESCRIPTION
The new cets just simply exposes a start_link callback that I want to I can add workers to a supervision tree.