### PR TITLE
Add error text when message with given ID is not found

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -68,6 +68,7 @@
          assert_only_one_of_many_is_equal/2,
          add_nostore_hint/1,
          assert_not_stored/2,
+         verify_id_error_text_msg/2,
          has_x_user_element/1,
          stanza_date_range_archive_request/1,
          make_iso_time/1,
@@ -3088,6 +3089,7 @@ server_returns_item_not_found_for_nonexistent_id(Config, RSM, StanzaID, Conditio
         Res = escalus:wait_for_stanza(Alice),
         escalus:assert(is_iq_error, [IQ], Res),
         escalus:assert(is_error, Condition, Res),
+        verify_id_error_text_msg(Condition, Res),
         ok
         end,
     parallel_story(Config, [{alice, 1}], F).

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -178,6 +178,7 @@ retract_tombstone_ns() -> <<"urn:xmpp:message-retract:0#tombstone">>.
 groupchat_field_ns() -> <<"urn:xmpp:mam:2#groupchat-field">>.
 groupchat_available_ns() -> <<"urn:xmpp:mam:2#groupchat-available">>.
 data_validate_ns() -> <<"http://jabber.org/protocol/xdata-validate">>.
+stanzas_ns() -> <<"urn:ietf:params:xml:ns:xmpp-stanzas">>.
 
 skip_undefined(Xs) ->
     [X || X <- Xs, X =/= undefined].
@@ -412,6 +413,16 @@ verify_archived_muc_light_aff_msg(Msg, AffUsersChanges, IsCreate) ->
     true = IsCreate orelse is_binary(Version),
     Items = exml_query:subelements(X, <<"user">>),
     muc_light_helper:verify_aff_users(Items, BinAffUsersChanges).
+
+verify_id_error_text_msg(Condition, Stanza) ->
+    Text = exml_query:path(Stanza, [{element, <<"error">>},
+                                    {element_with_ns, <<"text">>, stanzas_ns()}, cdata]),
+    case Condition of
+        [<<"modify">>, <<"not-acceptable">>] ->
+            ?assert_equal(<<"Invalid stanza ID provided">>, Text);
+        [<<"cancel">>, <<"item-not-found">>] ->
+            ?assert_equal(<<"Message with specified ID is not found">>, Text)
+    end.
 
 %% ----------------------------------------------------------------------
 %% PREFERENCE QUERIES

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -596,10 +596,11 @@ return_error_iq(IQ, {Reason, {stacktrace, _Stacktrace}}) ->
 return_error_iq(IQ, timeout) ->
     {error, timeout, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:service_unavailable(<<"en">>, <<"Timeout in mod_mam_muc">>)]}};
 return_error_iq(IQ, invalid_stanza_id) ->
-    Text = mongoose_xmpp_errors:not_acceptable(<<"en">>, <<"Invalid stanza id provided">>),
+    Text = mongoose_xmpp_errors:not_acceptable(<<"en">>, <<"Invalid stanza ID provided">>),
     {error, invalid_stanza_id, IQ#iq{type = error, sub_el = [Text]}};
 return_error_iq(IQ, item_not_found) ->
-    {error, item_not_found, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:item_not_found()]}};
+    Text = mongoose_xmpp_errors:item_not_found(<<"en">>, <<"Message with specified ID is not found">>),
+    {error, item_not_found, IQ#iq{type = error, sub_el = [Text]}};
 return_error_iq(IQ, not_implemented) ->
     {error, not_implemented, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:feature_not_implemented(<<"en">>, <<"From mod_mam_muc">>)]}};
 return_error_iq(IQ, missing_with_jid) ->

--- a/src/mam/mod_mam_pm.erl
+++ b/src/mam/mod_mam_pm.erl
@@ -668,10 +668,11 @@ return_error_iq(IQ, timeout) ->
     E = mongoose_xmpp_errors:service_unavailable(<<"en">>, <<"Timeout">>),
     {error, timeout, IQ#iq{type = error, sub_el = [E]}};
 return_error_iq(IQ, invalid_stanza_id) ->
-    Text = mongoose_xmpp_errors:not_acceptable(<<"en">>, <<"Invalid stanza id provided">>),
+    Text = mongoose_xmpp_errors:not_acceptable(<<"en">>, <<"Invalid stanza ID provided">>),
     {error, invalid_stanza_id, IQ#iq{type = error, sub_el = [Text]}};
 return_error_iq(IQ, item_not_found) ->
-    {error, item_not_found, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:item_not_found()]}};
+    Text = mongoose_xmpp_errors:item_not_found(<<"en">>, <<"Message with specified ID is not found">>),
+    {error, item_not_found, IQ#iq{type = error, sub_el = [Text]}};
 return_error_iq(IQ, not_implemented) ->
     {error, not_implemented, IQ#iq{type = error, sub_el = [mongoose_xmpp_errors:feature_not_implemented()]}};
 return_error_iq(IQ, Reason) ->


### PR DESCRIPTION
This PR adds a text to the error stanza when the message with the ID specified inside `<after/>` or `<before/>` is not found in the archive