### PR TITLE
Instrument mod_csi

### DIFF
--- a/big_tests/tests/xep_0352_csi_SUITE.erl
+++ b/big_tests/tests/xep_0352_csi_SUITE.erl
@@ -35,6 +35,7 @@ suite() ->
     escalus:suite().
 
 init_per_suite(Config) ->
+    instrument_helper:start(instrument_helper:declared_events(mod_csi)),
     NewConfig = dynamic_modules:save_modules(host_type(), Config),
     Backend = mongoose_helper:mnesia_or_rdbms_backend(),
     dynamic_modules:ensure_modules(
@@ -45,7 +46,8 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     dynamic_modules:restore_modules(Config),
-    escalus:end_per_suite(Config).
+    escalus:end_per_suite(Config),
+    instrument_helper:stop().
 
 init_per_group(_, Config) ->
     escalus_users:update_userspec(Config, alice, stream_management, true).
@@ -91,7 +93,8 @@ alice_gets_msgs_after_activate(Config, N) ->
         csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
         Msgs = csi_helper:given_messages_are_sent(Alice, Bob, N),
         csi_helper:given_client_is_active(Alice),
-        csi_helper:then_client_receives_message(Alice, Msgs)
+        csi_helper:then_client_receives_message(Alice, Msgs),
+        assert_event(mod_csi_active, Alice)
     end).
 
 inactive_twice_does_not_reset_buffer(Config) ->
@@ -184,6 +187,7 @@ alice_gets_message_after_buffer_overflow(Config) ->
 bob_gets_msgs_from_inactive_alice(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         given_client_is_inactive_but_sends_messages(Alice, Bob, 1),
+        assert_event(mod_csi_inactive, Alice),
         escalus:assert(is_chat_message, escalus:wait_for_stanza(Bob))
     end).
 
@@ -201,5 +205,9 @@ given_client_is_inactive_but_sends_messages(Alice, Bob, N) ->
     MsgsToAlice = csi_helper:given_messages_are_sent(Alice, Bob, N),
     MsgsToBob = csi_helper:gen_msgs(<<"Hi, Bob">>, N),
     csi_helper:send_msgs(Alice, Bob, MsgsToBob),
-    timer:sleep(1),
     {MsgsToAlice, MsgsToBob}.
+
+assert_event(Event, Client) ->
+    instrument_helper:assert(Event, #{host_type => host_type()},
+                             fun(#{count := 1, jid := JID}) ->
+                                 jid:to_binary(JID) =:= escalus_client:full_jid(Client) end).

--- a/doc/modules/mod_csi.md
+++ b/doc/modules/mod_csi.md
@@ -25,7 +25,7 @@ Buffer size for messages queued when session was `inactive`.
 
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Name | Type | Description (when it gets incremented) |
-| ---- | ---- | -------------------------------------- |
-| `[Host, modCSIInactive]` | spiral | A client becomes inactive. |
-| `[Host, modCSIActive]` | spiral | A client becomes active. |
+| Name               | Type   | Description (when it gets incremented) |
+|--------------------|--------|----------------------------------------|
+| `mod_csi_active`   | spiral | A client becomes active.               |
+| `mod_csi_inactive` | spiral | A client becomes inactive.             |


### PR DESCRIPTION
A rather straightforward module instrumentation PR.

Similarly to mod_muc instrumentation, [JIDs are added as measurements to events](https://github.com/esl/MongooseIM/pull/4268/files#diff-40d0c686e8f057e968e9d74babe7ec7cb8727bb0b3799f05aec2ae8248662d03R761). I'm not sure if this is and ideal solution, but I don't have a better idea.

I decided to change the documentation since I'm already changing the module. The issue is that the full metric name will depend on the metrics backend in the current implementation if I understand correctly, but the "short name" will stay the same, so I'd say the docs are correct even in this state.