### PR TITLE
Instrument/backend

### DIFF
--- a/src/instrument/mongoose_instrument.erl
+++ b/src/instrument/mongoose_instrument.erl
@@ -7,7 +7,7 @@
          start_link/0, persist/0,
          set_up/1, set_up/3,
          tear_down/1, tear_down/2,
-         span/4, span/5,
+         span/4, span/5, span/6,
          execute/3]).
 
 %% Test API
@@ -119,6 +119,15 @@ span(EventName, Labels, F, MeasureF) ->
 span(EventName, Labels, F, Args, MeasureF) ->
     Handlers = get_handlers(EventName, Labels),
     {Time, Result} = timer:tc(F, Args),
+    handle_event(EventName, Labels, MeasureF(Time, Result), Handlers),
+    Result.
+
+%% @doc Calls `Mod:F' with `Args', measuring its execution time.
+%% @see span/5
+-spec span(event_name(), labels(), module(), atom(), list(), measure_fun(Result)) -> Result.
+span(EventName, Labels, Mod, F, Args, MeasureF) ->
+    Handlers = get_handlers(EventName, Labels),
+    {Time, Result} = timer:tc(Mod, F, Args),
     handle_event(EventName, Labels, MeasureF(Time, Result), Handlers),
     Result.
 

--- a/src/instrument/mongoose_instrument.erl
+++ b/src/instrument/mongoose_instrument.erl
@@ -22,9 +22,10 @@
 -include("mongoose_config_spec.hrl").
 
 -type event_name() :: atom().
--type labels() :: #{host_type => mongooseim:host_type()}. % to be extended
--type label_key() :: host_type. % to be extended
--type label_value() :: mongooseim:host_type(). % to be extended
+-type labels() :: #{host_type => mongooseim:host_type(),
+                    function => atom()}. % to be extended
+-type label_key() :: host_type | function. % to be extended
+-type label_value() :: mongooseim:host_type() | atom(). % to be extended
 -type metrics() :: #{metric_name() => metric_type()}.
 -type metric_name() :: atom().
 -type metric_type() :: gauge | spiral | histogram. % to be extended

--- a/src/mod_caps_backend.erl
+++ b/src/mod_caps_backend.erl
@@ -29,7 +29,7 @@
     HostType :: mongooseim:host_type(),
     Opts :: gen_mod:module_opts().
 init(HostType, Opts) ->
-    TrackedFuns = [],
+    TrackedFuns = [read, write, delete_node],
     mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/mod_last_backend.erl
+++ b/src/mod_last_backend.erl
@@ -46,7 +46,7 @@
 
 -spec init(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 init(HostType, Opts) ->
-    TrackedFuns = [get_last, set_last_info],
+    TrackedFuns = [get_last, set_last_info, session_cleanup],
     mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/rdbms/mongoose_rdbms.erl
+++ b/src/rdbms/mongoose_rdbms.erl
@@ -170,12 +170,13 @@
 -type dirty_result() :: {ok, any()} | {error, any()}.
 -export_type([query_name/0, query_result/0, transaction_result/0]).
 
--type options() :: #{driver := pgsql | mysql | odbc,
+-type backend() :: pgsql | mysql | odbc.
+-type options() :: #{driver := backend(),
                      max_start_interval := pos_integer(),
                      query_timeout := pos_integer(),
                      atom() => any()}.
 
--export_type([options/0]).
+-export_type([options/0, backend/0]).
 
 %%%----------------------------------------------------------------------
 %%% API

--- a/src/rdbms/mongoose_rdbms_backend.erl
+++ b/src/rdbms/mongoose_rdbms_backend.erl
@@ -5,7 +5,8 @@
 %%% @end
 %%%-------------------------------------------------------------------
 -module(mongoose_rdbms_backend).
--export([escape_binary/1,
+-export([init/1,
+         escape_binary/1,
          escape_string/1,
          unescape_binary/1,
          connect/2,
@@ -36,6 +37,9 @@
 %% If not defined, generic escaping is used
 -optional_callbacks([escape_string/1]).
 
+-spec init(mongoose_rdbms:backend()) -> ok.
+init(Backend) ->
+    mongoose_backend:init(global, mongoose_rdbms, [query, execute], #{backend => Backend}).
 
 -spec escape_binary(binary()) -> mongoose_rdbms:sql_query_part().
 escape_binary(Binary) ->

--- a/src/wpool/mongoose_wpool_rdbms.erl
+++ b/src/wpool/mongoose_wpool_rdbms.erl
@@ -28,7 +28,7 @@ stop(_, _) ->
 %% Helper functions
 do_start(HostType, Tag, WpoolOpts0, RdbmsOpts) when is_list(WpoolOpts0), is_map(RdbmsOpts) ->
     #{driver := BackendName} = RdbmsOpts,
-    mongoose_backend:init(global, mongoose_rdbms, [query, execute], #{backend => BackendName}),
+    mongoose_rdbms_backend:init(BackendName),
     mongoose_metrics:ensure_db_pool_metric({rdbms, HostType, Tag}),
     WpoolOpts = make_wpool_opts(WpoolOpts0, RdbmsOpts),
     ProcName = mongoose_wpool:make_pool_name(rdbms, HostType, Tag),

--- a/test/mongoose_rdbms_SUITE.erl
+++ b/test/mongoose_rdbms_SUITE.erl
@@ -1,13 +1,10 @@
 -module(mongoose_rdbms_SUITE).
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
--include("mongoose.hrl").
 
 -compile([export_all, nowarn_export_all]).
 
--define(_eq(E, I), ?_assertEqual(E, I)).
 -define(eq(E, I), ?assertEqual(E, I)).
--define(ne(E, I), ?assert(E =/= I)).
 
 -define(KEEPALIVE_INTERVAL, 1).
 -define(KEEPALIVE_QUERY, <<"SELECT 1;">>).
@@ -20,10 +17,13 @@ all() ->
 
 init_per_suite(Config) ->
     application:ensure_all_started(exometer_core),
-    Config.
+    set_opts(),
+    async_helper:start(Config, mongoose_instrument, start_link, []).
 
-end_per_suite(_Config) ->
+end_per_suite(Config) ->
     meck:unload(),
+    async_helper:stop_all(Config),
+    unset_opts(),
     application:stop(exometer_core).
 
 groups() ->
@@ -39,13 +39,13 @@ tests() ->
 init_per_group(odbc, Config) ->
     case code:ensure_loaded(eodbc) of
         {module, eodbc} ->
-            mongoose_backend:init(global, mongoose_rdbms, [], #{backend => odbc}),
+            mongoose_rdbms_backend:init(odbc),
             [{db_type, odbc} | Config];
         _ ->
             {skip, no_odbc_application}
     end;
 init_per_group(Group, Config) ->
-    mongoose_backend:init(global, mongoose_rdbms, [], #{backend => Group}),
+    mongoose_rdbms_backend:init(Group),
     [{db_type, Group} | Config].
 
 end_per_group(_, Config) ->
@@ -55,7 +55,6 @@ end_per_group(_, Config) ->
 
 init_per_testcase(does_backoff_increase_to_a_point, Config) ->
     DbType = ?config(db_type, Config),
-    set_opts(),
     meck_db(DbType),
     meck_connection_error(DbType),
     meck_rand(),
@@ -63,7 +62,6 @@ init_per_testcase(does_backoff_increase_to_a_point, Config) ->
     [{db_opts, ServerOpts#{query_timeout => 5000, keepalive_interval => 2, max_start_interval => 10}} | Config];
 init_per_testcase(_, Config) ->
     DbType = ?config(db_type, Config),
-    set_opts(),
     meck_db(DbType),
     ServerOpts = server_opts(DbType),
     [{db_opts, ServerOpts#{query_timeout => 5000, keepalive_interval => ?KEEPALIVE_INTERVAL,
@@ -73,11 +71,9 @@ end_per_testcase(does_backoff_increase_to_a_point, Config) ->
     meck_unload_rand(),
     Db = ?config(db_type, Config),
     meck_config_and_db_unload(Db),
-    unset_opts(),
     Config;
 end_per_testcase(_, Config) ->
     meck_config_and_db_unload(?config(db_type, Config)),
-    unset_opts(),
     Config.
 
 %% Test cases
@@ -142,7 +138,8 @@ unset_opts() ->
 
 opts() ->
     #{all_metrics_are_global => false,
-      max_fsm_queue => 1024}.
+      max_fsm_queue => 1024,
+      instrumentation => config_parser_helper:default_config([instrumentation])}.
 
 meck_db(odbc) ->
     meck:new(eodbc, [no_link]),


### PR DESCRIPTION
The goal is to use `mongoose_instrument` instead of `mongoose_metrics` in `mongoose_backend`.

The new event naming is different from the previously used metric naming:
- For consistency with other module events, events are named `Mod_Backend`, e.g. `mod_roster_rdbms`.
- Labels are `host_type` and `function` (which is a new label supported by `mongoose_instrument`). The events are per host type unless the backend is set up globally. This differs from the previously used global metrics, which were implemented before we introduced dynamic domains. With the limited number of host types and the possibility to use the `all_metrics_are_global` option, it shouldn't be an issue.
- Measurements contain `count`, `time` and `args`. The latter is a list of arguments, which can be used for debugging and is used in big tests to match expected events. Unless debug logs are enabled, a heavy term in arguments shouldn't cause any problems, because it is not copied anywhere.

Other changes:
- Support `M`, `F`, `A` arguments in `mongoose_instrument:span`.
- Fix missing `tracked_funs`, which were discovered because it is illegal to trigger a non-existing event.
- Update tests. Note that `metrics_roster_SUITE` checks two selected backends events now, which is as a sample used to verify that `mongoose_backend` events are working.

---

**Note:** if `mongoose_backend` had a `stop` function in addition to `init`, it would be possible to eliminate the `try ... catch` and prevent other unwanted issues when a backend is initialized many times. This would require a lot of changes, and I will log it as a separate story.

