### PR TITLE
Instrument `mod_pubsub`

### DIFF
--- a/big_tests/tests/instrument_helper.erl
+++ b/big_tests/tests/instrument_helper.erl
@@ -3,7 +3,7 @@
 
 -module(instrument_helper).
 
--export([declared_events/1, start/1, stop/0, assert/3, assert/4, wait_for_new/2, lookup/2, take/2]).
+-export([declared_events/1, start/1, stop/0, assert/3, assert/4, wait_for/2, wait_for_new/2, lookup/2, take/2]).
 
 -import(distributed_helper, [rpc/4, mim/0]).
 
@@ -70,6 +70,11 @@ assert(EventName, Labels, MeasurementsList, CheckF) ->
 -spec wait_for_new(event_name(), labels()) -> [measurements()].
 wait_for_new(EventName, Labels) ->
     take(EventName, Labels),
+    wait_for(EventName, Labels).
+
+%% @doc Lookup an element, or wait for it, if it didn't happen yet.
+-spec wait_for(event_name(), labels()) -> [measurements()].
+wait_for(EventName, Labels) ->
     {ok, MeasurementsList} = mongoose_helper:wait_until(fun() -> lookup(EventName, Labels) end,
                                                         fun(L) -> L =/= [] end,
                                                         #{name => EventName}),

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -356,15 +356,8 @@ subscribe_unsubscribe_test(Config) ->
 
               pubsub_tools:delete_node(Alice, Node, []),
 
-              BobJid = escalus_utils:get_jid(Bob),
-              instrument_helper:assert(mod_pubsub_set_subscribe, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso BobJid =:= jid:to_binary(From)
-                                       end),
-              instrument_helper:assert(mod_pubsub_set_unsubscribe, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso BobJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_set_subscribe, Bob),
+              assert_event(mod_pubsub_set_unsubscribe, Bob)
       end).
 
 subscribe_options_test(Config) ->
@@ -391,11 +384,7 @@ subscribe_options_test(Config) ->
               pubsub_tools:get_subscription_options(Bob, {node_addr(), NodeName},
                                                     [{expected_result, BobOpts}]),
 
-              BobJid = escalus_utils:get_jid(Bob),
-              instrument_helper:assert(mod_pubsub_get_options, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso BobJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_get_options, Bob)
       end).
 
 subscribe_options_deliver_option_test(Config) ->
@@ -446,11 +435,7 @@ subscribe_options_separate_request_test(Config) ->
 
               pubsub_tools:delete_node(Alice, Node, []),
 
-              AliceJid = escalus_utils:get_jid(Alice),
-              instrument_helper:assert(mod_pubsub_set_options, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_set_options, Alice)
       end).
 
 publish_test(Config) ->
@@ -467,11 +452,7 @@ publish_test(Config) ->
 
               pubsub_tools:delete_node(Alice, Node, []),
 
-              AliceJid = escalus_utils:get_jid(Alice),
-              instrument_helper:assert(mod_pubsub_set_publish, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_set_publish, Alice)
       end).
 
 publish_with_max_items_test(Config) ->
@@ -571,11 +552,7 @@ request_all_items_test(Config) ->
 
               pubsub_tools:delete_node(Alice, Node, []),
 
-              BobJid = escalus_utils:get_jid(Bob),
-              instrument_helper:assert(mod_pubsub_get_items, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso BobJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_get_items, Bob)
       end).
 
 request_particular_item_test(Config) ->
@@ -669,11 +646,7 @@ purge_all_items_test(Config) ->
 
               pubsub_tools:delete_node(Alice, Node, []),
 
-              AliceJid = escalus_utils:get_jid(Alice),
-              instrument_helper:assert(mod_pubsub_set_purge, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_set_purge, Alice)
       end).
 
 publish_only_retract_items_scope_test(Config) ->
@@ -701,11 +674,7 @@ publish_only_retract_items_scope_test(Config) ->
 
                 pubsub_tools:delete_node(Alice, Node, []),
 
-                BobJid = escalus_utils:get_jid(Bob),
-                instrument_helper:assert(mod_pubsub_set_retract, #{host_type => domain()},
-                                         fun(#{count := 1, jid := From, time := T}) ->
-                                             T >= 0 andalso BobJid =:= jid:to_binary(From)
-                                         end)
+                assert_event(mod_pubsub_set_retract, Bob)
       end).
 
 
@@ -742,12 +711,7 @@ retrieve_default_configuration_test(Config) ->
               pubsub_tools:get_default_configuration(Alice, NodeAddr,
                                                      [{expected_result, default_config()}]),
 
-              AliceJid = escalus_utils:get_jid(Alice),
-              Measurements = instrument_helper:wait_for(mod_pubsub_get_default, #{host_type => domain()}),
-              instrument_helper:assert(mod_pubsub_get_default, #{host_type => domain()}, Measurements,
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end)
+              assert_wait_for_event(mod_pubsub_get_default, Alice)
       end).
 
 retrieve_configuration_test(Config) ->
@@ -763,11 +727,7 @@ retrieve_configuration_test(Config) ->
 
               pubsub_tools:delete_node(Alice, Node, []),
 
-              AliceJid = escalus_utils:get_jid(Alice),
-              instrument_helper:assert(mod_pubsub_get_configure, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_get_configure, Alice)
       end).
 
 set_configuration_test(Config) ->
@@ -785,11 +745,7 @@ set_configuration_test(Config) ->
 
               pubsub_tools:delete_node(Alice, Node, []),
 
-              AliceJid = escalus_utils:get_jid(Alice),
-              instrument_helper:assert(mod_pubsub_set_configure, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_set_configure, Alice)
       end).
 
 set_configuration_errors_test(Config) ->
@@ -1002,11 +958,7 @@ get_affiliations_test(Config) ->
 
               pubsub_tools:delete_node(Alice, Node, []),
 
-              AliceJid = escalus_utils:get_jid(Alice),
-              instrument_helper:assert(mod_pubsub_get_affiliations, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_get_affiliations, Alice)
       end).
 
 add_publisher_and_member_test(Config) ->
@@ -1032,20 +984,9 @@ add_publisher_and_member_test(Config) ->
               pubsub_tools:receive_item_notification(Kate, <<"item1">>, Node, []),
 
               pubsub_tools:delete_node(Alice, Node, []),
-              AliceJid = escalus_utils:get_jid(Alice),
-              instrument_helper:assert(mod_pubsub_set_create, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end),
-              instrument_helper:assert(mod_pubsub_set_affiliations, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end),
-              Measurements = instrument_helper:wait_for(mod_pubsub_set_delete, #{host_type => domain()}),
-              instrument_helper:assert(mod_pubsub_set_delete, #{host_type => domain()}, Measurements,
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_set_create, Alice),
+              assert_event(mod_pubsub_set_affiliations, Alice),
+              assert_wait_for_event(mod_pubsub_set_delete, Alice)
       end).
 
 swap_owners_test(Config) ->
@@ -1120,11 +1061,7 @@ retrieve_user_subscriptions_test(Config) ->
               pubsub_tools:delete_node(Alice, Node, []),
               pubsub_tools:delete_node(Alice, Node2, []),
 
-              BobJid = escalus_utils:get_jid(Bob),
-              instrument_helper:assert(mod_pubsub_get_subscriptions, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso BobJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_get_subscriptions, Bob)
       end).
 
 retrieve_node_subscriptions_test(Config) ->
@@ -1195,11 +1132,7 @@ modify_node_subscriptions_test(Config) ->
                                        fun(#{errors := 1, jid := From}) ->
                                            BobJid =:= jid:to_binary(From)
                                        end),
-              AliceJid = escalus_utils:get_jid(Alice),
-              instrument_helper:assert(mod_pubsub_set_subscriptions, #{host_type => domain()},
-                                       fun(#{count := 1, jid := From, time := T}) ->
-                                           T >= 0 andalso AliceJid =:= jid:to_binary(From)
-                                       end)
+              assert_event(mod_pubsub_set_subscriptions, Alice)
       end).
 
 process_subscription_requests_test(Config) ->
@@ -2094,3 +2027,18 @@ is_not_allowed_and_closed(IQError) ->
     ?NS_PUBSUB_ERRORS = exml_query:path(IQError, [{element, <<"error">>},
                                                   {element, <<"closed-node">>},
                                                   {attr, <<"xmlns">>}]).
+
+assert_event(EventName, Client) ->
+    ClientJid = escalus_utils:get_jid(Client),
+    instrument_helper:assert(EventName, #{host_type => domain()},
+                             fun(#{count := 1, jid := From, time := T}) ->
+                                 T >= 0 andalso ClientJid =:= jid:to_binary(From)
+                             end).
+
+assert_wait_for_event(EventName, Client) ->
+    ClientJid = escalus_utils:get_jid(Client),
+    Measurements = instrument_helper:wait_for(EventName, #{host_type => domain()}),
+    instrument_helper:assert(EventName, #{host_type => domain()}, Measurements,
+                             fun(#{count := 1, jid := From, time := T}) ->
+                                 T >= 0 andalso ClientJid =:= jid:to_binary(From)
+                             end).

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -1321,7 +1321,7 @@ iq_pubsub(Host, ServerHost, From, IQType, #xmlel{children = SubEls} = QueryEl,
                                 lang => Lang},
             mongoose_instrument:span(event_name(IQType, Name), #{host_type => ServerHost}, fun iq_pubsub_action/6,
                                      [IQType, Name, Host, Node, From, ActionExtraArgs],
-                                     fun(Time, Result) -> ip_action_result_to_measurements(Time, Result, From) end);
+                                     fun(Time, Result) -> iq_action_result_to_measurements(Time, Result, From) end);
         Other ->
             ?LOG_INFO(#{what => pubsub_bad_request, exml_packet => Other}),
             {error, mongoose_xmpp_errors:bad_request()}
@@ -1430,9 +1430,9 @@ event_name(get, affiliations) ->
 event_name(set, affiliations) ->
     mod_pubsub_set_affiliations.
 
-ip_action_result_to_measurements(_Time, {error, _}, From) ->
+iq_action_result_to_measurements(_Time, {error, _}, From) ->
     #{errors => 1, jid => From};
-ip_action_result_to_measurements(Time, _Result, From) ->
+iq_action_result_to_measurements(Time, _Result, From) ->
     #{time => Time, count => 1, jid => From}.
 
 iq_pubsub_set_create(Host, Node, From,
@@ -1549,7 +1549,7 @@ iq_pubsub_owner(Host, ServerHost, From, IQType, SubEl, Lang) ->
                                 lang => Lang},
             mongoose_instrument:span(event_name(IQType, Name), #{host_type => ServerHost}, fun iq_pubsub_owner_action/6,
                                      [IQType, Name, Host, From, Node, ActionExtraArgs],
-                                     fun(Time, Result) -> ip_action_result_to_measurements(Time, Result, From) end);
+                                     fun(Time, Result) -> iq_action_result_to_measurements(Time, Result, From) end);
         _ ->
             ?LOG_INFO(#{what => pubsub_too_many_actions, exml_packet => Action}),
             {error, mongoose_xmpp_errors:bad_request()}

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -1313,14 +1313,14 @@ iq_pubsub(Host, ServerHost, From, IQType, #xmlel{children = SubEls} = QueryEl,
     case xml:remove_cdata(SubEls) of
         [#xmlel{name = Name} = ActionEl | _] ->
             Node = exml_query:attr(ActionEl, <<"node">>, <<>>),
+            ActionExtraArgs = #{server_host => ServerHost,
+                                plugins => Plugins,
+                                access => Access,
+                                action_el => ActionEl,
+                                query_el => QueryEl,
+                                lang => Lang},
             mongoose_instrument:span(event_name(IQType, Name), #{host_type => ServerHost}, fun iq_pubsub_action/6,
-                                     [IQType, Name, Host, Node, From,
-                                      #{server_host => ServerHost,
-                                        plugins => Plugins,
-                                        access => Access,
-                                        action_el => ActionEl,
-                                        query_el => QueryEl,
-                                        lang => Lang}],
+                                     [IQType, Name, Host, Node, From, ActionExtraArgs],
                                      fun(Time, Result) -> ip_action_result_to_measurements(Time, Result, From) end);
         Other ->
             ?LOG_INFO(#{what => pubsub_bad_request, exml_packet => Other}),
@@ -1544,11 +1544,11 @@ iq_pubsub_owner(Host, ServerHost, From, IQType, SubEl, Lang) ->
     case Action of
         [#xmlel{name = Name} = ActionEl] ->
             Node = exml_query:attr(ActionEl, <<"node">>, <<>>),
+            ActionExtraArgs = #{server_host => ServerHost,
+                                action_el => ActionEl,
+                                lang => Lang},
             mongoose_instrument:span(event_name(IQType, Name), #{host_type => ServerHost}, fun iq_pubsub_owner_action/6,
-                                     [IQType, Name, Host, From, Node,
-                                      #{server_host => ServerHost,
-                                        action_el => ActionEl,
-                                        lang => Lang}],
+                                     [IQType, Name, Host, From, Node, ActionExtraArgs],
                                      fun(Time, Result) -> ip_action_result_to_measurements(Time, Result, From) end);
         _ ->
             ?LOG_INFO(#{what => pubsub_too_many_actions, exml_packet => Action}),


### PR DESCRIPTION
This PR instruments `mod_pubsub`. Luckily, it war fairly straightforward.

I wasn't sure how to represent the event names without creating new atoms, which is why there is a new "table" in pubsub code, but I think it's OK, because: 1. It follows the style of the module (https://github.com/esl/MongooseIM/pull/4297/files#diff-8f3c86211cc3400d551754d19d3dbb12cecce86b38fe9f6ca2a7f2a2c87f5f05L1366 for example) 2. This way should be fast.
