### PR TITLE
Instrument `async_pools`

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -22,7 +22,8 @@
                        given_conversations_between/2,
                        assert_invalid_inbox_form_value_error/3,
                        assert_invalid_reset_inbox/4,
-                       extract_user_specs/1
+                       extract_user_specs/1,
+                       assert_async_request_event/2
                       ]).
 
 -define(ROOM3, <<"testroom3">>).
@@ -1474,9 +1475,3 @@ verify_hook_listener(RoomName) ->
     after 100 ->
               ct:pal("OK")
     end.
-
-assert_async_request_event(TS, ExpectedCount) ->
-    instrument_helper:assert(async_pool_request,
-        #{host_type => domain_helper:host_type(), pool_id => inbox},
-        fun(#{count := 1}) -> true end,
-        #{min_timestamp => TS, expected_count => ExpectedCount}).

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -23,7 +23,7 @@
                        assert_invalid_inbox_form_value_error/3,
                        assert_invalid_reset_inbox/4,
                        extract_user_specs/1,
-                       assert_async_request_event/2
+                       assert_async_request_event/1
                       ]).
 
 -define(ROOM3, <<"testroom3">>).
@@ -1363,7 +1363,7 @@ rest_api_bin_flush_user(Config) ->
         ?assertEqual(1, NumOfRows),
         check_inbox(Bob, [], #{box => bin})
     end),
-    assert_async_request_event(TS, 10).
+    assert_async_request_event(TS).
 
 rest_api_bin_flush_user_errors(Config) ->
     Config1 = escalus_fresh:create_users(Config, [{alice, 1}]),
@@ -1390,7 +1390,7 @@ rest_api_bin_flush_all(Config) ->
         check_inbox(Bob, [], #{box => bin}),
         check_inbox(Kate, [], #{box => bin})
     end),
-    assert_async_request_event(TS, 10).
+    assert_async_request_event(TS).
 
 rest_api_bin_flush_all_errors(_Config) ->
     HostTypePath = uri_string:normalize(#{path => domain_helper:host_type()}),
@@ -1407,7 +1407,7 @@ timeout_cleaner_flush_all(Config) ->
         check_inbox(Bob, [], #{box => bin}),
         check_inbox(Kate, [], #{box => bin})
     end),
-    assert_async_request_event(TS, 10).
+    assert_async_request_event(TS).
 
 xmpp_bin_flush(Config) ->
     TS = instrument_helper:timestamp(),
@@ -1423,7 +1423,7 @@ xmpp_bin_flush(Config) ->
         escalus:assert(is_iq_result, [Iq], escalus:wait_for_stanza(Bob)),
         check_inbox(Bob, [], #{box => bin})
     end),
-    assert_async_request_event(TS, 10).
+    assert_async_request_event(TS).
 
 
 %% helpers

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -72,7 +72,8 @@
          muc_domain/0,
          domain/0,
          to_bare_lower/1,
-         extract_user_specs/1
+         extract_user_specs/1,
+         assert_async_request_event/2
         ]).
 
 -import(muc_helper, [foreach_recipient/2]).
@@ -866,6 +867,12 @@ assert_invalid_form(User, Stanza, Field, Value) ->
 assert_message_content(Msg, Field, Value) ->
     ?assertNotEqual(nomatch, binary:match(Msg, Field)),
     ?assertNotEqual(nomatch, binary:match(Msg, Value)).
+
+assert_async_request_event(TS, ExpectedCount) ->
+    instrument_helper:assert(async_pool_request,
+        #{host_type => domain_helper:host_type(), pool_id => inbox},
+        fun(#{count := 1}) -> true end,
+        #{min_timestamp => TS, expected_count => ExpectedCount}).
 
 %% TODO: properly extract the specs from Bob
 extract_user_specs(User) ->

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -73,7 +73,7 @@
          domain/0,
          to_bare_lower/1,
          extract_user_specs/1,
-         assert_async_request_event/2
+         assert_async_request_event/1
         ]).
 
 -import(muc_helper, [foreach_recipient/2]).
@@ -868,11 +868,12 @@ assert_message_content(Msg, Field, Value) ->
     ?assertNotEqual(nomatch, binary:match(Msg, Field)),
     ?assertNotEqual(nomatch, binary:match(Msg, Value)).
 
-assert_async_request_event(TS, ExpectedCount) ->
-    instrument_helper:assert(async_pool_request,
+assert_async_request_event(TS) ->
+    instrument_helper:assert(
+        async_pool_request,
         #{host_type => domain_helper:host_type(), pool_id => inbox},
         fun(#{count := 1}) -> true end,
-        #{min_timestamp => TS, expected_count => ExpectedCount}).
+        #{min_timestamp => TS}).
 
 %% TODO: properly extract the specs from Bob
 extract_user_specs(User) ->

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -113,6 +113,8 @@
          assert_archive_message_event/2,
          assert_lookup_event/2,
          assert_flushed_event_if_async/2,
+         assert_async_batch_flush_event/3,
+         assert_async_timed_flush_event/4,
          assert_dropped_iq_event/2,
          assert_event_with_jid/2,
          assert_no_event_with_jid/2
@@ -430,7 +432,8 @@ muc_light_cases() ->
      muc_light_chat_markers_are_archived_if_enabled,
      muc_light_chat_markers_are_not_archived_if_disabled,
      muc_light_failed_to_decode_message_in_database,
-     muc_light_sql_query_failed
+     muc_light_sql_query_failed,
+     muc_light_async_pools_batch_flush
     ].
 
 muc_rsm_cases() ->
@@ -503,13 +506,18 @@ muc_prefs_cases() ->
 impl_specific() ->
     [check_user_exist,
      pm_failed_to_decode_message_in_database,
-     pm_sql_query_failed].
+     pm_sql_query_failed,
+     async_pools_batch_flush].
 
 suite() ->
     require_rpc_nodes([mim]) ++ escalus:suite().
 
 init_per_suite(Config) ->
-    instrument_helper:start(instrument_helper:declared_events(instrumented_modules())),
+    PoolIds = [pm_mam, muc_mam],
+    AsyncPoolsEvents = [{async_pool_flush, #{host_type => host_type(), pool_id => PoolId}}
+                        || PoolId <- PoolIds],
+    instrument_helper:start(
+        instrument_helper:declared_events(instrumented_modules()) ++ AsyncPoolsEvents),
     muc_helper:load_muc(),
     mongoose_helper:inject_module(mim(), ?MODULE, reload),
     mam_helper:prepare_for_suite(
@@ -568,7 +576,6 @@ init_per_group(rsm04_comp, Config) ->
     [{props, mam04_props()}|Config];
 init_per_group(with_rsm04, Config) ->
     [{props, mam04_props()}, {with_rsm, true}|Config];
-    
 init_per_group(nostore, Config) ->
     Config;
 init_per_group(archived, Config) ->
@@ -801,6 +808,10 @@ maybe_skip(C, Config) when C =:= easy_text_search_request;
                            C =:= muc_text_search_request ->
     skip_if(?config(configuration, Config) =:= cassandra,
             "full text search is not implemented for cassandra backend");
+maybe_skip(C, Config) when C =:= muc_light_async_pools_batch_flush;
+                           C =:= async_pools_batch_flush ->
+    skip_if(?config(configuration, Config) =/= rdbms_async_pool,
+            "only for async pool");
 maybe_skip(_C, _Config) ->
     ok.
 
@@ -904,6 +915,11 @@ required_modules(CaseName, Config) when CaseName =:= muc_light_service_discovery
                                         CaseName =:= muc_light_include_groupchat_filter ->
     Opts = #{pm := PM} = ?config(mam_meta_opts, Config),
     NewOpts = Opts#{pm := PM#{archive_groupchats => true}},
+    [{mod_mam, NewOpts}];
+required_modules(CaseName, Config) when CaseName =:= async_pools_batch_flush;
+                                        CaseName =:= muc_light_async_pools_batch_flush ->
+    Opts = #{async_writer := Async} = ?config(mam_meta_opts, Config),
+    NewOpts = Opts#{async_writer := Async#{batch_size => 3, flush_interval => 5000}},
     [{mod_mam, NewOpts}];
 required_modules(muc_light_chat_markers_are_archived_if_enabled, Config) ->
     Opts = #{muc := MUC} = ?config(mam_meta_opts, Config),
@@ -1705,6 +1721,7 @@ muc_light_easy(Config) ->
         end).
 
 muc_light_shouldnt_modify_pm_archive(Config) ->
+    TS = instrument_helper:timestamp(),
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
             Room = muc_helper:fresh_room_name(),
             given_muc_light_room(Room, Alice, [{Bob, member}]),
@@ -1731,7 +1748,9 @@ muc_light_shouldnt_modify_pm_archive(Config) ->
             then_archive_response_is(Alice, [{message, Alice, <<"private hi!">>}], Config),
             when_archive_query_is_sent(Bob, undefined, Config),
             then_archive_response_is(Bob, [{message, Alice, <<"private hi!">>}], Config)
-        end).
+        end),
+    assert_async_timed_flush_event(Config, TS, 2, pm_mam),
+    assert_async_timed_flush_event(Config, TS, 2, muc_mam).
 
 muc_light_stored_in_pm_if_allowed_to(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
@@ -1911,6 +1930,23 @@ muc_light_sql_query_failed(Config) ->
             escalus:assert(is_error, [<<"wait">>, <<"internal-server-error">>], Error)
         end).
 
+muc_light_async_pools_batch_flush(Config) ->
+    TS = instrument_helper:timestamp(),
+    escalus:story(Config, [{alice, 1}], fun(Alice) ->
+            Room = muc_helper:fresh_room_name(),
+            given_muc_light_room(Room, Alice, []),
+
+            M1 = when_muc_light_message_is_sent(Alice, Room,<<"Msg 1">>, <<"Id1">>),
+            then_muc_light_message_is_received_by([Alice], M1),
+
+            M2 = when_muc_light_message_is_sent(Alice, Room, <<"Msg 2">>, <<"Id2">>),
+            then_muc_light_message_is_received_by([Alice], M2),
+
+            M3 = when_muc_light_message_is_sent(Alice, Room, <<"Msg 3">>, <<"Id3">>),
+            then_muc_light_message_is_received_by([Alice], M3)
+        end),
+    assert_async_batch_flush_event(TS, 1, muc_mam).
+
 pm_failed_to_decode_message_in_database(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
             escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Hi">>)),
@@ -1931,6 +1967,16 @@ pm_sql_query_failed(Config) ->
             Error = escalus:wait_for_stanza(Alice),
             escalus:assert(is_error, [<<"wait">>, <<"internal-server-error">>], Error)
         end).
+
+async_pools_batch_flush(Config) ->
+    TS = instrument_helper:timestamp(),
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+            escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Msg 1">>)),
+            escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Msg 2">>)),
+            escalus:send(Alice, escalus_stanza:chat_to(Bob, <<"Msg 3">>)),
+            mam_helper:wait_for_archive_size(Alice, 3)
+        end),
+    assert_async_batch_flush_event(TS, 2, pm_mam).
 
 retrieve_form_fields(ConfigIn) ->
     escalus_fresh:story(ConfigIn, [{alice, 1}], fun(Alice) ->
@@ -3449,7 +3495,7 @@ muc_prefs_set_request(ConfigIn) ->
         %%     </never>
         %%   </prefs>
         %% </iq>
-        
+
         Room = ?config(room, Config),
         RoomAddr = room_address(Room),
         escalus:send(Alice, stanza_to_room(stanza_prefs_set_request(<<"roster">>,
@@ -3666,7 +3712,7 @@ muc_run_prefs_cases(DefaultPolicy, ConfigIn) ->
         maybe_wait_for_archive(Config),
 
         %% Get ALL messages using several queries if required
-        
+
         Room = ?config(room, Config),
         IQ = stanza_archive_request([{mam_ns, <<"urn:xmpp:mam:1">>}], <<>>),
         escalus:send(Alice, stanza_to_room(IQ, Room)),

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -114,7 +114,7 @@
          assert_lookup_event/2,
          assert_flushed_event_if_async/2,
          assert_async_batch_flush_event/3,
-         assert_async_timed_flush_event/4,
+         assert_async_timed_flush_event/3,
          assert_dropped_iq_event/2,
          assert_event_with_jid/2,
          assert_no_event_with_jid/2
@@ -1749,8 +1749,8 @@ muc_light_shouldnt_modify_pm_archive(Config) ->
             when_archive_query_is_sent(Bob, undefined, Config),
             then_archive_response_is(Bob, [{message, Alice, <<"private hi!">>}], Config)
         end),
-    assert_async_timed_flush_event(Config, TS, 2, pm_mam),
-    assert_async_timed_flush_event(Config, TS, 2, muc_mam).
+    assert_async_timed_flush_event(Config, TS, pm_mam),
+    assert_async_timed_flush_event(Config, TS, muc_mam).
 
 muc_light_stored_in_pm_if_allowed_to(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1456,18 +1456,18 @@ assert_flushed_event_if_async(EventName, Config) ->
 assert_async_batch_flush_event(TS, ExpectedCount, PoolId) ->
     instrument_helper:assert(
         async_pool_flush,
-        #{host_type => domain_helper:host_type(), pool_id => PoolId},
+        #{host_type => host_type(), pool_id => PoolId},
         fun(#{batch := 1}) -> true end,
         #{min_timestamp => TS, expected_count => ExpectedCount}).
 
-assert_async_timed_flush_event(Config, TS, ExpectedCount, PoolId) ->
+assert_async_timed_flush_event(Config, TS, PoolId) ->
     case ?config(configuration, Config) of
         rdbms_async_pool ->
             instrument_helper:assert(
                 async_pool_flush,
-                #{host_type => domain_helper:host_type(), pool_id => PoolId},
+                #{host_type => host_type(), pool_id => PoolId},
                 fun(#{timed := 1}) -> true end,
-                #{min_timestamp => TS, expected_count => ExpectedCount});
+                #{min_timestamp => TS});
         _ ->
             ok
     end.

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -1453,6 +1453,25 @@ assert_flushed_event_if_async(EventName, Config) ->
             ok
     end.
 
+assert_async_batch_flush_event(TS, ExpectedCount, PoolId) ->
+    instrument_helper:assert(
+        async_pool_flush,
+        #{host_type => domain_helper:host_type(), pool_id => PoolId},
+        fun(#{batch := 1}) -> true end,
+        #{min_timestamp => TS, expected_count => ExpectedCount}).
+
+assert_async_timed_flush_event(Config, TS, ExpectedCount, PoolId) ->
+    case ?config(configuration, Config) of
+        rdbms_async_pool ->
+            instrument_helper:assert(
+                async_pool_flush,
+                #{host_type => domain_helper:host_type(), pool_id => PoolId},
+                fun(#{timed := 1}) -> true end,
+                #{min_timestamp => TS, expected_count => ExpectedCount});
+        _ ->
+            ok
+    end.
+
 assert_dropped_iq_event(Config, BinJid) ->
     EventName = case ?config(room, Config) of
                     undefined -> mod_mam_pm_dropped_iq;

--- a/src/async_pools/mongoose_aggregator_worker.erl
+++ b/src/async_pools/mongoose_aggregator_worker.erl
@@ -229,7 +229,8 @@ make_async_request(Request, #state{host_type = HostType, pool_id = PoolId,
         drop ->
             State;
         ReqId ->
-            mongoose_metrics:update(HostType, [mongoose_async_pools, PoolId, async_request], 1),
+            mongoose_instrument:execute(async_pool_request, #{host_type => HostType, pool_id => PoolId},
+                                        #{count => 1}),
             State#state{async_request = {ReqId, Request}}
     end.
 

--- a/src/async_pools/mongoose_async_pools.erl
+++ b/src/async_pools/mongoose_async_pools.erl
@@ -174,6 +174,6 @@ maybe_init_handler(_, _, _, Extra) ->
 
 instrumentation(HostType, PoolId) ->
     [{async_pool_flush, #{pool_id => PoolId, host_type => HostType},
-      #{metrics => #{timed => counter, batch => counter}}},
+      #{metrics => #{timed => spiral, batch => spiral}}},
      {async_pool_request, #{pool_id => PoolId, host_type => HostType},
-      #{metrics => #{count => counter}}}].
+      #{metrics => #{count => spiral}}}].

--- a/src/async_pools/mongoose_batch_worker.erl
+++ b/src/async_pools/mongoose_batch_worker.erl
@@ -61,7 +61,8 @@ init(#{host_type := HostType,
 -spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}.
 handle_call(sync, _From, State = #state{host_type = HostType, pool_id = PoolId,
                                         flush_queue = [_|_]}) ->
-    mongoose_metrics:update(HostType, [mongoose_async_pools, PoolId, timed_flushes], 1),
+    mongoose_instrument:execute(async_pool_flush, #{host_type => HostType, pool_id => PoolId},
+                                #{timed => 1}),
     {reply, ok, run_flush(State)};
 handle_call(sync, _From, State = #state{flush_queue = []}) ->
     {reply, skipped, State};
@@ -84,7 +85,8 @@ handle_cast(Msg, State) ->
 handle_info({timeout, TimerRef, flush}, State = #state{flush_interval_tref = TimerRef,
                                                        host_type = HostType,
                                                        pool_id = PoolId}) ->
-    mongoose_metrics:update(HostType, [mongoose_async_pools, PoolId, timed_flushes], 1),
+    mongoose_instrument:execute(async_pool_flush, #{host_type => HostType, pool_id => PoolId},
+                                #{timed => 1}),
     {noreply, run_flush(State)};
 handle_info({garbage_collect, asynchronous_gc_triggered, true}, State) ->
     {noreply, State};
@@ -153,7 +155,8 @@ maybe_run_flush(#state{host_type = HostType,
     case Length >= MaxSize of
         false -> State;
         true ->
-            mongoose_metrics:update(HostType, [mongoose_async_pools, PoolId, batch_flushes], 1),
+            mongoose_instrument:execute(async_pool_flush, #{host_type => HostType, pool_id => PoolId},
+                                        #{batch => 1}),
             run_flush(State)
     end.
 

--- a/src/instrument/mongoose_instrument.erl
+++ b/src/instrument/mongoose_instrument.erl
@@ -25,8 +25,9 @@
 -type labels() :: #{host_type => mongooseim:host_type(),
                     function => atom(),
                     cache_name => atom(),
+                    pool_id => atom(),
                     pool_tag => mongoose_wpool:tag()}. % to be extended
--type label_key() :: host_type | function | cache_name | pool_tag. % to be extended
+-type label_key() :: host_type | function | cache_name | pool_id | pool_tag. % to be extended
 -type label_value() :: mongooseim:host_type() | atom() | mongoose_wpool:tag(). % to be extended
 -type metrics() :: #{metric_name() => metric_type()}.
 -type metric_name() :: atom().

--- a/test/batches_SUITE.erl
+++ b/test/batches_SUITE.erl
@@ -21,7 +21,7 @@ groups() ->
        external_stop_does_nothing,
        shared_cache_inserts_in_shared_table
       ]},
-     {async_workers, [sequence],
+     {async_workers, [parallel],
       [
        broadcast_reaches_all_workers,
        broadcast_reaches_all_keys,
@@ -42,27 +42,64 @@ groups() ->
 
 init_per_suite(Config) ->
     mongoose_config:set_opts(opts()),
-    async_helper:start(Config, mongoose_instrument, start_link, []).
+    Config.
 
-end_per_suite(Config) ->
-    async_helper:stop_all(Config),
+end_per_suite(_Config) ->
     mongoose_config:erase_opts(),
     meck:unload().
 
-init_per_group(_, Config) ->
-    Config.
+init_per_group(cache, Config) ->
+    async_helper:start(Config, mongoose_instrument, start_link, []);
+init_per_group(async_workers, Config) ->
+    meck:new(logger, [passthrough, unstick, no_link]),
+    async_helper:start(Config, [{mongoose_instrument, start_link, []},
+                                {mim_ct_sup, start_link, [ejabberd_sup]}]).
 
-end_per_group(_, _Config) ->
-    ok.
+end_per_group(cache, Config) ->
+    async_helper:stop_all(Config);
+end_per_group(async_workers, Config) ->
+    async_helper:stop_all(Config),
+    meck:unload(logger).
 
-init_per_testcase(_TestCase, Config) ->
+init_per_testcase(TestCase, Config) when TestCase =:= internal_starts_another_cache;
+                                         TestCase =:= external_does_not_start_another_cache;
+                                         TestCase =:= internal_stop_does_stop_the_cache;
+                                         TestCase =:= external_stop_does_nothing;
+                                         TestCase =:= shared_cache_inserts_in_shared_table ->
     pg:start_link(mim_scope),
     mim_ct_sup:start_link(ejabberd_sup),
     meck:new(gen_mod, [passthrough]),
+    Config;
+init_per_testcase(broadcast_reaches_all_workers = TestCase, Config) ->
+    {ok, Server} = gen_server:start_link(?MODULE, [], []),
+    WPoolOpts = (default_aggregator_opts(Server))#{pool_type => aggregate,
+                                                   pool_size => 10},
+    {ok, _} = mongoose_async_pools:start_pool(host_type(), TestCase, WPoolOpts),
+    [{server_pid, Server} | Config];
+init_per_testcase(broadcast_reaches_all_keys = TestCase, Config) ->
+    {ok, Server} = gen_server:start_link(?MODULE, [], []),
+    Tid = ets:new(table, [public, {read_concurrency, true}]),
+    Req = create_request_callback(Tid, Server),
+    WPoolOpts = (default_aggregator_opts(Server))#{pool_type => aggregate,
+                                                   pool_size => 3,
+                                                   request_callback => Req},
+    {ok, _} = mongoose_async_pools:start_pool(host_type(), TestCase, WPoolOpts),
+    [{server_pid, Server}, {tid, Tid} | Config];
+init_per_testcase(TestCase, Config) ->
+    {ok, Server} = gen_server:start_link(?MODULE, [], []),
+    WPoolOpts = (default_aggregator_opts(Server))#{pool_type => aggregate,
+                                                   pool_size => 3},
+    {ok, _} = mongoose_async_pools:start_pool(host_type(), TestCase, WPoolOpts),
     Config.
 
+
+end_per_testcase(TestCase, _Config) when TestCase =:= internal_starts_another_cache;
+                                         TestCase =:= external_does_not_start_another_cache;
+                                         TestCase =:= internal_stop_does_stop_the_cache;
+                                         TestCase =:= external_stop_does_nothing;
+                                         TestCase =:= shared_cache_inserts_in_shared_table ->
+    meck:unload(gen_mod);
 end_per_testcase(_TestCase, _Config) ->
-    meck:unload(gen_mod),
     ok.
 
 opts() ->
@@ -76,6 +113,17 @@ cache_config(internal) ->
     Def#{module => internal};
 cache_config(Module) ->
     #{module => Module}.
+
+create_request_callback(Tid, Server) ->
+    fun(Task, _) ->
+        case ets:member(Tid, continue) of
+            true ->
+                gen_server:send_request(Server, Task);
+            false ->
+                async_helper:wait_until(fun() -> ets:member(Tid, continue) end, true),
+                gen_server:send_request(Server, 0)
+        end
+    end.
 
 %% Tests
 internal_starts_another_cache(_) ->
@@ -121,41 +169,25 @@ aggregation_might_produce_noop_requests(_) ->
     {ok, Server} = gen_server:start_link(?MODULE, [], []),
     Requestor = fun(1, _) -> timer:sleep(1), gen_server:send_request(Server, 1);
                    (_, _) -> drop end,
-    Opts = (default_aggregator_opts(Server))#{pool_id => test_pool,
+    Opts = (default_aggregator_opts(Server))#{pool_id => ?FUNCTION_NAME,
                                               request_callback => Requestor},
     {ok, Pid} = gen_server:start_link(mongoose_aggregator_worker, Opts, []),
     [ gen_server:cast(Pid, {task, key, N}) || N <- lists:seq(1, 1000) ],
     async_helper:wait_until(
       fun() -> gen_server:call(Server, get_acc) end, 1).
 
-broadcast_reaches_all_workers(_) ->
-    {ok, Server} = gen_server:start_link(?MODULE, [], []),
-    WPoolOpts = (default_aggregator_opts(Server))#{pool_type => aggregate,
-                                                   pool_size => 10},
-    {ok, _} = mongoose_async_pools:start_pool(host_type(), first_pool, WPoolOpts),
-    mongoose_async_pools:broadcast_task(host_type(), first_pool, key, 1),
+broadcast_reaches_all_workers(Config) ->
+    Server = proplists:get_value(server_pid, Config),
+    mongoose_async_pools:broadcast_task(host_type(), ?FUNCTION_NAME, key, 1),
     async_helper:wait_until(
       fun() -> gen_server:call(Server, get_acc) end, 10).
 
-broadcast_reaches_all_keys(_) ->
+broadcast_reaches_all_keys(Config) ->
     HostType = host_type(),
-    {ok, Server} = gen_server:start_link(?MODULE, [], []),
-    Tid = ets:new(table, [public, {read_concurrency, true}]),
-    Req = fun(Task, _) ->
-                  case ets:member(Tid, continue) of
-                      true ->
-                          gen_server:send_request(Server, Task);
-                      false ->
-                          async_helper:wait_until(fun() -> ets:member(Tid, continue) end, true),
-                          gen_server:send_request(Server, 0)
-                  end
-          end,
-    WPoolOpts = (default_aggregator_opts(Server))#{pool_type => aggregate,
-                                                   pool_size => 3,
-                                                   request_callback => Req},
-    {ok, _} = mongoose_async_pools:start_pool(HostType, test_pool, WPoolOpts),
-    [ mongoose_async_pools:put_task(HostType, test_pool, N, 1) || N <- lists:seq(0, 1000) ],
-    mongoose_async_pools:broadcast(HostType, test_pool, -1),
+    Server = proplists:get_value(server_pid, Config),
+    Tid = proplists:get_value(tid, Config),
+    [ mongoose_async_pools:put_task(HostType, ?FUNCTION_NAME, N, 1) || N <- lists:seq(0, 1000) ],
+    mongoose_async_pools:broadcast(HostType, ?FUNCTION_NAME, -1),
     ets:insert(Tid, {continue, true}),
     async_helper:wait_until(
       fun() -> gen_server:call(Server, get_acc) end, 0).
@@ -163,9 +195,8 @@ broadcast_reaches_all_keys(_) ->
 timeouts_and_canceled_timers_do_not_need_to_log_messages(_) ->
     Timeout = 10,
     QueueSize = 2,
-    meck:new(logger, [passthrough, unstick]),
     Opts = #{host_type => host_type(),
-             pool_id => test_pool,
+             pool_id => ?FUNCTION_NAME,
              batch_size => QueueSize,
              flush_interval => Timeout,
              flush_callback => fun(_, _) -> ok end,
@@ -173,14 +204,14 @@ timeouts_and_canceled_timers_do_not_need_to_log_messages(_) ->
     {ok, Pid} = gen_server:start_link(mongoose_batch_worker, Opts, []),
     [ gen_server:cast(Pid, {task, ok}) || _ <- lists:seq(1, QueueSize) ],
     ct:sleep(Timeout*2),
-    ?assertEqual(0, meck:num_calls(logger, macro_log, '_')).
+    ?assertEqual(0, meck:num_calls(logger, macro_log, ['_', '_', #{pool_id => ?FUNCTION_NAME}])).
+
 prepare_task_works(_) ->
     Timeout = 1000,
     QueueSize = 2,
     T = self(),
-    meck:new(logger, [passthrough, unstick]),
     Opts = #{host_type => host_type(),
-             pool_id => test_pool,
+             pool_id => ?FUNCTION_NAME,
              batch_size => QueueSize,
              flush_interval => Timeout,
              prep_callback => fun(0, _) -> {error, bad};
@@ -196,11 +227,11 @@ prepare_task_works(_) ->
     after
         Timeout*2 -> ct:fail(no_answer_received)
     end,
-    ?assert(0 < meck:num_calls(logger, macro_log, '_')).
+    ?assert(0 < meck:num_calls(logger, macro_log, ['_', '_', #{pool_id => ?FUNCTION_NAME}])).
 
 sync_flushes_down_everything(_) ->
     Opts = #{host_type => host_type(),
-             pool_id => test_pool,
+             pool_id => ?FUNCTION_NAME,
              batch_size => 5000,
              flush_interval => 5000,
              flush_callback => fun(_, _) -> ok end,
@@ -212,7 +243,7 @@ sync_flushes_down_everything(_) ->
 
 sync_aggregates_down_everything(_) ->
     {ok, Server} = gen_server:start_link(?MODULE, [], []),
-    Opts = (default_aggregator_opts(Server))#{pool_id => test_pool},
+    Opts = (default_aggregator_opts(Server))#{pool_id => ?FUNCTION_NAME},
     {ok, Pid} = gen_server:start_link(mongoose_aggregator_worker, Opts, []),
     ?assertEqual(skipped, gen_server:call(Pid, sync)),
     [ gen_server:cast(Pid, {task, key, N}) || N <- lists:seq(1, 1000) ],
@@ -222,7 +253,7 @@ sync_aggregates_down_everything(_) ->
 aggregating_error_is_handled_and_can_continue(_) ->
     {ok, Server} = gen_server:start_link(?MODULE, [], []),
     Requestor = fun(Task, _) -> timer:sleep(1), gen_server:send_request(Server, Task) end,
-    Opts = (default_aggregator_opts(Server))#{pool_id => test_pool,
+    Opts = (default_aggregator_opts(Server))#{pool_id => ?FUNCTION_NAME,
                                               request_callback => Requestor},
     {ok, Pid} = gen_server:start_link(mongoose_aggregator_worker, Opts, []),
     [ gen_server:cast(Pid, {task, key, N}) || N <- lists:seq(1, 10) ],
@@ -236,14 +267,14 @@ aggregating_error_is_handled_and_can_continue(_) ->
 
 async_request(_) ->
     {ok, Server} = gen_server:start_link(?MODULE, [], []),
-    Opts = (default_aggregator_opts(Server))#{pool_id => test_pool},
+    Opts = (default_aggregator_opts(Server))#{pool_id => ?FUNCTION_NAME},
     {ok, Pid} = gen_server:start_link(mongoose_aggregator_worker, Opts, []),
     [ gen_server:cast(Pid, {task, key, N}) || N <- lists:seq(1, 1000) ],
     async_helper:wait_until(
       fun() -> gen_server:call(Server, get_acc) end, 500500).
 
 retry_request(_) ->
-    Opts = (retry_aggregator_opts())#{pool_id => test_pool},
+    Opts = (retry_aggregator_opts())#{pool_id => ?FUNCTION_NAME},
     {ok, Pid} = gen_server:start_link(mongoose_aggregator_worker, Opts, []),
     gen_server:cast(Pid, {task, key, 1}),
     receive_task_called(0),
@@ -254,7 +285,7 @@ retry_request(_) ->
     ensure_no_tasks_to_receive().
 
 retry_request_cancelled(_) ->
-    Opts = (retry_aggregator_opts())#{pool_id => test_pool,
+    Opts = (retry_aggregator_opts())#{pool_id => ?FUNCTION_NAME,
                                       request_callback => fun do_cancel_request/2},
     {ok, Pid} = gen_server:start_link(mongoose_aggregator_worker, Opts, []),
     gen_server:cast(Pid, {task, key, 1}),
@@ -269,7 +300,7 @@ retry_request_cancelled(_) ->
     receive_task_called(0).
 
 retry_request_cancelled_in_verify_function(_) ->
-    Opts = (retry_aggregator_opts())#{pool_id => test_pool,
+    Opts = (retry_aggregator_opts())#{pool_id => ?FUNCTION_NAME,
                                       request_callback => fun do_request/2,
                                       verify_callback => fun validate_all_fails/3},
     {ok, Pid} = gen_server:start_link(mongoose_aggregator_worker, Opts, []),
@@ -285,7 +316,7 @@ retry_request_cancelled_in_verify_function(_) ->
     receive_task_called(0).
 
 ignore_msg_when_waiting_for_reply(_) ->
-    Opts = (retry_aggregator_opts())#{pool_id => test_pool,
+    Opts = (retry_aggregator_opts())#{pool_id => ?FUNCTION_NAME,
                                       request_callback => fun do_request_but_ignore_other_messages/2},
     {ok, Pid} = gen_server:start_link(mongoose_aggregator_worker, Opts, []),
     gen_server:cast(Pid, {task, key, 1}),
@@ -298,7 +329,7 @@ async_request_fails(_) ->
     %% Does request that crashes the gen_server, but not the aggregator
     {ok, Server} = gen_server:start({local, async_req_fails_server}, ?MODULE, [], []),
     Ref = monitor(process, Server),
-    Opts = (default_aggregator_opts(async_req_fails_server))#{pool_id => test_pool},
+    Opts = (default_aggregator_opts(async_req_fails_server))#{pool_id => ?FUNCTION_NAME},
     {ok, Pid} = gen_server:start_link(mongoose_aggregator_worker, Opts, []),
     gen_server:cast(Pid, {task, key, {ack_and_die, self()}}),
     %% Acked and the server dies
@@ -413,7 +444,7 @@ handle_call(get_acc, _From, Acc) ->
     {reply, Acc, Acc};
 handle_call(return_error, _From, Acc) ->
     {reply, {error, return_error}, Acc};
-handle_call({ack_and_die, Pid}, _From, Acc) ->
+handle_call({ack_and_die, Pid}, _From, _Acc) ->
     Pid ! {acked, self()},
     error(oops);
 handle_call({ack, Pid}, _From, Acc) ->


### PR DESCRIPTION
This PR updates the metrics in `async_pools` to use `mongoose_instrument`. Events are tested in separate suites due to the need for specific types of pools for testing. That's why one type of event is tested in `mod_inbox` and the other one in `mod_mam`.

Some of the tests do not check the exact number of events because the number of events can depend on how long a given operation takes. For example, `async_pool_flush.timed` can be executed a different number of times depending on how many messages are flushed in a given time interval.