### PR TITLE
Unify hook names, removing the (seldom used) '_hook' suffix

### DIFF
--- a/doc/developers-guide/Hooks-and-handlers.md
+++ b/doc/developers-guide/Hooks-and-handlers.md
@@ -26,7 +26,7 @@ I.e. if `mod_offline` was not available, the code would simply crash; if it was 
 To avoid that coupling and also to enable other ([possibly yet to be written](#sidenote-code-yet-to-be-written)) code to carry out some action at this particular moment, `ejabberd_sm` calls instead:
 
 ```erlang
-mongoose_hooks:offline_message_hook(Acc, From, To, Packet);
+mongoose_hooks:offline_message(Acc, From, To, Packet);
 ```
 
 `mongoose_hooks` is a module which serves as an API for calling hooks in the server. All such modules are placed in `src/hooks`.
@@ -37,7 +37,7 @@ This means that there is some degree of coupling still - but this time between t
 The extra level of indirection introduced by this call gives the flexibility to determine at runtime what code actually gets run at this point.
 This depends on which handlers are registered to process the event.
 
-`offline_message_hook` is the name of the hook (in other words of the event that is being signalled);
+`offline_message` is the name of the hook (in other words of the event that is being signalled);
 `Acc` is the [Accumulator, described later](#using-accumulators);
 `From`, `To` and `Packet` are the arguments passed to the handler, just as they would in case of the function being called directly.
 
@@ -86,10 +86,10 @@ If a Mongoose accumulator is passed to a hook, handlers should store their retur
 * If the value is to be passed on to be reused within the current processing context, use `mongoose_acc:set(Namespace, Key, Value, Acc)`.
 * If the value should be passed on to the recipient's session, pubsub node etc. use `mongoose_acc:set_permanent(Namespace, Key, Value, Acc)`.
 
-A real life example, then, with regard to `mod_offline` is the `resend_offline_messages_hook` run in `mod_presence`:
+A real life example, then, with regard to `mod_offline` is the `resend_offline_messages` hook run in `mod_presence`:
 
 ```erlang
-Acc1 = mongoose_hooks:resend_offline_messages_hook(Acc, Jid),
+Acc1 = mongoose_hooks:resend_offline_messages(Acc, Jid),
 Rs = mongoose_acc:get(offline, messages, [], Acc1),
 ```
 
@@ -122,7 +122,7 @@ It is decided when creating a hook and can be checked in the `mongoose_hooks` mo
 
 ## Registering hook handlers
 
-In order to store a packet when `ejabberd_sm` runs `offline_message_hook`, the relevant module must register a handler for this hook.
+In order to store a packet when `ejabberd_sm` runs `offline_message`, the relevant module must register a handler for this hook.
 To attain the runtime configurability the module should register the handlers when it's loaded and unregister them when
 it's unloaded.
 That's usually done in, respectively, `start/2` and `stop/1` functions.
@@ -133,10 +133,10 @@ gen_hook:add_handlers(hooks(HostType)),
 ```
 and the `hooks/1` function returns a list of tuples describing hook handlers, like:
 ```erlang
-{offline_message_hook, HostType, fun ?MODULE:inspect_packet/3, #{}, 50}
+{offline_message, HostType, fun ?MODULE:inspect_packet/3, #{}, 50}
 ```
 
-It is clearly visible that the handler `inspect_packet` is added to the `offline_message_hook`.
+It is clearly visible that the handler `inspect_packet` is added to the `offline_message` hook.
 
 `HostType` is the one for which the handler will be executed.
 In the case of statically defined domains, it is the same as the host, as configured in the [`general.hosts` section](../configuration/general.md#generalhosts).

--- a/doc/developers-guide/Stanza-routing.md
+++ b/doc/developers-guide/Stanza-routing.md
@@ -57,7 +57,7 @@ If the check passes, the next step is to call the handler associated with the co
 
 `ejabberd_sm` determines the available resources of the recipient, takes into account their priorities and whether the message is addressed to a particular resource or a bare JID.
 It appropriately replicates (or not) the message and sends it to the recipient's C2S process(es) by calling `mongoose_c2s:route/2`.
-In case no resources are available for delivery (hence no C2S processes to pass the message to), `offline_message_hook` is run.
+In case no resources are available for delivery (hence no C2S processes to pass the message to), the `offline_message` hook is run.
 
 As Bob has one online session, the message is sent to the C2S process associated with that session.
 

--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -127,10 +127,10 @@ These hooks are handled by the following modules:
 * [`mod_privacy`](../modules/mod_privacy.md) - filters received stanzas according to privacy lists.
 * [`mod_stream_management`](../modules/mod_stream_management.md) - filters out stanzas with conflicting session ID's.
 
-## `offline_message_hook`
+## `offline_message`
 
 ```erlang
-mongoose_hooks:offline_message_hook(Acc, From, To, Packet)
+mongoose_hooks:offline_message(Acc, From, To, Packet)
 ```
 
 `ejabberd_sm` runs this hook for each message which cannot be delivered, because no resource (i.e. device or desktop client application) of its recipient is available online for delivery.
@@ -212,7 +212,7 @@ This is the perfect place to plug in custom security control.
 * amp_check_condition
 * amp_determine_strategy
 * amp_verify_support
-* anonymous_purge_hook
+* anonymous_purge
 * auth_failed
 * c2s_stream_features
 * can_access_identity
@@ -235,7 +235,7 @@ This is the perfect place to plug in custom security control.
 * filter_pep_recipient
 * filter_room_packet
 * filter_unacknowledged_messages
-* forbidden_session_hook
+* forbidden_session
 * foreign_event
 * forget_room
 * get_key
@@ -273,10 +273,10 @@ This is the perfect place to plug in custom security control.
 * mod_global_distrib_known_recipient
 * mod_global_distrib_unknown_recipient
 * node_cleanup
-* offline_groupchat_message_hook
-* offline_message_hook
+* offline_groupchat_message
+* offline_message
 * packet_to_component
-* presence_probe_hook
+* presence_probe
 * privacy_check_packet
 * privacy_get_user_list
 * privacy_iq_get
@@ -289,7 +289,7 @@ This is the perfect place to plug in custom security control.
 * remove_domain
 * remove_user
 * reroute_unacked_messages
-* resend_offline_messages_hook
+* resend_offline_messages
 * room_exists
 * room_new_affiliations
 * room_packet
@@ -309,16 +309,16 @@ This is the perfect place to plug in custom security control.
 * s2s_stream_features
 * session_cleanup
 * session_opening_allowed_for_user
-* set_presence_hook
+* set_presence
 * set_vcard
 * sm_filter_offline_message
-* sm_register_connection_hook
-* sm_remove_connection_hook
+* sm_register_connection
+* sm_remove_connection
 * unacknowledged_message
 * unregister_subhost
-* unset_presence_hook
+* unset_presence
 * update_inbox_for_muc
-* user_available_hook
+* user_available
 * user_open_session
 * user_ping_response
 * user_receive_iq

--- a/doc/developers-guide/mod_muc_light_developers_guide.md
+++ b/doc/developers-guide/mod_muc_light_developers_guide.md
@@ -84,7 +84,7 @@ There are 2 test suites and one helper module in `big_tests/tests`.
 
 ## Hooks handled by this extension
 
-* `offline_groupchat_message_hook` handled by `mod_muc_light:prevent_service_unavailable/3`
+* `offline_groupchat_message` handled by `mod_muc_light:prevent_service_unavailable/3`
 
 Prevents the default behaviour of sending `service-unavailable` error to the room when a groupchat message is sent to an offline occupant.
 

--- a/doc/migrations/6.2.1_x.x.x.md
+++ b/doc/migrations/6.2.1_x.x.x.md
@@ -1,0 +1,4 @@
+## Hooks
+
+Hook names have been unified by removing the `_hook` prefix from the few hooks which used it,
+e.g. `offline_message_hook` is now called `offline_message`. This change affects the hook metric names as well.

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -73,7 +73,7 @@ As a result it makes more sense to maintain a list of the most relevant or usefu
 
 | Name | Type | Description (when it gets incremented) |
 | ---- | ---- | -------------------------------------- |
-| `[HostType, anonymous_purge_hook]` | spiral | An anonymous user disconnects. |
+| `[HostType, anonymous_purge]` | spiral | An anonymous user disconnects. |
 | `[HostType, disco_info]` | spiral | An information about the server has been requested via Disco protocol. |
 | `[HostType, disco_local_features]` | spiral | A list of server features is gathered. |
 | `[HostType, disco_local_identity]` | spiral | A list of server identities is gathered. |
@@ -82,15 +82,15 @@ As a result it makes more sense to maintain a list of the most relevant or usefu
 | `[HostType, disco_sm_identity]` | spiral | A list of user's identities is gathered. |
 | `[HostType, disco_sm_items]` | spiral | A list of user's items is gathered. |
 | `[HostType, mam_lookup_messages]` | spiral | An archive lookup is performed. |
-| `[HostType, offline_message_hook]` | spiral | A message was sent to an offline user. (Except for "error", "headline" and "groupchat" message types.) |
-| `[HostType, offline_groupchat_message_hook]` | spiral | A groupchat message was sent to an offline user. |
+| `[HostType, offline_message]` | spiral | A message was sent to an offline user. (Except for "error", "headline" and "groupchat" message types.) |
+| `[HostType, offline_groupchat_message]` | spiral | A groupchat message was sent to an offline user. |
 | `[HostType, privacy_updated_list]` | spiral | User's privacy list is updated. |
-| `[HostType, resend_offline_messages_hook]` | spiral | A list of offline messages is gathered for delivery to a user's new connection. |
+| `[HostType, resend_offline_messages]` | spiral | A list of offline messages is gathered for delivery to a user's new connection. |
 | `[HostType, roster_get_subscription_lists]` |  spiral | Presence subscription lists (based on which presence updates are broadcasted) are gathered. |
 | `[HostType, roster_in_subscription]` | spiral | A presence with subscription update is processed. |
 | `[HostType, roster_out_subscription]` | spiral | A presence with subscription update is received from a client. |
 | `[HostType, sm_broadcast]` | spiral | A stanza is broadcasted to all of user's resources. |
-| `[HostType, unset_presence_hook]` | spiral | A user disconnects or sends an `unavailable` presence. |
+| `[HostType, unset_presence]` | spiral | A user disconnects or sends an `unavailable` presence. |
 
 ### Presences & rosters
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,6 +194,7 @@ nav:
       - '6.0.0 to 6.1.0': 'migrations/6.0.0_6.1.0.md'
       - '6.1.0 to 6.2.0': 'migrations/6.1.0_6.2.0.md'
       - '6.2.0 to 6.2.1': 'migrations/6.2.0_6.2.1.md'
+      - '6.2.1 to x.x.x': 'migrations/6.2.1_x.x.x.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - 'Contributions to the Ecosystem': 'Contributions.md'
   - 'MongooseIM History': 'History.md'

--- a/src/auth/ejabberd_auth_anonymous.erl
+++ b/src/auth/ejabberd_auth_anonymous.erl
@@ -77,8 +77,8 @@ stop(HostType) ->
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
     [
-        {sm_register_connection_hook, HostType, fun ?MODULE:register_connection/3, #{}, 100},
-        {sm_remove_connection_hook, HostType, fun ?MODULE:unregister_connection/3, #{}, 100},
+        {sm_register_connection, HostType, fun ?MODULE:register_connection/3, #{}, 100},
+        {sm_remove_connection, HostType, fun ?MODULE:unregister_connection/3, #{}, 100},
         {session_cleanup, HostType, fun ?MODULE:session_cleanup/3, #{}, 50}
     ].
 
@@ -155,7 +155,7 @@ purge_hook(true, HostType, LUser, LServer) ->
                               host_type => HostType,
                               lserver => LServer,
                               element => undefined }),
-    mongoose_hooks:anonymous_purge_hook(LServer, Acc, LUser).
+    mongoose_hooks:anonymous_purge(LServer, Acc, LUser).
 
 -spec session_cleanup(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_acc:t(),

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -545,7 +545,7 @@ verify_user(session_established, HostType, #{c2s_data := StateData} = HookParams
             {ok, Acc1};
         {stop, Acc1} ->
             Jid = StateData#c2s_data.jid,
-            Acc2 = mongoose_hooks:forbidden_session_hook(HostType, Acc1, Jid),
+            Acc2 = mongoose_hooks:forbidden_session(HostType, Acc1, Jid),
             ?LOG_INFO(#{what => forbidden_session, text => <<"User not allowed to open session">>,
                         acc => Acc2, c2s_state => StateData}),
             {stop, Acc2}

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -130,8 +130,8 @@ merge_acc(Acc, EventPusherAcc) ->
 hooks(HostType) ->
     [
         {filter_local_packet, HostType, fun ?MODULE:filter_local_packet/3, #{}, 80},
-        {unset_presence_hook, HostType, fun ?MODULE:user_not_present/3, #{}, 90},
-        {user_available_hook, HostType, fun ?MODULE:user_present/3, #{}, 90},
+        {unset_presence, HostType, fun ?MODULE:user_not_present/3, #{}, 90},
+        {user_available, HostType, fun ?MODULE:user_present/3, #{}, 90},
         {user_send_message, HostType, fun ?MODULE:user_send_message/3, #{}, 90},
         {unacknowledged_message, HostType, fun ?MODULE:unacknowledged_message/3, #{}, 90}
     ].

--- a/src/global_distrib/mod_global_distrib_mapping.erl
+++ b/src/global_distrib/mod_global_distrib_mapping.erl
@@ -226,8 +226,8 @@ hooks(HostType) ->
     [{register_subhost, global, fun ?MODULE:register_subhost/3, #{}, 90},
      {unregister_subhost, global, fun ?MODULE:unregister_subhost/3, #{}, 90},
      {packet_to_component, global, fun ?MODULE:packet_to_component/3, #{}, 90},
-     {sm_register_connection_hook, HostType, fun ?MODULE:session_opened/3, #{}, 90},
-     {sm_remove_connection_hook, HostType, fun ?MODULE:session_closed/3, #{}, 90}].
+     {sm_register_connection, HostType, fun ?MODULE:session_opened/3, #{}, 90},
+     {sm_remove_connection, HostType, fun ?MODULE:session_closed/3, #{}, 90}].
 
 -spec normalize_jid(jid:ljid()) -> [binary()].
 normalize_jid({_, _, _} = FullJid) ->

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -10,7 +10,7 @@
 
 -export([adhoc_local_commands/4,
          adhoc_sm_commands/4,
-         anonymous_purge_hook/3,
+         anonymous_purge/3,
          auth_failed/3,
          does_user_exist/3,
          failed_to_store_message/1,
@@ -20,19 +20,19 @@
          extend_inbox_result/3,
          get_key/2,
          packet_to_component/3,
-         presence_probe_hook/5,
+         presence_probe/5,
          push_notifications/4,
          register_subhost/2,
          register_user/3,
          remove_user/3,
-         resend_offline_messages_hook/2,
+         resend_offline_messages/2,
          session_cleanup/5,
          sessions_cleanup/2,
          set_vcard/3,
          unacknowledged_message/2,
          filter_unacknowledged_messages/3,
          unregister_subhost/1,
-         user_available_hook/2,
+         user_available/2,
          user_ping_response/5,
          vcard_set/4,
          xmpp_send_element/3,
@@ -49,7 +49,7 @@
          filter_pep_recipient/3,
          c2s_stream_features/3,
          check_bl_c2s/1,
-         forbidden_session_hook/3,
+         forbidden_session/3,
          session_opening_allowed_for_user/2]).
 
 -export([privacy_check_packet/5,
@@ -59,13 +59,13 @@
          privacy_updated_list/3,
          privacy_list_push/5]).
 
--export([offline_groupchat_message_hook/4,
-         offline_message_hook/4,
-         set_presence_hook/3,
+-export([offline_groupchat_message/4,
+         offline_message/4,
+         set_presence/3,
          sm_filter_offline_message/4,
-         sm_register_connection_hook/4,
-         sm_remove_connection_hook/5,
-         unset_presence_hook/3,
+         sm_register_connection/4,
+         sm_remove_connection/5,
+         unset_presence/3,
          xmpp_bounce_message/1]).
 
 -export([roster_get/3,
@@ -183,17 +183,17 @@ adhoc_sm_commands(HostType, From, To, AdhocRequest) ->
     Params = #{from => From, to => To, request => AdhocRequest},
     run_hook_for_host_type(adhoc_sm_commands, HostType, empty, Params).
 
-%%% @doc The `anonymous_purge_hook' hook is called when anonymous user's data is removed.
--spec anonymous_purge_hook(LServer, Acc, LUser) -> Result when
+%%% @doc The `anonymous_purge' hook is called when anonymous user's data is removed.
+-spec anonymous_purge(LServer, Acc, LUser) -> Result when
     LServer :: jid:lserver(),
     Acc :: mongoose_acc:t(),
     LUser :: jid:user(),
     Result :: mongoose_acc:t().
-anonymous_purge_hook(LServer, Acc, LUser) ->
+anonymous_purge(LServer, Acc, LUser) ->
     Jid = jid:make_bare(LUser, LServer),
     Params = #{jid => Jid},
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(anonymous_purge_hook, HostType, Acc, Params).
+    run_hook_for_host_type(anonymous_purge, HostType, Acc, Params).
 
 -spec auth_failed(HostType, Server, Username) -> Result when
     HostType :: mongooseim:host_type(),
@@ -291,16 +291,16 @@ packet_to_component(Acc, From, To) ->
     Params = #{from => From, to => To},
     run_global_hook(packet_to_component, Acc, Params).
 
--spec presence_probe_hook(HostType, Acc, From, To, Pid) -> Result when
+-spec presence_probe(HostType, Acc, From, To, Pid) -> Result when
     HostType :: mongooseim:host_type(),
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     To :: jid:jid(),
     Pid :: pid(),
     Result :: mongoose_acc:t().
-presence_probe_hook(HostType, Acc, From, To, Pid) ->
+presence_probe(HostType, Acc, From, To, Pid) ->
     Params = #{from => From, to => To, pid => Pid},
-    run_hook_for_host_type(presence_probe_hook, HostType, Acc, Params).
+    run_hook_for_host_type(presence_probe, HostType, Acc, Params).
 
 %%% @doc The `push_notifications' hook is called to push notifications.
 -spec push_notifications(HostType, Acc, NotificationForms, Options) -> Result when
@@ -347,14 +347,14 @@ remove_user(Acc, LServer, LUser) ->
     HostType = mongoose_acc:host_type(Acc),
     run_hook_for_host_type(remove_user, HostType, Acc, Params).
 
--spec resend_offline_messages_hook(Acc, JID) -> Result when
+-spec resend_offline_messages(Acc, JID) -> Result when
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
-resend_offline_messages_hook(Acc, JID) ->
+resend_offline_messages(Acc, JID) ->
     Params = #{jid => JID},
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(resend_offline_messages_hook, HostType, Acc, Params).
+    run_hook_for_host_type(resend_offline_messages, HostType, Acc, Params).
 
 %%% @doc The `session_cleanup' hook is called when sm backend cleans up a user's session.
 -spec session_cleanup(Server, Acc, User, Resource, SID) -> Result when
@@ -411,14 +411,14 @@ unregister_subhost(LDomain) ->
     Params = #{ldomain => LDomain},
     run_global_hook(unregister_subhost, ok, Params).
 
--spec user_available_hook(Acc, JID) -> Result when
+-spec user_available(Acc, JID) -> Result when
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
-user_available_hook(Acc, JID) ->
+user_available(Acc, JID) ->
     Params = #{jid => JID},
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(user_available_hook, HostType, Acc, Params).
+    run_hook_for_host_type(user_available, HostType, Acc, Params).
 
 %%% @doc The `user_ping_response' hook is called when a user responds to a ping, or times out
 -spec user_ping_response(HostType, Acc, JID, Response, TDelta) -> Result when
@@ -548,14 +548,14 @@ check_bl_c2s(IP) ->
     Params = #{ip => IP},
     run_global_hook(check_bl_c2s, false, Params).
 
--spec forbidden_session_hook(HostType, Acc, JID) -> Result when
+-spec forbidden_session(HostType, Acc, JID) -> Result when
     HostType :: mongooseim:host_type(),
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     Result :: mongoose_acc:t().
-forbidden_session_hook(HostType, Acc, JID) ->
+forbidden_session(HostType, Acc, JID) ->
     Params = #{jid => JID},
-    run_hook_for_host_type(forbidden_session_hook, HostType, Acc, Params).
+    run_hook_for_host_type(forbidden_session, HostType, Acc, Params).
 
 -spec session_opening_allowed_for_user(HostType, JID) -> Result when
     HostType :: mongooseim:host_type(),
@@ -635,37 +635,37 @@ privacy_list_push(HostType, LUser, LServer, Item, SessionCount) ->
 
 %% Session management related hooks
 
--spec offline_groupchat_message_hook(Acc, From, To, Packet) -> Result when
+-spec offline_groupchat_message(Acc, From, To, Packet) -> Result when
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: mongoose_acc:t().
-offline_groupchat_message_hook(Acc, From, To, Packet) ->
+offline_groupchat_message(Acc, From, To, Packet) ->
     Params = #{from => From, to => To, packet => Packet},
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(offline_groupchat_message_hook, HostType, Acc, Params).
+    run_hook_for_host_type(offline_groupchat_message, HostType, Acc, Params).
 
--spec offline_message_hook(Acc, From, To, Packet) -> Result when
+-spec offline_message(Acc, From, To, Packet) -> Result when
     Acc :: mongoose_acc:t(),
     From :: jid:jid(),
     To :: jid:jid(),
     Packet :: exml:element(),
     Result :: mongoose_acc:t().
-offline_message_hook(Acc, From, To, Packet) ->
+offline_message(Acc, From, To, Packet) ->
     Params = #{from => From, to => To, packet => Packet},
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(offline_message_hook, HostType, Acc, Params).
+    run_hook_for_host_type(offline_message, HostType, Acc, Params).
 
--spec set_presence_hook(Acc, JID, Presence) -> Result when
+-spec set_presence(Acc, JID, Presence) -> Result when
     Acc :: mongoose_acc:t(),
     JID :: jid:jid(),
     Presence :: any(),
     Result :: mongoose_acc:t().
-set_presence_hook(Acc, JID, Presence) ->
+set_presence(Acc, JID, Presence) ->
     Params = #{jid => JID, presence => Presence},
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(set_presence_hook, HostType, Acc, Params).
+    run_hook_for_host_type(set_presence, HostType, Acc, Params).
 
 -spec sm_filter_offline_message(HostType, From, To, Packet) -> Result when
     HostType :: mongooseim:host_type(),
@@ -677,37 +677,37 @@ sm_filter_offline_message(HostType, From, To, Packet) ->
     Params = #{from => From, to => To, packet => Packet},
     run_hook_for_host_type(sm_filter_offline_message, HostType, false, Params).
 
--spec sm_register_connection_hook(HostType, SID, JID, Info) -> Result when
+-spec sm_register_connection(HostType, SID, JID, Info) -> Result when
     HostType :: mongooseim:host_type(),
     SID :: 'undefined' | ejabberd_sm:sid(),
     JID :: jid:jid(),
     Info :: ejabberd_sm:info(),
     Result :: ok.
-sm_register_connection_hook(HostType, SID, JID, Info) ->
+sm_register_connection(HostType, SID, JID, Info) ->
     Params = #{sid => SID, jid => JID, info => Info},
-    run_hook_for_host_type(sm_register_connection_hook, HostType, ok, Params).
+    run_hook_for_host_type(sm_register_connection, HostType, ok, Params).
 
--spec sm_remove_connection_hook(Acc, SID, JID, Info, Reason) -> Result when
+-spec sm_remove_connection(Acc, SID, JID, Info, Reason) -> Result when
     Acc :: mongoose_acc:t(),
     SID :: 'undefined' | ejabberd_sm:sid(),
     JID :: jid:jid(),
     Info :: ejabberd_sm:info(),
     Reason :: ejabberd_sm:close_reason(),
     Result :: mongoose_acc:t().
-sm_remove_connection_hook(Acc, SID, JID, Info, Reason) ->
+sm_remove_connection(Acc, SID, JID, Info, Reason) ->
     Params = #{sid => SID, jid => JID, info => Info, reason => Reason},
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(sm_remove_connection_hook, HostType, Acc, Params).
+    run_hook_for_host_type(sm_remove_connection, HostType, Acc, Params).
 
--spec unset_presence_hook(Acc, JID, Status) -> Result when
+-spec unset_presence(Acc, JID, Status) -> Result when
     Acc :: mongoose_acc:t(),
     JID:: jid:jid(),
     Status :: binary(),
     Result :: mongoose_acc:t().
-unset_presence_hook(Acc, JID, Status) ->
+unset_presence(Acc, JID, Status) ->
     Params = #{jid => JID, status => Status},
     HostType = mongoose_acc:host_type(Acc),
-    run_hook_for_host_type(unset_presence_hook, HostType, Acc, Params).
+    run_hook_for_host_type(unset_presence, HostType, Acc, Params).
 
 -spec xmpp_bounce_message(Acc) -> Result when
     Acc :: mongoose_acc:t(),

--- a/src/mam/mod_mam_pm.erl
+++ b/src/mam/mod_mam_pm.erl
@@ -714,7 +714,7 @@ hooks(HostType) ->
         {user_send_message, HostType, fun ?MODULE:user_send_message/3, #{}, 60},
         {filter_local_packet, HostType, fun ?MODULE:filter_packet/3, #{}, 60},
         {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
-        {anonymous_purge_hook, HostType, fun ?MODULE:remove_user/3, #{}, 50},
+        {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50},
         {amp_determine_strategy, HostType, fun ?MODULE:determine_amp_strategy/3, #{}, 20},
         {sm_filter_offline_message, HostType, fun ?MODULE:sm_filter_offline_message/3, #{}, 50},
         {get_personal_data, HostType, fun ?MODULE:get_personal_data/3, #{}, 50}

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -355,8 +355,8 @@ remove_metric({Name, _, _}) ->
 
 %% decided whether to use a metric for given hook or not
 -spec filter_hook(hook_name()) -> use_or_skip().
-filter_hook(sm_register_connection_hook) -> skip;
-filter_hook(sm_remove_connection_hook) -> skip;
+filter_hook(sm_register_connection) -> skip;
+filter_hook(sm_remove_connection) -> skip;
 filter_hook(auth_failed) -> skip;
 filter_hook(user_send_packet) -> skip;
 filter_hook(user_send_message) -> skip;

--- a/src/metrics/mongoose_metrics_hooks.erl
+++ b/src/metrics/mongoose_metrics_hooks.erl
@@ -15,8 +15,8 @@
 %%-------------------
 %% Internal exports
 %%-------------------
--export([sm_register_connection_hook/3,
-         sm_remove_connection_hook/3,
+-export([sm_register_connection/3,
+         sm_remove_connection/3,
          auth_failed/3,
          user_send_packet/3,
          user_open_session/3,
@@ -42,8 +42,8 @@
 %% @doc Here will be declared which hooks should be registered
 -spec get_hooks(_) -> [gen_hook:hook_tuple(), ...].
 get_hooks(HostType) ->
-    [ {sm_register_connection_hook, HostType, fun ?MODULE:sm_register_connection_hook/3, #{}, 50},
-      {sm_remove_connection_hook, HostType, fun ?MODULE:sm_remove_connection_hook/3, #{}, 50},
+    [ {sm_register_connection, HostType, fun ?MODULE:sm_register_connection/3, #{}, 50},
+      {sm_remove_connection, HostType, fun ?MODULE:sm_remove_connection/3, #{}, 50},
       {auth_failed, HostType, fun ?MODULE:auth_failed/3, #{}, 50},
       {xmpp_stanza_dropped, HostType, fun ?MODULE:xmpp_stanza_dropped/3, #{}, 50},
       {xmpp_bounce_message, HostType, fun ?MODULE:xmpp_bounce_message/3, #{}, 50},
@@ -65,20 +65,20 @@ c2s_hooks(HostType) ->
     [{user_send_packet, HostType, fun ?MODULE:user_send_packet/3, #{}, 50},
      {user_open_session, HostType, fun ?MODULE:user_open_session/3, #{}, 50}].
 
--spec sm_register_connection_hook(Acc, Params, Extra) -> {ok, Acc} when
+-spec sm_register_connection(Acc, Params, Extra) -> {ok, Acc} when
       Acc :: any(),
       Params :: map(),
       Extra :: #{host_type := mongooseim:host_type()}.
-sm_register_connection_hook(Acc, _, #{host_type := HostType}) ->
+sm_register_connection(Acc, _, #{host_type := HostType}) ->
     mongoose_metrics:update(HostType, sessionSuccessfulLogins, 1),
     mongoose_metrics:update(HostType, sessionCount, 1),
     {ok, Acc}.
 
--spec sm_remove_connection_hook(Acc, Params, Extra) -> {ok, Acc} when
+-spec sm_remove_connection(Acc, Params, Extra) -> {ok, Acc} when
       Acc :: mongoose_acc:t(),
       Params :: map(),
       Extra :: #{host_type := mongooseim:host_type()}.
-sm_remove_connection_hook(Acc, _, #{host_type := HostType}) ->
+sm_remove_connection(Acc, _, #{host_type := HostType}) ->
     mongoose_metrics:update(HostType, sessionLogouts, 1),
     mongoose_metrics:update(HostType, sessionCount, -1),
     {ok, Acc}.

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -93,7 +93,7 @@ hooks(HostType) ->
      {disco_local_features, HostType, fun ?MODULE:disco_local_features/3, #{}, 99},
      {bind2_stream_features, HostType, fun ?MODULE:bind2_stream_features/3, #{}, 50},
      {bind2_enable_features, HostType, fun ?MODULE:bind2_enable_features/3, #{}, 50},
-     {unset_presence_hook, HostType, fun ?MODULE:remove_connection/3, #{}, 10},
+     {unset_presence, HostType, fun ?MODULE:remove_connection/3, #{}, 10},
      {user_send_message, HostType, fun ?MODULE:user_send_message/3, #{}, 89},
      {user_receive_message, HostType, fun ?MODULE:user_receive_message/3, #{}, 89}
     ].

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -44,7 +44,7 @@
          process_local_iq/5,
          process_sm_iq/5,
          remove_user/3,
-         unset_presence_hook/3,
+         unset_presence/3,
          session_cleanup/3,
          sessions_cleanup/3,
          remove_domain/3]).
@@ -89,8 +89,8 @@ iq_handlers() ->
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
     [{remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
-     {anonymous_purge_hook, HostType, fun ?MODULE:remove_user/3, #{}, 50},
-     {unset_presence_hook, HostType, fun ?MODULE:unset_presence_hook/3, #{}, 50},
+     {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50},
+     {unset_presence, HostType, fun ?MODULE:unset_presence/3, #{}, 50},
      {session_cleanup, HostType, fun ?MODULE:session_cleanup/3, #{}, 50},
      {sessions_cleanup, HostType, fun ?MODULE:sessions_cleanup/3, #{}, 50},
      {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50}
@@ -264,11 +264,11 @@ maybe_forward_last(Acc) ->
             {stop, Acc}
     end.
 
--spec unset_presence_hook(Acc, Params, Extra) -> {ok, Acc} when
+-spec unset_presence(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_acc:t(),
     Params :: #{jid := jid:jid(), status := status()},
     Extra :: gen_hook:extra().
-unset_presence_hook(Acc, #{jid := #jid{luser = LUser, lserver = LServer}, status := Status}, _) ->
+unset_presence(Acc, #{jid := #jid{luser = LUser, lserver = LServer}, status := Status}, _) ->
     {ok, store_last_info(Acc, LUser, LServer, Status)}.
 
 -spec session_cleanup(Acc, Params, Extra) -> {ok, Acc} when

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -86,7 +86,7 @@ supported_features() -> [dynamic_domains].
 hooks(HostType) ->
     [{remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
      {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
-     {anonymous_purge_hook, HostType, fun ?MODULE:remove_user/3, #{}, 50},
+     {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50},
      {get_personal_data, HostType, fun ?MODULE:get_personal_data/3, #{}, 50}].
 
 config_spec() ->

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -288,7 +288,7 @@ hooks(HostType) ->
      {room_exists, HostType, fun ?MODULE:room_exists/3, #{}, 50},
      {can_access_identity, HostType, fun ?MODULE:can_access_identity/3, #{}, 50},
       %% Prevent sending service-unavailable on groupchat messages
-     {offline_groupchat_message_hook, HostType, fun ?MODULE:prevent_service_unavailable/3, #{}, 90},
+     {offline_groupchat_message, HostType, fun ?MODULE:prevent_service_unavailable/3, #{}, 90},
      {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
      {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
      {disco_local_items, HostType, fun ?MODULE:disco_local_items/3, #{}, 50}] ++

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -134,11 +134,11 @@ supported_features() -> [dynamic_domains].
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
     DefaultHooks = [
-        {offline_message_hook, HostType, fun ?MODULE:inspect_packet/3, #{}, 50},
-        {resend_offline_messages_hook, HostType, fun ?MODULE:pop_offline_messages/3, #{}, 50},
+        {offline_message, HostType, fun ?MODULE:inspect_packet/3, #{}, 50},
+        {resend_offline_messages, HostType, fun ?MODULE:pop_offline_messages/3, #{}, 50},
         {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
         {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
-        {anonymous_purge_hook, HostType, fun ?MODULE:remove_user/3, #{}, 50},
+        {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50},
         {disco_sm_features, HostType, fun ?MODULE:disco_features/3, #{}, 50},
         {disco_local_features, HostType, fun ?MODULE:disco_features/3, #{}, 50},
         {amp_determine_strategy, HostType, fun ?MODULE:determine_amp_strategy/3, #{}, 30},
@@ -147,7 +147,7 @@ hooks(HostType) ->
     ],
     case gen_mod:get_module_opt(HostType, ?MODULE, store_groupchat_messages) of
         true ->
-            GroupChatHook = {offline_groupchat_message_hook,
+            GroupChatHook = {offline_groupchat_message,
                              HostType, fun ?MODULE:inspect_packet/3, #{}, 50},
             [GroupChatHook | DefaultHooks];
         _ -> DefaultHooks

--- a/src/offline/mod_offline_chatmarkers.erl
+++ b/src/offline/mod_offline_chatmarkers.erl
@@ -9,13 +9,13 @@
 %%%            timestamp field added by mod_smart_markers.
 %%%
 %%%          * These packets are not going to mod_offline (notice the
-%%%            difference in priorities for the offline_message_hook handlers)
+%%%            difference in priorities for the offline_message hook handlers)
 %%%
 %%%          * The information about these chat markers is stored in DB,
 %%%            timestamp added by mod_smart_markers is important here!
 %%%
 %%%      2) After all the offline messages are inserted by mod_offline (notice
-%%%         the difference in priorities for the resend_offline_messages_hook
+%%%         the difference in priorities for the resend_offline_messages hook
 %%%         handlers), this module adds the latest chat markers as the last
 %%%         offline messages:
 %%%
@@ -76,13 +76,13 @@ stop(_HostType) ->
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
     DefaultHooks = [
-        {offline_message_hook, HostType, fun ?MODULE:inspect_packet/3, #{}, 40},
-        {resend_offline_messages_hook, HostType, fun ?MODULE:pop_offline_messages/3, #{}, 60},
+        {offline_message, HostType, fun ?MODULE:inspect_packet/3, #{}, 40},
+        {resend_offline_messages, HostType, fun ?MODULE:pop_offline_messages/3, #{}, 60},
         {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50}
     ],
     case gen_mod:get_module_opt(HostType, ?MODULE, store_groupchat_messages) of
         true ->
-            GroupChatHook = {offline_groupchat_message_hook,
+            GroupChatHook = {offline_groupchat_message,
                              HostType, fun ?MODULE:inspect_packet/3, #{}, 40},
             [GroupChatHook | DefaultHooks];
         _ -> DefaultHooks

--- a/src/offline/mod_offline_stub.erl
+++ b/src/offline/mod_offline_stub.erl
@@ -47,7 +47,7 @@ supported_features() -> [dynamic_domains].
 
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
-    [{offline_message_hook, HostType, fun ?MODULE:stop_hook_processing/3, #{}, 75}].
+    [{offline_message, HostType, fun ?MODULE:stop_hook_processing/3, #{}, 75}].
 
 -spec stop_hook_processing(Acc, Params, Extra) -> {stop, Acc} when
     Acc :: mongoose_acc:t(),

--- a/src/privacy/mod_privacy.erl
+++ b/src/privacy/mod_privacy.erl
@@ -104,7 +104,7 @@ hooks(HostType) ->
      {privacy_updated_list, HostType, fun ?MODULE:updated_list/3, #{}, 50},
      {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
      {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
-     {anonymous_purge_hook, HostType, fun ?MODULE:remove_user/3, #{}, 50}
+     {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50}
      | c2s_hooks(HostType)].
 
 -spec c2s_hooks(mongooseim:host_type()) -> gen_hook:hook_list(mongoose_c2s_hooks:fn()).

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -449,12 +449,12 @@ init_backend(ServerHost, Opts) ->
 
 hooks(ServerHost) ->
     [{disco_local_features, ServerHost, fun ?MODULE:disco_local_features/3, #{}, 75},
-     {sm_remove_connection_hook, ServerHost, fun ?MODULE:on_user_offline/3, #{}, 75},
-     {presence_probe_hook, ServerHost, fun ?MODULE:presence_probe/3, #{}, 80},
+     {sm_remove_connection, ServerHost, fun ?MODULE:on_user_offline/3, #{}, 75},
+     {presence_probe, ServerHost, fun ?MODULE:presence_probe/3, #{}, 80},
      {roster_in_subscription, ServerHost, fun ?MODULE:in_subscription/3, #{}, 50},
      {roster_out_subscription, ServerHost, fun ?MODULE:out_subscription/3, #{}, 50},
      {remove_user, ServerHost, fun ?MODULE:remove_user/3, #{}, 50},
-     {anonymous_purge_hook, ServerHost, fun ?MODULE:remove_user/3, #{}, 50},
+     {anonymous_purge, ServerHost, fun ?MODULE:remove_user/3, #{}, 50},
      {get_personal_data, ServerHost, fun ?MODULE:get_personal_data/3, #{}, 50}].
 
 pep_hooks(ServerHost) ->

--- a/src/roster/mod_roster.erl
+++ b/src/roster/mod_roster.erl
@@ -170,7 +170,7 @@ hooks(HostType) ->
      {roster_get_jid_info, HostType, fun ?MODULE:get_jid_info/3, #{}, 50},
      {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
      {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
-     {anonymous_purge_hook, HostType, fun ?MODULE:remove_user/3, #{}, 50},
+     {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50},
      {roster_get_versioning_feature, HostType, fun ?MODULE:get_versioning_feature/3, #{}, 50},
      {get_personal_data, HostType, fun ?MODULE:get_personal_data/3, #{}, 50}].
 

--- a/src/vcard/mod_vcard.erl
+++ b/src/vcard/mod_vcard.erl
@@ -163,7 +163,7 @@ supported_features() -> [dynamic_domains].
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
     [{remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
-     {anonymous_purge_hook, HostType, fun ?MODULE:remove_user/3, #{}, 50},
+     {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50},
      {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
      {set_vcard, HostType, fun ?MODULE:set_vcard/3, #{}, 50},
      {get_personal_data, HostType, fun ?MODULE:get_personal_data/3, #{}, 50}].

--- a/test/common/mongoose_helper.erl
+++ b/test/common/mongoose_helper.erl
@@ -117,7 +117,7 @@ total_roster_items() ->
     generic_count(mod_roster_backend).
 
 %% Need to clear last_activity after carol (connected over BOSH)
-%% It is possible that from time to time the unset_presence_hook,
+%% It is possible that from time to time the unset_presence hook,
 %% for user connected over BOSH, is called after user removal.
 %% This happens when the BOSH session is closed (on server side)
 %% after user's removal

--- a/test/mongoose_cleanup_SUITE.erl
+++ b/test/mongoose_cleanup_SUITE.erl
@@ -184,7 +184,7 @@ last(_Config) ->
                           config_parser_helper:mod_config(mod_last, #{iqdisc => no_queue})),
     not_found = mod_last:get_last_info(HostType, U, S),
     Status1 = <<"status1">>,
-    {ok, #{}} = mod_last:unset_presence_hook(new_acc(S), #{jid => JID, status => Status1}, #{}),
+    {ok, #{}} = mod_last:unset_presence(new_acc(S), #{jid => JID, status => Status1}, #{}),
     {ok, TS1, Status1} = mod_last:get_last_info(HostType, U, S),
     async_helper:wait_until(
       fun() ->

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -157,8 +157,8 @@ queued_messages_increase(_C) ->
       end, Fun).
 
 no_skip_metric(_C) ->
-    ok = mongoose_metrics:create_generic_hook_metric(<<"localhost">>, sm_register_connection_hook),
-    undefined = exometer:info([<<"localhost">>, sm_register_connection_hook]).
+    ok = mongoose_metrics:create_generic_hook_metric(<<"localhost">>, sm_register_connection),
+    undefined = exometer:info([<<"localhost">>, sm_register_connection]).
 
 subscriptions_initialised(_C) ->
     true = wait_for_update(exometer:get_value([carbon, packets], count), 60).


### PR DESCRIPTION
Apart from improving naming consistency, this change will be useful for naming instrumentation events, removing the extra `hook` from the name.