### PR TITLE
Use mongoose_instrument for roster hook metrics

### DIFF
--- a/big_tests/tests/instrument_helper.erl
+++ b/big_tests/tests/instrument_helper.erl
@@ -62,7 +62,8 @@ assert(EventName, Labels, MeasurementsList, CheckF) ->
                    [EventName, Labels, MeasurementsList]),
             ct:fail("No instrumentation events matched");
         Filtered ->
-            ct:log("Matching measurements: ~p", [Filtered]),
+            ct:log("Matching measurements for event ~p with labels ~p:~n~p",
+                   [EventName, Labels, Filtered]),
             event_tested(EventName, Labels)
     end.
 

--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -178,7 +178,7 @@ one_iq_sent(Config) ->
         end,
        [{xmppIqSent, 3},
         {xmppIqReceived, 3},
-        {modRosterGets, 1},
+        {'mod_roster_get.count', 1},
         {xmppStanzaSent, 1 + user_alpha(3)},
         {xmppStanzaReceived, 1 + user_alpha(3)}]).
 

--- a/big_tests/tests/roster_helper.erl
+++ b/big_tests/tests/roster_helper.erl
@@ -1,5 +1,5 @@
 -module(roster_helper).
--export([set_versioning/3]).
+-compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0, rpc/4]).
 -import(domain_helper, [host_type/0]).
@@ -10,3 +10,20 @@ set_versioning(Versioning, VersionStore, Config) ->
     dynamic_modules:ensure_modules(host_type(), [{mod_roster, Opts#{versioning => Versioning,
                                                                     store_current_id => VersionStore}}]),
     Config.
+
+%% Intrumentation events
+
+assert_roster_event(Client, Event) ->
+    ClientJid = jid:from_binary(escalus_utils:get_jid(Client)),
+    instrument_helper:assert(
+      Event, #{host_type => host_type()},
+      fun(#{count := 1, jid := Jid}) -> jid:are_bare_equal(ClientJid, Jid) end).
+
+assert_subscription_event(FromClient, ToClient, CheckF) ->
+    FromClientJid = jid:from_binary(escalus_utils:get_short_jid(FromClient)),
+    ToClientJid = jid:from_binary(escalus_utils:get_short_jid(ToClient)),
+    instrument_helper:assert(
+      sm_presence_subscription, #{},
+      fun(#{from_jid := FromJid, to_jid := ToJid} = M) ->
+              FromClientJid =:= FromJid andalso ToClientJid =:= ToJid andalso CheckF(M)
+      end).

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -47,6 +47,12 @@
   tls.mode = \"starttls\"
   tls.ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
 
+{instrumentation, "[instrumentation.exometer]
+
+[instrumentation.prometheus]
+
+[instrumentation.log]"}.
+
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -96,6 +96,12 @@
 {mod_cache_users, "  time_to_live = 2
   number_of_segments = 5\n"}.
 
+{instrumentation, "[instrumentation.exometer]
+
+[instrumentation.prometheus]
+
+[instrumentation.log]"}.
+
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -48,6 +48,13 @@
   password = \"secret\""}.
 {all_metrics_are_global, "true"}.
 
+{instrumentation, "[instrumentation.exometer]
+  all_metrics_are_global = true
+
+[instrumentation.prometheus]
+
+[instrumentation.log]"}.
+
 {http_server_name, "\"Classified\""}.
 
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -34,6 +34,12 @@
   tls.mode = \"starttls\"
   tls.ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
 
+{instrumentation, "[instrumentation.exometer]
+
+[instrumentation.prometheus]
+
+[instrumentation.log]"}.
+
 {secondary_c2s,
   "[[listen.c2s]]
   port = {{ c2s_tls_port }}

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -43,6 +43,12 @@
   tls.mode = \"starttls\"
   tls.ciphers = \"ECDHE-RSA-AES256-GCM-SHA384\""}.
 
+{instrumentation, "[instrumentation.exometer]
+
+[instrumentation.prometheus]
+
+[instrumentation.log]"}.
+
 {c2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 {s2s_dhfile, "\"priv/ssl/fake_dh_server.pem\""}.
 

--- a/rel/vars-toml.config
+++ b/rel/vars-toml.config
@@ -20,13 +20,6 @@
 {s2s_certfile, "\"priv/ssl/fake_server.pem\""}.
 {internal_databases, "[internal_databases.mnesia]"}.
 
-%% This is temporary, and most likely we will only enable Prometheus by default
-{instrumentation, "[instrumentation.exometer]
-
-[instrumentation.prometheus]
-
-[instrumentation.log]"}.
-
 "./configure.vars.config".
 
 %% Defined by appending configure.vars.config

--- a/src/metrics/mongoose_metrics.erl
+++ b/src/metrics/mongoose_metrics.erl
@@ -125,15 +125,19 @@ get_metric_values(HostType) ->
 sample_metric(Metric) ->
     exometer:sample(Metric).
 
+%% Return metrics that have simple values, i.e. that can be used with get_aggregated_values/1
 get_host_type_metric_names(HostType) ->
     HostTypeName = get_host_type_prefix(HostType),
-    [MetricName || {[_HostTypeName | MetricName], _, _} <- exometer:find_entries([HostTypeName])].
+    [MetricName || {[_HostTypeName | MetricName], Type, _} <- exometer:find_entries([HostTypeName]),
+                   Type =:= gauge orelse Type =:= counter orelse Type =:= spiral].
 
 get_global_metric_names() ->
     get_host_type_metric_names(global).
 
-get_aggregated_values(Metric) ->
-    exometer:aggregate([{{['_', Metric], '_', '_'}, [], [true]}], [one, count, value]).
+get_aggregated_values(Metric) when is_list(Metric) ->
+    exometer:aggregate([{{['_' | Metric], '_', '_'}, [], [true]}], [one, count, value]);
+get_aggregated_values(Metric) when is_atom(Metric) ->
+    get_aggregated_values([Metric]).
 
 get_rdbms_data_stats() ->
     Pools = lists:filter(fun({Type, _Host, _Tag}) -> Type == rdbms end, mongoose_wpool:get_pools()),

--- a/src/metrics/mongoose_metrics_hooks.erl
+++ b/src/metrics/mongoose_metrics_hooks.erl
@@ -23,10 +23,6 @@
          xmpp_bounce_message/3,
          xmpp_stanza_dropped/3,
          xmpp_send_element/3,
-         roster_get/3,
-         roster_set/3,
-         roster_push/3,
-         roster_in_subscription/3,
          register_user/3,
          remove_user/3,
          privacy_iq_get/3,
@@ -48,10 +44,6 @@ get_hooks(HostType) ->
       {xmpp_stanza_dropped, HostType, fun ?MODULE:xmpp_stanza_dropped/3, #{}, 50},
       {xmpp_bounce_message, HostType, fun ?MODULE:xmpp_bounce_message/3, #{}, 50},
       {xmpp_send_element, HostType, fun ?MODULE:xmpp_send_element/3, #{}, 50},
-      {roster_get, HostType, fun ?MODULE:roster_get/3, #{}, 55},
-      {roster_set, HostType, fun ?MODULE:roster_set/3, #{}, 50},
-      {roster_push, HostType, fun ?MODULE:roster_push/3, #{}, 50},
-      {roster_in_subscription, HostType, fun ?MODULE:roster_in_subscription/3, #{}, 55},
       {register_user, HostType, fun ?MODULE:register_user/3, #{}, 50},
       {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
       {privacy_iq_get, HostType, fun ?MODULE:privacy_iq_get/3, #{}, 1},
@@ -175,46 +167,6 @@ user_open_session(Acc, _Params, #{host_type := HostType}) ->
     mongoose_metrics:update(HostType, xmppStanzaCount, 1),
     mongoose_metrics:update(HostType, xmppIqSent, 1),
     {ok, Acc}.
-
-%% Roster
-
--spec roster_get(Acc, Params, Extra) -> {ok, Acc} when
-      Acc :: term(),
-      Params :: map(),
-      Extra :: #{host_type := mongooseim:host_type()}.
-roster_get(Acc, _, #{host_type := HostType}) ->
-    mongoose_metrics:update(HostType, modRosterGets, 1),
-    {ok, Acc}.
-
--spec roster_set(Acc, Params, Extra) -> {ok, Acc} when
-      Acc :: any(),
-      Params :: #{from := jid:jid()},
-      Extra :: map().
-roster_set(Acc, #{from := #jid{lserver = LServer}}, _) ->
-    {ok, HostType} = mongoose_domain_api:get_host_type(LServer),
-    mongoose_metrics:update(HostType, modRosterSets, 1),
-    {ok, Acc}.
-
--spec roster_in_subscription(Acc, Params, Extra) -> {ok, Acc} when
-      Acc :: mongoose_acc:t(),
-      Params :: #{type := mod_roster:sub_presence()},
-      Extra :: #{host_type := mongooseim:host_type()}.
-roster_in_subscription(Acc, #{type := subscribed}, #{host_type := HostType}) ->
-    mongoose_metrics:update(HostType, modPresenceSubscriptions, 1),
-    {ok, Acc};
-roster_in_subscription(Acc, #{type := unsubscribed}, #{host_type := HostType}) ->
-    mongoose_metrics:update(HostType, modPresenceUnsubscriptions, 1),
-    {ok, Acc};
-roster_in_subscription(Acc, _, _) ->
-    {ok, Acc}.
-
--spec roster_push(Acc, Params, Extra) -> {ok, Acc} when
-      Acc :: any(),
-      Params :: map(),
-      Extra :: #{host_type := mongooseim:host_type()}.
-roster_push(HookAcc, _, #{host_type := HostType}) ->
-    mongoose_metrics:update(HostType, modRosterPush, 1),
-    {ok, HookAcc}.
 
 %% Register
 

--- a/src/roster/mod_roster.erl
+++ b/src/roster/mod_roster.erl
@@ -45,6 +45,7 @@
          hooks/1,
          config_spec/0,
          supported_features/0,
+         instrumentation/1,
          process_iq/5,
          get_roster_entry/4,
          item_to_map/1,
@@ -161,6 +162,12 @@ config_spec() ->
       }.
 
 supported_features() -> [dynamic_domains].
+
+-spec instrumentation(mongooseim:host_type()) -> [mongoose_instrument:spec()].
+instrumentation(HostType) ->
+    [{mod_roster_get, #{host_type => HostType}, #{metrics => #{count => spiral}}},
+     {mod_roster_set, #{host_type => HostType}, #{metrics => #{count => spiral}}},
+     {mod_roster_push, #{host_type => HostType}, #{metrics => #{count => spiral}}}].
 
 hooks(HostType) ->
     [{roster_get, HostType, fun ?MODULE:get_user_roster/3, #{}, 50},
@@ -364,6 +371,8 @@ group_el(Name) ->
 -spec process_iq_set(mongooseim:host_type(), jid:jid(), jid:jid(), jlib:iq()) -> jlib:iq().
 process_iq_set(HostType, From, To, #iq{sub_el = SubEl} = IQ) ->
     #xmlel{children = Els} = SubEl,
+    mongoose_instrument:execute(mod_roster_set, #{host_type => HostType},
+                                #{count => 1, jid => From}),
     mongoose_hooks:roster_set(HostType, From, To, SubEl),
     lists:foreach(fun(El) -> process_item_set(HostType, From, To, El) end, Els),
     IQ#iq{type = result, sub_el = []}.
@@ -497,6 +506,8 @@ broadcast_item(#jid{luser = LUser, lserver = LServer}, ContactJid, Subscription)
     lists:foreach(fun({_, Pid}) -> mongoose_c2s:cast(Pid, ?MODULE, Item) end, UserPids).
 
 push_item_without_version(HostType, JID, Resource, From, Item) ->
+    mongoose_instrument:execute(mod_roster_push, #{host_type => HostType},
+                                #{count => 1, jid => From}),
     mongoose_hooks:roster_push(HostType, From, Item),
     push_item_final(jid:replace_resource(JID, Resource), From, Item, not_found).
 
@@ -962,6 +973,8 @@ get_roster_old(HostType, DestServer, JID) ->
                             lserver => DestServer,
                             host_type => HostType,
                             element => undefined }),
+    mongoose_instrument:execute(mod_roster_get, #{host_type => HostType},
+                                #{count => 1, jid => JID}),
     mongoose_hooks:roster_get(A, JID, false).
 
 -spec item_to_map(roster()) -> map().

--- a/src/roster/mod_roster_api.erl
+++ b/src/roster/mod_roster_api.erl
@@ -46,6 +46,8 @@ list_contacts(#jid{lserver = LServer} = CallerJID) ->
         {ok, HostType} ->
             case ejabberd_auth:does_user_exist(CallerJID) of
                 true ->
+                    mongoose_instrument:execute(mod_roster_get, #{host_type => HostType},
+                                                #{count => 1, jid => CallerJID}),
                     Acc0 = mongoose_acc:new(#{ location => ?LOCATION,
                                                host_type => HostType,
                                                lserver => LServer,


### PR DESCRIPTION
The main goal is to replace the roster-related hook handlers in `mongoose_metrics_hooks` with instrumentation in the code executing the hooks.

Instrumentation is placed in `mod_roster`, `mod_roster_api` and  `mod_disco` to cover the same cases as before. Big tests are added for all the new instrumentation events.

The `modRosterGets` metric was renamed to `mod_roster_get.count`. This metric was checked in `metrics_api_SUITE`, and the issue was, that the REST API for metrics didn't support metrics with multi-part names. As we are going to rename all metrics, we would have to remove the tests, decreasing coverage. As we aren't planning to remove the REST API yet, I decided to add support for multi-part metric names in the REST API. The API was also working only for selected metric types (gauge, counter, spiral), which was the case for the metrics with single-part names, so the tests were succeeding. Now, as we are returning all metrics, I needed to add explicit filtering of metrics by type to make the tests pass.

**Notes:**
- Remove test repeat for `disco_and_caps_SUITE`
- Replacing metrics with events in `metrics_roster_SUITE` allowed parallelizing tests.
- The instrumentation for listing contacts in `mod_roster_api` fails if `mod_roster` is not running, but it has to be running for other operations, and it only affects the legacy REST API, so I didn't add extra error handling for this particular operation.
- Use `all_metrics_are_global` consistently - on `mim2`, it should be enabled for instrumentation as well as for metrics.

