### PR TITLE
Fix no-match in tools/summarise-ct-results

### DIFF
--- a/tools/summarise-ct-results
+++ b/tools/summarise-ct-results
@@ -79,7 +79,8 @@ summaries(Directories, Filename) ->
 
 add_up_suite_results(SuiteSummaries) ->
     lists:foldl(fun(Filename, {OkAcc, FAcc, USAcc, ASAcc}) ->
-                        {ok, [{summary, {Ok, F, US, AS}}]} = file:consult(Filename),
+                        {ok, [{summary, Summary}]} = file:consult(Filename),
+                        [Ok, F, US, AS | _] = tuple_to_list(Summary),
                         {OkAcc + Ok, FAcc + F, USAcc + US, ASAcc + AS}
                 end, {0, 0, 0, 0}, SuiteSummaries).
 


### PR DESCRIPTION
Proposed changes include:
* Erlang27 includes one more element (total execution time)
* Fix no-match in tools/summarise-ct-results

