### PR TITLE
Fix and update package building scripts

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -659,7 +659,7 @@ jobs:
         type: executor
       platform:
         type: enum
-        enum: [centos_7, rockylinux_9, rockylinux_8, almalinux_9, almalinux_8, debian_bullseye, debian_buster, ubuntu_xenial, ubuntu_focal, ubuntu_bionic]
+        enum: [centos_7, rockylinux_9, rockylinux_8, almalinux_9, almalinux_8, debian_bullseye, debian_buster, ubuntu_xenial, ubuntu_focal, ubuntu_bionic, ubuntu_jammy]
         description: Platform type
       otp_package:
         type: string
@@ -711,49 +711,56 @@ workflows:
           executor: otp_26
           platform: centos_7
           context: mongooseim-org
-          otp_package: "25.0.3-1"
+          otp_package: "26.2.2"
           filters: *all_tags
       - package:
           name: rockylinux_8
           executor: otp_26
           platform: rockylinux_8
           context: mongooseim-org
-          otp_package: "24.1.7-1"
+          otp_package: "26.2.4"
           filters: *all_tags
       - package:
           name: almalinux_8
           executor: otp_26
           platform: almalinux_8
           context: mongooseim-org
-          otp_package: "24.1.7-1"
+          otp_package: "26.2.4"
           filters: *all_tags
       - package:
           name: debian_bullseye
           executor: otp_26
           platform: debian_bullseye
           context: mongooseim-org
-          otp_package: "25.3-1"
+          otp_package: "26.2.1"
           filters: *all_tags
       - package:
           name: debian_buster
           executor: otp_26
           platform: debian_buster
           context: mongooseim-org
-          otp_package: "25.3-1"
+          otp_package: "26.2.3"
+          filters: *all_tags
+      - package:
+          name: ubuntu_jammy
+          executor: otp_26
+          platform: ubuntu_jammy
+          context: mongooseim-org
+          otp_package: "26.2.3"
           filters: *all_tags
       - package:
           name: ubuntu_focal
           executor: otp_26
           platform: ubuntu_focal
           context: mongooseim-org
-          otp_package: "25.3-1"
+          otp_package: "26.2.1"
           filters: *all_tags
       - package:
           name: ubuntu_bionic
           executor: otp_26
           platform: ubuntu_bionic
           context: mongooseim-org
-          otp_package: "25.3-1"
+          otp_package: "26.2.3"
           filters: *all_tags
       # ======== BASE DOCKER BUILDS ========
       - build_in_docker:

--- a/tools/pkg/Dockerfile_deb
+++ b/tools/pkg/Dockerfile_deb
@@ -6,14 +6,9 @@ FROM $dockerfile_platform AS builder
 # Install build deps
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -y locales git make zlib1g-dev unixodbc-dev gcc g++ libssl-dev
+RUN apt-get install -y locales git make zlib1g-dev unixodbc-dev gcc g++ libssl-dev curl
 
-RUN apt-get -y update && apt-get -y install curl gnupg && \
-        curl -O http://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && \
-        dpkg -i erlang-solutions_2.0_all.deb && apt-get update
 ARG erlang_version
-RUN apt-get install -y esl-erlang=1:$erlang_version
-
 
 # Fix locales
 RUN locale-gen en_US.UTF-8
@@ -25,6 +20,9 @@ WORKDIR /root/
 COPY . ./mongooseim
 
 RUN cp -r ./mongooseim/tools/pkg/scripts/deb .
+
+ARG dockerfile_platform
+RUN ./deb/install_erlang.sh
 
 ARG version
 ARG revision

--- a/tools/pkg/Dockerfile_rpm
+++ b/tools/pkg/Dockerfile_rpm
@@ -26,10 +26,6 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 ARG erlang_version
 
-RUN curl -O https://packages.erlang-solutions.com/erlang-solutions-2.0-1.noarch.rpm && \
-    rpm -Uvh erlang-solutions-2.0-1.noarch.rpm && \
-    yum install -y "esl-erlang-$erlang_version"
-
 # Copy source code and put building files in proper directories according to
 # defaults of `rpmdev-setuptree` and `rpmbuild` commands
 # The .dockerignore file in root dir ensures only needed files
@@ -37,6 +33,7 @@ RUN curl -O https://packages.erlang-solutions.com/erlang-solutions-2.0-1.noarch.
 RUN rpmdev-setuptree
 WORKDIR /root/rpmbuild
 COPY --from=source /SOURCE ./BUILD/mongooseim
+RUN ./BUILD/mongooseim/tools/pkg/scripts/rpm/install_erlang.sh
 
 RUN cp ./BUILD/mongooseim/tools/pkg/scripts/rpm/mongooseim.spec ./SPECS/.
 RUN cp ./BUILD/mongooseim/tools/pkg/scripts/rpm/mongooseim.service \

--- a/tools/pkg/Dockerfile_rpm
+++ b/tools/pkg/Dockerfile_rpm
@@ -14,7 +14,7 @@ FROM $dockerfile_platform AS builder
 
 # Install the build dependencies
 RUN yum install -y epel-release
-RUN yum install -y rpm-build rpmdevtools git make zlib-devel unixODBC-devel gcc gcc-c++ openssl openssl-devel
+RUN yum install -y rpm-build rpmdevtools git make zlib-devel unixODBC-devel gcc gcc-c++ openssl openssl-devel chrpath
 
 # Fix locale setup
 # See https://github.com/CentOS/sig-cloud-instance-images/issues/71#issuecomment-266957519

--- a/tools/pkg/scripts/deb/build_package.sh
+++ b/tools/pkg/scripts/deb/build_package.sh
@@ -44,5 +44,5 @@ source /etc/os-release
 os=$ID
 os_version=$VERSION_CODENAME
 package_os_file_name=${os}~${os_version}
-mv mongooseim_*.deb ~/mongooseim_${version}_${revision}_otp_${otp_version/-1/}~${package_os_file_name}_${arch}.deb
+mv mongooseim_*.deb ~/mongooseim_${version}_${revision}_otp_${otp_version}~${package_os_file_name}_${arch}.deb
 

--- a/tools/pkg/scripts/deb/install_erlang.sh
+++ b/tools/pkg/scripts/deb/install_erlang.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DISTRO=$(echo $dockerfile_platform | cut -f1 -d:)
+ERLANG_PKG=esl-erlang_${erlang_version}-1~${dockerfile_platform/:/\~}_amd64.deb
+
+curl -O https://binaries2.erlang-solutions.com/$DISTRO/pool/contrib/e/esl-erlang/$ERLANG_PKG
+apt-get -y --no-install-recommends install ./$ERLANG_PKG
+
+rm $ERLANG_PKG

--- a/tools/pkg/scripts/rpm/build_package.sh
+++ b/tools/pkg/scripts/rpm/build_package.sh
@@ -21,4 +21,4 @@ os_version=$VERSION_ID
 package_os_file_name=${os}~${os_version}
 
 mv ~/rpmbuild/RPMS/${arch}/mongooseim-${version}-${revision}.${arch}.rpm \
-    ~/mongooseim_${version}_${revision}_otp_${otp_version/-1/}~${package_os_file_name}_${package_name_arch}.rpm
+    ~/mongooseim_${version}_${revision}_otp_${otp_version}~${package_os_file_name}_${package_name_arch}.rpm

--- a/tools/pkg/scripts/rpm/install_erlang.sh
+++ b/tools/pkg/scripts/rpm/install_erlang.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DISTRO=$(echo $dockerfile_platform | cut -f1 -d:)
+OS_RELEASE=$(echo $dockerfile_platform | cut -f2 -d:)
+
+# There is no Erlang package for Almalinux, so let's use the one for Rockylinux
+if [ $DISTRO == almalinux ]; then DISTRO=rockylinux; fi
+
+ERLANG_PKG=esl-erlang_${erlang_version}_1~${DISTRO}~${OS_RELEASE}_x86_64.rpm
+if [ $DISTRO == centos ]; then
+    MAJOR_VSN=$(echo $erlang_version | cut -f1 -d.)
+    PREFIX=esl-erlang-${MAJOR_VSN}
+elif [ $DISTRO == rockylinux ]; then
+    PREFIX=${OS_RELEASE}
+fi
+
+curl -O https://binaries2.erlang-solutions.com/$DISTRO/$PREFIX/$ERLANG_PKG
+yum install -y ./$ERLANG_PKG
+
+rm $ERLANG_PKG

--- a/tools/pkg/scripts/rpm/mongooseim.spec
+++ b/tools/pkg/scripts/rpm/mongooseim.spec
@@ -43,6 +43,8 @@ make install
 sed -i 's#RUNNER_USER=\"root\"#RUNNER_USER=\"mongooseim\"#' %{buildroot}/usr/bin/mongooseimctl
 sed -i 's#RUNNER_USER=\"root\"#RUNNER_USER=\"mongooseim\"#' %{buildroot}/usr/lib/mongooseim/bin/mongooseimctl
 sed -i 's#RUNNER_USER=root#RUNNER_USER=\"mongooseim\"#' %{buildroot}/usr/lib/mongooseim/bin/mongooseim
+chrpath -d %{buildroot}/usr/lib/mongooseim/lib/crypto-*/priv/lib/crypto.so
+chrpath -d %{buildroot}/usr/lib/mongooseim/lib/crypto-*/priv/lib/otp_test_engine.so
 
 install -p -D -m 0644 %{SOURCE0} %{buildroot}%{_unitdir}/mongooseim.service
 


### PR DESCRIPTION
This PR fixes and updates the packages built with CircleCI.

The original issue was that the `packages.erlang-solutions.com/...` repos stopped working. I reported this, and they are almost fully functional again (except for Centos 7).

In the meantime, I researched possible alternatives, because the repos are now considered old and discontinued.
- Using the new repos `binaries2.erlang-solutions.com/...` would be a good option, but they don't work. I reported this, but it will take time to fix these issues.
- Using directly downloaded packages from https://www.erlang-solutions.com/downloads/. This option worked correctly, so I used it.

With the new packages it was possible to update the Erlang versions, and add support for the newer Ubuntu 22.04 Jammy Jellyfish.

Notes:
- I had to use a few different Erlang versions, because of the availability of downloadable packages. This should be fixed, because we need to support all distros for each new Erlang version, and currently it is random. I reported all the issues with ESL Erlang packages.
- In the future we might want to support Arm64, but Erlang packages are not available atm, so it's a task for the future.
- I had to remove RPaths from the `rpm` packages to avoid errors, just like here https://github.com/esl/packages-pipeline/blob/master/esl_erlang/ctx/scripts/rpm/script.sh#L100-L101.