### PR TITLE
Instrument mod_bosh

### DIFF
--- a/big_tests/tests/instrument_helper.erl
+++ b/big_tests/tests/instrument_helper.erl
@@ -66,7 +66,7 @@ assert(EventName, Labels, MeasurementsList, CheckF) ->
             event_tested(EventName, Labels)
     end.
 
-%% @doc Remove previous events, and wait for a new one.
+%% @doc Remove previous events, and wait for a new one. Use for probes only.
 -spec wait_for_new(event_name(), labels()) -> [measurements()].
 wait_for_new(EventName, Labels) ->
     take(EventName, Labels),

--- a/src/instrument/mongoose_instrument_exometer.erl
+++ b/src/instrument/mongoose_instrument_exometer.erl
@@ -77,7 +77,9 @@ update_metric(Name, histogram, Value) when is_integer(Value) ->
 -spec exometer_metric_name(mongoose_instrument:event_name(), mongoose_instrument:labels(),
                            mongoose_instrument:metric_name()) -> exometer:name().
 exometer_metric_name(EventName, #{host_type := HostType}, MetricName) ->
-    [get_host_type_prefix(HostType), EventName, MetricName].
+    [get_host_type_prefix(HostType), EventName, MetricName];
+exometer_metric_name(EventName, #{}, MetricName) ->
+    [global, EventName, MetricName].
 
 -spec get_host_type_prefix(mongooseim:host_type()) -> global | binary().
 get_host_type_prefix(HostType) ->

--- a/src/metrics/mongoose_metrics_definitions.hrl
+++ b/src/metrics/mongoose_metrics_definitions.hrl
@@ -37,13 +37,11 @@
 -define(GLOBAL_SPIRALS, [
     [data, xmpp, received, c2s, tcp],
     [data, xmpp, received, c2s, tls],
-    [data, xmpp, received, c2s, bosh],
     [data, xmpp, received, c2s, websocket],
     [data, xmpp, received, s2s],
     [data, xmpp, received, component],
     [data, xmpp, sent, c2s, tcp],
     [data, xmpp, sent, c2s, tls],
-    [data, xmpp, sent, c2s, bosh],
     [data, xmpp, sent, c2s, websocket],
     [data, xmpp, sent, s2s],
     [data, xmpp, sent, component]

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -191,7 +191,7 @@ info(forward_body, Req, S) ->
 info({bosh_reply, El}, Req, S) ->
     BEl = exml:to_binary(El),
     %% 'mod_bosh_data_sent' metric includes 'body' wrapping elements and resending attempts
-    mongoose_instrument:execute(mod_bosh_data_sent, #{}, #{byte_size =>  byte_size(BEl)}),
+    mongoose_instrument:execute(mod_bosh_data_sent, #{}, #{byte_size => byte_size(BEl)}),
     ?LOG_DEBUG(#{what => bosh_send, req_sid => S#rstate.req_sid, reply_body => BEl,
                  sid => exml_query:attr(El, <<"sid">>, <<"missing">>)}),
     Headers = bosh_reply_headers(),
@@ -316,7 +316,7 @@ forward_body(Req, #xmlel{} = Body, #rstate{opts = Opts} = S) ->
 -spec handle_request(pid(), event_type(), exml:element()) -> ok.
 handle_request(Socket, EventType, Body) ->
     %% 'mod_bosh_data_received' metric includes 'body' wrapping elements
-    mongoose_instrument:execute(mod_bosh_data_received, #{}, #{byte_size =>  exml:xml_size(Body)}),
+    mongoose_instrument:execute(mod_bosh_data_received, #{}, #{byte_size => exml:xml_size(Body)}),
     mod_bosh_socket:handle_request(Socket, {EventType, self(), Body}).
 
 

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -94,6 +94,7 @@ start(_HostType, Opts) ->
 
 -spec stop(mongooseim:host_type()) -> ok.
 stop(_HostType) ->
+    mod_bosh_socket:stop_supervisor(),
     gen_hook:delete_handlers(hooks()),
     ok.
 

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -28,11 +28,11 @@
 -export([node_cleanup/3]).
 
 %% For testing and debugging
--export([get_session_socket/1, store_session/2]).
+-export([get_session_socket/1, store_session/2, instrumentation/0]).
 
 -export([config_metrics/1]).
 
--ignore_xref([get_session_socket/1, store_session/2]).
+-ignore_xref([get_session_socket/1, store_session/2, instrumentation/0]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
@@ -89,18 +89,29 @@ start(_HostType, Opts) ->
         false ->
             mod_bosh_backend:start(Opts),
             {ok, _Pid} = mod_bosh_socket:start_supervisor(),
-            gen_hook:add_handlers(hooks())
+            gen_hook:add_handlers(hooks()),
+            % Because mod_bosh acts more like a service, than a module, instrumentation has to be
+            % set up manually, only once.
+            mongoose_instrument:set_up(instrumentation())
     end.
 
 -spec stop(mongooseim:host_type()) -> ok.
 stop(_HostType) ->
     mod_bosh_socket:stop_supervisor(),
+    mongoose_instrument:tear_down(instrumentation()),
     gen_hook:delete_handlers(hooks()),
     ok.
 
 -spec hooks() -> gen_hook:hook_list().
 hooks() ->
     [{node_cleanup, global, fun ?MODULE:node_cleanup/3, #{}, 50}].
+
+-spec instrumentation() -> [mongoose_instrument:spec()].
+instrumentation() ->
+    [{mod_bosh_data_sent, #{},
+      #{metrics => #{byte_size => spiral}}},
+     {mod_bosh_data_received, #{},
+      #{metrics => #{byte_size => spiral}}}].
 
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
@@ -179,9 +190,8 @@ info(forward_body, Req, S) ->
     forward_body(Req1, BodyElem, S#rstate{req_sid = Sid});
 info({bosh_reply, El}, Req, S) ->
     BEl = exml:to_binary(El),
-    %% for BOSH 'data.xmpp.sent.raw' metric includes 'body' wrapping elements
-    %% and resending attempts
-    mongoose_metrics:update(global, [data, xmpp, sent, c2s, bosh], byte_size(BEl)),
+    %% 'mod_bosh_data_sent' metric includes 'body' wrapping elements and resending attempts
+    mongoose_instrument:execute(mod_bosh_data_sent, #{}, #{byte_size =>  byte_size(BEl)}),
     ?LOG_DEBUG(#{what => bosh_send, req_sid => S#rstate.req_sid, reply_body => BEl,
                  sid => exml_query:attr(El, <<"sid">>, <<"missing">>)}),
     Headers = bosh_reply_headers(),
@@ -305,8 +315,8 @@ forward_body(Req, #xmlel{} = Body, #rstate{opts = Opts} = S) ->
 
 -spec handle_request(pid(), event_type(), exml:element()) -> ok.
 handle_request(Socket, EventType, Body) ->
-    %% for BOSH 'data.xmpp.received.raw' metric includes 'body' wrapping elements
-    mongoose_metrics:update(global, [data, xmpp, received, c2s, bosh], exml:xml_size(Body)),
+    %% 'mod_bosh_data_received' metric includes 'body' wrapping elements
+    mongoose_instrument:execute(mod_bosh_data_received, #{}, #{byte_size =>  exml:xml_size(Body)}),
     mod_bosh_socket:handle_request(Socket, {EventType, self(), Body}).
 
 

--- a/src/mod_bosh_socket.erl
+++ b/src/mod_bosh_socket.erl
@@ -8,6 +8,7 @@
          start_link/5,
          start_supervisor/0,
          is_supervisor_started/0,
+         stop_supervisor/0,
          handle_request/2,
          pause/2]).
 
@@ -119,7 +120,7 @@ start_supervisor() ->
         {ChildId,
          {ejabberd_tmp_sup, start_link,
           [ChildId, ?MODULE]},
-         permanent,
+         transient,
          infinity,
          supervisor,
          [ejabberd_tmp_sup]},
@@ -139,6 +140,10 @@ start_supervisor() ->
 -spec is_supervisor_started() -> boolean().
 is_supervisor_started() ->
     is_pid(whereis(?BOSH_SOCKET_SUP)).
+
+-spec stop_supervisor() -> ok | {error, any()}.
+stop_supervisor() ->
+    ejabberd_sup:stop_child(?BOSH_SOCKET_SUP).
 
 -spec handle_request(Pid :: pid(),
                     {EventTag :: mod_bosh:event_type(),

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -75,7 +75,7 @@ add_handler_routes(#{host := Host, path := Path, module := Module} = HandlerOpts
     HostRoutes = proplists:get_value(Host, Routes, []),
     lists:keystore(Host, 1, Routes, {Host, HostRoutes ++ HandlerRoutes}).
 
-%% @doc Translate "_" used in TOML to '_' expected by COwboy
+%% @doc Translate "_" used in TOML to '_' expected by Cowboy
 cowboy_host("_") -> '_';
 cowboy_host(Host) -> Host.
 


### PR DESCRIPTION
Add instrumentation to `mod_bosh`.
I think there are two non-obvious things in this PR:
1. Why not use `instrument/1` and let the new mongoose_instrument modules deal with the event registration?

	The reason is that when running with multiple host_types, instrumentation callback would be run multiple times, per host type. However, `mod_bosh` acts more like a service, in that its handlers are global. Therefore, the BOSH handlers don't have access to which host types they actually run for, and therfore I decided that the instrumentation will omit the host_type label. But if we omit this label, we have to ensure that event registration is run only once - globally.
2. Why change the type of the BOSH socket supervisor?

    I've noticed that after adding the call to `mongoose_instrument:tear_down/1` in `mod_bosh` the tests started failing. It turned out, that when `mod_bosh` was stopped, only the handlers were stopped, but the whole supervision tree remained in place. As the supervision tree is the thing that `mod_bosh` tests to see if it has already been started once (as described in 1.), it was problematic for tests, which have to restart `mod_bosh` multiple times. They started failing, because, simplifying:
    1. Test group started `mod_bosh` and registered instrumentation events. 
    2. Test group ended and `mod_bosh` was stopped, as well as instrumentation events were deregistered.
    5. Next test group started and tried to start `mod_bosh`. Since it checked that the supervisor was up, it didn't register the instrumentation events.
    6. Test failed, because the events weren't registered and trying to execute them failed.
    
	Maybe the other solution would be to check something else when starting `mod_bosh`, but I think the proposed solution is clean, and follows the expectations when stopping a module.
	
Note: presence_one test in metrics_c2s_SUITE on the mssql_mnesia_26 preset has been really flaky, but has finally passed after a few tries. I don't see a connection to this PR.
