### PR TITLE
Removing unused mod_keystore opts from graphql_token_SUITE

### DIFF
--- a/big_tests/tests/graphql_token_SUITE.erl
+++ b/big_tests/tests/graphql_token_SUITE.erl
@@ -83,9 +83,7 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 required_modules() ->
-    KeyOpts = #{keys => #{token_secret => ram,
-                          provision_pre_shared => ram},
-                backend => ct_helper:get_internal_database()},
+    KeyOpts = #{keys => #{token_secret => ram, provision_pre_shared => ram}},
     KeyStoreOpts = config_parser_helper:mod_config(mod_keystore, KeyOpts),
     [{mod_keystore, KeyStoreOpts},
      {mod_auth_token, auth_token_opts()}].


### PR DESCRIPTION
Cleaning mod_keystore opts in graphql_token_SUITE. The opts that are being currently used don't comply with the opts available in mod_keystore.