### PR TITLE
Exit codecov with non-zero code if fails to upload

### DIFF
--- a/tools/circle-upload-codecov.sh
+++ b/tools/circle-upload-codecov.sh
@@ -15,4 +15,4 @@ gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
 shasum -a 256 -c codecov.SHA256SUM
 
 chmod +x codecov
-./codecov -t ${CODECOV_TOKEN} -e PRESET
+./tools/retry.sh ./codecov -t ${CODECOV_TOKEN} -e PRESET --nonZero


### PR DESCRIPTION
This PR addresses "MIM-2151 We should fail CI if codecov upload fails".

Proposed changes include:
* Exit codecov with non-zero code if fails to upload
* Retry uploading 5 times

