### PR TITLE
Instrument mod_websockets

### DIFF
--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -952,6 +952,4 @@ wait_for_zero_bosh_sessions() ->
                                #{name => get_bosh_sessions}).
 
 instrumentation_events() ->
-    % because mod_bosh starts instrumentation manually, it doesn't export instrumentation/1
-    Specs = rpc(mim(), mod_bosh, instrumentation, []),
-    [{Event, Labels} || {Event, Labels, _Config} <- Specs].
+    instrument_helper:declared_events(mod_bosh, []).

--- a/big_tests/tests/instrument_helper.erl
+++ b/big_tests/tests/instrument_helper.erl
@@ -3,7 +3,11 @@
 
 -module(instrument_helper).
 
--export([declared_events/1, declared_events/2, start/1, stop/0, assert/3, assert/4, wait_for/2, wait_for_new/2, lookup/2, take/2]).
+-export([declared_events/1, declared_events/2,
+         start/1, stop/0,
+         assert/3, assert/4,
+         wait_for/2, wait_for_new/2,
+         lookup/2, take/2]).
 
 -import(distributed_helper, [rpc/4, mim/0]).
 

--- a/big_tests/tests/instrument_helper.erl
+++ b/big_tests/tests/instrument_helper.erl
@@ -3,7 +3,7 @@
 
 -module(instrument_helper).
 
--export([declared_events/1, start/1, stop/0, assert/3, assert/4, wait_for/2, wait_for_new/2, lookup/2, take/2]).
+-export([declared_events/1, declared_events/2, start/1, stop/0, assert/3, assert/4, wait_for/2, wait_for_new/2, lookup/2, take/2]).
 
 -import(distributed_helper, [rpc/4, mim/0]).
 
@@ -19,11 +19,14 @@
 %% API
 
 %% @doc Helper to get `DeclaredEvents' needed by `start/1'
--spec declared_events([module()] | module()) -> [{event_name(), labels()}].
-declared_events(Modules) when is_list(Modules) ->
-    lists:flatmap(fun declared_events/1, Modules);
-declared_events(Module) ->
-    Specs = rpc(mim(), Module, instrumentation, [domain_helper:host_type()]),
+declared_events(Modules) ->
+    declared_events(Modules, [domain_helper:host_type()]).
+
+-spec declared_events([module()] | module(), Args :: list()) -> [{event_name(), labels()}].
+declared_events(Modules, Args) when is_list(Modules) ->
+    lists:flatmap(fun(Module) -> declared_events(Module, Args) end, Modules);
+declared_events(Module, Args) ->
+    Specs = rpc(mim(), Module, instrumentation, Args),
     [{Event, Labels} || {Event, Labels, _Config} <- Specs].
 
 %% @doc Only `DeclaredEvents' will be logged, and can be tested with `assert/3'

--- a/big_tests/tests/websockets_SUITE.erl
+++ b/big_tests/tests/websockets_SUITE.erl
@@ -169,8 +169,5 @@ escape_attrs(Config) ->
     end).
 
 instrumentation_events() ->
-    % because mod_websockets is mongoose_http_handler, it starts http_handler_instrumentation globally.
-    % To avoid conflicts with cases when the module is both mongoose_http_handler and gen_mod,
-    % we use http_handler_instrumentation/0 name instead of instrumentation/0.
-    Specs = rpc(mim(), mod_websockets, http_handler_instrumentation, []),
+    Specs = rpc(mim(), mod_websockets, instrumentation, []),
     [{Event, Labels} || {Event, Labels, _Config} <- Specs].

--- a/big_tests/tests/websockets_SUITE.erl
+++ b/big_tests/tests/websockets_SUITE.erl
@@ -169,5 +169,4 @@ escape_attrs(Config) ->
     end).
 
 instrumentation_events() ->
-    Specs = rpc(mim(), mod_websockets, instrumentation, []),
-    [{Event, Labels} || {Event, Labels, _Config} <- Specs].
+    instrument_helper:declared_events(mod_websockets, []).

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -22,7 +22,7 @@
 
 %% mongoose_listener API
 -export([start_listener/1,
-         listener_instrumentation/1]).
+         instrumentation/1]).
 
 %% cowboy_middleware API
 -export([execute/2]).
@@ -61,9 +61,9 @@
 %% mongoose_listener API
 %%--------------------------------------------------------------------
 
--spec listener_instrumentation(listener_options()) -> [mongoose_instrument:spec()].
-listener_instrumentation(#{handlers := Handlers}) ->
-    [Spec || #{module := Module} <- Handlers, Spec <- handler_instumentation(Module)].
+-spec instrumentation(listener_options()) -> [mongoose_instrument:spec()].
+instrumentation(#{handlers := Handlers}) ->
+    [Spec || #{module := Module} <- Handlers, Spec <- mongoose_http_handler:instrumentation(Module)].
 
 -spec start_listener(listener_options()) -> ok.
 start_listener(Opts = #{proto := tcp}) ->
@@ -222,13 +222,4 @@ store_trails(Routes) ->
     catch Class:Reason:Stacktrace ->
               ?LOG_WARNING(#{what => store_trails_failed,
                              class => Class, reason => Reason, stacktrace => Stacktrace})
-    end.
-
--spec handler_instumentation(module()) -> [mongoose_instrument:spec()].
-handler_instumentation(Module) ->
-    case erlang:function_exported(Module, http_handler_instrumentation, 0) of
-        true ->
-            Module:http_handler_instrumentation();
-        false ->
-            []
     end.

--- a/src/metrics/mongoose_metrics_definitions.hrl
+++ b/src/metrics/mongoose_metrics_definitions.hrl
@@ -37,12 +37,10 @@
 -define(GLOBAL_SPIRALS, [
     [data, xmpp, received, c2s, tcp],
     [data, xmpp, received, c2s, tls],
-    [data, xmpp, received, c2s, websocket],
     [data, xmpp, received, s2s],
     [data, xmpp, received, component],
     [data, xmpp, sent, c2s, tcp],
     [data, xmpp, sent, c2s, tls],
-    [data, xmpp, sent, c2s, websocket],
     [data, xmpp, sent, s2s],
     [data, xmpp, sent, component]
 ]).

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -9,6 +9,7 @@
 -behaviour(mongoose_module_metrics).
 %% cowboy_loop is a long polling handler
 -behaviour(cowboy_loop).
+-behaviour(mongoose_http_handler).
 
 -xep([{xep, 206}, {version, "1.4"}]).
 -xep([{xep, 124}, {version, "1.11.2"}]).
@@ -28,11 +29,14 @@
 -export([node_cleanup/3]).
 
 %% For testing and debugging
--export([get_session_socket/1, store_session/2, instrumentation/0]).
+-export([get_session_socket/1, store_session/2]).
+
+%% mongoose_http_listener callbacks
+-export([instrumentation/0]).
 
 -export([config_metrics/1]).
 
--ignore_xref([get_session_socket/1, store_session/2, instrumentation/0]).
+-ignore_xref([get_session_socket/1, store_session/2]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
@@ -89,16 +93,12 @@ start(_HostType, Opts) ->
         false ->
             mod_bosh_backend:start(Opts),
             {ok, _Pid} = mod_bosh_socket:start_supervisor(),
-            gen_hook:add_handlers(hooks()),
-            % Because mod_bosh acts more like a service, than a module, instrumentation has to be
-            % set up manually, only once.
-            mongoose_instrument:set_up(instrumentation())
+            gen_hook:add_handlers(hooks())
     end.
 
 -spec stop(mongooseim:host_type()) -> ok.
 stop(_HostType) ->
     mod_bosh_socket:stop_supervisor(),
-    mongoose_instrument:tear_down(instrumentation()),
     gen_hook:delete_handlers(hooks()),
     ok.
 
@@ -106,6 +106,7 @@ stop(_HostType) ->
 hooks() ->
     [{node_cleanup, global, fun ?MODULE:node_cleanup/3, #{}, 50}].
 
+%% mongoose_http_handler instrumentation
 -spec instrumentation() -> [mongoose_instrument:spec()].
 instrumentation() ->
     [{mod_bosh_data_sent, #{},

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -9,7 +9,11 @@
 -behaviour(mongoose_module_metrics).
 %% cowboy_loop is a long polling handler
 -behaviour(cowboy_loop).
--behaviour(mongoose_http_handler).
+%% Implements mongoose_http_handler, but we cannot add the option
+%% because we would get conflicting config_spec/0 callback warning.
+%% config_spec/0 is not called by mongoose_http_handler, because
+%% mod_bosh is not in a list of configurable HTTP handlers.
+%%-behaviour(mongoose_http_handler).
 
 -xep([{xep, 206}, {version, "1.4"}]).
 -xep([{xep, 124}, {version, "1.11.2"}]).
@@ -36,7 +40,7 @@
 
 -export([config_metrics/1]).
 
--ignore_xref([get_session_socket/1, store_session/2]).
+-ignore_xref([get_session_socket/1, store_session/2, instrumentation/0]).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").

--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -10,7 +10,8 @@
 -behaviour(mongoose_c2s_socket).
 
 %% mongoose_http_handler callbacks
--export([config_spec/0]).
+-export([config_spec/0,
+         http_handler_instrumentation/0]).
 
 %% cowboy_http_websocket_handler callbacks
 -export([init/2,
@@ -78,6 +79,13 @@ config_spec() ->
                           <<"backwards_compatible_session">> => true}
             }.
 
+-spec http_handler_instrumentation() -> [mongoose_instrument:spec()].
+http_handler_instrumentation() ->
+    [{mod_websocket_data_sent, #{},
+      #{metrics => #{byte_size => spiral}}},
+     {mod_websocket_data_received, #{},
+      #{metrics => #{byte_size => spiral}}}].
+
 %%--------------------------------------------------------------------
 %% Common callbacks for all cowboy behaviours
 %%--------------------------------------------------------------------
@@ -133,7 +141,7 @@ websocket_handle(Any, State) ->
 websocket_info({send_xml, XML}, State) ->
     XML1 = process_server_stream_root(replace_stream_ns(XML)),
     Text = exml:to_iolist(XML1),
-    mongoose_metrics:update(global, [data, xmpp, sent, c2s, websocket], iolist_size(Text)),
+    mongoose_instrument:execute(mod_websocket_data_sent, #{}, #{byte_size => iolist_size(Text)}),
     ?LOG_DEBUG(#{what => ws_send, text => <<"Sending xml over WebSockets">>,
                  packet => Text, peer => State#ws_state.peer}),
     {reply, {text, Text}, State};
@@ -161,7 +169,7 @@ handle_text(Text, #ws_state{ parser = undefined } = State) ->
 handle_text(Text, #ws_state{parser = Parser} = State) ->
     case exml_stream:parse(Parser, Text) of
     {ok, NewParser, Elements} ->
-        mongoose_metrics:update(global, [data, xmpp, received, c2s, websocket], byte_size(Text)),
+        mongoose_instrument:execute(mod_websocket_data_received, #{}, #{byte_size => byte_size(Text)}),
         State1 = State#ws_state{ parser = NewParser },
         case maybe_start_fsm(Elements, State1) of
             {ok, State2} ->

--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -34,6 +34,8 @@
          get_tls_last_message/1,
          is_ssl/1]).
 
+-ignore_xref([instrumentation/0]).
+
 -include("mongoose.hrl").
 -include("mongoose_config_spec.hrl").
 -include("jlib.hrl").

--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -11,7 +11,7 @@
 
 %% mongoose_http_handler callbacks
 -export([config_spec/0,
-         http_handler_instrumentation/0]).
+         instrumentation/0]).
 
 %% cowboy_http_websocket_handler callbacks
 -export([init/2,
@@ -79,8 +79,9 @@ config_spec() ->
                           <<"backwards_compatible_session">> => true}
             }.
 
--spec http_handler_instrumentation() -> [mongoose_instrument:spec()].
-http_handler_instrumentation() ->
+%% mongoose_http_handler instrumentation
+-spec instrumentation() -> [mongoose_instrument:spec()].
+instrumentation() ->
     [{mod_websocket_data_sent, #{},
       #{metrics => #{byte_size => spiral}}},
      {mod_websocket_data_received, #{},

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -18,9 +18,9 @@
 
 -callback config_spec() -> mongoose_config_spec:config_section().
 -callback routes(options()) -> routes().
--callback http_handler_instrumentation() -> [mongoose_instrument:spec()].
+-callback instrumentation() -> [mongoose_instrument:spec()].
 
--optional_callbacks([config_spec/0, routes/1, http_handler_instrumentation/0]).
+-optional_callbacks([config_spec/0, routes/1, instrumentation/0]).
 
 -include("mongoose.hrl").
 -include("mongoose_config_spec.hrl").

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -92,7 +92,7 @@ configurable_handler_modules() ->
 %% @doc Call instrumentation for a module of `mongoose_http_handler' behaviour
 -spec instrumentation(module()) -> [mongoose_instrument:spec()].
 instrumentation(Module) ->
-    case erlang:function_exported(Module, instrumentation, 0) of
+    case mongoose_lib:is_exported(Module, instrumentation, 0) of
         true ->
             Module:instrumentation();
         false ->

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -16,8 +16,9 @@
 
 -callback config_spec() -> mongoose_config_spec:config_section().
 -callback routes(options()) -> routes().
+-callback http_handler_instrumentation() -> [mongoose_instrument:spec()].
 
--optional_callbacks([config_spec/0, routes/1]).
+-optional_callbacks([config_spec/0, routes/1, http_handler_instrumentation/0]).
 
 -include("mongoose.hrl").
 -include("mongoose_config_spec.hrl").

--- a/src/mongoose_http_handler.erl
+++ b/src/mongoose_http_handler.erl
@@ -4,6 +4,8 @@
 
 -export([config_spec/0, process_config/2, cowboy_host/1, get_routes/1]).
 
+-export([instrumentation/1]).
+
 -type options() :: #{host := '_' | string(),
                      path := string(),
                      module := module(),
@@ -86,3 +88,13 @@ configurable_handler_modules() ->
      mongoose_client_api,
      mongoose_admin_api,
      mongoose_graphql_handler].
+
+%% @doc Call instrumentation for a module of `mongoose_http_handler' behaviour
+-spec instrumentation(module()) -> [mongoose_instrument:spec()].
+instrumentation(Module) ->
+    case erlang:function_exported(Module, instrumentation, 0) of
+        true ->
+            Module:instrumentation();
+        false ->
+            []
+    end.

--- a/src/mongoose_listener.erl
+++ b/src/mongoose_listener.erl
@@ -58,14 +58,14 @@ stop_listener(Opts) ->
     supervisor:delete_child(mongoose_listener_sup, ListenerId).
 
 %% Return deduplicated instrumentation specs.
-%% Each listener module could be started more than on different ports.
+%% Each listener module could be started more than once on different ports.
 -spec instrumentation([options()]) -> [mongoose_instrument:spec()].
 instrumentation(Listeners) ->
     lists:usort([Spec || Listener <- Listeners, Spec <- listener_instrumentation(Listener)]).
 
 -spec listener_instrumentation(options()) -> [mongoose_instrument:spec()].
 listener_instrumentation(Opts = #{module := Module}) ->
-    case erlang:function_exported(Module, instrumentation, 1) of
+    case mongoose_lib:is_exported(Module, instrumentation, 1) of
         true ->
             Module:instrumentation(Opts);
         false ->


### PR DESCRIPTION
This PR is part of "MIM-2229 Instrument mod_*"

Proposed changes include:
* mod_websockets is not gen_mod
* Introduce a way to define instruments for listeners
* Introduce a way to define instruments for http_handlers.

When starting `mongoose_listener` module collects instruments by calling `listener_instrumentation(ListenerOpts)` for all listeners.

From there `mongoose_http_handler` calls `http_handler_instrumentation()` for each of handlers.

After that we setup or tear down instrumentation at once.

This avoids duplicates when same handler is defined for different listeners (for different HTTP ports).

Tests are similar to  the `mod_bosh` tests.

Name is `listener_instrumentation` because it accepts `ListenerOpts` argument.
Name is `http_handler_instrumentation` because `mod_bosh` exports `instrumentation/0` by being both `gen_mod` and `http_handler` (so, would be called twice if name is the same)


**Update:** use `instrumentation` function name instead of http_handler_instrumentation and listener_instrumentation.