### PR TITLE
Fix ldap dialyzer warnings on Erlang 27

### DIFF
--- a/src/eldap_filter_yecc.yrl
+++ b/src/eldap_filter_yecc.yrl
@@ -54,7 +54,7 @@ Erlang code.
 
 'and'(Value)                -> eldap:'and'(eldap_utils:maybe_b2list(Value)).
 'or'(Value)                 -> eldap:'or'(eldap_utils:maybe_b2list(Value)).
-'not'(Value)                -> eldap:'not'(eldap_utils:maybe_b2list(Value)).
+'not'(Value)                -> eldap:'not'(Value).
 equal(Desc, Value)          -> eldap:equalityMatch(Desc, eldap_utils:maybe_b2list(Value)).
 approx(Desc, Value)         -> eldap:approxMatch(Desc, eldap_utils:maybe_b2list(Value)).
 greater(Desc, Value)        -> eldap:greaterOrEqual(Desc, eldap_utils:maybe_b2list(Value)).

--- a/src/eldap_utils.erl
+++ b/src/eldap_utils.erl
@@ -191,7 +191,7 @@ match_filter_name({<<"%u">>, [Value | _]}, NewUIDs) when Value /= <<"">> ->
   end;
 match_filter_name({Name, [Value | _]}, _NewUIDs) when Value /= <<"">> ->
   case binary:match(Value, <<"*">>) of
-    nomatch -> [eldap:equalityMatch(Name, Value)];
+    nomatch -> [eldap:equalityMatch(maybe_b2list(Name), maybe_b2list(Value))];
     _ -> [eldap:substrings(maybe_b2list(Name),
       generate_substring_list(Value))]
   end;


### PR DESCRIPTION
This PR addresses "Compilation issues in Erlang 27 related to ldap".

Proposed changes include:
* We pass anon_auth option into eldap:open/2, which is not allowed in the dialyzer spec for this function. But this option is there and works. Maybe OTP team forgot to add it into the spec.

So we extract options into connect_opts, which is enough to not raise the dialyzer warning.

* `maybe_b2list` usage in some places was adjusted to not cause warnings in Erlang 27
