### PR TITLE
Fix slow MAM muc_prefs_cases tests

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -3573,6 +3573,13 @@ muc_run_prefs_cases(DefaultPolicy, ConfigIn) ->
     F = fun(Config, Alice, Bob, Kate) ->
         %% Just send messages for each prefs configuration
         Namespace = mam_ns_binary_v04(),
+
+        Room = ?config(room, Config),
+        escalus:send(Alice, stanza_muc_enter_room(Room, nick(Alice))),
+        escalus:send(Bob, stanza_muc_enter_room(Room, nick(Bob))),
+        escalus:send(Kate, stanza_muc_enter_room(Room, nick(Kate))),
+        escalus:wait_for_stanzas(Alice, 4),
+
         Funs = [muc_run_prefs_case(Case, Namespace, Alice, Bob, Kate, Config)
                 || Case <- prefs_cases2_muc(),
                 default_policy(Case) =:= DefaultPolicy],

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1261,10 +1261,6 @@ run_prefs_case({PrefsState, ExpectedMessageStates}, Namespace, Alice, Bob, Kate,
 muc_run_prefs_case({PrefsState, ExpectedMessageStates}, Namespace, Alice, Bob, Kate, Config) ->
     Room = ?config(room, Config),
     RoomAddr = room_address(Room),
-    escalus:send(Alice, stanza_muc_enter_room(Room, nick(Alice))),
-    escalus:send(Bob, stanza_muc_enter_room(Room, nick(Bob))),
-    escalus:send(Kate, stanza_muc_enter_room(Room, nick(Kate))),
-    escalus:wait_for_stanzas(Alice, 4),
 
     {DefaultMode, AlwaysUsers, NeverUsers} = PrefsState,
     IqSet = stanza_prefs_set_request_muc({DefaultMode, AlwaysUsers, NeverUsers, Namespace}, Config),


### PR DESCRIPTION
This PR fixes three testcase added recently. I'm having issues with this case in my other PR, and noticed that it's surprisingly slow.
Time before fix:
![obraz](https://github.com/esl/MongooseIM/assets/34194983/8998352e-f8dd-42fb-8c76-16d0837482fb)
Time after fix:
![obraz](https://github.com/esl/MongooseIM/assets/34194983/eaa93917-d220-4ba7-8e54-42c4f643551a)

Explanation:
Since the room is reused across `muc_run_prefs_case` calls, there is no need to resend presence every time - the users are room participants all the time. The issue is that when (re)entering, Alice would wait for 4 stanzas - 3 presences and 1 room subject message. However, only in the beginning, as a new user would she receive the room subject - subsequent waits for 4 stanzas failed silently after only 3 presences, but only after waiting the 5s timeout. This has happend 6 times per testcase, and there were 3 tescases using this mechanism, so there is 3*6*5=90s less pointless waiting now.

I think maybe Escalus should fail loudly when less then N stanzas arrive when waiting for N stanzas.

