### PR TITLE
Instrument/hook handlers: privacy

### DIFF
--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -118,6 +118,7 @@ init_per_suite(Config) ->
     {Mod, Code} = rpc(mim(), dynamic_compile, from_string, [amp_test_helper_code()]),
     rpc(mim(), code, load_binary, [Mod, "amp_test_helper.erl", Code]),
     setup_meck(suite),
+    instrument_helper:start(declared_events()),
     escalus:init_per_suite(ConfigWithHooks).
 
 amp_test_helper_code() ->
@@ -131,10 +132,16 @@ amp_test_helper_code() ->
     "    _ -> meck:passthrough([Socket, Data])\n"
     "  end.\n".
 
+declared_events() ->
+    [
+     {mod_privacy_set, #{host_type => host_type()}} % tested by privacy helpers
+    ].
+
 end_per_suite(C) ->
     teardown_meck(suite),
     escalus_fresh:clean(),
-    escalus:end_per_suite(C).
+    escalus:end_per_suite(C),
+    instrument_helper:stop().
 
 init_per_group(GroupName, Config) ->
     Config1 = case lists:member(GroupName, main_group_names()) of

--- a/big_tests/tests/mod_blocking_SUITE.erl
+++ b/big_tests/tests/mod_blocking_SUITE.erl
@@ -18,14 +18,10 @@
 -compile([export_all, nowarn_export_all]).
 
 -include_lib("exml/include/exml.hrl").
--include_lib("escalus/include/escalus.hrl").
--include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
 
 -import(config_parser_helper, [mod_config_with_auto_backend/1]).
-
--define(SLEEP_TIME, 50).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -103,12 +99,14 @@ init_per_suite(Config0) ->
     Config1 = dynamic_modules:save_modules(HostType, Config0),
     ModConfig = [{mod_blocking, mod_config_with_auto_backend(mod_blocking)}],
     dynamic_modules:ensure_modules(HostType, ModConfig),
+    instrument_helper:start(instrument_helper:declared_events(mod_privacy)),
     escalus:init_per_suite(Config1).
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
     dynamic_modules:restore_modules(Config),
-    escalus:end_per_suite(Config).
+    escalus:end_per_suite(Config),
+    instrument_helper:stop().
 
 init_per_group(_GroupName, Config) ->
     escalus_fresh:create_users(Config, escalus:get_users([alice, bob, kate, mike, john])).
@@ -147,7 +145,6 @@ get_block_list(Config) ->
             escalus:assert(is_iq_result, Result),
             escalus:assert(fun is_blocklist_result_empty/1, Result)
         end).
-
 
 add_user_to_blocklist(Config) ->
     escalus:fresh_story(
@@ -237,7 +234,9 @@ messages_from_blocked_user_dont_arrive(Config) ->
             message(User2, User1, <<"Hi!">>),
             ct:sleep(100),
             escalus_assert:has_no_stanzas(User1),
-            privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>)
+            privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>),
+            privacy_helper:assert_privacy_check_packet_event(User2, #{dir => out}),
+            privacy_helper:assert_privacy_check_packet_event(User1, #{dir => in, blocked_count => 1})
         end).
 
 messages_from_unblocked_user_arrive_again(Config) ->
@@ -259,12 +258,9 @@ messages_from_any_blocked_resource_dont_arrive(Config) ->
             %% given
             user_blocks(User2, [User1a]),
             %% then
-            message_is_not_delivered(User1a, [User2], <<"roar!">>),
-            privacy_helper:gets_error(User1a, <<"cancel">>, <<"service-unavailable">>),
-            message_is_not_delivered(User1b, [User2], <<"woof!">>),
-            privacy_helper:gets_error(User1b, <<"cancel">>, <<"service-unavailable">>),
-            message_is_not_delivered(User1c, [User2], <<"grrr!">>),
-            privacy_helper:gets_error(User1c, <<"cancel">>, <<"service-unavailable">>),
+            message_is_blocked_by_recipient(User1a, User2),
+            message_is_blocked_by_recipient(User1b, User2),
+            message_is_blocked_by_recipient(User1c, User2),
             ct:sleep(100),
             escalus_assert:has_no_stanzas(User2)
         end).
@@ -276,8 +272,7 @@ blocking_doesnt_interfere(Config) ->
             %% given
             user_blocks(User1, [User2]),
             %% then
-            message_is_not_delivered(User2, [User1], <<"!@#@$@#$%">>),
-            privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>),
+            message_is_blocked_by_recipient(User2, User1),
             message_is_delivered(User3, [User1], <<"Ni hao.">>)
         end).
 
@@ -290,15 +285,11 @@ blocking_propagates_to_resources(Config) ->
             %% then
             client_gets_block_iq(User1b),
             % Alice can't send from any of her resources
-            message_is_not_delivered(User1a, [User2], <<"roar!">>),
-            client_gets_blocking_error(User1a),
-            message_is_not_delivered(User1b, [User2], <<"woof!">>),
-            client_gets_blocking_error(User1b),
+            message_is_blocked_by_sender(User1a, User2),
+            message_is_blocked_by_sender(User1b, User2),
             % Bob can't send to any of Alice's resources
-            message_is_not_delivered(User2, [User1a], <<"hau!">>),
-            privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>),
-            message_is_not_delivered(User2, [User1b], <<"miau!">>),
-            privacy_helper:gets_error(User2, <<"cancel">>, <<"service-unavailable">>)
+            message_is_blocked_by_recipient(User2, User1a),
+            message_is_blocked_by_recipient(User2, User1b)
         end).
 
 iq_reply_doesnt_crash_user_process(Config) ->
@@ -418,7 +409,8 @@ block_push_sent(Config) ->
         Config, [{alice, 2}, {bob, 2}],
         fun(User1a, User1b, User2a, _User2b) ->
             user_blocks(User1a, [User2a]),
-            client_gets_block_iq(User1b)
+            client_gets_block_iq(User1b),
+            privacy_helper:assert_privacy_push_item_event(User1a, 2)
         end).
 
 notify_blockee(Config) ->
@@ -447,7 +439,9 @@ notify_blockee(Config) ->
 get_blocklist(User) ->
     IQGet = get_blocklist_stanza(),
     escalus_client:send(User, IQGet),
-    escalus_client:wait_for_stanza(User).
+    Result = escalus_client:wait_for_stanza(User),
+    privacy_helper:assert_privacy_get_event(User),
+    Result.
 
 %%
 %% stanza generators
@@ -601,7 +595,8 @@ user_blocks(Blocker, Blockees) when is_list(Blockees) ->
     Res = escalus:wait_for_stanzas(Blocker, 2),
     CheckPush = fun(E) -> is_xep191_push(<<"block">>, BlockeeJIDs, E) end,
     Preds = [is_iq_result, CheckPush],
-    escalus:assert_many(Preds, Res).
+    escalus:assert_many(Preds, Res),
+    privacy_helper:assert_privacy_set_event(Blocker, #{}).
 
 blocklist_is_empty(BlockList) ->
     escalus:assert(is_iq_result, BlockList),
@@ -618,11 +613,13 @@ user_unblocks(Unblocker, Unblockees) when is_list(Unblockees) ->
     Res = escalus:wait_for_stanzas(Unblocker, 2),
     CheckPush = fun(E) -> is_xep191_push(<<"unblock">>, UnblockeeJIDs, E) end,
     Preds = [is_iq_result, CheckPush],
-    escalus:assert_many(Preds, Res);
+    escalus:assert_many(Preds, Res),
+    privacy_helper:assert_privacy_set_event(Unblocker, #{});
 user_unblocks(Unblocker, Unblockee) ->
     JID = escalus_utils:jid_to_lower(escalus_client:short_jid(Unblockee)),
     escalus_client:send(Unblocker, unblock_user_stanza(JID)),
-    user_gets_remove_result(Unblocker, [JID]).
+    user_gets_remove_result(Unblocker, [JID]),
+    privacy_helper:assert_privacy_set_event(Unblocker, #{}).
 
 blocklist_doesnt_contain_jid(BlockList, Client) ->
     JID = escalus_utils:jid_to_lower(escalus_client:short_jid(Client)),
@@ -647,11 +644,26 @@ message_is_delivered(From, [To|_] = Tos, MessageText) ->
     BareTo = escalus_utils:jid_to_lower(escalus_client:short_jid(To)),
     escalus:send(From, escalus_stanza:chat_to(BareTo, MessageText)),
     [ escalus:assert(is_chat_message, [MessageText], escalus:wait_for_stanza(C)) ||
-        C <- Tos ];
+        C <- Tos ],
+    privacy_helper:assert_privacy_check_packet_event(From, #{dir => out}),
+    privacy_helper:assert_privacy_check_packet_event(To, #{dir => in});
 message_is_delivered(From, To, MessageText) ->
     BareTo =  escalus_utils:jid_to_lower(escalus_client:short_jid(To)),
     escalus:send(From, escalus_stanza:chat_to(BareTo, MessageText)),
-    escalus:assert(is_chat_message, [MessageText], escalus:wait_for_stanza(To)).
+    escalus:assert(is_chat_message, [MessageText], escalus:wait_for_stanza(To)),
+    privacy_helper:assert_privacy_check_packet_event(From, #{dir => out}),
+    privacy_helper:assert_privacy_check_packet_event(To, #{dir => in}).
+
+message_is_blocked_by_recipient(From, To) ->
+    message_is_not_delivered(From, [To], <<"You blocked me!">>),
+    privacy_helper:gets_error(From, <<"cancel">>, <<"service-unavailable">>),
+    privacy_helper:assert_privacy_check_packet_event(From, #{dir => out}),
+    privacy_helper:assert_privacy_check_packet_event(To, #{dir => in, blocked_count => 1}).
+
+message_is_blocked_by_sender(From, To) ->
+    message_is_not_delivered(From, [To], <<"I blocked you!">>),
+    client_gets_blocking_error(From),
+    privacy_helper:assert_privacy_check_packet_event(From, #{dir => out, blocked_count => 1}).
 
 message_is_not_delivered(From, [To|_] = Tos, MessageText) ->
     BareTo = escalus_utils:jid_to_lower(escalus_client:short_jid(To)),

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -56,8 +56,7 @@
          privacy_get_user_list/2,
          privacy_iq_get/6,
          privacy_iq_set/5,
-         privacy_updated_list/3,
-         privacy_list_push/5]).
+         privacy_updated_list/3]).
 
 -export([offline_groupchat_message/4,
          offline_message/4,
@@ -619,17 +618,6 @@ privacy_iq_set(HostType, Acc, From, To, IQ) ->
 privacy_updated_list(HostType, OldList, NewList) ->
     Params = #{old_list => OldList, new_list => NewList},
     run_hook_for_host_type(privacy_updated_list, HostType, false, Params).
-
--spec privacy_list_push(HostType, LUser, LServer, Item, SessionCount) -> Result when
-    HostType :: mongooseim:host_type(),
-    LUser :: jid:luser(),
-    LServer :: jid:lserver(),
-    Item :: term(),
-    SessionCount :: non_neg_integer(),
-    Result :: any().
-privacy_list_push(HostType, LUser, LServer, Item, SessionCount) ->
-    Params = #{luse => LUser, lserver => LServer, item => Item, session_count => SessionCount},
-    run_hook_for_host_type(privacy_list_push, HostType, ok, Params).
 
 %% Session management related hooks
 

--- a/src/privacy/mod_blocking.erl
+++ b/src/privacy/mod_blocking.erl
@@ -300,10 +300,8 @@ broadcast_blocking_command(Acc, LUser, LServer, UserList, _Changed, unblock_all)
     broadcast_blocking_command(Acc, LUser, LServer, UserList, [], unblock);
 broadcast_blocking_command(Acc, LUser, LServer, UserList, Changed, Type) ->
     Item = {blocking, UserList, Type, Changed},
-    UserPids = ejabberd_sm:get_user_present_pids(LUser, LServer),
     HostType = mongoose_acc:host_type(Acc),
-    mongoose_hooks:privacy_list_push(HostType, LUser, LServer, Item, length(UserPids)),
-    lists:foreach(fun({_, Pid}) -> mongoose_c2s:cast(Pid, ?MODULE, Item) end, UserPids).
+    mod_privacy:broadcast_item(HostType, LUser, LServer, ?MODULE, Item).
 
 -spec blocking_query_response([mod_privacy:list_name()]) -> exml:element().
 blocking_query_response(Lst) ->


### PR DESCRIPTION
The goal is to use instrumentation rather than hook handlers to collect metrics in the privacy modules (`mod_privacy`, `mod_blocking`).

Main changes:
- Events are triggered in `mod_privacy`, because `mod_blocking` is calling functions from the former.
- One hook is removed, because it was used only for metrics.
- The event is usually generated either before the relevant hook is triggered. However, the `check_packet` event is triggered in the handler, because the hook is called from other modules, while it is handled in `mod_privacy`, which performs the actual check.
- Events are checked in tests for both modules. I added the check to most of the places, but the goal was not to cover all test cases with them. Some checks are in the helpers, and this is why I needed to declare one event in AMP test suite.

