### PR TITLE
Drop CentOS

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -659,7 +659,7 @@ jobs:
         type: executor
       platform:
         type: enum
-        enum: [centos_7, rockylinux_9, rockylinux_8, almalinux_9, almalinux_8, debian_bullseye, debian_buster, ubuntu_xenial, ubuntu_focal, ubuntu_bionic, ubuntu_jammy]
+        enum: [rockylinux_9, rockylinux_8, almalinux_9, almalinux_8, debian_bullseye, debian_buster, ubuntu_xenial, ubuntu_focal, ubuntu_bionic, ubuntu_jammy]
         description: Platform type
       otp_package:
         type: string
@@ -706,13 +706,6 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+/
       # ============= PACKAGES =============
-      - package:
-          name: centos_7
-          executor: otp_26
-          platform: centos_7
-          context: mongooseim-org
-          otp_package: "26.2.2"
-          filters: *all_tags
       - package:
           name: rockylinux_8
           executor: otp_26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pkg: [centos_7, ubuntu_xenial]
+        pkg: [ubuntu_xenial]
     runs-on: ubuntu-22.04
     env:
       ESL_ERLANG_PKG_VER: "25.0.3"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It is brought to you by [Erlang Solutions](https://www.erlang-solutions.com/).
 
 For a quick start just download:
 
-* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS, AlmaLinux and Rocky Linux)
+* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
 * The [Docker image](https://hub.docker.com/r/mongooseim/mongooseim/): [https://hub.docker.com/r/mongooseim/mongooseim/](https://hub.docker.com/r/mongooseim/mongooseim/) (source code repository: [https://github.com/esl/mongooseim-docker](https://github.com/esl/mongooseim-docker))
 * The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
 

--- a/doc/configuration/database-backends-configuration.md
+++ b/doc/configuration/database-backends-configuration.md
@@ -151,7 +151,7 @@ MSSQL can be used from MongooseIM through the ODBC layer with FreeTDS driver, so
 # Ubuntu
 $ sudo apt install freetds-dev tdsodbc
 
-# CentOS
+# CentOS compatible systems (Rocky, Alma)
 $ sudo yum install freetds
 
 # macOS
@@ -166,7 +166,7 @@ Add your database (`mongooseim` here) to the `/etc/odbc.ini` or `$HOME/.odbc.ini
 ; Ubuntu
 Driver      = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so
 Setup       = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so
-; CentOS
+; CentOS compatible
 ; Driver      = /usr/lib64/libtdsodbc.so.0
 ; Setup       = /usr/lib64/libtdsS.so
 ; macOS

--- a/doc/developers-guide/Bootstrap-Scripts.md
+++ b/doc/developers-guide/Bootstrap-Scripts.md
@@ -66,5 +66,5 @@ tools/pkg/scripts/smoke_templates.escript
 Testing command:
 
 ```bash
-PRESET=pkg pkg_PLATFORM=centos_7 ESL_ERLANG_PKG_VER=23.3.1-2 ./tools/test.sh
+PRESET=pkg pkg_PLATFORM=ubuntu_xenial ESL_ERLANG_PKG_VER=23.3.1-2 ./tools/test.sh
 ```

--- a/doc/developers-guide/Testing-MongooseIM.md
+++ b/doc/developers-guide/Testing-MongooseIM.md
@@ -34,7 +34,7 @@ Please install the driver:
 # Ubuntu
 $ sudo apt install freetds-dev tdsodbc
 
-# CentOS
+# CentOS compatible systems (Rocky, Alma)
 $ sudo yum install freetds
 
 # macOS
@@ -44,7 +44,8 @@ $ brew install freetds
 In case you are using an operating system different from Ubuntu or MacOS or have a custom FreeTDS installation,
 you may have to modify the `tools/setup-db.sh` script to use the proper paths.
 Find a configuration block starting with `[mongoose-mssql]` and change the `Driver` and `Setup`.
-For example, for CentOS change them to `/usr/lib64/libtdsodbc.so.0` and `/usr/lib64/libtdsS.so` respectively.
+For example, for CentOS compatible systems change them to `/usr/lib64/libtdsodbc.so.0` and `/usr/lib64/libtdsS.so`
+respectively.
 
 ## How to print the instructions
 

--- a/doc/getting-started/Installation.md
+++ b/doc/getting-started/Installation.md
@@ -22,7 +22,7 @@ The following sections describe the installation process for different operating
     sudo dpkg -i mongooseim_[version here].deb
     ```
 
-=== "CentOS / AlmaLinux / Rocky Linux"
+=== "CentOS compatible: AlmaLinux / Rocky Linux"
 
     An ODBC (RDBMS) driver must be installed on your machine to unpack and install from RPM packages. Enter the following command in a terminal window to install the latest unixODBC driver:
     

--- a/doc/getting-started/Quick-setup.md
+++ b/doc/getting-started/Quick-setup.md
@@ -306,7 +306,7 @@ Otherwise, the clients will keep disconnecting each other, because MongooseIM al
 
 ### Connect Gajim
 
-Gajim is available on Ubuntu, CentOS & Windows.
+Gajim is available on many Linux platforms, macOS & Windows.
 
 !!! Warning
     Gajim has an obsolete UX. However, it is still well maintained, and has a console that is extremely useful for debugging and testing/validation purposes at the XMPP protocol level.

--- a/doc/index.md
+++ b/doc/index.md
@@ -59,7 +59,7 @@ We offer a set of additional server-side components:
 
 For a quick start just download:
 
-* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS, AlmaLinux and Rocky Linux)
+* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
 * The [Docker image](https://hub.docker.com/r/mongooseim/mongooseim/) ([source code repository](https://github.com/esl/mongooseim-docker))
 * The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
 

--- a/doc/tutorials/How-to-build.md
+++ b/doc/tutorials/How-to-build.md
@@ -2,7 +2,7 @@
 
 Instructions provided in this page are verified for:
 
-* CentOS 7
+* Rocky Linux 8
 * Ubuntu 16.04 LTS (Xenial)
 * Ubuntu 18.04 LTS (Bionic)
 * macOS 13.3 (Ventura)
@@ -13,12 +13,12 @@ For any other OS versions, the instructions should still work, however, some ste
 
 To compile MongooseIM you need:
 
-=== "CentOS"
+=== "Rocky/Alma"
 
       *   Make: `make`,
-      *   C and C++ compiler: `gcc`, `gcc-c++`,
-      *   Erlang/OTP 24.0 or higher:
-        * `erlang` package, or,
+      *   C and C++ compiler: `gcc`, `g++`,
+      *   Erlang/OTP 26.0 or higher:
+        * `erlang` EPEL package, or,
         * `esl-erlang` from [Erlang Solutions website](https://www.erlang-solutions.com/resources/download.html), or,
         * install using [kerl](https://github.com/kerl/kerl),
       *   OpenSSL 0.9.8 or higher, for STARTTLS, SASL and SSL encryption: `openssl` and `openssl-devel`,
@@ -48,12 +48,14 @@ To compile MongooseIM you need:
 
 ## Preparing the environment
 
-=== "centOS"
+=== "Rocky/Alma"
 
     Please install the required dependencies:
 
     ```bash
-    sudo yum install git make zlib-devel openssl openssl-devel unixODBC-devel gcc gcc-c++ erlang
+    sudo yum install git make zlib-devel openssl openssl-devel unixODBC-devel gcc gcc-c++
+    wget https://binaries2.erlang-solutions.com/rockylinux/8/esl-erlang_26.2.4_1~rockylinux~8_x86_64.rpm
+    sudo dnf -Uvh esl-erlang_26.2.4_1~rockylinux~8_x86_64.rpm
     ```
 
     Now, please proceed to the "Building" section.

--- a/tools/pkg/README.md
+++ b/tools/pkg/README.md
@@ -40,7 +40,7 @@ To build a package run:
 
 Where:
 
-* `$PLATFORM` - an OS and an OS version name separated by "_" (e.g. centos_7,
+* `$PLATFORM` - an OS and an OS version name separated by "_" (e.g. rockylinux_8,
 debian_stretch),
 * `$VERSION` - a version of MongooseIM (for most cases version from the `VERSION`
 file will be suitable),
@@ -50,7 +50,7 @@ is built for the same source code but with the usage of changed build scripts),
 while compiling MongooseIM (please remember about concerning minimal erlang version
 specified in the `rebar.config` file and the esl-erlang package revision - e.g. 23.3.1-1),
 * `DOCKERFILE_PATH` - a dockerfile path which should be used to build a package
-for given platform (e.g. path of `Dockerfile_rpm` for `centos_7`),
+for given platform (e.g. path of `Dockerfile_rpm` for `rockylinux_8`),
 * `CONTEXT_PATH` - a root directory of the MongooseIM project (during building
 whole source code is copied to a building docker image container and the `_build`
 directory is erased),
@@ -63,9 +63,9 @@ container. The container instance is removed once the build finishes.
 A resulting package will be called:
 
 ```
-mongooseim_3.6.0-1~centos~7_amd64.rpm
+mongooseim_3.6.0-1~rockylinux~8_amd64.rpm
 ```
-For passed `version`: "3.6.0", `revision`: "1" and `platform`: "centos_7".
+For passed `version`: "3.6.0", `revision`: "1" and `platform`: "rockylinux_8".
 
 ## Sample configuration
 

--- a/tools/pkg/scripts/rpm/install_erlang.sh
+++ b/tools/pkg/scripts/rpm/install_erlang.sh
@@ -8,14 +8,8 @@ OS_RELEASE=$(echo $dockerfile_platform | cut -f2 -d:)
 if [ $DISTRO == almalinux ]; then DISTRO=rockylinux; fi
 
 ERLANG_PKG=esl-erlang_${erlang_version}_1~${DISTRO}~${OS_RELEASE}_x86_64.rpm
-if [ $DISTRO == centos ]; then
-    MAJOR_VSN=$(echo $erlang_version | cut -f1 -d.)
-    PREFIX=esl-erlang-${MAJOR_VSN}
-elif [ $DISTRO == rockylinux ]; then
-    PREFIX=${OS_RELEASE}
-fi
 
-curl -O https://binaries2.erlang-solutions.com/$DISTRO/$PREFIX/$ERLANG_PKG
+curl -O https://binaries2.erlang-solutions.com/$DISTRO/$OS_RELEASE/$ERLANG_PKG
 yum install -y ./$ERLANG_PKG
 
 rm $ERLANG_PKG

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -287,7 +287,7 @@ build_pkg () {
   local esl_erlang_pkg_vsn=$2
   local project_root=$(git rev-parse --show-toplevel)
 
-  if [[ $platform == centos* ]] || [[ $platform == rockylinux* ]] || [[ $platform == almalinux* ]]; then
+  if [[ $platform == rockylinux* ]] || [[ $platform == almalinux* ]]; then
       local dockerfile_name="Dockerfile_rpm"
   elif [[ $platform == debian* ]] || [[ $platform == ubuntu* ]]; then
       local dockerfile_name="Dockerfile_deb"


### PR DESCRIPTION
[CentOS has reached End Of Life](https://www.redhat.com/en/topics/linux/centos-linux-eol) and because of that our builds started failing on CI. This PR gets rid of CentOS builds so that we can have green CI once again.

Manual run of GH Actions: https://github.com/esl/MongooseIM/actions/runs/9792072400

I changed the docs to reflect what we support, and updated the `How to build MongooseIM from source` page. The issue there is, that there is no `erlang` package in the official repositories, and the EPEL (a repository with additional packages) package is OTP22. The solutions I found on the internet of adding ESL repositories for rpm didn't work from me in a VM - I assume those are outdated. There is no better solution on our website, hence, the "manual" downloading of a newer package.

