### PR TITLE
Fix Erlang version for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
         pkg: [centos_7, ubuntu_xenial]
     runs-on: ubuntu-22.04
     env:
-      ESL_ERLANG_PKG_VER: "25.0.3-1"
+      ESL_ERLANG_PKG_VER: "25.0.3"
       pkg_PLATFORM: ${{matrix.pkg}}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Currently, Erlang does not download on GitHub Actions, which we use to test the master branch. See 
https://github.com/esl/MongooseIM/actions/runs/8971880579 for example.
The issue was with the new scripts that download the Erlang package from our website.
The fix is taken from 05f03eb from https://github.com/esl/MongooseIM/pull/4273.

I've run GH Actions for this branch manually, and the packages jobs have passed: https://github.com/esl/MongooseIM/actions/runs/8984746064.
There are some red results, but they should be unrelated (flaky tests?).