### PR TITLE
Invalidate CircleCI deps cache if the plugin list changes

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -6,7 +6,7 @@ references:
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3
-  - &DEPS_CACHE_KEY deps-cache-{{ checksum "rebar.lock" }}-{{ checksum "big_tests/rebar.lock" }}-{{ checksum "otp_version" }}-v5
+  - &DEPS_CACHE_KEY deps-cache-{{ checksum "rebar.lock" }}-{{ checksum "big_tests/rebar.lock" }}-__REBAR_PLUGINS_HASH__-{{ checksum "otp_version" }}-v5
   - &BUILD_CACHE_KEY build-cache-{{ .Branch }}-{{ .Revision }}-{{ checksum "otp_version" }}-v6
 
 # list of references to be used inside executors block

--- a/tools/circle-generate-config.sh
+++ b/tools/circle-generate-config.sh
@@ -35,6 +35,9 @@ CACERT=$(cat32 tools/ssl/ca/cacert.pem)
 
 CERTS_CACHE_KEY=$(cat certs_cache_key)
 
+# Matches plugins list in the rebar.config
+REBAR_PLUGINS_HASH=$(cat rebar.config | sed -n '/^{plugins/,/]}./p' | sha1sum | awk '{print $1}')
+
 sed -e "s/__MYSQL_CNF__/${MYSQL_CNF}/" \
     -e "s/__MYSQL_SQL__/${MYSQL_SQL}/" \
     -e "s/__MYSQL_SETUP__/${MYSQL_SETUP}/" \
@@ -69,5 +72,6 @@ sed -e "s/__MYSQL_CNF__/${MYSQL_CNF}/" \
     -e "s/__PYTHON2_BASE32_DEC__/${PYTHON2_BASE32_DEC}/" \
     -e "s/__PYTHON3_BASE32_DEC__/${PYTHON3_BASE32_DEC}/" \
     -e "s/__CERTS_CACHE_KEY__/${CERTS_CACHE_KEY}/" \
+    -e "s/__REBAR_PLUGINS_HASH__/${REBAR_PLUGINS_HASH}/" \
     .circleci/template.yml \
     > "$OUT_FILE"


### PR DESCRIPTION
This PR addresses MIM-2265. 

It is hard to handle updates of plugins, circleci would always use the cached old version. And rebar.lock is not tracking plugins.

Proposed changes include:
* Hashing of `{plugins, ...}.` block. Useful if you are developing or updating plugins
* Invalidate CircleCI deps cache if the plugin list changes
* We use base circle ci image for initial template generation, which has no Erlang. So we use sed to match plugins block and we hash it.

