### PR TITLE
Doc improvements

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
     - navigation.instant
     - navigation.instant.progress
     - navigation.top
+    - content.tabs.link
     - toc.follow
 extra:
   version:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,10 @@ theme:
       toggle:
         icon: material/weather-night
         name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.top
 extra:
   version:
     provider: mike

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: MongooseIM Docs
 site_description: "Documentation for MongooseIM - a mobile messaging platform with focus on performance and scalability"
 site_author: "Erlang Solutions"
-site_url: https://esl.github.io/MongooseDocs/latest/
+site_url: https://esl.github.io/MongooseDocs/
 repo_url: https://github.com/esl/MongooseIM
 edit_uri: edit/master/doc/
 docs_dir: doc

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
     - navigation.instant
     - navigation.instant.progress
     - navigation.top
+    - toc.follow
 extra:
   version:
     provider: mike


### PR DESCRIPTION
The main change in this PR is a bugfix for wrong links which I found by accident, relating to our documentation versions, which should improve our search engine rankings. Other than that, there are some quality of life improvements that have been added to [our theme](https://squidfunk.github.io/mkdocs-material/setup/) that we can use.

#### Wrong `site_url`

The bug was introduced in 5dee72a2b116a653720ad3390146f13fc4a34ea6 by adding a `"latest/"` suffix to the `site_url` option, and justified with the sitemap not being up to date. However, now the sitemap has doubled "latest/", see for example: https://github.com/esl/MongooseDocs/blob/e1191e40a1156d2831dc232afc55f7089270b668/latest/sitemap.xml#L4

It is even worse, because each page has a "canonical" link set up by Mike (documentation versioning tool for MkDocs), that should point to the main docs version (`latest` in our case). Now, it points to a similar, doubled link, see https://github.com/esl/MongooseDocs/blob/e1191e40a1156d2831dc232afc55f7089270b668/latest/sitemap.xml#L4 for example. This link is used by search engines, and now it serves 404. Merging this PR should improve our search engines ranking.

I think our docs still work anyway, because the documentation is served by GH pages from directories created for each version by Mike, and they don't rely on the `site_url` setting, they are just copied documentation files that have been built.

#### Other improvements:

Our docs will behave more like Single Page Applications - there will be no reload when changing pages. Current behaviour:

https://github.com/user-attachments/assets/dfeb2101-50b8-41b4-888c-04c3a09f66c8

New behaviour:

https://github.com/user-attachments/assets/54db5b84-25f5-41a0-a48c-aa47510c8730

On slow connections, there is a progress bar:

https://github.com/user-attachments/assets/beded403-c609-4ee9-9101-d28ed075ca09

A "back to top" button will appear when scrolling up from somewhere down on a page:

https://github.com/user-attachments/assets/52484ed5-9773-4d94-a164-03e40f8267f0

Table of Contents will now scroll automatically if the current header would go out of view on longer pages:

https://github.com/user-attachments/assets/0c49d854-bd8c-4708-999f-2c18ddf31678

Content that is tabbed will now link across a page when user clicks:

https://github.com/user-attachments/assets/2c7c825e-ecf8-4be4-a524-d4ae6003ea54