### PR TITLE
Instrument `mongoose_user_cache`

### DIFF
--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -95,7 +95,8 @@
                            default_config/1,
                            default_schema/0,
                            eq_bjid/2,
-                           pos_int/1
+                           pos_int/1,
+                           cache_name/0
                           ]).
 -import(config_parser_helper, [mod_config/2]).
 
@@ -105,8 +106,6 @@
 -define(ROOM2, <<"testroom2">>).
 
 -define(MUCHOST, (muc_light_helper:muc_host())).
-
--define(CACHE_NAME, mod_muc_light_cache_localhost).
 
 -type ct_aff_user() :: {EscalusClient :: escalus:client(), Aff :: atom()}.
 -type ct_aff_users() :: [ct_aff_user()].
@@ -208,7 +207,7 @@ init_per_suite(Config) ->
     Config1 = dynamic_modules:save_modules(host_type(), Config),
     Config2 = escalus:init_per_suite(Config1),
     instrument_helper:start([{user_cache_lookup, #{host_type => host_type(),
-                                                   cache_name => ?CACHE_NAME}}]),
+                                                   cache_name => cache_name()}}]),
     escalus:create_users(Config2, escalus:get_users([alice, bob, kate, mike])).
 
 end_per_suite(Config) ->
@@ -1167,7 +1166,7 @@ assert_cache_event(TS, Count, BinJid, CacheResult) ->
         end,
     instrument_helper:assert(
         user_cache_lookup,
-        #{host_type => host_type(), cache_name => ?CACHE_NAME},
+        #{host_type => host_type(), cache_name => cache_name()},
         F,
         % Due to implementation, for every lookup the event is raised two times
         #{min_timestamp => TS, expected_count => Count * 2}

--- a/big_tests/tests/muc_light_helper.erl
+++ b/big_tests/tests/muc_light_helper.erl
@@ -32,6 +32,14 @@ muc_host() ->
 muc_host_pattern() ->
     ct:get_config({hosts, mim, muc_light_service_pattern}).
 
+cache_name() ->
+    case domain_helper:host_type() of
+        <<"localhost">> ->
+            mod_muc_light_cache_localhost;
+        <<"test type">> ->
+            'mod_muc_light_cache_test type'
+    end.
+
 create_room(RoomU, MUCHost, Owner, Members, Config, Version) ->
     DefaultConfig = default_internal_config(MUCHost),
     RoomUS = {RoomU, MUCHost},

--- a/big_tests/tests/muc_light_helper.erl
+++ b/big_tests/tests/muc_light_helper.erl
@@ -299,3 +299,7 @@ stanza_blocking_set(BlocklistChanges) ->
                      children = [#xmlcdata{ content = Who }] }
              || {What, Action, Who} <- BlocklistChanges],
     escalus_stanza:to(escalus_stanza:iq_set(?NS_MUC_LIGHT_BLOCKING, Items), muc_host()).
+
+eq_bjid(Jid, BinJid) -> Jid =:= jid:from_binary(BinJid).
+
+pos_int(T) -> is_integer(T) andalso T > 0.

--- a/src/instrument/mongoose_instrument.erl
+++ b/src/instrument/mongoose_instrument.erl
@@ -24,8 +24,9 @@
 -type event_name() :: atom().
 -type labels() :: #{host_type => mongooseim:host_type(),
                     function => atom(),
+                    cache_name => atom(),
                     pool_tag => mongoose_wpool:tag()}. % to be extended
--type label_key() :: host_type | function | pool_tag. % to be extended
+-type label_key() :: host_type | function | cache_name | pool_tag. % to be extended
 -type label_value() :: mongooseim:host_type() | atom() | mongoose_wpool:tag(). % to be extended
 -type metrics() :: #{metric_name() => metric_type()}.
 -type metric_name() :: atom().

--- a/src/mongoose_user_cache.erl
+++ b/src/mongoose_user_cache.erl
@@ -7,13 +7,17 @@
 
 -export([is_member/3, get_entry/3, merge_entry/4, delete_user/3, delete_domain/3]).
 
+%% Used by small tests
+-export([cache_name/2, key/1]).
+
+-ignore_xref([cache_name/2, key/1]).
+
 -spec is_member(mongooseim:host_type(), module(), jid:jid()) -> boolean().
 is_member(HostType, Module, Jid) ->
     CacheName = cache_name(HostType, Module),
     mongoose_instrument:span(user_cache_lookup, #{host_type => HostType, cache_name => CacheName},
                              fun segmented_cache:is_member/2, [CacheName, key(Jid)],
-                             fun(Time, Result) ->
-                                handle_is_member_result(Time, Result, Jid) end).
+                             fun(Time, Result) -> handle_is_member_result(Time, Result, Jid) end).
 
 handle_is_member_result(Time, false, Jid) ->
     #{misses => 1, latency => Time, jid => Jid};
@@ -25,8 +29,7 @@ get_entry(HostType, Module, Jid) ->
     CacheName = cache_name(HostType, Module),
     mongoose_instrument:span(user_cache_lookup, #{host_type => HostType, cache_name => CacheName},
                              fun segmented_cache:get_entry/2, [CacheName, key(Jid)],
-                             fun(Time, Result) ->
-                                handle_get_entry_result(Time, Result, Jid) end).
+                             fun(Time, Result) -> handle_get_entry_result(Time, Result, Jid) end).
 
 handle_get_entry_result(Time, not_found, Jid) ->
     #{misses => 1, latency => Time, jid => Jid};

--- a/src/mongoose_user_cache.erl
+++ b/src/mongoose_user_cache.erl
@@ -2,7 +2,7 @@
 
 -include("mongoose_config_spec.hrl").
 
--export([start_new_cache/3, stop_cache/2, handle_telemetry_event/4,
+-export([start_new_cache/3, stop_cache/2,
          config_spec/0, process_cache_config/1]).
 
 -export([is_member/3, get_entry/3, merge_entry/4, delete_user/3, delete_domain/3]).
@@ -10,12 +10,28 @@
 -spec is_member(mongooseim:host_type(), module(), jid:jid()) -> boolean().
 is_member(HostType, Module, Jid) ->
     CacheName = cache_name(HostType, Module),
-    segmented_cache:is_member(CacheName, key(Jid)).
+    mongoose_instrument:span(user_cache_lookup, #{host_type => HostType, cache_name => CacheName},
+                             fun segmented_cache:is_member/2, [CacheName, key(Jid)],
+                             fun(Time, Result) ->
+                                handle_is_member_result(Time, Result, Jid) end).
+
+handle_is_member_result(Time, false, Jid) ->
+    #{misses => 1, latency => Time, jid => Jid};
+handle_is_member_result(Time, true, Jid) ->
+    #{hits => 1, latency => Time, jid => Jid}.
 
 -spec get_entry(mongooseim:host_type(), module(), jid:jid()) -> term() | not_found.
 get_entry(HostType, Module, Jid) ->
     CacheName = cache_name(HostType, Module),
-    segmented_cache:get_entry(CacheName, key(Jid)).
+    mongoose_instrument:span(user_cache_lookup, #{host_type => HostType, cache_name => CacheName},
+                             fun segmented_cache:get_entry/2, [CacheName, key(Jid)],
+                             fun(Time, Result) ->
+                                handle_get_entry_result(Time, Result, Jid) end).
+
+handle_get_entry_result(Time, not_found, Jid) ->
+    #{misses => 1, latency => Time, jid => Jid};
+handle_get_entry_result(Time, _Entry, Jid) ->
+    #{hits => 1, latency => Time, jid => Jid}.
 
 -spec merge_entry(mongooseim:host_type(), module(), jid:jid(), map()) -> boolean().
 merge_entry(HostType, Module, Jid, Entry) ->
@@ -74,31 +90,17 @@ do_start_new_cache(HostType, Module, Opts) ->
              restart => permanent, shutdown => 5000,
              type => worker, modules => [segmented_cache]},
     {ok, _} = ejabberd_sup:start_child(Spec),
-    create_metrics(HostType, Module, CacheName),
+    mongoose_instrument:set_up(instrumentation(HostType, CacheName)),
     ok.
 
-create_metrics(HostType, Module, CacheName) ->
-    telemetry:attach(CacheName,
-                     [segmented_cache, CacheName, request, stop],
-                     fun ?MODULE:handle_telemetry_event/4,
-                     #{host_type => HostType, cache_name => CacheName, module => Module}),
-    mongoose_metrics:ensure_metric(HostType, [Module, hit], counter),
-    mongoose_metrics:ensure_metric(HostType, [Module, miss], counter),
-    mongoose_metrics:ensure_metric(HostType, [Module, latency], histogram).
-
-handle_telemetry_event([segmented_cache, CacheName, request, stop],
-                       #{duration := Latency},
-                       #{hit := Hit},
-                       #{host_type := HostType, cache_name := CacheName, module := Module}) ->
-    case Hit of
-        true -> mongoose_metrics:update(HostType, [Module, hit], 1);
-        false -> mongoose_metrics:update(HostType, [Module, miss], 1)
-    end,
-    mongoose_metrics:update(HostType, [Module, latency], Latency),
-    ok.
+instrumentation(HostType, CacheName) ->
+    [{user_cache_lookup, #{cache_name => CacheName, host_type => HostType},
+      #{metrics => #{hits => counter, misses => counter, latency => histogram}}}].
 
 -spec stop_cache(mongooseim:host_type(), module()) -> ok.
 stop_cache(HostType, Module) ->
+    CacheName = gen_mod:get_module_proc(HostType, Module),
+    mongoose_instrument:tear_down(instrumentation(HostType, CacheName)),
     case gen_mod:get_module_opt(HostType, Module, module, internal) of
         internal -> ok = ejabberd_sup:stop_child(cache_name(HostType, Module));
         _ConfiguredModule -> ok

--- a/src/mongoose_user_cache.erl
+++ b/src/mongoose_user_cache.erl
@@ -7,11 +7,6 @@
 
 -export([is_member/3, get_entry/3, merge_entry/4, delete_user/3, delete_domain/3]).
 
-%% Used by small tests
--export([cache_name/2, key/1]).
-
--ignore_xref([cache_name/2, key/1]).
-
 -spec is_member(mongooseim:host_type(), module(), jid:jid()) -> boolean().
 is_member(HostType, Module, Jid) ->
     CacheName = cache_name(HostType, Module),

--- a/test/batches_SUITE.erl
+++ b/test/batches_SUITE.erl
@@ -43,8 +43,8 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    application:ensure_all_started(telemetry),
     meck:new(mongoose_metrics, [stub_all, no_link]),
+    meck:new(mongoose_instrument, [stub_all, no_link]),
     Config.
 
 end_per_suite(_Config) ->
@@ -113,7 +113,8 @@ shared_cache_inserts_in_shared_table(_) ->
     mongoose_user_cache:start_new_cache(host_type(), ?mod(1), cache_config()),
     mongoose_user_cache:start_new_cache(host_type(), ?mod(2), cache_config(?mod(1))),
     mongoose_user_cache:merge_entry(host_type(), ?mod(2), some_jid(), #{}),
-    ?assert(mongoose_user_cache:is_member(host_type(), ?mod(1), some_jid())).
+    CacheName = mongoose_user_cache:cache_name(host_type(), ?mod(1)),
+    ?assert(segmented_cache:is_member(CacheName, mongoose_user_cache:key(some_jid()))).
 
 aggregation_might_produce_noop_requests(_) ->
     {ok, Server} = gen_server:start_link(?MODULE, [], []),


### PR DESCRIPTION
This PR updates the `mongoose_user_cache` metrics to use `mongoose_instrument`. It removes old telemetry events and uses `span` to collect the needed information.

### Code changes

- **Metric migration**: Changed `mongoose_user_cache` metrics to use `mongoose_instrument`.
- **Telemetry removal**: Removed telemetry events and replaced them with `span` to collect relevant information.

### Testing

- **Cache event checks**: Added checks for cache events to the `muc_light_SUITE` tests, as this module uses them.
- **Test updates**: Added these checks to the tests where they are most relevant.