### PR TITLE
Instrument mod_event_pusher

### DIFF
--- a/big_tests/tests/mod_event_pusher_http_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_http_SUITE.erl
@@ -117,7 +117,7 @@ simple_message(Config) ->
     {_, _} = binary:match(Body, <<"Simple">>),
     AliceName = escalus_client:username(Alice),
     instrument_helper:assert(mod_event_pusher_http_sent, #{host_type => host_type()},
-                             fun(#{count := 1, sender := S, response_code := 200, response_time := T}) ->
+                             fun(#{count := 1, sender := S, response_code := <<"200">>, response_time := T}) ->
                                  ?assert(T > 0), AliceName =:= S end).
 
 simple_message_no_listener(Config) ->
@@ -131,7 +131,7 @@ simple_message_failing_listener(Config) ->
     Alice = do_simple_message(Config, <<"Hi, Failing!">>),
     AliceName = escalus_client:username(Alice),
     instrument_helper:assert(mod_event_pusher_http_sent, #{host_type => host_type()},
-                             fun(#{count := 1, sender := S, response_code := 500, response_time := T}) ->
+                             fun(#{count := 1, sender := S, response_code := <<"500">>, response_time := T}) ->
                                  ?assert(T > 0), AliceName =:= S end).
 
 do_simple_message(Config0, Msg) ->

--- a/big_tests/tests/mod_event_pusher_http_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_http_SUITE.erl
@@ -51,11 +51,13 @@ groups() ->
     ct_helper:repeat_all_until_all_ok(G).
 
 init_per_suite(Config0) ->
+    instrument_helper:start(instrument_helper:declared_events(mod_event_pusher_http)),
     escalus:init_per_suite(Config0).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
-    escalus:end_per_suite(Config).
+    escalus:end_per_suite(Config),
+    instrument_helper:stop().
 
 init_per_group(no_prefix, Config) ->
     set_modules(Config, #{});
@@ -108,17 +110,29 @@ proper_http_message_encode_decode(Config) ->
 
 simple_message(Config) ->
     %% we expect one notification message
-    do_simple_message(Config, <<"Hi, Simple!">>),
+    Alice = do_simple_message(Config, <<"Hi, Simple!">>),
     %% fail if we didn't receive http notification
     Body = get_http_request(),
     {_, _} = binary:match(Body, <<"alice">>),
-    {_, _} = binary:match(Body, <<"Simple">>).
+    {_, _} = binary:match(Body, <<"Simple">>),
+    AliceName = escalus_client:username(Alice),
+    instrument_helper:assert(mod_event_pusher_http_sent, #{host_type => host_type()},
+                             fun(#{count := 1, sender := S, response_code := 200, response_time := T}) ->
+                                 ?assert(T > 0), AliceName =:= S end).
 
 simple_message_no_listener(Config) ->
-    do_simple_message(Config, <<"Hi, NoListener!">>).
+    Alice = do_simple_message(Config, <<"Hi, NoListener!">>),
+    AliceName = escalus_client:username(Alice),
+    instrument_helper:assert(mod_event_pusher_http_sent, #{host_type => host_type()},
+                             fun(#{failure_count := 1, sender := S}) -> AliceName =:= S end).
+
 
 simple_message_failing_listener(Config) ->
-    do_simple_message(Config, <<"Hi, Failing!">>).
+    Alice = do_simple_message(Config, <<"Hi, Failing!">>),
+    AliceName = escalus_client:username(Alice),
+    instrument_helper:assert(mod_event_pusher_http_sent, #{host_type => host_type()},
+                             fun(#{count := 1, sender := S, response_code := 500, response_time := T}) ->
+                                 ?assert(T > 0), AliceName =:= S end).
 
 do_simple_message(Config0, Msg) ->
     Config = escalus_fresh:create_users(Config0, [{alice, 1}, {bob, 1}]),
@@ -135,7 +149,8 @@ do_simple_message(Config0, Msg) ->
     %% He receives his initial presence and the message
     Stanzas = escalus:wait_for_stanzas(Bob, 2),
     escalus_new_assert:mix_match([is_presence, is_chat(Msg)], Stanzas),
-    escalus_client:stop(Config, Bob).
+    escalus_client:stop(Config, Bob),
+    Alice.
 
 %%%===================================================================
 %%% Helpers

--- a/big_tests/tests/mod_event_pusher_http_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_http_SUITE.erl
@@ -193,7 +193,7 @@ start_http_listener(simple_message, Prefix) ->
 start_http_listener(simple_message_no_listener, _) ->
     ok;
 start_http_listener(simple_message_failing_listener, Prefix) ->
-    http_helper:start(http_notifications_port(), Prefix, fun(Req) -> Req end);
+    http_helper:start(http_notifications_port(), Prefix, fun(_Req) -> erlang:error(failing_listener) end);
 start_http_listener(proper_http_message_encode_decode, Prefix) ->
     http_helper:start(http_notifications_port(), Prefix, fun process_notification/1).
 

--- a/src/event_pusher/mod_event_pusher.erl
+++ b/src/event_pusher/mod_event_pusher.erl
@@ -75,8 +75,7 @@ config_spec() ->
 -spec config_metrics(mongooseim:host_type()) -> [{gen_mod:opt_key(), gen_mod:opt_value()}].
 config_metrics(HostType) ->
     case gen_mod:get_module_opts(HostType, ?MODULE) of
-        Empty when Empty =:= #{};
-                   Empty =:= [] -> % TODO remove when get_module_opts does not return [] anymore
+        Empty when Empty =:= #{} ->
             [{none, none}];
         Opts ->
             [{backend, Backend} || Backend <- maps:keys(Opts)]

--- a/src/event_pusher/mod_event_pusher_http.erl
+++ b/src/event_pusher/mod_event_pusher_http.erl
@@ -118,9 +118,7 @@ make_req(Acc, Dir, Domain, Sender, Receiver, Message, Opts) ->
                              fun mongoose_http_client:post/5, [HostType, PoolName, Path, Headers, Body],
                              fun(Time, Result) -> handle_post_result(Time, Result, LogMeta) end).
 
-handle_post_result(Time, {ok, {CodeBin, _Body}}, #{sender := Sender}) ->
-    % Fusco returns HTTP response codes as binaries
-    Code = binary_to_integer(CodeBin),
+handle_post_result(Time, {ok, {Code, _Body}}, #{sender := Sender}) ->
     #{count => 1, response_time => Time, sender => Sender, response_code => Code};
 handle_post_result(_Time, {error, Reason}, LogMeta = #{sender := Sender}) ->
     ?LOG_WARNING(LogMeta#{what => event_pusher_http_req_failed,

--- a/src/event_pusher/mod_event_pusher_http.erl
+++ b/src/event_pusher/mod_event_pusher_http.erl
@@ -39,7 +39,7 @@
 -include("jlib.hrl").
 
 %% API
--export([start/2, stop/1, config_spec/0, push_event/2]).
+-export([start/2, stop/1, config_spec/0, push_event/2, instrumentation/1]).
 
 %% config spec callbacks
 -export([fix_path/1]).
@@ -48,13 +48,10 @@
 -include("jlib.hrl").
 -include("mongoose_config_spec.hrl").
 
--define(SENT_METRIC, [mod_event_pusher_http, sent]).
--define(FAILED_METRIC, [mod_event_pusher_http, failed]).
--define(RESPONSE_METRIC, [mod_event_pusher_http, response_time]).
+-define(SENT_METRIC, mod_event_pusher_http_sent).
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
-start(HostType, _Opts) ->
-    ensure_metrics(HostType),
+start(_HostType, _Opts) ->
     ok.
 
 -spec stop(mongooseim:host_type()) -> ok.
@@ -79,6 +76,10 @@ handler_config_spec() ->
                           <<"path">> => <<>>,
                           <<"callback_module">> => mod_event_pusher_http_defaults}
             }.
+
+instrumentation(HostType) ->
+    [{?SENT_METRIC, #{host_type => HostType},
+      #{metrics => #{count => spiral, response_time => histogram, failure_count => spiral}}}].
 
 push_event(Acc, #chat_event{direction = Dir, from = From, to = To, packet = Packet}) ->
     HostType = mongoose_acc:host_type(Acc),
@@ -113,33 +114,19 @@ make_req(Acc, Dir, Domain, Sender, Receiver, Message, Opts) ->
                 sender => Sender, receiver => Receiver, direction => Dir,
                 server => Domain, pool_name => PoolName, acc => Acc},
     ?LOG_INFO(LogMeta),
-    T0 = os:timestamp(),
-    {Res, Elapsed} = case mongoose_http_client:post(HostType, PoolName, Path, Headers, Body) of
-                         {ok, _} ->
-                             {ok, timer:now_diff(os:timestamp(), T0)};
-                         {error, Reason} ->
-                             {{error, Reason}, 0}
-                     end,
-    record_result(HostType, Res, Elapsed, LogMeta),
-    ok.
+    mongoose_instrument:span(?SENT_METRIC, #{host_type => HostType},
+                             fun mongoose_http_client:post/5, [HostType, PoolName, Path, Headers, Body],
+                             fun(Time, Result) -> handle_post_result(Time, Result, LogMeta) end).
 
-ensure_metrics(HostType) ->
-    mongoose_metrics:ensure_metric(HostType, ?SENT_METRIC, spiral),
-    mongoose_metrics:ensure_metric(HostType, ?FAILED_METRIC, spiral),
-    mongoose_metrics:ensure_metric(HostType, ?RESPONSE_METRIC, histogram),
-    ok.
-
-record_result(HostType, ok, Elapsed, _LogMeta) ->
-    mongoose_metrics:update(HostType, ?SENT_METRIC, 1),
-    mongoose_metrics:update(HostType, ?RESPONSE_METRIC, Elapsed),
-    ok;
-record_result(HostType, {error, Reason}, _, LogMeta) ->
-    mongoose_metrics:update(HostType, ?FAILED_METRIC, 1),
+handle_post_result(Time, {ok, {CodeBin, _Body}}, #{sender := Sender}) ->
+    % Fusco returns HTTP response codes as binaries
+    Code = binary_to_integer(CodeBin),
+    #{count => 1, response_time => Time, sender => Sender, response_code => Code};
+handle_post_result(_Time, {error, Reason}, LogMeta = #{sender := Sender}) ->
     ?LOG_WARNING(LogMeta#{what => event_pusher_http_req_failed,
                           text => <<"mod_event_pusher_http HTTP call failed">>,
-                          reason => Reason
-                  }),
-    ok.
+                          reason => Reason}),
+    #{failure_count => 1, sender => Sender}.
 
 %% @doc Strip initial slash (it is added by mongoose_http_client)
 fix_path(<<"/", R/binary>>) ->


### PR DESCRIPTION
This PR addresses instruments mod_event_pusher. I didn't touch `mod_event_pusher_rabbit`, because it reports `mongoose_rabbit_worker`, and it's better to do them together with other workers' metrics.

`mod_event_pusher_http` treats any HTTP reason code as a success, and I didn't change this behaviour.

