### PR TITLE
Instrument/probe

### DIFF
--- a/src/instrument/mongoose_instrument.erl
+++ b/src/instrument/mongoose_instrument.erl
@@ -27,7 +27,7 @@
 -type label_value() :: mongooseim:host_type(). % to be extended
 -type metrics() :: #{metric_name() => metric_type()}.
 -type metric_name() :: atom().
--type metric_type() :: spiral | histogram. % to be extended
+-type metric_type() :: gauge | spiral | histogram. % to be extended
 -type measurements() :: #{atom() => term()}.
 -type spec() :: {event_name(), labels(), config()}.
 -type config() :: #{metrics => metrics()}. % to be extended

--- a/src/instrument/mongoose_instrument.erl
+++ b/src/instrument/mongoose_instrument.erl
@@ -30,7 +30,11 @@
 -type metric_type() :: gauge | spiral | histogram. % to be extended
 -type measurements() :: #{atom() => term()}.
 -type spec() :: {event_name(), labels(), config()}.
--type config() :: #{metrics => metrics()}. % to be extended
+-type config() :: #{metrics => metrics(),
+                    loglevel => logger:level(),
+                    probe => probe_config()}.
+-type probe_config() :: #{module := module(),
+                          interval => pos_integer()}.
 -type handler_key() :: atom(). % key in the `instrumentation' section of the config file
 -type handler_fun() :: fun((event_name(), labels(), config(), measurements()) -> any()).
 -type handlers() :: {[handler_fun()], config()}.
@@ -46,7 +50,7 @@
 -optional_callbacks([config_spec/0, start/0, stop/0]).
 
 -export_type([event_name/0, labels/0, label_key/0, label_value/0, config/0, measurements/0,
-              spec/0, handlers/0, metric_name/0, metric_type/0]).
+              spec/0, handlers/0, metric_name/0, metric_type/0, probe_config/0]).
 
 %% API
 
@@ -54,7 +58,9 @@
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
     Items = [{atom_to_binary(Key), config_spec(Key)} || Key <- all_handler_keys()],
-    #section{items = maps:from_list(Items),
+    Options = #{<<"probe_interval">> => #option{type = integer, validate = positive}},
+    #section{items = maps:merge(maps:from_list(Items), Options),
+             defaults = #{<<"probe_interval">> => 15},
              wrap = global_config,
              include = always}.
 
@@ -141,60 +147,66 @@ remove_handler(Key) ->
 
 %% gen_server callbacks
 
--type state() :: #{event_name() => #{labels() => handlers()}}.
+-type state() :: #{events := event_map(), probe_timers := probe_timer_map()}.
+-type event_map() :: #{event_name() => #{labels() => handlers()}}.
+-type probe_timer_map() :: #{{event_name(), labels()} => timer:tref()}.
 
 -spec init([]) -> {ok, state()}.
 init([]) ->
     lists:foreach(fun start_handler/1, handler_modules()),
     erlang:process_flag(trap_exit, true), % Make sure that terminate is called
     persistent_term:erase(?MODULE), % Prevent inconsistency when restarted after a kill
-    {ok, #{}}.
+    {ok, #{events => #{}, probe_timers => #{}}}.
 
 -spec handle_call(any(), gen_server:from(), state()) ->
           {reply, ok | {ok, handlers()} | {error, map()}, state()}.
-handle_call({set_up, EventName, Labels, Config}, _From, State) ->
-    case set_up_and_register(EventName, Labels, Config, State) of
+handle_call({set_up, EventName, Labels, Config}, _From,
+            #{events := Events, probe_timers := ProbeTimers} = State) ->
+    case set_up_and_register_event(EventName, Labels, Config, Events) of
         {error, _} = Error ->
             {reply, Error, State};
-        NewState = #{} ->
-            update_if_persisted(State, NewState),
-            {reply, ok, NewState}
+        NewEvents = #{} ->
+            update_if_persisted(Events, NewEvents),
+            NewProbeTimers = start_probe_if_needed(EventName, Labels, Config, ProbeTimers),
+            {reply, ok, #{events => NewEvents, probe_timers => NewProbeTimers}}
     end;
-handle_call({tear_down, EventName, Labels}, _From, State) ->
-    NewState = deregister(EventName, Labels, State),
-    update_if_persisted(State, NewState),
-    {reply, ok, NewState};
-handle_call({add_handler, Key, ConfigOpts}, _From, State) ->
+handle_call({tear_down, EventName, Labels}, _From,
+            #{events := Events, probe_timers := ProbeTimers}) ->
+    NewProbeTimers = deregister_probe_timer(EventName, Labels, ProbeTimers),
+    NewEvents = deregister_event(EventName, Labels, Events),
+    update_if_persisted(Events, NewEvents),
+    {reply, ok, #{events => NewEvents, probe_timers => NewProbeTimers}};
+handle_call({add_handler, Key, ConfigOpts}, _From, State = #{events := Events}) ->
     case mongoose_config:lookup_opt([instrumentation, Key]) of
         {error, not_found} ->
             mongoose_config:set_opt([instrumentation, Key], ConfigOpts),
             Module = handler_module(Key),
             start_handler(Module),
-            NewState = update_handlers(State, [], [Module]),
-            update_if_persisted(State, NewState),
-            {reply, ok, NewState};
+            NewEvents = update_handlers(Events, [], [Module]),
+            update_if_persisted(Events, NewEvents),
+            {reply, ok, State#{events := NewEvents}};
         {ok, ExistingConfig} ->
             {reply, {error, #{what => handler_already_configured, handler_key => Key,
                               existing_config => ExistingConfig}},
              State}
     end;
-handle_call({remove_handler, Key}, _From, State) ->
+handle_call({remove_handler, Key}, _From, State = #{events := Events}) ->
     case mongoose_config:lookup_opt([instrumentation, Key]) of
         {error, not_found} ->
             {reply, {error, #{what => handler_not_configured, handler_key => Key}}, State};
         {ok, _} ->
             mongoose_config:unset_opt([instrumentation, Key]),
             Module = handler_module(Key),
-            NewState = update_handlers(State, [Module], []),
-            update_if_persisted(State, NewState),
+            NewEvents = update_handlers(Events, [Module], []),
+            update_if_persisted(Events, NewEvents),
             stop_handler(Module),
-            {reply, ok, NewState}
+            {reply, ok, State#{events := NewEvents}}
     end;
-handle_call(persist, _From, State) ->
-    persistent_term:put(?MODULE, State),
+handle_call(persist, _From, State = #{events := Events}) ->
+    persistent_term:put(?MODULE, Events),
     {reply, ok, State};
-handle_call({lookup, EventName, Labels}, _From, State) ->
-    {reply, lookup(EventName, Labels, State), State};
+handle_call({lookup, EventName, Labels}, _From, State = #{events := Events}) ->
+    {reply, lookup(EventName, Labels, Events), State};
 handle_call(Request, From, State) ->
     ?UNEXPECTED_CALL(Request, From),
     {reply, {error, #{what => unexpected_call, request => Request}}, State}.
@@ -220,18 +232,19 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% Internal functions
 
--spec update_if_persisted(state(), state()) -> ok.
-update_if_persisted(State, NewState) ->
+-spec update_if_persisted(event_map(), event_map()) -> ok.
+update_if_persisted(Events, NewEvents) ->
     try persistent_term:get(?MODULE) of
-        State -> persistent_term:put(?MODULE, NewState)
+        Events -> persistent_term:put(?MODULE, NewEvents)
     catch
         error:badarg -> ok
     end.
 
--spec set_up_and_register(event_name(), labels(), config(), state()) -> state() | {error, map()}.
-set_up_and_register(EventName, Labels, Config, State) ->
+-spec set_up_and_register_event(event_name(), labels(), config(), event_map()) ->
+          event_map() | {error, map()}.
+set_up_and_register_event(EventName, Labels, Config, Events) ->
     LabelKeys = label_keys(Labels),
-    case State of
+    case Events of
         #{EventName := #{Labels := _}} ->
             {error, #{what => event_already_registered,
                       event_name => EventName, labels => Labels}};
@@ -240,7 +253,7 @@ set_up_and_register(EventName, Labels, Config, State) ->
             case label_keys(ExistingLabels) of
                 LabelKeys ->
                     Handlers = do_set_up(EventName, Labels, Config),
-                    State#{EventName := HandlerMap#{Labels => Handlers}};
+                    Events#{EventName := HandlerMap#{Labels => Handlers}};
                 ExistingKeys ->
                     {error, #{what => inconsistent_labels,
                               event_name => EventName, labels => Labels,
@@ -248,7 +261,7 @@ set_up_and_register(EventName, Labels, Config, State) ->
             end;
         #{} ->
             Handlers = do_set_up(EventName, Labels, Config),
-            State#{EventName => #{Labels => Handlers}}
+            Events#{EventName => #{Labels => Handlers}}
     end.
 
 -spec do_set_up(event_name(), labels(), config()) -> handlers().
@@ -256,14 +269,27 @@ do_set_up(EventName, Labels, Config) ->
     HandlerFuns = set_up_handlers(EventName, Labels, Config, handler_modules()),
     {HandlerFuns, Config}.
 
--spec update_handlers(state(), [module()], [module()]) -> state().
-update_handlers(State, ToRemove, ToAdd) ->
+-spec start_probe_if_needed(event_name(), labels(), config(), probe_timer_map()) ->
+          probe_timer_map().
+start_probe_if_needed(EventName, Labels, #{probe := ProbeConfig}, ProbeTimers) ->
+    TRef = mongoose_instrument_probe:start_probe_timer(EventName, Labels, ProbeConfig),
+    add_probe_timer(EventName, Labels, TRef, ProbeTimers);
+start_probe_if_needed(_EventName, _Labels, _Config, ProbeTimers) ->
+    ProbeTimers.
+
+-spec add_probe_timer(event_name(), labels(), timer:tref(), probe_timer_map()) -> probe_timer_map().
+add_probe_timer(EventName, Labels, TRef, ProbeTimers) ->
+    false = maps:is_key({EventName, Labels}, ProbeTimers), % sanity check to detect timer leak
+    ProbeTimers#{{EventName, Labels} => TRef}.
+
+-spec update_handlers(event_map(), [module()], [module()]) -> event_map().
+update_handlers(Events, ToRemove, ToAdd) ->
     maps:map(fun(EventName, HandlerMap) ->
                      maps:map(fun(Labels, Handlers) ->
                                       update_event_handlers(EventName, Labels, Handlers,
                                                             ToRemove, ToAdd)
                               end, HandlerMap)
-             end, State).
+             end, Events).
 
 -spec update_event_handlers(event_name(), labels(), handlers(), [module()], [module()]) ->
           handlers().
@@ -278,25 +304,35 @@ set_up_handlers(EventName, Labels, Config, Modules) ->
     UsedModules = lists:filter(fun(Mod) -> Mod:set_up(EventName, Labels, Config) end, Modules),
     modules_to_funs(UsedModules).
 
--spec deregister(event_name(), labels(), state()) -> state().
-deregister(EventName, Labels, State) ->
-    case State of
+-spec deregister_event(event_name(), labels(), event_map()) -> event_map().
+deregister_event(EventName, Labels, Events) ->
+    case Events of
         #{EventName := HandlerMap} ->
             case maps:remove(Labels, HandlerMap) of
                 Empty when Empty =:= #{} ->
-                    maps:remove(EventName, State);
+                    maps:remove(EventName, Events);
                 NewHandlerMap ->
-                    State#{EventName := NewHandlerMap}
+                    Events#{EventName := NewHandlerMap}
             end;
         #{} ->
-            State
+            Events
+    end.
+
+-spec deregister_probe_timer(event_name(), labels(), probe_timer_map()) -> probe_timer_map().
+deregister_probe_timer(EventName, Labels, ProbeTimers) ->
+    case maps:take({EventName, Labels}, ProbeTimers) of
+        {TRef, NewProbeTimers} ->
+            timer:cancel(TRef),
+            NewProbeTimers;
+        error ->
+            ProbeTimers % no timer was registered
     end.
 
 -spec lookup(event_name(), labels()) -> {ok, handlers()} | {error, map()}.
 lookup(EventName, Labels) ->
     try persistent_term:get(?MODULE) of
-        State ->
-            lookup(EventName, Labels, State)
+        Events ->
+            lookup(EventName, Labels, Events)
     catch
         %% Although persist/0 should be called before handling traffic,
         %% some instrumented events might happen before that, and they shouldn't fail.
@@ -306,9 +342,9 @@ lookup(EventName, Labels) ->
             gen_server:call(?MODULE, {lookup, EventName, Labels})
     end.
 
--spec lookup(event_name(), labels(), state()) -> {ok, handlers()} | {error, map()}.
-lookup(EventName, Labels, State) ->
-    case State of
+-spec lookup(event_name(), labels(), event_map()) -> {ok, handlers()} | {error, map()}.
+lookup(EventName, Labels, Events) ->
+    case Events of
         #{EventName := #{Labels := Handlers}} ->
             {ok, Handlers};
         #{} ->
@@ -338,7 +374,8 @@ modules_to_funs(Modules) ->
 
 -spec handler_modules() -> [module()].
 handler_modules() ->
-    [handler_module(Key) || Key <- maps:keys(mongoose_config:get_opt(instrumentation))].
+    Keys = [Key || {Key, #{}} <- maps:to_list(mongoose_config:get_opt(instrumentation))],
+    lists:map(fun handler_module/1, Keys).
 
 -spec handler_module(handler_key()) -> module().
 handler_module(Key) ->
@@ -372,13 +409,7 @@ stop_handler(Module) ->
 
 -spec call_handler(handler_fun(), event_name(), labels(), config(), measurements()) -> any().
 call_handler(HandlerFun, EventName, Labels, Config, Measurements) ->
-    try
-        HandlerFun(EventName, Labels, Config, Measurements)
-    catch
-        Class:Reason:StackTrace ->
-            ?LOG_ERROR(#{what => event_handler_failed,
-                         handler_fun => HandlerFun,
-                         event_name => EventName, labels => Labels, config => Config,
-                         measurements => Measurements,
-                         class => Class, reason => Reason, stacktrace => StackTrace})
-    end.
+    safely:apply_and_log(HandlerFun, [EventName, Labels, Config, Measurements],
+                         #{what => event_handler_failed, handler_fun => HandlerFun,
+                           event_name => EventName, labels => Labels, config => Config,
+                           measurements => Measurements}).

--- a/src/instrument/mongoose_instrument_exometer.erl
+++ b/src/instrument/mongoose_instrument_exometer.erl
@@ -66,6 +66,8 @@ handle_metric_event(EventName, Labels, MetricName, MetricType, Measurements) ->
     end.
 
 -spec update_metric(exometer:name(), spiral | histogram, integer()) -> ok.
+update_metric(Name, gauge, Value) when is_integer(Value) ->
+    ok = exometer:update(Name, Value);
 update_metric(Name, spiral, Value) when is_integer(Value), Value >= 0 ->
     ok = exometer:update(Name, Value);
 update_metric(Name, histogram, Value) when is_integer(Value) ->

--- a/src/instrument/mongoose_instrument_probe.erl
+++ b/src/instrument/mongoose_instrument_probe.erl
@@ -1,0 +1,33 @@
+-module(mongoose_instrument_probe).
+
+-export([start_probe_timer/3, call/3]).
+
+-callback probe(mongoose_instrument:event_name(), mongoose_instrument:labels()) ->
+    mongoose_instrument:measurements().
+
+-ignore_xref([call/3]).
+
+-spec start_probe_timer(mongoose_instrument:event_name(),
+                        mongoose_instrument:labels(),
+                        mongoose_instrument:probe_config()) -> timer:tref().
+start_probe_timer(EventName, Labels, #{module := Module} = ProbeConfig) ->
+    Interval = timer:seconds(get_probe_interval(ProbeConfig)),
+    %% TODO: when dropping support for OTP25, consider changing this to apply_repeatedly
+    {ok, TRef} = timer:apply_interval(Interval, ?MODULE, call, [Module, EventName, Labels]),
+    TRef.
+
+call(ProbeMod, EventName, Labels) ->
+    case safely:apply_and_log(ProbeMod, probe, [EventName, Labels],
+                              #{what => probe_failed, probe_mod => ProbeMod,
+                                event_name => EventName, labels => Labels}) of
+        {exception, _} ->
+            ok; % Already logged
+        Measurements = #{} ->
+            mongoose_instrument:execute(EventName, Labels, Measurements)
+    end.
+
+-spec get_probe_interval(mongoose_instrument:probe_config()) -> pos_integer().
+get_probe_interval(#{interval := Interval}) when is_integer(Interval), Interval > 0 ->
+    Interval;
+get_probe_interval(#{}) ->
+    mongoose_config:get_opt([instrumentation, probe_interval]).

--- a/src/instrument/mongoose_instrument_prometheus.erl
+++ b/src/instrument/mongoose_instrument_prometheus.erl
@@ -34,10 +34,14 @@ set_up_metric(EventName, Labels, MetricName, MetricType) ->
     LabelKeys = labels_to_keys(Labels),
     LabelValues = labels_to_values(Labels),
     MetricSpec = metric_spec(EventName, LabelKeys, MetricName),
+    FullName = proplists:get_value(name, MetricSpec),
     case declare_metric(MetricSpec, MetricType) of
-        true -> ok;
-        false -> reset_metric(proplists:get_value(name, MetricSpec), LabelValues, MetricType)
-    end.
+        true ->
+            ok; %% Metric does not exist - no need to reset
+        false ->
+            reset_metric(FullName, LabelValues, MetricType)
+    end,
+    initialize_metric(FullName, LabelValues, MetricType).
 
 -spec declare_metric(proplists:proplist(), mongoose_instrument:metric_type()) -> boolean().
 declare_metric(MetricSpec, spiral) ->
@@ -46,12 +50,20 @@ declare_metric(MetricSpec, histogram) ->
     prometheus_histogram:declare([{buckets, histogram_buckets()} | MetricSpec]).
 
 -spec reset_metric(name(), [mongoose_instrument:label_value()],
-                   mongoose_instrument:metric_type()) -> ok.
+                   mongoose_instrument:metric_type()) -> boolean().
 reset_metric(Name, LabelValues, spiral) ->
-    prometheus_counter:reset(Name, LabelValues),
-    prometheus_counter:inc(Name, LabelValues, 0);
+    prometheus_counter:remove(Name, LabelValues);
 reset_metric(Name, LabelValues, histogram) ->
-    prometheus_histogram:reset(Name, LabelValues),
+    prometheus_histogram:remove(Name, LabelValues).
+
+-spec initialize_metric(name(), [mongoose_instrument:label_value()],
+                        mongoose_instrument:metric_type()) -> ok.
+initialize_metric(Name, LabelValues, spiral) ->
+    %% Initialize counter, because it has a meaningful initial value of zero
+    %% Additionally, leaving it undefined would delay rate calculation in Prometheus
+    prometheus_counter:inc(Name, LabelValues, 0);
+initialize_metric(_Name, _LabelValues, _) ->
+    %% Don't initialize, because no meaningful value could be provided
     ok.
 
 -spec metric_spec(mongoose_instrument:event_name(), [mongoose_instrument:label_key()],

--- a/src/instrument/mongoose_instrument_prometheus.erl
+++ b/src/instrument/mongoose_instrument_prometheus.erl
@@ -44,6 +44,8 @@ set_up_metric(EventName, Labels, MetricName, MetricType) ->
     initialize_metric(FullName, LabelValues, MetricType).
 
 -spec declare_metric(proplists:proplist(), mongoose_instrument:metric_type()) -> boolean().
+declare_metric(MetricSpec, gauge) ->
+    prometheus_gauge:declare(MetricSpec);
 declare_metric(MetricSpec, spiral) ->
     prometheus_counter:declare(MetricSpec);
 declare_metric(MetricSpec, histogram) ->
@@ -51,6 +53,8 @@ declare_metric(MetricSpec, histogram) ->
 
 -spec reset_metric(name(), [mongoose_instrument:label_value()],
                    mongoose_instrument:metric_type()) -> boolean().
+reset_metric(Name, LabelValues, gauge) ->
+    prometheus_gauge:remove(Name, LabelValues);
 reset_metric(Name, LabelValues, spiral) ->
     prometheus_counter:remove(Name, LabelValues);
 reset_metric(Name, LabelValues, histogram) ->
@@ -113,6 +117,8 @@ labels_to_values(Labels) ->
 
 -spec update_metric(name(), [mongoose_instrument:label_value()],
                     mongoose_instrument:metric_type(), integer()) -> ok.
+update_metric(Name, Labels, gauge, Value) when is_integer(Value) ->
+    ok = prometheus_gauge:set(Name, Labels, Value);
 update_metric(Name, Labels, spiral, Value) when is_integer(Value), Value >= 0 ->
     ok = prometheus_counter:inc(Name, Labels, Value);
 update_metric(Name, Labels, histogram, Value) when is_integer(Value) ->

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -28,7 +28,7 @@ options("host_types") ->
      {sm_backend, mnesia},
      {component_backend, mnesia},
      {s2s_backend, mnesia},
-     {instrumentation, #{}},
+     {instrumentation, default_config([instrumentation])},
      {{s2s, <<"another host type">>}, default_s2s()},
      {{s2s, <<"localhost">>}, default_s2s()},
      {{s2s, <<"some host type">>}, default_s2s()},
@@ -93,9 +93,11 @@ options("miscellaneous") ->
                                               id => "G-12345678",
                                               secret => "Secret"
                                              }}}},
-     {instrumentation, #{prometheus => #{},
-                         exometer => #{all_metrics_are_global => true},
-                         log => #{level => info}}},
+     {instrumentation, config([instrumentation],
+                              #{probe_interval => 10,
+                                prometheus => #{},
+                                exometer => #{all_metrics_are_global => true},
+                                log => #{level => info}})},
      {{s2s, <<"anonymous.localhost">>}, default_s2s()},
      {{s2s, <<"localhost">>}, default_s2s()},
      {sm_backend, mnesia},
@@ -129,7 +131,7 @@ options("modules") ->
      {sm_backend, mnesia},
      {component_backend, mnesia},
      {s2s_backend, mnesia},
-     {instrumentation, #{}},
+     {instrumentation, default_config([instrumentation])},
      {{auth, <<"dummy_host">>}, default_auth()},
      {{auth, <<"localhost">>}, default_auth()},
      {{modules, <<"dummy_host">>}, all_modules()},
@@ -265,8 +267,7 @@ options("mongooseim-pgsql") ->
      {sm_backend, mnesia},
      {component_backend, mnesia},
      {s2s_backend, mnesia},
-     {instrumentation, #{exometer => default_config([instrumentation, exometer]),
-                         log => default_config([instrumentation, log])}},
+     {instrumentation, config([instrumentation], #{exometer => #{}, log => #{}})},
      {{outgoing_pools, <<"anonymous.localhost">>},
       [host_pool_config(
          #{tag => special,
@@ -384,7 +385,7 @@ options("outgoing_pools") ->
      {sm_backend, mnesia},
      {component_backend, mnesia},
      {s2s_backend, mnesia},
-     {instrumentation, #{}},
+     {instrumentation, default_config([instrumentation])},
      {{auth, <<"anonymous.localhost">>}, default_auth()},
      {{auth, <<"localhost">>}, default_auth()},
      {{auth, <<"localhost.bis">>}, default_auth()},
@@ -412,7 +413,7 @@ options("s2s_only") ->
      {sm_backend, mnesia},
      {component_backend, mnesia},
      {s2s_backend, mnesia},
-     {instrumentation, #{}},
+     {instrumentation, default_config([instrumentation])},
      {{auth, <<"dummy_host">>}, default_auth()},
      {{auth, <<"localhost">>}, default_auth()},
      {{modules, <<"dummy_host">>}, #{}},
@@ -1102,6 +1103,8 @@ extra_service_listener_config() ->
       conflict_behaviour => disconnect,
       connection_type => component}.
 
+default_config([instrumentation]) ->
+    #{probe_interval => 15};
 default_config([instrumentation, log]) ->
     #{level => debug};
 default_config([instrumentation, exometer]) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -2934,10 +2934,12 @@ service_mongoose_system_metrics(_Config) ->
 instrumentation(_Config) ->
     P = [instrumentation],
     T = fun(Opts) -> #{<<"instrumentation">> => Opts} end,
-    ?cfg(P, #{}, T(#{})),
-    ?cfg(P, #{prometheus => #{}}, T(#{<<"prometheus">> => #{}})),
+    ?cfg(P, default_config(P), T(#{})),
+    ?cfg(P ++ [prometheus], #{}, T(#{<<"prometheus">> => #{}})),
+    ?cfg(P ++ [probe_interval], 10, T(#{<<"probe_interval">> => 10})),
     ?err(T(#{<<"prometheus">> => #{<<"fire">> => 1}})),
-    ?err(T(#{<<"bad_module">> => #{}})).
+    ?err(T(#{<<"bad_module">> => #{}})),
+    ?err(T(#{<<"probe_interval">> => 0})).
 
 instrumentation_log(_Config) ->
     P = [instrumentation, log],

--- a/test/config_parser_SUITE_data/miscellaneous.toml
+++ b/test/config_parser_SUITE_data/miscellaneous.toml
@@ -80,10 +80,13 @@
 
 [internal_databases.cets]
 
-[instrumentation.prometheus]
+[instrumentation]
+  probe_interval = 10
 
-[instrumentation.exometer]
-  all_metrics_are_global = true
+  [instrumentation.prometheus]
 
-[instrumentation.log]
-  level = "info"
+  [instrumentation.exometer]
+    all_metrics_are_global = true
+
+  [instrumentation.log]
+    level = "info"

--- a/test/log_helper.hrl
+++ b/test/log_helper.hrl
@@ -2,25 +2,34 @@
 %% For set-up and tear-down, see log_helper.erl
 
 -define(assertNoLog(LevelPattern, MsgPattern),
-        case ?receiveLog(LevelPattern, MsgPattern) of
+        ?assertNoLog(LevelPattern, MsgPattern, 0)).
+
+-define(assertNoLog(LevelPattern, MsgPattern, Timeout),
+        case ?receiveLog(LevelPattern, MsgPattern, Timeout) of
             no_log -> ok;
             _ -> ct:fail("Received unexpected log")
         end).
 
 -define(assertLog(LevelPattern, MsgPattern),
-        case ?receiveLog(LevelPattern, MsgPattern) of
+        ?assertLog(LevelPattern, MsgPattern, 0)).
+
+-define(assertLog(LevelPattern, MsgPattern, Timeout),
+        case ?receiveLog(LevelPattern, MsgPattern, Timeout) of
             no_log -> ct:fail("Expected log not received");
             _ -> ok
         end).
 
 -define(receiveLog(LevelPattern, MsgPattern),
+        ?receiveLog(LevelPattern, MsgPattern, 0)).
+
+-define(receiveLog(LevelPattern, MsgPattern, Timeout),
         ?wrap(receive
                   {log, #{level := Level = LevelPattern,
                           msg := {report, Msg = MsgPattern}}} ->
                       ct:log("Received ~p log: ~p", [Level, Msg]),
                       {Level, Msg}
               after
-                  0 -> no_log
+                  Timeout -> no_log
               end)).
 
 %% Wrap in a fun to avoid unsafe variables

--- a/test/mongoose_config_SUITE.erl
+++ b/test/mongoose_config_SUITE.erl
@@ -187,7 +187,7 @@ minimal_config_opts() ->
       {modules, <<"localhost">>} => #{},
       {replaced_wait_timeout, <<"localhost">>} => 2000,
       {s2s, <<"localhost">>} => config_parser_helper:default_s2s(),
-      instrumentation => #{}}.
+      instrumentation => config_parser_helper:default_config([instrumentation])}.
 
 start_slave_node(Config) ->
     SlaveNode = do_start_slave_node(),


### PR DESCRIPTION
The main goal is to support probes in `mongoose_instrument`.

A probe is a metric (typically a gauge - simple numerical value), that is updated with a callback function.

The probe is executed at a configurable rate. By default the interval is 15 seconds, and it can be modified:
- either globally - with the `instrumentation.probe_interval` option in TOML,
- or when an event is set up - with the `probe => #{interval => ...}}` option.

Previously the interval was the same as the `exometer` report interval, but the new design separates instrumentation from data collection, so we don't want to have such dependencies. Furthermore, for Prometheus we don't know the scrape interval.

Other changes:
- Added support for gauges for Prometheus and Exometer.
- Fixed initialisation of Prometheus metrics, with improved tests.
- Added missing `loglevel` to the `config()` type.

**Notes:** both Exometer and Prometheus have behaviours for callback modules, that can provide metrics directly. This way there would be no interval, and each reporting/scraping event would cause direct calls to calculate the metrics. I implemented and benchmarked that solution, and for `mod_muc` (with 10k rooms) it would cause noticeable delays in the Prometheus Cowboy endpoint, so I didn't include the solution in this PR. I could make a separate PR for it though.

Additionally, I think that if the calculation is periodic, there is no benefit in using the Prometheus/Exometer-specific callback modules, so I chose to use the periodic events instead. This way it is also possible to log the events for debugging.

Regarding coverage: the only uncovered line is tested in the upcoming MUC PR.