### PR TITLE
More specific assertions for instrumentation events

### DIFF
--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -189,19 +189,21 @@ unregister(Config) ->
     assert_event(auth_unregister_user, escalus_users:get_jid(Config, UserSpec)).
 
 already_registered(Config) ->
-    escalus_fresh:story(Config, [{alice, 1}], fun(Alice) ->
-        escalus:send(Alice, escalus_stanza:get_registration_fields()),
-        Stanza = escalus:wait_for_stanza(Alice),
-        escalus:assert(is_iq_result, Stanza),
-        true = has_registered_element(Stanza)
+    escalus_fresh:story(Config, [{alice, 1}], fun already_registered_story/1).
 
-                                              end).
+already_registered_story(Alice) ->
+    AliceJid = escalus_utils:get_short_jid(Alice),
+    assert_event(auth_register_user, AliceJid), % one event expected
+    escalus:send(Alice, escalus_stanza:get_registration_fields()),
+    Stanza = escalus:wait_for_stanza(Alice),
+    escalus:assert(is_iq_result, Stanza),
+    true = has_registered_element(Stanza),
+    assert_event(auth_register_user, AliceJid). % still one event - nothing new
+
 registration_conflict(Config) ->
     [Alice] = escalus_users:get_users([alice]),
     {ok, result, _Stanza} = escalus_users:create_user(Config, Alice),
     {ok, conflict, _Raw} = escalus_users:create_user(Config, Alice).
-
-
 
 admin_notify(Config) ->
     [{Name1, UserSpec1}, {Name2, UserSpec2}] = escalus_users:get_users([alice, bob]),

--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -133,8 +133,9 @@ amp_test_helper_code() ->
     "  end.\n".
 
 declared_events() ->
-    [
-     {mod_privacy_set, #{host_type => host_type()}} % tested by privacy helpers
+    [ % tested by privacy helpers
+     {mod_privacy_set, #{host_type => host_type()}},
+     {mod_privacy_get, #{host_type => host_type()}}
     ].
 
 end_per_suite(C) ->

--- a/big_tests/tests/anonymous_SUITE.erl
+++ b/big_tests/tests/anonymous_SUITE.erl
@@ -89,7 +89,7 @@ connection_is_registered_with_login(Config) ->
         true = F(),
         escalus_connection:kill(Anna),
         mongoose_helper:wait_until(F, false),
-        assert_event(auth_anonymous_register_user, JID)
+        assert_event(auth_anonymous_unregister_user, JID)
     end).
 
 messages_story(Config) ->
@@ -110,5 +110,6 @@ host_type() ->
     domain_helper:anonymous_host_type().
 
 assert_event(EventName, #jid{luser = LUser, lserver = LServer}) ->
-    instrument_helper:assert(EventName, #{host_type => host_type()},
-                             fun(M) -> M =:= #{count => 1, user => LUser, server => LServer} end).
+    instrument_helper:assert_one(
+      EventName, #{host_type => host_type()},
+      fun(M) -> M =:= #{count => 1, user => LUser, server => LServer} end).

--- a/big_tests/tests/auth_helper.erl
+++ b/big_tests/tests/auth_helper.erl
@@ -10,17 +10,18 @@ assert_event(EventName, BinJid)
     F = fun(M) ->
             M =:= #{count => 1, user => LUser, server => LServer}
         end,
-    instrument_helper:assert(EventName, #{host_type => host_type()}, F);
+    instrument_helper:assert_one(EventName, #{host_type => host_type()}, F);
 assert_event(EventName, BinJid)
     when EventName =:= auth_authorize ->
     #jid{lserver = LServer} = jid:from_binary(BinJid),
     F = fun(#{time := Time, count := 1, server := Server}) ->
            (Time > 0) and (Server =:= LServer)
         end,
+    %% Note: this could match events from other tests because there is no user name
     instrument_helper:assert(EventName, #{host_type => host_type()}, F);
 assert_event(EventName, BinJid) ->
     #jid{luser = LUser, lserver = LServer} = jid:from_binary(BinJid),
     F = fun(#{time := Time, count := 1, user := User, server := Server}) ->
            (Time > 0) and (User =:= LUser) and (Server =:= LServer)
         end,
-    instrument_helper:assert(EventName, #{host_type => host_type()}, F).
+    instrument_helper:assert_one(EventName, #{host_type => host_type()}, F).

--- a/big_tests/tests/disco_and_caps_SUITE.erl
+++ b/big_tests/tests/disco_and_caps_SUITE.erl
@@ -235,5 +235,5 @@ urls(sales) -> [<<"sales@example.com">>].
 
 assert_roster_get_event(Client) ->
     ClientJid = jid:from_binary(escalus_client:full_jid(Client)),
-    instrument_helper:assert(mod_disco_roster_get, #{host_type => host_type()},
-                             fun(#{count := 1, jid := Jid}) -> ClientJid =:= Jid end).
+    instrument_helper:assert_one(mod_disco_roster_get, #{host_type => host_type()},
+                                 fun(#{count := 1, jid := Jid}) -> ClientJid =:= Jid end).

--- a/big_tests/tests/domain_isolation_SUITE.erl
+++ b/big_tests/tests/domain_isolation_SUITE.erl
@@ -157,7 +157,7 @@ verify_alice_has_no_pending_messages(Alice, Bob) ->
 assert_stanza_dropped(Sender, Recipient, Stanza) ->
     SenderJid = jid:from_binary(escalus_utils:get_jid(Sender)),
     RecipientJid = jid:from_binary(escalus_utils:get_jid(Recipient)),
-    instrument_helper:assert(
+    instrument_helper:assert_one(
       router_stanza_dropped, #{host_type => host_type()},
       fun(#{count := 1, from_jid := From, to_jid := To, stanza := DroppedStanza}) ->
               From =:= SenderJid andalso To =:= RecipientJid andalso DroppedStanza =:= Stanza

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -398,7 +398,7 @@ admin_list_contacts_story(Config, Alice, Bob) ->
     [#{<<"subscription">> := <<"NONE">>, <<"ask">> := <<"NONE">>, <<"jid">> := BobBin,
        <<"name">> := BobName, <<"groups">> := ?DEFAULT_GROUPS}] =
         get_ok_value([data, roster, listContacts], Res),
-    roster_helper:assert_roster_event(Alice, mod_roster_get).
+    roster_helper:assert_roster_event(escalus_client:short_jid(Alice), mod_roster_get).
 
 admin_list_contacts_wrong_user(Config) ->
     % User with a non-existent domain
@@ -548,7 +548,7 @@ user_list_contacts_story(Config, Alice, Bob) ->
     [#{<<"subscription">> := <<"NONE">>, <<"ask">> := <<"NONE">>, <<"jid">> := BobBin,
        <<"name">> := Name, <<"groups">> := ?DEFAULT_GROUPS}] =
         get_ok_value(?LIST_CONTACTS_PATH, Res),
-    roster_helper:assert_roster_event(Alice, mod_roster_get).
+    roster_helper:assert_roster_event(escalus_client:short_jid(Alice), mod_roster_get).
 
 user_get_contact(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],

--- a/big_tests/tests/instrument_cets_SUITE.erl
+++ b/big_tests/tests/instrument_cets_SUITE.erl
@@ -42,15 +42,13 @@ end_per_group(_, _Config) ->
 init_per_testcase(_, Config) ->
     Config.
 
-check_instrumentation(Config) ->
-    instrument_helper:wait_for_new(cets_info, #{}),
-    instrument_helper:assert(cets_info, #{}, fun(Res) ->
-            %% Values are integers
-            lists:all(fun(Name) -> is_integer(maps:get(Name, Res)) end, instrumentation_metrics_names())
-            andalso
-            %% Check that there are no unknown fields
-            [] =:= maps:keys(maps:without(instrumentation_metrics_names(), Res))
-        end).
+check_instrumentation(_Config) ->
+    instrument_helper:wait_and_assert_new(cets_info, #{}, fun check_info/1).
+
+%% Check that values are integers and there are no unknown fields
+check_info(Res) ->
+    lists:all(fun(Name) -> is_integer(maps:get(Name, Res)) end, instrumentation_metrics_names())
+        andalso #{} =:= maps:without(instrumentation_metrics_names(), Res).
 
 instrumentation_metrics_names() ->
     [available_nodes,

--- a/big_tests/tests/instrument_helper.erl
+++ b/big_tests/tests/instrument_helper.erl
@@ -3,12 +3,12 @@
 
 -module(instrument_helper).
 
--export([declared_events/1, declared_events/2,
-         start/1, start/2, stop/0,
-         assert/3, assert/4, filter/2,
-         assert_not_emitted/1, assert_not_emitted/2,
-         wait_for/2, wait_for_new/2,
-         lookup/2, take/2]).
+%% API for setup and teardown in test suites
+-export([declared_events/1, declared_events/2, start/1, start/2, stop/0]).
+
+%% API for assertions in test cases
+-export([assert/3, assert_one/3, assert_not_emitted/3, assert_not_emitted/2, assert_not_emitted/1,
+         wait_and_assert/3, wait_and_assert_new/3, assert/4]).
 
 -import(distributed_helper, [rpc/4, mim/0]).
 
@@ -20,8 +20,14 @@
 -type event_name() :: atom().
 -type labels() :: #{atom() => term()}.
 -type measurements() :: #{atom() => term()}.
+-type check_fun() :: fun((measurements()) -> boolean()).
+-type event_count() :: non_neg_integer() | positive.
+-type opts() :: #{timestamp => integer(),
+                  retries := non_neg_integer(),
+                  delay := non_neg_integer(),
+                  expected_count := event_count()}.
 
-%% API
+%% API for setup and teardown in test suites
 
 %% @doc Helper to get `DeclaredEvents' needed by `start/1'
 declared_events(Modules) ->
@@ -59,35 +65,56 @@ stop() ->
     verify_unlogged((Untested -- Logged) -- Negative),
     verify_logged_but_untested((Logged -- Tested) -- Negative).
 
--spec assert(event_name(), labels(), fun((measurements()) -> boolean())) -> ok.
+%% API for assertions in test cases
+
+%% @doc Checks that there is at least one event with `EventName', `Labels'
+%%      and matching measurements.
+ -spec assert(event_name(), labels(), check_fun()) -> ok.
 assert(EventName, Labels, CheckF) ->
-    assert(EventName, Labels, lookup(EventName, Labels), CheckF).
+    assert(EventName, Labels, CheckF, #{}).
 
-%% @doc `CheckF' can return a boolean or fail with `function_clause', which means `false'.
-%% This is for convenience - you only have to code one clause.
--spec assert(event_name(), labels(), [measurements()], fun((measurements()) -> boolean())) -> ok.
-assert(EventName, Labels, MeasurementsList, CheckF) ->
-    case filter(CheckF, MeasurementsList) of
-        [] ->
-            ct:log("All measurements for event ~p with labels ~p:~n~p",
-                   [EventName, Labels, MeasurementsList]),
-            ct:fail("No instrumentation events matched");
-        Filtered ->
-            ct:log("Matching measurements for event ~p with labels ~p:~n~p",
-                   [EventName, Labels, Filtered]),
-            event_tested(EventName, Labels)
-    end.
+%% @doc Checks that there is exactly one event with `EventName', `Labels'
+%%      and matching measurements.
+-spec assert_one(event_name(), labels(), check_fun()) -> ok.
+assert_one(EventName, Labels, CheckF) ->
+    assert(EventName, Labels, CheckF, #{expected_count => 1}).
 
+%% @doc Checks that there is no event with `EventName', `Labels' and matching measurements.
+-spec assert_not_emitted(event_name(), labels(), check_fun()) -> ok.
+assert_not_emitted(EventName, Labels, CheckF) ->
+    assert(EventName, Labels, CheckF, #{expected_count => 0}).
+
+%% @doc Checks that there is no event with `EventName' and `Labels'.
+-spec assert_not_emitted(event_name(), labels()) -> ok.
 assert_not_emitted(EventName, Labels) ->
-    case lookup(EventName, Labels) of
-        [] ->
-            ok;
-        Events ->
-            ct:fail("Measurements emitted but should not ~p", [Events])
-    end.
+    assert_not_emitted(EventName, Labels, fun(_) -> true end).
 
+%% @doc Checks that there is no event for any of the `{EventName, Labels}' tuples.
+-spec assert_not_emitted([{event_name(), labels()}]) -> ok.
 assert_not_emitted(Events) ->
-    [assert_not_emitted(Event, Label) || {Event, Label} <- Events].
+    [assert_not_emitted(Event, Label) || {Event, Label} <- Events],
+    ok.
+
+%% @doc Waits for a matching event.
+-spec wait_and_assert(event_name(), labels(), check_fun()) -> ok.
+wait_and_assert(EventName, Labels, CheckF) ->
+    assert(EventName, Labels, CheckF, #{retries => 50, delay => 100}).
+
+%% @doc Waits for a matching event, ignoring past events.
+-spec wait_and_assert_new(event_name(), labels(), check_fun()) -> ok.
+wait_and_assert_new(EventName, Labels, CheckF) ->
+    assert(EventName, Labels, CheckF, #{timestamp => timestamp(), retries => 50, delay => 100}).
+
+%% @doc Assert that an expected number of events with `EventName' and `Labels' are present.
+%% Events are filtered by applying `CheckF' to the map of measurements.
+%% `CheckF' can return a boolean or fail with `function_clause', which means `false'.
+%% This is for convenience - you only have to code one clause.
+-spec assert(event_name(), labels(), check_fun(), opts()) -> ok.
+assert(EventName, Labels, CheckF, Opts) ->
+    FullOpts = maps:merge(default_opts(), Opts),
+    assert_loop(EventName, Labels, CheckF, FullOpts).
+
+%% Low-level API
 
 -spec filter(fun((measurements()) -> boolean()), [measurements()]) -> [measurements()].
 filter(CheckF, MeasurementsList) ->
@@ -95,29 +122,60 @@ filter(CheckF, MeasurementsList) ->
                          try CheckF(Measurements) catch error:function_clause -> false end
                  end, MeasurementsList).
 
-%% @doc Remove previous events, and wait for a new one. Use for probes only.
--spec wait_for_new(event_name(), labels()) -> [measurements()].
-wait_for_new(EventName, Labels) ->
-    take(EventName, Labels),
-    wait_for(EventName, Labels).
+-spec select(event_name(), labels()) -> [measurements()].
+select(EventName, Labels) ->
+    rpc(mim(), ?HANDLER_MODULE, select, [EventName, Labels]).
 
-%% @doc Lookup an element, or wait for it, if it didn't happen yet.
--spec wait_for(event_name(), labels()) -> [measurements()].
-wait_for(EventName, Labels) ->
-    {ok, MeasurementsList} = mongoose_helper:wait_until(fun() -> lookup(EventName, Labels) end,
-                                                        fun(L) -> L =/= [] end,
-                                                        #{name => EventName}),
-    MeasurementsList.
+-spec select_new(event_name(), labels(), integer()) -> [measurements()].
+select_new(EventName, Labels, Timestamp) ->
+    rpc(mim(), ?HANDLER_MODULE, select_new, [EventName, Labels, Timestamp]).
 
--spec lookup(event_name(), labels()) -> [measurements()].
-lookup(EventName, Labels) ->
-    [Measurements || {_, Measurements} <- rpc(mim(), ?HANDLER_MODULE, lookup, [EventName, Labels])].
-
--spec take(event_name(), labels()) -> [measurements()].
-take(EventName, Labels) ->
-    [Measurements || {_, Measurements} <- rpc(mim(), ?HANDLER_MODULE, take, [EventName, Labels])].
+-spec timestamp() -> integer().
+timestamp() ->
+    rpc(mim(), ?HANDLER_MODULE, timestamp, []).
 
 %% Internal functions
+
+-spec assert_loop(event_name(), labels(), check_fun(), opts()) -> ok.
+assert_loop(EventName, Labels, CheckF, Opts) ->
+    #{retries := Retries, expected_count := ExpectedCount, delay := Delay} = Opts,
+    All = case Opts of
+              #{timestamp := Timestamp} ->
+                  select_new(EventName, Labels, Timestamp);
+              #{} ->
+                  select(EventName, Labels)
+          end,
+    Filtered = filter(CheckF, All),
+    case check(Filtered, ExpectedCount) of
+        false when Retries > 0 ->
+            timer:sleep(Delay),
+            assert_loop(EventName, Labels, CheckF, Opts#{retries := Retries - 1});
+        CheckResult ->
+            assert_check_result(EventName, Labels, All, Filtered, CheckResult, ExpectedCount)
+    end.
+
+-spec default_opts() -> opts().
+default_opts() ->
+    #{retries => 0, delay => timer:seconds(1), expected_count => positive}.
+
+-spec check([measurements()], event_count()) -> boolean().
+check(Filtered, positive) ->
+    length(Filtered) > 0;
+check(Filtered, ExpectedCount) ->
+    length(Filtered) =:= ExpectedCount.
+
+-spec assert_check_result(event_name(), labels(), All :: [measurements()],
+                          Filtered :: [measurements()], CheckResult :: boolean(),
+                          event_count()) -> ok.
+assert_check_result(_EventName, _Labels, _All, [], true, _ExpectedCount) ->
+    ok; % don't mark events as tested
+assert_check_result(EventName, Labels, _All, Filtered, true, _ExpectedCount) ->
+    ct:log("Matching measurements for event ~p with labels ~p:~n~p", [EventName, Labels, Filtered]),
+    event_tested(EventName, Labels);
+assert_check_result(EventName, Labels, All, Filtered, false, ExpectedCount) ->
+    ct:log("All measurements for event ~p with labels ~p:~n~p", [EventName, Labels, All]),
+    ct:fail("Incorrect number of instrumentation events - matched: ~p, expected: ~p",
+            [length(Filtered), ExpectedCount]).
 
 %% Don't fail if some events are unlogged, because we don't have full test coverage (yet)
 verify_unlogged([]) -> ok;

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -113,7 +113,8 @@
          assert_lookup_event/2,
          assert_flushed_event_if_async/2,
          assert_dropped_iq_event/2,
-         assert_event_with_jid/2
+         assert_event_with_jid/2,
+         assert_no_event_with_jid/2
         ]).
 
 -import(muc_light_helper,
@@ -3285,7 +3286,7 @@ prefs_set_request(Config) ->
         ?assert_equal(ResultIQ1, ResultIQ2),
         ok
         end,
-    escalus:story(Config, [{alice, 1}], F).
+    escalus:fresh_story(Config, [{alice, 1}], F).
 
 query_get_request(Config) ->
     F = fun(Alice) ->
@@ -3375,11 +3376,13 @@ muc_prefs_set_request(ConfigIn) ->
 muc_prefs_set_request_not_an_owner(ConfigIn) ->
     F = fun(Config, _Alice, Bob) ->
         Room = ?config(room, Config),
+        RoomAddr = room_address(Room),
         escalus:send(Bob, stanza_to_room(stanza_prefs_set_request(<<"roster">>,
                                                                     [<<"romeo@montague.net">>],
                                                                     [<<"montague@montague.net">>],
                                                                     mam_ns_binary()), Room)),
-        escalus:assert(is_error, [<<"cancel">>, <<"not-allowed">>], escalus:wait_for_stanza(Bob))
+        escalus:assert(is_error, [<<"cancel">>, <<"not-allowed">>], escalus:wait_for_stanza(Bob)),
+        assert_no_event_with_jid(mod_mam_muc_get_prefs, RoomAddr)
     end,
     RoomOpts = [{persistent, true}],
     UserSpecs = [{alice, 1}, {bob, 1}],

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1414,16 +1414,18 @@ assert_list_size(N, List) when N =:= length(List) -> List.
 %% Assertions for instrumentation events
 
 assert_archive_message_event(EventName, BinJid) ->
-    assert_event(EventName,
-                 fun(#{count := 1, time := T, params := #{local_jid := LocalJid}}) ->
-                         eq_bjid(LocalJid, BinJid) andalso pos_int(T)
-                 end).
+    instrument_helper:assert_one(
+      EventName, labels(),
+      fun(#{count := 1, time := T, params := #{local_jid := LocalJid}}) ->
+              eq_bjid(LocalJid, BinJid) andalso pos_int(T)
+      end).
 
 assert_lookup_event(EventName, BinJid) ->
-    assert_event(EventName,
-                 fun(#{count := 1, size := 1, time := T, params := #{caller_jid := CallerJid}}) ->
-                         eq_bjid(CallerJid, BinJid) andalso pos_int(T)
-                 end).
+    instrument_helper:assert_one(
+      EventName, labels(),
+      fun(#{count := 1, size := 1, time := T, params := #{caller_jid := CallerJid}}) ->
+              eq_bjid(CallerJid, BinJid) andalso pos_int(T)
+      end).
 
 %% The event might originate from a different test case running in parallel,
 %% but there is no easy way around it other than adding all flushed messages to measurements.
@@ -1431,10 +1433,11 @@ assert_flushed_event_if_async(EventName, Config) ->
     case ?config(configuration, Config) of
         C when C =:= rdbms_async_pool;
                C =:= rdbms_async_cache ->
-            assert_event(EventName,
-                         fun(#{count := Count, time := T, time_per_message := T1}) ->
-                                 pos_int(Count) andalso pos_int(T) andalso pos_int(T1) andalso T >= T1
-                         end);
+            instrument_helper:assert(
+              EventName, labels(),
+              fun(#{count := Count, time := T, time_per_message := T1}) ->
+                      pos_int(Count) andalso pos_int(T) andalso pos_int(T1) andalso T >= T1
+              end);
         _ ->
             ok
     end.
@@ -1444,18 +1447,19 @@ assert_dropped_iq_event(Config, BinJid) ->
                     undefined -> mod_mam_pm_dropped_iq;
                     _ -> mod_mam_muc_dropped_iq
                 end,
-    assert_event(EventName, fun(#{acc := #{stanza := #{from_jid := FromJid}}}) ->
-                                    eq_bjid(FromJid, BinJid)
-                            end).
+    instrument_helper:assert_one(
+      EventName, labels(),
+      fun(#{acc := #{stanza := #{from_jid := FromJid}}}) -> eq_bjid(FromJid, BinJid) end).
 
 assert_event_with_jid(EventName, BinJid) ->
-    assert_event(EventName, fun(#{count := 1, jid := Jid}) -> eq_bjid(Jid, BinJid) end).
+    instrument_helper:assert_one(
+      EventName, labels(), fun(#{count := 1, jid := Jid}) -> eq_bjid(Jid, BinJid) end).
 
-assert_dropped_msg_event(EventName) ->
-    assert_event(EventName, fun(#{count := 1}) -> true end).
+assert_no_event_with_jid(EventName, BinJid) ->
+    instrument_helper:assert_not_emitted(
+      EventName, labels(), fun(#{count := 1, jid := Jid}) -> eq_bjid(Jid, BinJid) end).
 
-assert_event(EventName, F) ->
-    instrument_helper:assert(EventName, #{host_type => host_type()}, F).
+labels() -> #{host_type => host_type()}.
 
 pos_int(T) -> is_integer(T) andalso T > 0.
 

--- a/big_tests/tests/metrics_c2s_SUITE.erl
+++ b/big_tests/tests/metrics_c2s_SUITE.erl
@@ -80,8 +80,8 @@ login_story(Alice) ->
 
     %% Note: The first two events might originate from other tests because of unknown JID.
     %% It is acceptable, because the goal is to check that they are emitted when users log in.
-    assert_event(out, fun(#xmlel{name = Name}) -> Name =:= <<"stream:features">> end),
-    assert_event(in, fun(#xmlel{name = Name}) -> Name =:= <<"auth">> end),
+    assert_events(out, fun(#xmlel{name = Name}) -> Name =:= <<"stream:features">> end),
+    assert_events(in, fun(#xmlel{name = Name}) -> Name =:= <<"auth">> end),
 
     assert_event(out, AliceBareJid, #{},
                  fun(#xmlel{name = Name}) -> Name =:= <<"success">> end),
@@ -189,11 +189,11 @@ has_child(SubElName, El) ->
 
 assert_event(Dir, ClientOrJid, Measurements) ->
     Jid = jid:from_binary(escalus_utils:get_jid(ClientOrJid)),
-    instrument_helper:assert(
+    instrument_helper:assert_one(
       event_name(Dir), #{host_type => host_type()},
       fun(M) -> M =:= Measurements#{jid => Jid, count => 1} end).
 
-assert_event(Dir, CheckElFun) ->
+assert_events(Dir, CheckElFun) ->
     instrument_helper:assert(
       event_name(Dir), #{host_type => host_type()},
       fun(M = #{element := El}) ->
@@ -202,7 +202,7 @@ assert_event(Dir, CheckElFun) ->
 
 assert_event(Dir, ClientOrJid, Measurements, CheckElFun) ->
     Jid = jid:from_binary(escalus_utils:get_jid(ClientOrJid)),
-    instrument_helper:assert(
+    instrument_helper:assert_one(
       event_name(Dir), #{host_type => host_type()},
       fun(M = #{element := El}) ->
                maps:remove(element, M) =:= Measurements#{jid => Jid, count => 1}
@@ -217,7 +217,7 @@ event_name(in) -> c2s_element_in.
 assert_message_bounced_event(Sender, Recipient) ->
     FromJid = jid:from_binary(escalus_utils:get_jid(Sender)),
     ToJid = jid:from_binary(escalus_utils:get_jid(Recipient)),
-    instrument_helper:assert(
+    instrument_helper:assert_one(
       sm_message_bounced, #{host_type => host_type()},
       fun(#{count := 1, from_jid := From, to_jid := To}) ->
                From =:= FromJid andalso To =:= ToJid

--- a/big_tests/tests/metrics_roster_SUITE.erl
+++ b/big_tests/tests/metrics_roster_SUITE.erl
@@ -301,7 +301,7 @@ declared_backend_events() ->
 %% This works only for get_roster and get_subscription_lists because of the function arguments
 assert_backend_event(Client, Function) ->
     ClientJid = jid:from_binary(escalus_utils:get_short_jid(Client)),
-    instrument_helper:assert(
+    instrument_helper:assert_one(
       backend_mod(), #{host_type => host_type(), function => Function},
       fun(#{count := 1, time := T, args := [_, User, Server]}) when T > 0 ->
               ClientJid =:= jid:make_bare(User, Server)

--- a/big_tests/tests/mod_event_pusher_http_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_http_SUITE.erl
@@ -116,23 +116,28 @@ simple_message(Config) ->
     {_, _} = binary:match(Body, <<"alice">>),
     {_, _} = binary:match(Body, <<"Simple">>),
     AliceName = escalus_client:username(Alice),
-    instrument_helper:assert(mod_event_pusher_http_sent, #{host_type => host_type()},
-                             fun(#{count := 1, sender := S, response_code := <<"200">>, response_time := T}) ->
-                                 ?assert(T > 0), AliceName =:= S end).
+    instrument_helper:assert_one(
+      mod_event_pusher_http_sent, #{host_type => host_type()},
+      fun(#{count := 1, sender := S, response_code := <<"200">>, response_time := T}) ->
+              ?assert(T > 0), AliceName =:= S
+      end).
 
 simple_message_no_listener(Config) ->
     Alice = do_simple_message(Config, <<"Hi, NoListener!">>),
     AliceName = escalus_client:username(Alice),
-    instrument_helper:assert(mod_event_pusher_http_sent, #{host_type => host_type()},
-                             fun(#{failure_count := 1, sender := S}) -> AliceName =:= S end).
+    instrument_helper:assert_one(
+      mod_event_pusher_http_sent, #{host_type => host_type()},
+      fun(#{failure_count := 1, sender := S}) -> AliceName =:= S end).
 
 
 simple_message_failing_listener(Config) ->
     Alice = do_simple_message(Config, <<"Hi, Failing!">>),
     AliceName = escalus_client:username(Alice),
-    instrument_helper:assert(mod_event_pusher_http_sent, #{host_type => host_type()},
-                             fun(#{count := 1, sender := S, response_code := <<"500">>, response_time := T}) ->
-                                 ?assert(T > 0), AliceName =:= S end).
+    instrument_helper:assert_one(
+      mod_event_pusher_http_sent, #{host_type => host_type()},
+      fun(#{count := 1, sender := S, response_code := <<"500">>, response_time := T}) ->
+              ?assert(T > 0), AliceName =:= S
+      end).
 
 do_simple_message(Config0, Msg) ->
     Config = escalus_fresh:create_users(Config0, [{alice, 1}, {bob, 1}]),

--- a/big_tests/tests/mod_ping_SUITE.erl
+++ b/big_tests/tests/mod_ping_SUITE.erl
@@ -283,11 +283,10 @@ wait_for_pong_hook(Alice) ->
     end.
 
 assert_event(EventName, F) ->
-    instrument_helper:assert(EventName, #{host_type => host_type()}, F).
+    instrument_helper:assert_one(EventName, #{host_type => host_type()}, F).
 
 assert_no_event(EventName, User) ->
-    Events = instrument_helper:lookup(EventName, #{host_type => host_type()}),
-    EventsWithJid = lists:filter(fun(#{jid := Jid}) -> eq_jid(User, Jid) end, Events),
-    ?assertEqual([], EventsWithJid).
+    F = fun(#{jid := Jid}) -> eq_jid(User, Jid) end,
+    instrument_helper:assert_not_emitted(EventName, #{host_type => host_type()}, F).
 
 eq_jid(User, Jid) -> jid:from_binary(escalus_utils:get_jid(User)) =:= Jid.

--- a/big_tests/tests/mongoose_instrument_event_table.erl
+++ b/big_tests/tests/mongoose_instrument_event_table.erl
@@ -12,7 +12,7 @@
 -export([start/0, stop/0, set_up/3, handle_event/4]).
 
 start() ->
-    ets_helper:new(?TABLE, [bag]). % repeating measurements are stored only once
+    ets_helper:new(?TABLE, [duplicate_bag]).
 
 stop() ->
     ets_helper:delete(?TABLE).

--- a/big_tests/tests/mongoose_instrument_event_table.erl
+++ b/big_tests/tests/mongoose_instrument_event_table.erl
@@ -6,7 +6,7 @@
 -define(TABLE, ?MODULE).
 
 %% API
--export([lookup/2, take/2, all_keys/0]).
+-export([select/2, select_new/3, all_keys/0, timestamp/0]).
 
 %% mongoose_instrument callbacks
 -export([start/0, stop/0, set_up/3, handle_event/4]).
@@ -22,13 +22,16 @@ set_up(EventName, Labels, _Config) ->
     lists:member({EventName, Labels}, DeclaredEvents).
 
 handle_event(EventName, Labels, _Config, Measurements) ->
-    ets:insert(?TABLE, {{EventName, Labels}, Measurements}).
+    ets:insert(?TABLE, {{EventName, Labels}, Measurements, timestamp()}).
 
-lookup(EventName, Labels) ->
-    ets:lookup(?TABLE, {EventName, Labels}).
+select(EventName, Labels) ->
+    ets:select(?TABLE, [{{{EventName, Labels}, '$2', '$3'}, [], ['$2']}]).
 
-take(EventName, Labels) ->
-    ets:take(?TABLE, {EventName, Labels}).
+select_new(EventName, Labels, Timestamp) ->
+    ets:select(?TABLE, [{{{EventName, Labels}, '$2', '$3'}, [{'>=', '$3', Timestamp}], ['$2']}]).
+
+timestamp() ->
+    erlang:monotonic_time().
 
 all_keys() ->
     all_keys(?TABLE).

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -342,15 +342,14 @@ set_nick(User, Nick) ->
 %% Instrumentation utilities
 
 wait_for_room_count(ExpectedCounts) ->
-    [Measurements | _] = instrument_helper:wait_for_new(mod_muc_rooms, labels()),
     F = fun(Counts) -> Counts =:= ExpectedCounts end,
-    instrument_helper:assert(mod_muc_rooms, labels(), [Measurements], F).
+    instrument_helper:wait_and_assert_new(mod_muc_rooms, labels(), F).
 
 assert_room_event(EventName, RoomJid) ->
     assert_event(EventName, fun(#{count := 1, jid := Jid}) -> Jid =:= RoomJid end).
 
 assert_event(EventName, F) ->
-    instrument_helper:assert(EventName, labels(), F).
+    instrument_helper:assert_one(EventName, labels(), F).
 
 count_rooms() ->
     rpc(mim(), mod_muc, probe, [mod_muc_rooms, labels()]).

--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -475,9 +475,9 @@ test_wrapped_request(Config) ->
             SelectResult = sql_query(Config, "SELECT unicode FROM test_types"),
             ?assertEqual({selected, [{<<"check1">>}]}, selected_to_sorted(SelectResult))
         end, ok, #{name => request_queries}),
-    Measurements = instrument_helper:wait_for(test_wrapped_request, #{pool_tag => Tag}),
-    instrument_helper:assert(test_wrapped_request, #{pool_tag => Tag}, Measurements,
-                             fun(#{time := T, count := 1, ref := Ref}) -> T > 0 end).
+    instrument_helper:wait_and_assert(
+      test_wrapped_request, #{pool_tag => Tag},
+      fun(#{time := T, count := 1, ref := R}) -> R =:= Ref andalso T > 0 end).
 
 test_failed_wrapper(Config) ->
     % given
@@ -697,9 +697,8 @@ pool_probe_metrics_are_updated(Config) ->
 
     select_one_works_case(Config),
 
-    Measurements = instrument_helper:wait_for_new(Event, Labels),
     F = fun(#{recv_oct := NewRecv, send_oct := NewSend}) -> NewRecv > Recv andalso NewSend > Send end,
-    instrument_helper:assert(Event, Labels, Measurements, F).
+    instrument_helper:wait_and_assert_new(Event, Labels, F).
 
 %%--------------------------------------------------------------------
 %% Text searching

--- a/big_tests/tests/roster_helper.erl
+++ b/big_tests/tests/roster_helper.erl
@@ -13,16 +13,16 @@ set_versioning(Versioning, VersionStore, Config) ->
 
 %% Instrumentation events
 
-assert_roster_event(Client, Event) ->
-    ClientJid = jid:from_binary(escalus_utils:get_jid(Client)),
-    instrument_helper:assert(
+assert_roster_event(ClientOrJid, Event) ->
+    ClientJid = jid:from_binary(escalus_utils:get_jid(ClientOrJid)),
+    instrument_helper:assert_one(
       Event, #{host_type => host_type()},
-      fun(#{count := 1, jid := Jid}) -> jid:are_bare_equal(ClientJid, Jid) end).
+      fun(#{count := 1, jid := Jid}) -> ClientJid =:= Jid end).
 
 assert_subscription_event(FromClient, ToClient, CheckF) ->
     FromClientJid = jid:from_binary(escalus_utils:get_short_jid(FromClient)),
     ToClientJid = jid:from_binary(escalus_utils:get_short_jid(ToClient)),
-    instrument_helper:assert(
+    instrument_helper:assert_one(
       sm_presence_subscription, #{host_type => host_type()},
       fun(#{from_jid := FromJid, to_jid := ToJid} = M) ->
               FromClientJid =:= FromJid andalso ToClientJid =:= ToJid andalso CheckF(M)

--- a/big_tests/tests/xep_0352_csi_SUITE.erl
+++ b/big_tests/tests/xep_0352_csi_SUITE.erl
@@ -208,6 +208,6 @@ given_client_is_inactive_but_sends_messages(Alice, Bob, N) ->
     {MsgsToAlice, MsgsToBob}.
 
 assert_event(Event, Client) ->
-    instrument_helper:assert(Event, #{host_type => host_type()},
-                             fun(#{count := 1, jid := JID}) ->
-                                 jid:to_binary(JID) =:= escalus_client:full_jid(Client) end).
+    instrument_helper:assert_one(
+      Event, #{host_type => host_type()},
+      fun(#{count := 1, jid := JID}) -> jid:to_binary(JID) =:= escalus_client:full_jid(Client) end).

--- a/src/roster/mod_roster.erl
+++ b/src/roster/mod_roster.erl
@@ -506,10 +506,11 @@ broadcast_item(#jid{luser = LUser, lserver = LServer}, ContactJid, Subscription)
     lists:foreach(fun({_, Pid}) -> mongoose_c2s:cast(Pid, ?MODULE, Item) end, UserPids).
 
 push_item_without_version(HostType, JID, Resource, From, Item) ->
+    TargetJID = jid:replace_resource(JID, Resource),
     mongoose_instrument:execute(mod_roster_push, #{host_type => HostType},
-                                #{count => 1, jid => From}),
+                                #{count => 1, jid => TargetJID}),
     mongoose_hooks:roster_push(HostType, From, Item),
-    push_item_final(jid:replace_resource(JID, Resource), From, Item, not_found).
+    push_item_final(TargetJID, From, Item, not_found).
 
 push_item_version(JID, From, Item, RosterVersion) ->
     lists:foreach(fun(Resource) ->


### PR DESCRIPTION
The goal is to make instrumentation assertions more specific and flexible, allowing to test negative cases, wait for specific events, and expect a specific number of events.

In a test case, you can now use:
1. Convenience functions: `assert/3, assert_one/3, assert_not_emitted/1-3, wait_and_assert/3, wait_and_assert_new/3`. They cover most of the typical cases.
2. For more complex checks, e.g. expecting more than one event, you can use `assert/4`, which takes a map of options as the last argument. All the convenience functions are calling `assert/4`. This can be especially useful with `timestamp/0`, allowing to check events after a given point in time.

The `take` function is replaced with selection based on timestamp. By not removing events, we can now use all assertions in parallel tests without the risk of accidental event removal.

The test suites are changed to use the new assertions.
- When possible, assert the exact number of events (usually one).
  - For privacy tests, this required the use of timestamps, because assertions happen in helpers, which can be executed many times per test case, making the evens accumulate. Alternatively, we could add more metadata to the events, but I tried to limit such changes in this PR, and sometimes the events would be difficult to distinguish anyway. IMO it is good that we have some tests actually using the timestamps.
- When suitable, test negative conditions.
- Replace custom waiting code with `wait_and_assert(_new)`.
- For `mod_global_distrib_SUITE`, there were some fixes needed (details in commit messages). it was also difficult to make the test more strict, because the cases seem to test some events that have occurred before they start, while during the test there could be more such events happening. This was the case for multiple events (I checked them one by one). I haven't investigated the reasons behind the asynchronous events.

The helpers were tested manually by making various assertions fail. The new logs for failed assertions are also more detailed, for example (output is truncated):
```
Assertion failed for event mod_privacy_check_packet with labels #{host_type =>
                                                                      <<"localhost">>}.
Matching measurements:
[#{count => 1,dir => out,
   jid =>
       {jid,<<"bob_unnamed_14_messages_from_blocked_user_dont_arrive_15">>,
            <<"localhost">>,<<"res1">>}},
 #{count => 1,dir => out,
   jid =>
       {jid,<<"bob_unnamed_14_messages_from_blocked_user_dont_arrive_15">>,
            <<"localhost">>,<<"res1">>}},
 #{count => 1,dir => out,
   jid =>
       {jid,<<"bob_unnamed_14_messages_from_blocked_user_dont_arrive_15">>,
            <<"localhost">>,<<"res1">>}}]

Other measurements:
[#{count => 1,dir => out,
   jid =>
       {jid,<<"alice_unnamed_3_invalid_block_request_13">>,<<"localhost">>,
            <<"res1">>}},
 #{count => 1,dir => out,
   jid =>
       {jid,<<"alice_unnamed_3_remove_user_from_blocklist_6">>,
            <<"localhost">>,<<"res1">>}},
 #{count => 1,dir => out,
   jid =>
       {jid,<<"alice_unnamed_3_discovering_support_9">>,<<"localhost">>,
            <<"res1">>}},
 #{count => 1,dir => out,
   jid =>
       {jid,<<"alice_unnamed_3_remove_many_user_from_blocklist_12">>,
            <<"localhost">>,<<"res1">>}},
 #{count => 1,dir => out,
   jid =>
       {jid,<<"alice_unnamed_3_clear_blocklist_4">>,<<"localhost">>,
            <<"res1">>}},
...

*** CT Error Notification 2024-07-04 09:49:52.597 ***
mod_blocking_SUITE:'-messages_from_blocked_user_dont_arrive/1-fun-0-' failed on line 239
Reason: {test_case_failed,Incorrect number of instrumentation events - matched: 3, expected: 1}
```
