### PR TITLE
Fix a race condition in tr_util tests

### DIFF
--- a/big_tests/tests/tr_util_SUITE.erl
+++ b/big_tests/tests/tr_util_SUITE.erl
@@ -62,15 +62,17 @@ c2s_elements_story(Alice, Bob) ->
     BobJid = escalus_utils:get_jid(Bob),
 
     %% Get elements exchanged between bare JIDs
-    [Sent, Recv] = rpc(mim(), tr_util, c2s_elements_between_jids, [[AliceBareJid, BobBareJid]]),
+    %% There can be more than 2 elements if the hook traces are interleaved
+    %% between the sender and the receiver
+    [Sent, Recv | _] = Events =
+        rpc(mim(), tr_util, c2s_elements_between_jids, [[AliceBareJid, BobBareJid]]),
     ?assertMatch(#{name := <<"message">>, type := <<"chat">>,
                    jid := AliceJid, from_jid := AliceJid, to_jid := BobJid}, Sent),
     ?assertMatch(#{name := <<"message">>, type := <<"chat">>,
                    jid := BobJid, from_jid := AliceJid, to_jid := BobJid}, Recv),
 
     %% Get elements exchanged between full JIDs
-    ?assertEqual([Sent, Recv],
-                 rpc(mim(), tr_util, c2s_elements_between_jids, [[AliceJid, BobJid]])),
+    ?assertEqual(Events, rpc(mim(), tr_util, c2s_elements_between_jids, [[AliceJid, BobJid]])),
 
     %% Get all elements
     AllElements = rpc(mim(), tr_util, c2s_elements, []),


### PR DESCRIPTION
This PR fixes a flaky test.

The expected traces are from 2 different processes, so sometimes the hook events become interleaved, and they are not aggregated. This is expected, and the tests are now less strict, allowing such condition to occur.

The test logic could be more strict, allowing specific orderings, but it would make them less readable.

Tested 1000 times. Before the change, tests were failing in 1-2% cases. Now they don't fail anymore.
