### PR TITLE
Instrument `mod_ping`

### DIFF
--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -215,15 +215,15 @@ handle_ping_action(HostType, Reason) ->
 
 -spec user_ping_response(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_acc:t(),
-    Params :: #{response := timeout | jlib:iq(), time_delta := non_neg_integer()},
+    Params :: #{response := timeout | jlib:iq(), time_delta := non_neg_integer(), jid := jid:jid()},
     Extra :: #{host_type := mongooseim:host_type()}.
-user_ping_response(Acc, #{response := timeout}, #{host_type := HostType}) ->
+user_ping_response(Acc, #{response := timeout, jid := Jid}, #{host_type := HostType}) ->
     mongoose_instrument:execute(mod_ping_response_timeout, #{host_type => HostType},
-                                #{count => 1}),
+                                #{count => 1, jid => Jid}),
     {ok, Acc};
-user_ping_response(Acc, #{time_delta := TDelta}, #{host_type := HostType}) ->
+user_ping_response(Acc, #{time_delta := TDelta, jid := Jid}, #{host_type := HostType}) ->
     mongoose_instrument:execute(mod_ping_response, #{host_type => HostType},
-                                #{count => 1, time => TDelta}),
+                                #{count => 1, time => TDelta, jid => Jid}),
     {ok, Acc}.
 
 %%====================================================================

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -30,7 +30,8 @@
          user_send_iq/3,
          user_ping_response/3,
          filter_local_packet/3,
-         iq_ping/5]).
+         iq_ping/5,
+         instrumentation/1]).
 
 %% Record that will be stored in the c2s state when the server pings the client,
 %% in order to indentify the possible client's answer.
@@ -52,10 +53,12 @@ c2s_hooks(HostType) ->
      {user_send_iq, HostType, fun ?MODULE:user_send_iq/3, #{}, 100}
     ].
 
-ensure_metrics(HostType) ->
-    mongoose_metrics:ensure_metric(HostType, [mod_ping, ping_response], spiral),
-    mongoose_metrics:ensure_metric(HostType, [mod_ping, ping_response_timeout], spiral),
-    mongoose_metrics:ensure_metric(HostType, [mod_ping, ping_response_time], histogram).
+-spec instrumentation(mongooseim:host_type()) -> [mongoose_instrument:spec()].
+instrumentation(HostType) ->
+    [{mod_ping_response, #{host_type => HostType},
+      #{metrics => #{count => spiral, time => histogram}}},
+     {mod_ping_response_timeout, #{host_type => HostType},
+      #{metrics => #{count => spiral}}}].
 
 %%====================================================================
 %% gen_mod callbacks
@@ -63,7 +66,6 @@ ensure_metrics(HostType) ->
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, #{send_pings := SendPings, iqdisc := IQDisc}) ->
-    ensure_metrics(HostType),
     gen_iq_handler:add_iq_handler_for_domain(
       HostType, ?NS_PING, ejabberd_sm, fun ?MODULE:iq_ping/5, #{}, IQDisc),
     gen_iq_handler:add_iq_handler_for_domain(
@@ -216,11 +218,12 @@ handle_ping_action(HostType, Reason) ->
     Params :: #{response := timeout | jlib:iq(), time_delta := non_neg_integer()},
     Extra :: #{host_type := mongooseim:host_type()}.
 user_ping_response(Acc, #{response := timeout}, #{host_type := HostType}) ->
-    mongoose_metrics:update(HostType, [mod_ping, ping_response_timeout], 1),
+    mongoose_instrument:execute(mod_ping_response_timeout, #{host_type => HostType},
+                                #{count => 1}),
     {ok, Acc};
 user_ping_response(Acc, #{time_delta := TDelta}, #{host_type := HostType}) ->
-    mongoose_metrics:update(HostType, [mod_ping, ping_response_time], TDelta),
-    mongoose_metrics:update(HostType, [mod_ping, ping_response], 1),
+    mongoose_instrument:execute(mod_ping_response, #{host_type => HostType},
+                                #{count => 1, time => TDelta}),
     {ok, Acc}.
 
 %%====================================================================


### PR DESCRIPTION
This PR adds instrumentation to `mod_ping`.

One important change is the merging of two events (`ping_response_time` and `ping_response`) into one, as they were always invoked simultaneously.

The measurement of time in `mod_ping_response` does not use `mongoose_instrument:span` because the time measurement is done through hooks.