### PR TITLE
Remove geas dependency of GraphQL

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -214,7 +214,10 @@
    {del, eper, [{erl_opts, [warnings_as_errors]}]},
    %% Erlang JWT Library is in elixir and wants elvis for tests
    %% Remove elvis plugin to reduce deps
-   {override, jwerl, [{plugins, [rebar3_elixir, rebar3_hex]}]}
+   {override, jwerl, [{plugins, [rebar3_elixir, rebar3_hex]}]},
+   %% GraphQL pulls geas_rebar3, which is a dev dependency
+   %% geas takes some time to compile, but we do not need it
+   {override, graphql, [{plugins, [rebar3_hex]}]}
  ]}.
 
 {dialyzer, [


### PR DESCRIPTION
There were some issues with geas https://github.com/crownedgrouse/geas/issues/15
But we don't even need it for MongooseIM. 

Proposed changes include:
* Disable geas and geas_rebar3
