### PR TITLE
Instrument/hooks

### DIFF
--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -251,7 +251,7 @@ end_per_group(_GroupName, Config) ->
     end.
 
 init_per_testcase(rest_cannot_enable_deleting, Config) ->
-    HostType = <<"type1">>,
+    HostType = dummy_auth_host_type(),
     Server = start_domain_removal_hook(HostType),
     init_per_testcase(generic, [{server, Server}, {host_type, HostType} | Config]);
 init_per_testcase(db_crash_on_initial_load_restarts_service, Config) ->

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -96,12 +96,12 @@ prep_stop(State) ->
     broadcast_c2s_shutdown_sup(),
     mongoose_wpool:stop(),
     mongoose_metrics:remove_all_metrics(),
-    mongoose_config:stop(),
     mongoose_graphql_commands:stop(),
     State.
 
 %% All the processes were killed when this function is called
 stop(_State) ->
+    mongoose_config:stop(),
     ?LOG_NOTICE(#{what => mongooseim_node_stopped, version => ?MONGOOSE_VERSION, node => node()}),
     delete_pid_file(),
     update_status_file(stopped),

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -94,7 +94,6 @@
          mam_remove_archive/3,
          mam_lookup_messages/2,
          mam_archive_message/2,
-         mam_flush_messages/2,
          mam_archive_sync/1,
          mam_retraction/3]).
 
@@ -106,7 +105,6 @@
          mam_muc_remove_archive/3,
          mam_muc_lookup_messages/2,
          mam_muc_archive_message/2,
-         mam_muc_flush_messages/2,
          mam_muc_archive_sync/1,
          mam_muc_retraction/3]).
 
@@ -1005,14 +1003,6 @@ mam_lookup_messages(HostType, Params) ->
 mam_archive_message(HostType, Params) ->
     run_hook_for_host_type(mam_archive_message, HostType, ok, Params).
 
-%%% @doc The `mam_flush_messages' hook is run after the async bulk write
-%%% happens for messages despite the result of the write.
--spec mam_flush_messages(HostType :: mongooseim:host_type(),
-                         MessageCount :: integer()) -> ok.
-mam_flush_messages(HostType, MessageCount) ->
-    Params = #{count => MessageCount},
-    run_hook_for_host_type(mam_flush_messages, HostType, ok, Params).
-
 %% @doc Waits until all pending messages are written
 -spec mam_archive_sync(HostType :: mongooseim:host_type()) -> ok.
 mam_archive_sync(HostType) ->
@@ -1132,14 +1122,6 @@ mam_muc_lookup_messages(HostType, Params) ->
     Result :: ok | {error, timeout}.
 mam_muc_archive_message(HostType, Params) ->
     run_hook_for_host_type(mam_muc_archive_message, HostType, ok, Params).
-
-%%% @doc The `mam_muc_flush_messages' hook is run after the async bulk write
-%%% happens for MUC messages despite the result of the write.
--spec mam_muc_flush_messages(HostType :: mongooseim:host_type(),
-                             MessageCount :: integer()) -> ok.
-mam_muc_flush_messages(HostType, MessageCount) ->
-    Params = #{count => MessageCount},
-    run_hook_for_host_type(mam_muc_flush_messages, HostType, ok, Params).
 
 %% @doc Waits until all pending messages are written
 -spec mam_muc_archive_sync(HostType :: mongooseim:host_type()) -> ok.

--- a/src/instrument/mongoose_instrument_hooks.erl
+++ b/src/instrument/mongoose_instrument_hooks.erl
@@ -1,0 +1,96 @@
+-module(mongoose_instrument_hooks).
+
+-export([set_up/2, tear_down/2, execute/2]).
+
+-include("mongoose.hrl").
+
+-spec set_up(gen_hook:hook_name(), gen_hook:hook_tag()) -> ok.
+set_up(HookName, Tag) ->
+    case is_instrumented(HookName) of
+        true ->
+            EventName = event_name(HookName),
+            persistent_term:put({?MODULE, HookName}, EventName),
+            try
+                mongoose_instrument:set_up(EventName, labels(Tag), #{metrics => #{count => spiral}})
+            catch
+                error:#{what := inconsistent_labels} ->
+                    log_tag_error(HookName, Tag)
+            end;
+        false ->
+            ok
+    end.
+
+-spec log_tag_error(gen_hook:hook_name(), gen_hook:hook_tag()) -> ok.
+log_tag_error(HookName, Tag) ->
+    ?LOG_ERROR(#{what => inconsistent_hook_handler_tags,
+                 text => <<"A single hook should not have both global and host-type handlers. "
+                           "Instrumentation is not set up.">>,
+                 hook_name => HookName, tag => Tag}).
+
+-spec tear_down(gen_hook:hook_name(), gen_hook:hook_tag()) -> ok.
+tear_down(HookName, Tag) ->
+    case is_instrumented(HookName) of
+        true ->
+            EventName = event_name(HookName),
+            mongoose_instrument:tear_down(EventName, labels(Tag)),
+            persistent_term:erase({?MODULE, HookName});
+        false ->
+            ok
+    end.
+
+-spec execute(gen_hook:hook_name(), gen_hook:hook_tag()) -> ok.
+execute(HookName, Tag) ->
+    case is_instrumented(HookName) of
+        true ->
+            try persistent_term:get({?MODULE, HookName}) of
+                EventName ->
+                    mongoose_instrument:execute(EventName, labels(Tag), #{count => 1})
+            catch error:badarg ->
+                    ok % no handlers registered for this hook
+            end;
+        false ->
+            ok
+    end.
+
+-spec event_name(gen_hook:hook_name()) -> mongoose_instrument:event_name().
+event_name(HookName) ->
+    list_to_atom("hook_" ++ atom_to_list(HookName)).
+
+-spec labels(gen_hook:hook_tag()) -> mongoose_instrument:labels().
+labels(global) -> #{};
+labels(HostType) -> #{host_type => HostType}.
+
+-spec is_instrumented(gen_hook:hook_name()) -> boolean().
+is_instrumented(sm_register_connection) -> false;
+is_instrumented(sm_remove_connection) -> false;
+is_instrumented(auth_failed) -> false;
+is_instrumented(user_send_packet) -> false;
+is_instrumented(user_send_message) -> false;
+is_instrumented(user_send_presence) -> false;
+is_instrumented(user_send_iq) -> false;
+is_instrumented(user_receive_packet) -> false;
+is_instrumented(user_receive_message) -> false;
+is_instrumented(user_receive_presence) -> false;
+is_instrumented(user_receive_iq) -> false;
+is_instrumented(xmpp_bounce_message) -> false;
+is_instrumented(xmpp_stanza_dropped) -> false;
+is_instrumented(xmpp_send_element) -> false;
+is_instrumented(roster_get) -> false;
+is_instrumented(roster_set) -> false;
+is_instrumented(roster_push) -> false;
+is_instrumented(register_user) -> false;
+is_instrumented(remove_user) -> false;
+is_instrumented(privacy_iq_get) -> false;
+is_instrumented(privacy_iq_set) -> false;
+is_instrumented(privacy_check_packet) -> false;
+is_instrumented(mam_get_prefs) -> false;
+is_instrumented(mam_set_prefs) -> false;
+is_instrumented(mam_remove_archive) -> false;
+is_instrumented(mam_archive_message) -> false;
+is_instrumented(mam_muc_get_prefs) -> false;
+is_instrumented(mam_muc_set_prefs) -> false;
+is_instrumented(mam_muc_remove_archive) -> false;
+is_instrumented(mam_muc_lookup_messages) -> false;
+is_instrumented(mam_muc_archive_message) -> false;
+is_instrumented(mam_muc_flush_messages) -> false;
+is_instrumented(_) -> true.

--- a/src/instrument/mongoose_instrument_hooks.erl
+++ b/src/instrument/mongoose_instrument_hooks.erl
@@ -92,5 +92,4 @@ is_instrumented(mam_muc_set_prefs) -> false;
 is_instrumented(mam_muc_remove_archive) -> false;
 is_instrumented(mam_muc_lookup_messages) -> false;
 is_instrumented(mam_muc_archive_message) -> false;
-is_instrumented(mam_muc_flush_messages) -> false;
 is_instrumented(_) -> true.

--- a/src/mam/mod_mam_muc_rdbms_arch_async.erl
+++ b/src/mam/mod_mam_muc_rdbms_arch_async.erl
@@ -81,7 +81,6 @@ do_flush_muc(Acc, #{host_type := HostType, queue_length := MessageCount,
             process_list_results(Process, HostType)
     end,
     [mod_mam_muc_rdbms_arch:retract_message(HostType, Params) || Params <- Acc],
-    mongoose_hooks:mam_muc_flush_messages(HostType, MessageCount),
     ok.
 
 process_batch_result({updated, _Count}, _, _, _) ->

--- a/src/mam/mod_mam_rdbms_arch_async.erl
+++ b/src/mam/mod_mam_rdbms_arch_async.erl
@@ -109,7 +109,6 @@ do_flush_pm(Acc, #{host_type := HostType, queue_length := MessageCount,
             process_list_results(Process, HostType)
     end,
     [mod_mam_rdbms_arch:retract_message(HostType, Params) || Params <- Acc],
-    mongoose_hooks:mam_flush_messages(HostType, MessageCount),
     ok.
 
 process_batch_result({updated, _Count}, _, _, _) ->

--- a/test/component_reg_SUITE.erl
+++ b/test/component_reg_SUITE.erl
@@ -9,25 +9,24 @@
 all() ->
     [ registering, registering_with_local ].
 
-init_per_suite(C) ->
+init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(jid),
     ok = mnesia:create_schema([node()]),
     ok = mnesia:start(),
     mongoose_config:set_opts(opts()),
     meck:new(mongoose_domain_api, [no_link]),
-    meck:expect(mongoose_domain_api, get_host_type,
-                fun(_) -> {error, not_found} end),
+    meck:expect(mongoose_domain_api, get_host_type, fun(_) -> {error, not_found} end),
     application:ensure_all_started(exometer_core),
-    mongooseim_helper:start_link_loaded_hooks(),
-    ejabberd_router:start_link(),
-    C.
+    async_helper:start(Config, [{mongoose_instrument, start_link, []},
+                                {mongooseim_helper, start_link_loaded_hooks, []},
+                                {ejabberd_router, start_link, []}]).
 
-init_per_testcase(_, C) ->
+init_per_testcase(_, Config) ->
     mongoose_router:start(),
-    mongooseim_helper:start_link_loaded_hooks(),
-    C.
+    Config.
 
-end_per_suite(_C) ->
+end_per_suite(Config) ->
+    async_helper:stop_all(Config),
     mnesia:stop(),
     mnesia:delete_schema([node()]),
     meck:unload(),
@@ -36,7 +35,8 @@ end_per_suite(_C) ->
 opts() ->
     #{all_metrics_are_global => false,
       component_backend => mnesia,
-      routing_modules => [xmpp_router_a, xmpp_router_b, xmpp_router_c]}.
+      routing_modules => [xmpp_router_a, xmpp_router_b, xmpp_router_c],
+      instrumentation => config_parser_helper:default_config([instrumentation])}.
 
 registering(_C) ->
     Dom = <<"aaa.bbb.com">>,

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -35,6 +35,8 @@ init_per_suite(C) ->
     application:load(exometer_core),
     application:set_env(exometer_core, mongooseim_report_interval, 1000),
     {Port, Socket} = carbon_cache_server:start(),
+    mongoose_config:set_opts(opts()),
+    C1 = async_helper:start(C, mongoose_instrument, start_link, []),
     Sup = spawn(fun() ->
         mim_ct_sup:start_link(ejabberd_sup),
         Hooks = {gen_hook,
@@ -55,11 +57,13 @@ init_per_suite(C) ->
     gen_tcp:controlling_process(Socket, PortServer),
     {ok, _Apps} = application:ensure_all_started(exometer_core),
     exometer:new([carbon, packets], spiral),
-    [{carbon_port, Port}, {test_sup, Sup}, {carbon_server, PortServer}, {carbon_socket, Socket} | C].
+    [{carbon_port, Port}, {test_sup, Sup}, {carbon_server, PortServer}, {carbon_socket, Socket} | C1].
 
 end_per_suite(C) ->
     Sup = ?config(test_sup, C),
     Sup ! stop,
+    async_helper:stop_all(C),
+    mongoose_config:erase_opts(),
     CarbonServer = ?config(carbon_server, C),
     erlang:exit(CarbonServer, kill),
     CarbonSocket = ?config(carbon_socket, C),
@@ -68,7 +72,7 @@ end_per_suite(C) ->
     C.
 
 init_per_group(Group, C) ->
-    mongoose_config:set_opts(opts(Group)),
+    mongoose_config:set_opt(all_metrics_are_global, Group =:= all_metrics_are_global),
     mongoose_metrics:init(),
     mongoose_metrics:init_mongooseim_metrics(),
     C.
@@ -76,7 +80,7 @@ init_per_group(Group, C) ->
 end_per_group(_Group, _C) ->
     mongoose_metrics:remove_host_type_metrics(<<"localhost">>),
     mongoose_metrics:remove_host_type_metrics(global),
-    mongoose_config:erase_opts().
+    mongoose_config:unset_opt(all_metrics_are_global).
 
 init_per_testcase(CN, C) when tcp_connections_detected =:= CN;
                               tcp_metric_varies_with_tcp_variations =:= CN ->
@@ -171,10 +175,10 @@ wait_for_update({ok, [{count,0}]}, N) ->
     timer:sleep(1000),
     wait_for_update(exometer:get_value([carbon, packets], count), N-1).
 
-opts(Group) ->
+opts() ->
     #{hosts => [<<"localhost">>],
       host_types => [],
-      all_metrics_are_global => Group =:= all_metrics_are_global}.
+      instrumentation => config_parser_helper:default_config([instrumentation])}.
 
 get_reporters_cfg(Port) ->
     [{reporters, [

--- a/test/mongooseim_metrics_SUITE.erl
+++ b/test/mongooseim_metrics_SUITE.erl
@@ -22,7 +22,6 @@ groups() ->
 
 all_metrics_list() ->
     [
-     no_skip_metric,
      subscriptions_initialised,
      tcp_connections_detected,
      tcp_metric_varies_with_tcp_variations,
@@ -159,10 +158,6 @@ queued_messages_increase(_C) ->
               {ok, L} = mongoose_metrics:get_metric_value(global, processQueueLengths),
               lists:sort(L)
       end, Fun).
-
-no_skip_metric(_C) ->
-    ok = mongoose_metrics:create_generic_hook_metric(<<"localhost">>, sm_register_connection),
-    undefined = exometer:info([<<"localhost">>, sm_register_connection]).
 
 subscriptions_initialised(_C) ->
     true = wait_for_update(exometer:get_value([carbon, packets], count), 60).


### PR DESCRIPTION
The main goal is to use `mongoose_instrument` instead of `mongoose_metrics` for the automatic hook metrics.

Main changes:
- `gen_hook` is using a new `mongoose_instrument_hooks` module to set up, tear down and execute events.
- Events are named `hook_HOOKNAME`, e.g. `hook_filter_packet`.
- Host type is a label, and this implies that if you try to set up both global and host-type-specific handlers for the same hook, it would result in an error. Such an error is caught and logged, but the handlers are set up anyway (as they were before). We could introduce a notion of scope defined statically per hook (global or host-type), but it would be a separate task - and a big one.
- The logic for skipping hooks is same as before, with the exception of `mam*_flush_messages` hooks, which are removed, because they were used only for instrumentation, and provided no value, because these operations are already instrumented.

Other minor changes are described in commit messages.