### PR TITLE
Docs: update packages download list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It is brought to you by [Erlang Solutions](https://www.erlang-solutions.com/).
 
 For a quick start just download:
 
-* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS, and macOS)
+* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS, AlmaLinux and Rocky Linux)
 * The [Docker image](https://hub.docker.com/r/mongooseim/mongooseim/): [https://hub.docker.com/r/mongooseim/mongooseim/](https://hub.docker.com/r/mongooseim/mongooseim/) (source code repository: [https://github.com/esl/mongooseim-docker](https://github.com/esl/mongooseim-docker))
 * The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
 

--- a/doc/getting-started/Installation.md
+++ b/doc/getting-started/Installation.md
@@ -22,7 +22,7 @@ The following sections describe the installation process for different operating
     sudo dpkg -i mongooseim_[version here].deb
     ```
 
-=== "CentOS"
+=== "CentOS / AlmaLinux / Rocky Linux"
 
     An ODBC (RDBMS) driver must be installed on your machine to unpack and install from RPM packages. Enter the following command in a terminal window to install the latest unixODBC driver:
     

--- a/doc/index.md
+++ b/doc/index.md
@@ -59,7 +59,7 @@ We offer a set of additional server-side components:
 
 For a quick start just download:
 
-* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian and CentOS)
+* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS, AlmaLinux and Rocky Linux)
 * The [Docker image](https://hub.docker.com/r/mongooseim/mongooseim/) ([source code repository](https://github.com/esl/mongooseim-docker))
 * The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
 


### PR DESCRIPTION
As I was looking into packages at our website (https://www.erlang-solutions.com/downloads/), I've noticed that the list in our docs was out of date.

