### PR TITLE
Document instrumentation

### DIFF
--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -193,7 +193,7 @@ create_and_terminate_session(Config) ->
 
     % Assert that correct events have been executed
     [instrument_helper:assert(Event, Label, fun(#{byte_size := BS}) -> BS > 0 end)
-     || {Event, Label} <- instrumentation_events(), Event =/= c2s_message_processing_time],
+     || {Event, Label} <- instrumentation_events(), Event =/= c2s_message_processed],
 
     %% Verify C2S listener is not used
     instrument_helper:assert_not_emitted(negative_instrumentation_events()),
@@ -954,7 +954,7 @@ wait_for_zero_bosh_sessions() ->
 instrumentation_events() ->
     instrument_helper:declared_events(mod_bosh, [])
     ++ instrument_helper:declared_events(mongoose_c2s, [global])
-    ++ [{c2s_message_processing_time, #{host_type => host_type()}}].
+    ++ [{c2s_message_processed, #{host_type => host_type()}}].
 
 negative_instrumentation_events() ->
     [{Name, #{}} || Name <- negative_instrumentation_events_names()].

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -407,7 +407,7 @@ metrics_test(Config) ->
     [instrument_helper:assert(Event, Label, fun(#{byte_size := BS}) -> BS > 0;
                                                (#{time := Time}) -> Time > 0 end)
      || {Event, Label} <- instrumentation_events(),
-        Event =/= c2s_message_processing_time].
+        Event =/= c2s_message_processed].
 
 tls_authenticate(Config) ->
     %% Given
@@ -818,4 +818,4 @@ proxy_info() ->
 instrumentation_events() ->
     instrument_helper:declared_events(mongoose_c2s_listener, [#{}])
     ++ instrument_helper:declared_events(mongoose_c2s, [global])
-    ++ [{c2s_message_processing_time, #{host_type => domain_helper:host_type()}}].
+    ++ [{c2s_message_processed, #{host_type => domain_helper:host_type()}}].

--- a/big_tests/tests/mim_c2s_SUITE.erl
+++ b/big_tests/tests/mim_c2s_SUITE.erl
@@ -241,7 +241,7 @@ escalus_start(Cfg, FlatCDs) ->
 instrumentation_events() ->
     instrument_helper:declared_events(mongoose_c2s_listener, [#{}])
     ++ instrument_helper:declared_events(mongoose_c2s, [global])
-    ++ [{c2s_message_processing_time, #{host_type => domain_helper:host_type()}}].
+    ++ [{c2s_message_processed, #{host_type => domain_helper:host_type()}}].
 
 tcp_instrumentation_events() ->
     [{c2s_tcp_data_out, #{}},
@@ -253,6 +253,6 @@ tls_instrumentation_events() ->
 
 common_instrumentation_events() ->
     HostType = domain_helper:host_type(),
-    [{c2s_message_processing_time, #{host_type => HostType}},
+    [{c2s_message_processed, #{host_type => HostType}},
      {c2s_xmpp_element_size_in, #{}},
      {c2s_xmpp_element_size_out, #{}}].

--- a/big_tests/tests/websockets_SUITE.erl
+++ b/big_tests/tests/websockets_SUITE.erl
@@ -171,7 +171,7 @@ escape_attrs(Config) ->
 instrumentation_events() ->
     instrument_helper:declared_events(mod_websockets, [])
     ++ instrument_helper:declared_events(mongoose_c2s, [global])
-    ++ [{c2s_message_processing_time, #{host_type => domain_helper:host_type()}}].
+    ++ [{c2s_message_processed, #{host_type => domain_helper:host_type()}}].
 
 negative_instrumentation_events() ->
     [{Name, #{}} || Name <- negative_instrumentation_events_names()].

--- a/doc/configuration/instrumentation.md
+++ b/doc/configuration/instrumentation.md
@@ -1,0 +1,108 @@
+This section is used to configure MongooseIM instrumentation.
+It is a system of executing events when something of interest happens in the server.
+They are mainly used for the purpose of metrics.
+
+Instrumentation events are acted upon by handlers. Available instrumentation handlers are:
+
+* `prometheus` - exposes a metrics endpoint for [Prometheus](https://prometheus.io/).
+* `exometer` - starts [Exometer](https://github.com/esl/exometer_core), a metrics server capable of exporting metrics using reporters. Currently available is a [Graphite](https://graphiteapp.org/) reporter.
+* `log` - logs instrumentation events to disk.
+
+Enable them by adding a corresponding sections and possible configuration values.
+
+## General options
+
+### `instrumentation.probe_interval`
+* **Syntax:** positive integer
+* **Default:** `15` (seconds)
+* **Example:** `probe_interval = 60`
+
+Sets the interval for periodic measurements (probes).
+
+## Exometer options
+
+General options for the Exometer reporter:
+
+### `instrumentation.exometer.all_metrics_are_global`
+* **Syntax:** boolean
+* **Default:** `false`
+* **Example:** `all_metrics_are_global = true`
+
+## Exometer reporter options
+
+Multiple reporters can be configured.
+Because of that, each reporter is configured in a section inside a TOML array, for example: `[[instrumentation.exometer.report.graphite]]`.
+
+### `instrumentation.exometer.report.graphite.interval`
+* **Syntax:** positive integer
+* **Default:** `60000` (milliseconds)
+* **Example:** `interval = 30_000`
+
+Interval at which metrics will be sent to Graphite.
+
+### `instrumentation.exometer.report.graphite.host`
+* **Syntax:** string
+* **Default:** no default, required
+* **Example:** `host = "graphite.local"`
+
+The name or IP address of the Graphite server.
+This option is mandatory.
+
+### `instrumentation.exometer.report.graphite.port`
+* **Syntax:** integer, between 0 and 65535
+* **Default:** `2003`
+* **Example:** `port = 2033`
+
+The port on which the Graphite server listens for connections.
+
+### `instrumentation.exometer.report.graphite.connect_timeout`
+* **Syntax:** positive integer
+* **Default:** `5000` (milliseconds)
+* **Example:** `connect_timeout = 10_000`
+
+The amount of time Graphite reporter will wait before timing out.
+
+### `instrumentation.exometer.report.graphite.api_key`
+* **Syntax:** string
+* **Default:** `""`
+* **Example:** `api_key = "hosted_graphite_api_key"`
+
+API key to use when reporting to a hosted graphite server.
+
+### `instrumentation.exometer.report.graphite.prefix`
+* **Syntax:** string
+* **Default:** no default
+* **Example:** `prefix = "mim_stats"`
+
+A prefix to prepend all metric names with before they are sent to the graphite server.
+
+### `instrumentation.exometer.report.graphite.env_prefix`
+* **Syntax:** string
+* **Default:** no default
+* **Example:** `env_prefix = "GRAPHITE_METRICS_PREFIX"`
+
+Specifies an environmental variable name from which an additional prefix will be taken.
+In case both `prefix` and `env_prefix` are defined, it will be placed before the `prefix` and separated with a dot.
+
+## Example configuration
+
+This configuration enables `prometheus`, `exometer` and `log` handlers:
+```toml
+[instrumentation]
+  probe_interval = 10_000
+
+[instrumentation.prometheus]
+
+[instrumentation.log]
+
+[[instrumentation.exometer.report.graphite]]
+  host = "127.0.0.1"
+  interval = 15_000
+  prefix = "mongooseim"
+  connect_timeout = 5000
+
+
+[[instrumentation.exometer.report.graphite]]
+  host = "hosted_graphite.com"
+  prefix = "mim"
+```

--- a/doc/configuration/instrumentation.md
+++ b/doc/configuration/instrumentation.md
@@ -9,6 +9,7 @@ Instrumentation events are acted upon by handlers. Available instrumentation han
 * `log` - logs instrumentation events to disk.
 
 Enable them by adding a corresponding sections and possible configuration values.
+We recommend choosing either Prometheus or Exometer as a solution for exposing metrics.
 
 ## General options
 
@@ -84,9 +85,9 @@ A prefix to prepend all metric names with before they are sent to the graphite s
 Specifies an environmental variable name from which an additional prefix will be taken.
 In case both `prefix` and `env_prefix` are defined, it will be placed before the `prefix` and separated with a dot.
 
-## Example configuration
+## Example Prometheus configuration
 
-This configuration enables `prometheus`, `exometer` and `log` handlers:
+This configuration enables `prometheus`, and `log` handlers:
 ```toml
 [instrumentation]
   probe_interval = 10_000
@@ -94,13 +95,17 @@ This configuration enables `prometheus`, `exometer` and `log` handlers:
 [instrumentation.prometheus]
 
 [instrumentation.log]
+```
 
+## Example Exometer configuration
+
+This configuration enables `exometer` handler with two different Graphite reporters.
+```toml
 [[instrumentation.exometer.report.graphite]]
   host = "127.0.0.1"
   interval = 15_000
   prefix = "mongooseim"
   connect_timeout = 5000
-
 
 [[instrumentation.exometer.report.graphite]]
   host = "hosted_graphite.com"

--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -109,7 +109,7 @@ When MongooseIM fails to connect to the DB, it retries with an exponential backo
 * **Example:** `host = "localhost"`
 
 #### `outgoing_pools.rdbms.*.connection.port`
-* **Syntax:** string
+* **Syntax:** integer, between 0 and 65535
 * **Default:** `5432` for `pgsql`; `3306` for `mysql`
 * **Example:** `port = 5343`
 
@@ -204,7 +204,7 @@ There are two important limitations:
 * **Example:** `host = "redis.local"`
 
 ### `outgoing_pools.redis.*.connection.port`
-* **Syntax:** integer, between 0 and 65535, non-inclusive
+* **Syntax:** integer, between 0 and 65535
 * **Default:** `6379`
 * **Example:** `port = 9876`
 

--- a/doc/listeners/listen-http.md
+++ b/doc/listeners/listen-http.md
@@ -13,6 +13,7 @@ Following configuration option is used to set up an HTTP handler:
 
     * `mod_bosh` - for [BOSH](https://xmpp.org/extensions/xep-0124.html) connections,
     * `mod_websockets` - for [WebSocket](https://tools.ietf.org/html/rfc6455) connections,
+    * `mongoose_prometheus_handler` - for [Prometheus]((https://prometheus.io/) metrics,
     * `mongoose_graphql_handler` - for GraphQL API,
     * `mongoose_admin_api`, `mongoose_client_api` - for REST API.
 
@@ -183,6 +184,12 @@ By default, all modules are enabled, so you don't need to change this option.
 The Swagger documentation of the client API is hosted at the `/api-docs` path.
 You can disable the hosted documentation by setting this option to `false`.
 
+## Handler types: Prometheus - `mongoose_prometheus_handler`
+
+Requires no additional options other than the [common handler options](#common-handler-options) in the listener section.
+In order to collect useful metrics, a `[prometheus]` section has to be added in [the instrumentation section](../configuration/instrumentation.md#).
+The default configuration available with MongooseIM is shown in [Example 7](#example-7-prometheus) below.
+
 ## Transport options
 
 The options listed below are used to modify the HTTP transport settings.
@@ -333,4 +340,19 @@ REST API for clients.
   [[listen.http.handlers.mongoose_client_api]]
     host = "_"
     path = "/api"
+```
+
+### Example 7. Prometheus
+
+Prometheus metrics endpoint.
+
+```toml
+[[listen.http]]
+  port = 9091
+
+  transport.num_acceptors = 10
+
+  [[listen.http.handlers.mongoose_prometheus_handler]]
+    host = "_"
+    path = "/metrics"
 ```

--- a/doc/modules/mod_csi.md
+++ b/doc/modules/mod_csi.md
@@ -25,7 +25,19 @@ Buffer size for messages queued when session was `inactive`.
 
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Name               | Type   | Description (when it gets incremented) |
-|--------------------|--------|----------------------------------------|
-| `mod_csi_active`   | spiral | A client becomes active.               |
-| `mod_csi_inactive` | spiral | A client becomes inactive.             |
+Prometheus metrics have a `host_type` label associated with these metrics.
+Since Exometer doesn't support labels, the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+=== "Prometheus"
+
+    | Name | Type | Description (when it gets incremented) |
+    |------|------|----------------------------------------|
+    | `mod_csi_active_count` | counter | A client becomes active. |
+    | `mod_csi_inactive_count` | counter | A client becomes inactive. |
+
+=== "Exometer"
+
+    | Name | Type | Description (when it gets incremented) |
+    |------|------|----------------------------------------|
+    | `[HostType, mod_csi_active, count]` | spiral | A client becomes active. |
+    | `[HostType, mod_csi_inactive, count]` | spiral | A client becomes inactive. |

--- a/doc/modules/mod_event_pusher_http.md
+++ b/doc/modules/mod_event_pusher_http.md
@@ -119,7 +119,7 @@ Since Exometer doesn't support labels, the host types, or word `global`, are par
     | ---- | ---- | -------------------------------------- |
     | `mod_event_pusher_http_sent_count` | counter | An HTTP notification is sent successfully. |
     | `mod_event_pusher_http_sent_failure_count` | counter | An HTTP notification failed. |
-    | `mod_event_pusher_http_sent_response_time` | histogram | Does not include timings of failed requests. |
+    | `mod_event_pusher_http_sent_response_time` | histogram | Time taken to send HTTP notification. Does not include timings of failed requests. |
 
 === "Exometer"
 

--- a/doc/modules/mod_event_pusher_http.md
+++ b/doc/modules/mod_event_pusher_http.md
@@ -127,6 +127,6 @@ Since Exometer doesn't support labels, the host types, or word `global`, are par
     | ---- | ---- | -------------------------------------- |
     | `[Host, mod_event_pusher_http_sent, count]` | spiral | An HTTP notification is sent successfully. |
     | `[Host, mod_event_pusher_http_sent, failure_count]` | spiral | An HTTP notification failed. |
-    | `[Host, mod_event_pusher_http_sent, response_time]` | histogram | Does not include timings of failed requests. |
+    | `[Host, mod_event_pusher_http_sent, response_time]` | histogram | Time taken to send HTTP notification. Does not include timings of failed requests. |
 
 [mod_event_pusher]: ./mod_event_pusher.md

--- a/doc/modules/mod_event_pusher_http.md
+++ b/doc/modules/mod_event_pusher_http.md
@@ -110,10 +110,23 @@ Below is an example of what the body of an HTTP POST request can look like:
 
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Name | Type | Description (when it gets incremented) |
-| ---- | ---- | -------------------------------------- |
-| `[Host, mod_event_pusher_http, sent]` | spiral | An HTTP notification is sent successfully. |
-| `[Host, mod_event_pusher_http, failed]` | spiral | An HTTP notification failed. |
-| `[Host, mod_event_pusher_http, response_time]` | histogram | Does not include timings of failed requests. |
+Prometheus metrics have a `host_type` label associated with these metrics.
+Since Exometer doesn't support labels, the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+=== "Prometheus"
+
+    | Name | Type | Description (when it gets incremented) |
+    | ---- | ---- | -------------------------------------- |
+    | `mod_event_pusher_http_sent_count` | counter | An HTTP notification is sent successfully. |
+    | `mod_event_pusher_http_sent_failure_count` | counter | An HTTP notification failed. |
+    | `mod_event_pusher_http_sent_response_time` | histogram | Does not include timings of failed requests. |
+
+=== "Exometer"
+
+    | Name | Type | Description (when it gets incremented) |
+    | ---- | ---- | -------------------------------------- |
+    | `[Host, mod_event_pusher_http_sent, count]` | spiral | An HTTP notification is sent successfully. |
+    | `[Host, mod_event_pusher_http_sent, failure_count]` | spiral | An HTTP notification failed. |
+    | `[Host, mod_event_pusher_http_sent, response_time]` | histogram | Does not include timings of failed requests. |
 
 [mod_event_pusher]: ./mod_event_pusher.md

--- a/doc/modules/mod_event_pusher_rabbit.md
+++ b/doc/modules/mod_event_pusher_rabbit.md
@@ -176,19 +176,38 @@ and for "received" events:
 ## Metrics
 
 The module provides some metrics related to RabbitMQ connections and messages
-as well. Provided metrics:
+as well.
 
-| name                                                             | type      | description (when it gets incremented/decremented)                                                                                               |
-|------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`HostType`, `wpool_rabbit_connections_active`]         | counter   | A connection to a RabbitMQ server is opened(+1)/closed(-1).                                                                                      |
-| [`HostType`, `wpool_rabbit_connections_opened`]         | spiral    | A connection to a RabbitMQ server is opened.                                                                                                     |
-| [`HostType`, `wpool_rabbit_connections_closed`]         | spiral    | A connection to a RabbitMQ server is closed.                                                                                                     |
-| [`HostType`, `wpool_rabbit_connections_failed` ]        | spiral    | A try to open a connection to a RabbitMQ server failed.                                                                                          |
-| [`HostType`, `wpool_rabbit_messages_published_count`]   | spiral    | A message to a RabbitMQ server is published.                                                                                                     |
-| [`HostType`, `wpool_rabbit_messages_published_failed`]  | spiral    | A message to a RabbitMQ server is rejected.                                                                                                      |
-| [`HostType`, `wpool_rabbit_messages_published_timeout`] | spiral    | A message to a RabbitMQ server timed out (weren't confirmed by the server).                                                                      |
-| [`HostType`, `wpool_rabbit_messages_published_time`]    | histogram | Amount of time it takes to publish a message to a RabbitMQ server and receive a confirmation. It's measured only for successful messages.        |
-| [`HostType`, `wpool_rabbit_messages_published_size`]    | histogram | Size of a message (in bytes) that was published to a RabbitMQ server (including message properties). It's measured only for successful messages. |
+Prometheus metrics have `host_type` and `pool_tag` labels associated with these metrics.
+Since Exometer doesn't support labels, the pool tag, as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+=== "Prometheus"
+
+    | Name                                                             | Type      | Description (when it gets incremented/decremented)                                                                                               |
+    |------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+    | `wpool_rabbit_connections_active`         | gauge   | A connection to a RabbitMQ server is opened(+1)/closed(-1).                                                                                      |
+    | `wpool_rabbit_connections_opened`         | counter    | A connection to a RabbitMQ server is opened.                                                                                                     |
+    | `wpool_rabbit_connections_closed`         | counter    | A connection to a RabbitMQ server is closed.                                                                                                     |
+    | `wpool_rabbit_connections_failed`         | counter    | A try to open a connection to a RabbitMQ server failed.                                                                                          |
+    | `wpool_rabbit_messages_published_count`   | counter    | A message to a RabbitMQ server is published.                                                                                                     |
+    | `wpool_rabbit_messages_published_failed`  | counter    | A message to a RabbitMQ server is rejected.                                                                                                      |
+    | `wpool_rabbit_messages_published_timeout` | counter    | A message to a RabbitMQ server timed out (weren't confirmed by the server).                                                                      |
+    | `wpool_rabbit_messages_published_time`    | histogram | Amount of time it takes to publish a message to a RabbitMQ server and receive a confirmation. It's measured only for successful messages.        |
+    | `wpool_rabbit_messages_published_size`    | histogram | Size of a message (in bytes) that was published to a RabbitMQ server (including message properties). It's measured only for successful messages. |
+
+=== "Exometer"
+
+    | Name                                                             | Type      | Description (when it gets incremented/decremented)                                                                                               |
+    |------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+    | `[HostType, PoolTag, wpool_rabbit_connections_active]`         | counter   | A connection to a RabbitMQ server is opened(+1)/closed(-1).                                                                                      |
+    | `[HostType, PoolTag, wpool_rabbit_connections_opened]`         | spiral    | A connection to a RabbitMQ server is opened.                                                                                                     |
+    | `[HostType, PoolTag, wpool_rabbit_connections_closed]`         | spiral    | A connection to a RabbitMQ server is closed.                                                                                                     |
+    | `[HostType, PoolTag, wpool_rabbit_connections_failed]`        | spiral    | A try to open a connection to a RabbitMQ server failed.                                                                                          |
+    | `[HostType, PoolTag, wpool_rabbit_messages_published_count]`   | spiral    | A message to a RabbitMQ server is published.                                                                                                     |
+    | `[HostType, PoolTag, wpool_rabbit_messages_published_failed]`  | spiral    | A message to a RabbitMQ server is rejected.                                                                                                      |
+    | `[HostType, PoolTag, wpool_rabbit_messages_published_timeout]` | spiral    | A message to a RabbitMQ server timed out (weren't confirmed by the server).                                                                      |
+    | `[HostType, PoolTag, wpool_rabbit_messages_published_time]`    | histogram | Amount of time it takes to publish a message to a RabbitMQ server and receive a confirmation. It's measured only for successful messages.        |
+    | `[HostType, PoolTag, wpool_rabbit_messages_published_size]`    | histogram | Size of a message (in bytes) that was published to a RabbitMQ server (including message properties). It's measured only for successful messages. |
 
 
 ## Guarantees

--- a/doc/modules/mod_extdisco.md
+++ b/doc/modules/mod_extdisco.md
@@ -34,7 +34,7 @@ Service type, common values are `"stun"`, `"turn"`, `"ftp"`.
 Hostname or an IP address where the service is hosted.
 
 #### `modules.mod_extdisco.service.port`
-* **Syntax:** integer, between 0 and 65535, non-inclusive
+* **Syntax:** integer, between 0 and 65535
 * **Default:** none, this option is recommended
 * **Example:** `port = 3478`
 

--- a/doc/modules/mod_global_distrib.md
+++ b/doc/modules/mod_global_distrib.md
@@ -76,30 +76,54 @@ In the example above, the message from **U2** would be temporarily stored at **D
 
 ### Metrics
 
-Global distribution modules expose several per-datacenter metrics that can be used to monitor health of the system. All metrics begin with **global.mod_global_distrib** prefix:
+Global distribution modules expose several per-datacenter metrics that can be used to monitor health of the system.
 
-* `mod_global_distrib_outgoing_messages_count`: number of cross-datacenter messages sent by this cluster.
-* `mod_global_distrib_incoming_messages_count`: number of cross-datacenter messages received by this cluster.
-* `mod_global_distrib_incoming_transfer_time` *[us]*: time elapsed between sending and receiving the message over the network.
-  The duration is calculated using wall clock times on sender and receiver node.
-* `mod_global_distrib_outgoing_queue_time` *[us]*: time elapsed while message waits in a queue of a sender's connection.
-  High value of this metric may be remedied by increasing the number of connections to other hosts.
-* `mod_global_distrib_incoming_queue_time` *[us]*: time elapsed while message waits in routing worker's queue.
-  This value is not reported per-host as routing workers are bound to the sender's JID.
-* `mod_global_distrib_incoming_established_count`: incremented when a new connection is established from another cluster.
-  At this point the origin domain of the cluster is not known, so this metric is common for all of them.
-* `mod_global_distrib_incoming_first_packet_count`: incremented when a receiver process gets the first packet from a remote cluster and learns its local domain.
-* `mod_global_distrib_incoming_closed_count`: incremented when an incoming connection gets closed.
-* `mod_global_distrib_incoming_errored_count`: incremented when an incoming connection gets closed with an error.
-* `mod_global_distrib_outgoing_established_count`: incremented when an outgoing connection is established.
-* `mod_global_distrib_outgoing_closed_count`: incremented when an outgoing connection gets closed.
-* `mod_global_distrib_outgoing_errored_count`: incremented when an outgoing connection gets closed with an error.
-* `mod_global_distrib_mapping_fetches_time` *[us]*: time spent on fetching an entry from the session table, cached or otherwise.
-* `mod_global_distrib_mapping_fetches_count`: number of fetches of session table entries, cached or otherwise.
-* `mod_global_distrib_mapping_cache_misses_count`: number of fetches of session table entries that hit the database.
-* `mod_global_distrib_delivered_with_ttl_value`: A histogram of packets' TTL values recorded when the global routing layer decides to route them locally (but not due to TTL = 0).
-* `mod_global_distrib_stop_ttl_zero_count`: A number of packets that weren't processed by global routing due to TTL=0.
-* `mod_global_distrib_bounce_queue_size`: a number of messages enqueued for rerouting (the value of this metric is individual per MongooseIM node!).
+=== "Prometheus"
+
+    | Name | Type | Description (when it gets incremented) |
+    | ---- | ---- | -------------------------------------- |
+    | `mod_global_distrib_outgoing_messages_count` | counter | Number of cross-datacenter messages sent by this cluster. |
+    | `mod_global_distrib_incoming_messages_count` | counter | Number of cross-datacenter messages received by this cluster. |
+    | `mod_global_distrib_incoming_transfer_time` | histogram | Time (*us*) elapsed between sending and receiving the message over the network. The duration is calculated using wall clock times on sender and receiver node. |
+    | `mod_global_distrib_outgoing_queue_time` | histogram | Time (*us*) elapsed while message waits in a queue of a sender's connection. High value of this metric may be remedied by increasing the number of connections to other hosts. |
+    | `mod_global_distrib_incoming_queue_time` | histogram |  Time (*us*) elapsed while message waits in routing worker's queue. This value is not reported per-host as routing workers are bound to the sender's JID. |
+    | `mod_global_distrib_incoming_established_count` | counter | Incremented when a new connection is established from another cluster. At this point the origin domain of the cluster is not known, so this metric is common for all of them. |
+    | `mod_global_distrib_incoming_first_packet_count` | counter | Incremented when a receiver process gets the first packet from a remote cluster and learns its local domain. |
+    | `mod_global_distrib_incoming_closed_count` | counter | Incremented when an incoming connection gets closed. |
+    | `mod_global_distrib_incoming_errored_count` | counter | Incremented when an incoming connection gets closed with an error. |
+    | `mod_global_distrib_outgoing_established_count` | counter | Incremented when an outgoing connection is established. |
+    | `mod_global_distrib_outgoing_closed_count` | counter | Incremented when an outgoing connection gets closed. |
+    | `mod_global_distrib_outgoing_errored_count` | counter | Incremented when an outgoing connection gets closed with an error. |
+    | `mod_global_distrib_mapping_fetches_time` | histogram | Time (*us*) spent on fetching an entry from the session table, cached or otherwise. |
+    | `mod_global_distrib_mapping_fetches_count` | counter | Number of fetches of session table entries, cached or otherwise. |
+    | `mod_global_distrib_mapping_cache_misses_count` | counter | Number of fetches of session table entries that hit the database. |
+    | `mod_global_distrib_delivered_with_ttl_value` | histogram | A histogram of packets' TTL values recorded when the global routing layer decides to route them locally (but not due to TTL = 0). |
+    | `mod_global_distrib_stop_ttl_zero_count` | counter | A number of packets that weren't processed by global routing due to TTL=0. |
+    | `mod_global_distrib_bounce_queue_size` | counter | A number of messages enqueued for rerouting (the value of this metric is individual per MongooseIM node!). |
+
+=== "Exometer"
+
+    | Name | Type | Description (when it gets incremented) |
+    | ---- | ---- | -------------------------------------- |
+    | `[mod_global_distrib_outgoing_messages, count]` | spiral | Number of cross-datacenter messages sent by this cluster. |
+    | `[mod_global_distrib_incoming_messages, count]` | spiral | Number of cross-datacenter messages received by this cluster. |
+    | `[mod_global_distrib_incoming_transfer, time]` | histogram | Time (*us*) elapsed between sending and receiving the message over the network. The duration is calculated using wall clock times on sender and receiver node. |
+    | `[mod_global_distrib_outgoing_queue, time]` | histogram | Time (*us*) elapsed while message waits in a queue of a sender's connection. High value of this metric may be remedied by increasing the number of connections to other hosts. |
+    | `[mod_global_distrib_incoming_queue, time]` | histogram |  Time (*us*) elapsed while message waits in routing worker's queue. This value is not reported per-host as routing workers are bound to the sender's JID. |
+    | `[mod_global_distrib_incoming_established, count]` | spiral | Incremented when a new connection is established from another cluster. At this point the origin domain of the cluster is not known, so this metric is common for all of them. |
+    | `[mod_global_distrib_incoming_first_packet, count]` | spiral | Incremented when a receiver process gets the first packet from a remote cluster and learns its local domain. |
+    | `[mod_global_distrib_incoming_closed, count]` | spiral | Incremented when an incoming connection gets closed. |
+    | `[mod_global_distrib_incoming_errored, count]` | spiral | Incremented when an incoming connection gets closed with an error. |
+    | `[mod_global_distrib_outgoing_established, count]` | spiral | Incremented when an outgoing connection is established. |
+    | `[mod_global_distrib_outgoing_closed, count]` | spiral | Incremented when an outgoing connection gets closed. |
+    | `[mod_global_distrib_outgoing_errored, count]` | spiral | Incremented when an outgoing connection gets closed with an error. |
+    | `[mod_global_distrib_mapping_fetches, time]` | histogram | Time (*us*) spent on fetching an entry from the session table, cached or otherwise. |
+    | `[mod_global_distrib_mapping_fetches, count]` | spiral | Number of fetches of session table entries, cached or otherwise. |
+    | `[mod_global_distrib_mapping_cache_misses, count]` | spiral | Number of fetches of session table entries that hit the database. |
+    | `[mod_global_distrib_delivered_with_ttl_value]` | histogram | A histogram of packets' TTL values recorded when the global routing layer decides to route them locally (but not due to TTL = 0). |
+    | `[mod_global_distrib_stop_ttl_zero, count]` | spiral | A number of packets that weren't processed by global routing due to TTL=0. |
+    | `[mod_global_distrib_bounce_queue, size]` | spiral | A number of messages enqueued for rerouting (the value of this metric is individual per MongooseIM node!). |
+
 
 ## Notes
 

--- a/doc/modules/mod_http_upload.md
+++ b/doc/modules/mod_http_upload.md
@@ -173,8 +173,22 @@ to [min.io][minio]
 
 ## Metrics
 
+This module provides [backend metrics](../operation-and-maintenance/MongooseIM-metrics.md#backend-metrics).
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Backend action | Description (when it gets incremented) |
-| ---- | -------------------------------------- |
-| `create_slot` | An upload slot is allocated. |
+Prometheus metrics have a `host_type` and `function` label associated with these metrics.
+Since Exometer doesn't support labels, the function as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_http_upload_s3_count` | counter | `create_slot` | An upload slot is allocated. |
+    | `mod_http_upload_s3_time` | histogram | `create_slot` | Time spent on allocating a slot. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_http_upload_s3, create_slot, count]` | spiral | An upload slot is allocated. |
+    | `[HostType, mod_http_upload_s3, create_slot, time]` | histogram |  Time spent on allocating a slot. |

--- a/doc/modules/mod_last.md
+++ b/doc/modules/mod_last.md
@@ -29,9 +29,32 @@ Storage backend.
 
 ## Metrics
 
+This module provides [backend metrics](../operation-and-maintenance/MongooseIM-metrics.md#backend-metrics).
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Backend action | Description (when it gets incremented) |
-| ---- | -------------------------------------- |
-| `get_last` | A timestamp is fetched from DB. |
-| `set_last_info` | A timestamp is stored in DB. |
+Prometheus metrics have a `host_type` and `function` label associated with these metrics.
+Since Exometer doesn't support labels, the function as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+Backend in the action name can be either `rdbms` or `mnesia`.
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_last_Backend_count` | counter | `get_last` | A timestamp is fetched from the database. |
+    | `mod_last_Backend_time` | histogram | `get_last` | Time spent fetching a timestamp from the database. |
+    | `mod_last_Backend_count` | counter | `set_last_info` |  A timestamp is stored in the database. |
+    | `mod_last_Backend_time` | histogram | `set_last_info` | Time spent storing a timestamp in the database. |
+    | `mod_last_Backend_count` | counter | `session_cleanup` | A session is cleaned up from the database. |
+    | `mod_last_Backend_time` | histogram | `session_cleanup` | Time spent cleaning up a from the database. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_last_Backend, get_last, count]` | counter | A timestamp is fetched from the database. |
+    | `[HostType, mod_last_Backend, get_last, time]` | histogram | Time spent fetching a timestamp from the database. |
+    | `[HostType, mod_last_Backend, set_last_info, count]` | counter |  A timestamp is stored in the database. |
+    | `[HostType, mod_last_Backend, set_last_info, time]` | histogram | Time spent storing a timestamp in the database. |
+    | `[HostType, mod_last_Backend, session_cleanup, count]` | counter | A session is cleaned up from the database. |
+    | `[HostType, mod_last_Backend, session_cleanup, time]` | histogram | Time spent cleaning up a from the database. |

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -408,29 +408,69 @@ This module can be used to add extra lookup parameters to MAM lookup queries.
 
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Name | Type | Description (when it gets incremented) |
-| ---- | ---- | -------------------------------------- |
-| `[HostType, modMamArchiveRemoved]` | spiral | User's entire archive is removed. |
-| `[HostType, modMamArchived]` | spiral | A message is stored in user's archive. |
-| `[HostType, modMamDropped]` | spiral | A message couldn't be stored in the DB (and got dropped). |
-| `[HostType, modMamDroppedIQ]` | spiral | MAM IQ has been dropped due to: high query frequency/invalid syntax or type. |
-| `[HostType, modMamFlushed]` | spiral | Message was stored in a DB asynchronously. |
-| `[HostType, modMamForwarded]` | spiral | A message is sent to a client as a part of a MAM query result. |
-| `[HostType, modMamLookups]` | spiral | A MAM lookup is performed. |
-| `[HostType, modMamPrefsGets]` | spiral | Archiving preferences have been requested by a client. |
-| `[HostType, modMamPrefsSets]` | spiral | Archiving preferences have been updated by a client. |
-| `[HostType, modMucMamArchiveRemoved]` | spiral | Room's entire archive is removed. |
-| `[HostType, modMucMamArchived]` | spiral | A message is stored in room's archive. |
-| `[HostType, modMucMamForwarded]` | spiral | A message is sent to a client as a part of a MAM query result from MUC room. |
-| `[HostType, modMucMamLookups]` | spiral | A MAM lookup in MUC room is performed. |
-| `[HostType, modMucMamPrefsGets]` | spiral | MUC archiving preferences have been requested by a client. |
-| `[HostType, modMucMamPrefsSets]` | spiral | MUC archiving preferences have been updated by a client. |
-| `[HostType, mod_mam_rdbms_async_pool_writer, per_message_flush_time]` | histogram | Average time per message insert measured in an async MAM worker. |
-| `[HostType, mod_mam_rdbms_async_pool_writer, flush_time]` | histogram | Average time per flush of all buffered messages measured in an async MAM worker. |
-| `[HostType, mod_mam_muc_rdbms_async_pool_writer, per_message_flush_time]` | histogram | Average time per message insert measured in an async MUC MAM worker. |
-| `[HostType, mod_mam_muc_rdbms_async_pool_writer, flush_time]` | histogram | Average time per flush of all buffered messages measured in an async MUC MAM worker. |
+Prometheus metrics have a `host_type` label associated with these metrics.
+Since Exometer doesn't support labels, the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
 
-| Backend action | Description (when it gets incremented) |
-| -------------- | ---------------------------------------|
-| `lookup` | A lookup in an archive. |
-| `archive` | One message is saved in an archive. |
+=== "Prometheus"
+
+    | Name | Type | Description (when it gets incremented) |
+    | ---- | ---- | -------------------------------------- |
+    | `mod_mam_pm_archive_message_count` | counter | A PM message is stored in user's archive. |
+    | `mod_mam_pm_archive_message_time` | histogram | Time it took to archive a user's message. |
+    | `mod_mam_pm_lookup_count` | counter | Any MAM PM lookup is performed. |
+    | `mod_mam_pm_lookup_simple` | counter | A simple MAM PM lookup is performed. |
+    | `mod_mam_pm_lookup_size` | histogram | MAM PM lookup size (row count). |
+    | `mod_mam_pm_lookup_time` | histogram | MAM PM lookup time. |
+    | `mod_mam_pm_dropped_iq_count` | counter | MAM IQ has been dropped due to: high query frequency/invalid syntax or type. |
+    | `mod_mam_pm_dropped_count` | counter | A message couldn't be stored in the DB (and got dropped). |
+    | `mod_mam_pm_remove_archive_count` | counter | User's PM archive is removed. |
+    | `mod_mam_pm_get_prefs_count` | counter | Archiving preferences have been requested by a client. |
+    | `mod_mam_pm_set_prefs_count` | counter | Archiving preferences have been updated by a client. |
+    | `mod_mam_muc_archive_message_count` | counter | A message is stored in room's archive. |
+    | `mod_mam_muc_archive_message_time` | histogram | Time it took to archive a MUC message. |
+    | `mod_mam_muc_lookup_count` | counter | Any MAM lookup in MUC room is performed. |
+    | `mod_mam_muc_lookup_size` | histogram | MAM MUC lookup size (row count). |
+    | `mod_mam_muc_lookup_time` | histogram | MAM MUC lookup time. |
+    | `mod_mam_muc_dropped_iq_count` | counter | MAM MUC IQ has been dropped due to: high query frequency/invalid syntax or type. |
+    | `mod_mam_muc_dropped_count` | counter | A MUC message couldn't be stored in the DB (and got dropped). |
+    | `mod_mam_muc_remove_archive_count` | counter | Room's entire archive is removed. |
+    | `mod_mam_muc_get_prefs_count` | counter | MUC archiving preferences have been requested by a client. |
+    | `mod_mam_muc_set_prefs_count` | counter | MUC archiving preferences have been updated by a client. |
+    | `mod_mam_pm_flushed_count` | counter | Async MAM worker flushed buffered messages. |
+    | `mod_mam_pm_flushed_time` | histogram | Average time per flush of all buffered messages measured in an async MAM worker. |
+    | `mod_mam_pm_flushed_time_per_message` | histogram | Average time per message insert measured in an async MAM worker. |
+    | `mod_mam_muc_flushed_count` | counter | Async MUC MAM worker flushed buffered messages. |
+    | `mod_mam_muc_flushed_time` | histogram | Average time per flush of all buffered messages measured in an async MUC MAM worker. |
+    | `mod_mam_muc_flushed_time_per_message` | histogram | Average time per message insert measured in an async MUC MAM worker. |
+
+=== "Exometer"
+
+    | Name | Type | Description (when it gets incremented) |
+    | ---- | ---- | -------------------------------------- |
+    | `[HostType, mod_mam_pm_archive_message, count]` | spiral | A PM message is stored in user's archive. |
+    | `[HostType, mod_mam_pm_archive_message, time]` | histogram | Time it took to archive a user's message. |
+    | `[HostType, mod_mam_pm_lookup, count]` | spiral | Any MAM PM lookup is performed. |
+    | `[HostType, mod_mam_pm_lookup_simple` | spiral | A simple MAM PM lookup is performed. |
+    | `[HostType, mod_mam_pm_lookup, size]` | histogram | MAM PM lookup size (row count). |
+    | `[HostType, mod_mam_pm_lookup, time]` | histogram | MAM PM lookup time. |
+    | `[HostType, mod_mam_pm_dropped_iq, count]` | spiral | MAM IQ has been dropped due to: high query frequency/invalid syntax or type. |
+    | `[HostType, mod_mam_pm_dropped, count]` | spiral | A message couldn't be stored in the DB (and got dropped). |
+    | `[HostType, mod_mam_pm_remove_archive, count]` | spiral | User's PM archive is removed. |
+    | `[HostType, mod_mam_pm_get_prefs, count]` | spiral | Archiving preferences have been requested by a client. |
+    | `[HostType, mod_mam_pm_set_prefs, count]` | spiral | Archiving preferences have been updated by a client. |
+    | `[HostType, mod_mam_muc_archive_message, count]` | spiral | A message is stored in room's archive. |
+    | `[HostType, mod_mam_muc_archive_message, time]` | histogram | Time it took to archive a MUC message. |
+    | `[HostType, mod_mam_muc_lookup, count]` | spiral | Any MAM lookup in MUC room is performed. |
+    | `[HostType, mod_mam_muc_lookup, size]` | histogram | MAM MUC lookup size (row count). |
+    | `[HostType, mod_mam_muc_lookup, time]` | histogram | MAM MUC lookup time. |
+    | `[HostType, mod_mam_muc_dropped_iq, count]` | spiral | MAM MUC IQ has been dropped due to: high query frequency/invalid syntax or type. |
+    | `[HostType, mod_mam_muc_dropped, count]` | spiral | A MUC message couldn't be stored in the DB (and got dropped). |
+    | `[HostType, mod_mam_muc_remove_archive, count]` | spiral | Room's entire archive is removed. |
+    | `[HostType, mod_mam_muc_get_prefs, count]` | spiral | MUC archiving preferences have been requested by a client. |
+    | `[HostType, mod_mam_muc_set_prefs, count]` | spiral | MUC archiving preferences have been updated by a client. |
+    | `[HostType, mod_mam_pm_flushed, count]` | spiral | Async MAM worker flushed buffered messages. |
+    | `[HostType, mod_mam_pm_flushed, time]` | histogram | Average time per flush of all buffered messages measured in an async MAM worker. |
+    | `[HostType, mod_mam_pm_flushed, time_per_message]` | histogram | Average time per message insert measured in an async MAM worker. |
+    | `[HostType, mod_mam_muc_flushed, count]` | spiral | Async MUC MAM worker flushed buffered messages. |
+    | `[HostType, mod_mam_muc_flushed, time]` | histogram | Average time per flush of all buffered messages measured in an async MUC MAM worker. |
+    | `[HostType, mod_mam_muc_flushed, time_per_message]` | histogram | Average time per message insert measured in an async MUC MAM worker. |

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -488,10 +488,25 @@ If the server returns something else, an error presence will be sent back to the
 
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Name | Type | Description (when it gets incremented) |
-| ---- | ---- | -------------------------------------- |
-| `[global, mod_muc, deep_hibernations]` | spiral | A room process is stopped (applies only to persistent rooms). |
-| `[global, mod_muc, process_recreations]` | spiral | A room process is recreated from a persisted state. |
-| `[global, mod_muc, hibernations]` | spiral | A room process becomes hibernated (garbage collected and put in wait state). |
-| `[global, mod_muc, hibernated_rooms]` | value | How many rooms are in hibernated state. Does not include rooms in "deep hibernation". |
-| `[global, mod_muc, online_rooms]` | value | How many rooms have running processes (includes rooms in a hibernated state). |
+Prometheus metrics have a `host_type` label associated with these metrics.
+Since Exometer doesn't support labels, the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+=== "Prometheus"
+
+  | Name | Type | Description (when it gets incremented) |
+  | ---- | ---- | -------------------------------------- |
+  | `mod_muc_deep_hibernations_count` | counter | A room process is stopped (applies only to persistent rooms). |
+  | `mod_muc_process_recreations_count` | counter | A room process is recreated from a persisted state. |
+  | `mod_muc_hibernations_count` | counter | A room process becomes hibernated (garbage collected and put in wait state). |
+  | `mod_muc_rooms_hibernated` | gauge | How many rooms are in hibernated state. Does not include rooms in "deep hibernation". |
+  | `mod_muc_rooms_online` | gauge | How many rooms have running processes (includes rooms in a hibernated state). |
+
+=== "Exometer"
+
+  | Name | Type | Description (when it gets incremented) |
+  | ---- | ---- | -------------------------------------- |
+  | `[HostType, mod_muc_deep_hibernations, count]` | spiral | A room process is stopped (applies only to persistent rooms). |
+  | `[HostType, mod_muc_process_recreations, count]` | spiral | A room process is recreated from a persisted state. |
+  | `[HostType, mod_muc_hibernations, count]` | spiral | A room process becomes hibernated (garbage collected and put in wait state). |
+  | `[HostType, mod_muc_rooms, hibernated]` | gauge | How many rooms are in hibernated state. Does not include rooms in "deep hibernation". |
+  | `[HostType, mod_muc_rooms, online]` | gauge | How many rooms have running processes (includes rooms in a hibernated state). |

--- a/doc/modules/mod_muc_light.md
+++ b/doc/modules/mod_muc_light.md
@@ -176,18 +176,72 @@ Each `config_schema` item is a TOML table with the following keys:
 
 ## Metrics
 
+This module provides [backend metrics](../operation-and-maintenance/MongooseIM-metrics.md#backend-metrics).
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Backend action | Description (when it gets incremented) |
-| | -------------------------------------- |
-| `create_room` | A new room is stored in a DB. |
-| `destroy_room` | Room data is removed from a DB. |
-| `room_exists` | A room existence is checked. |
-| `get_user_rooms` | A list of rooms the user is a participant of is retrieved from a DB. |
-| `remove_user` | All MUC Light related user data is removed from a DB. |
-| `get_config` | A room config is retrieved from a DB. |
-| `set_config` | A room config is updated in a DB. |
-| `get_blocking` | Blocking data is fetched from a DB. |
-| `set_blocking` | Blocking data is updated in a DB. |
-| `get_aff_users` | An affiliated users list is fetched from a DB. |
-| `modify_aff_users` | Affiliations in a room are updated in a DB. |
+Prometheus metrics have a `host_type` and `function` labels associated with these metrics.
+Since Exometer doesn't support labels, the function as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+Backend in the action name can be either `rdbms` or `mnesia`.
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_muc_light_Backend_count` | counter | `create_room` | A new room is stored in a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `create_room` | Time to store a new room in a DB. |
+    | `mod_muc_light_Backend_count` | counter | `destroy_room` | Room data is removed from a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `destroy_room` | Time to remove room data from a DB. |
+    | `mod_muc_light_Backend_count` | counter | `room_exists` | A room existence is checked. |
+    | `mod_muc_light_Backend_time`  | histogram | `room_exists` | Time to check the existance of a room. |
+    | `mod_muc_light_Backend_count` | counter | `get_user_rooms` | A list of rooms the user is a participant of is retrieved from a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `get_user_rooms` | Time to retrieve a list of rooms the user is a participant of from a DB. |
+    | `mod_muc_light_Backend_count` | counter | `get_user_rooms_count` | The count` of rooms the user is a participant of is retrieved from a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `get_user_rooms_count` | Time to retrieve the count` of rooms the user is a participant of from a DB. |
+    | `mod_muc_light_Backend_count` | counter | `remove_user` | All MUC Light related user data is removed from a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `remove_user` | Time to remove all MUC Light related user data from a DB. |
+    | `mod_muc_light_Backend_count` | counter | `remove_domain` | All MUC Light related domain data is removed from a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `remove_domain` |Time to remove all MUC Light related domain data from a DB. |
+    | `mod_muc_light_Backend_count` | counter | `get_config` | A room config is retrieved from a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `get_config` | Time to retrieve a room config from a DB. |
+    | `mod_muc_light_Backend_count` | counter | `set_config` | A room config is updated in a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `set_config` | Time to update a room config in a DB. |
+    | `mod_muc_light_Backend_count` | counter | `get_blocking` | Blocking data is fetched from a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `get_blocking` | Time to fetch blocking data from a DB. |
+    | `mod_muc_light_Backend_count` | counter | `set_blocking` | Blocking data is updated in a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `set_blocking` | Time to update blocking data in a DB. |
+    | `mod_muc_light_Backend_count` | counter | `get_aff_users` | Affiliated users list is fetched from a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `get_aff_users` | Time to fetch affiliated users list from a DB. |
+    | `mod_muc_light_Backend_count` | counter | `modify_aff_users` | Affiliations in a room are updated in a DB. |
+    | `mod_muc_light_Backend_time`  | histogram | `modify_aff_users` | Time to update affiliations in a room in a DB. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_muc_light_Backend, create_room,  count]` | counter   | A new room is stored in a DB. |
+    | `[HostType, mod_muc_light_Backend, create_room,  time]`  | histogram | Time to store a new room in a DB. |
+    | `[HostType, mod_muc_light_Backend, destroy_room, count]` | counter   | Room data is removed from a DB. |
+    | `[HostType, mod_muc_light_Backend, destroy_room, time]`  | histogram | Time to remove room data from a DB. |
+    | `[HostType, mod_muc_light_Backend, room_exists,  count]` | counter   | A room existence is checked. |
+    | `[HostType, mod_muc_light_Backend, room_exists,  time]`  | histogram | Time to check the existance of a room. |
+    | `[HostType, mod_muc_light_Backend, get_user_rooms, count]` | counter   | A list of rooms the user is a participant of is retrieved from a DB. |
+    | `[HostType, mod_muc_light_Backend, get_user_rooms, time]`  | histogram | Time to retrieve a list of rooms the user is a participant of from a DB. |
+    | `[HostType, mod_muc_light_Backend, get_user_rooms_count, count]` | counter   | The count of rooms the user is a participant of is retrieved from a DB. |
+    | `[HostType, mod_muc_light_Backend, get_user_rooms_count, time]`  | histogram | Time to retrieve the count of rooms the user is a participant of from a DB. |
+    | `[HostType, mod_muc_light_Backend, remove_user`, count]` | counter   | All MUC Light related user data is removed from a DB. |
+    | `[HostType, mod_muc_light_Backend, remove_user`, time]`  | histogram | Time to remove all MUC Light related user data from a DB. |
+    | `[HostType, mod_muc_light_Backend, remove_domain, count]` | counter   | All MUC Light related domain data is removed from a DB. |
+    | `[HostType, mod_muc_light_Backend, remove_domain, time]`  | histogram |Time to remove all MUC Light related domain data from a DB. |
+    | `[HostType, mod_muc_light_Backend, get_config, count]` | counter   | A room config is retrieved from a DB. |
+    | `[HostType, mod_muc_light_Backend, get_config, time]`  | histogram | Time to retrieve a room config from a DB. |
+    | `[HostType, mod_muc_light_Backend, set_config, count]` | counter   | A room config is updated in a DB. |
+    | `[HostType, mod_muc_light_Backend, set_config, time]`  | histogram | Time to update a room config in a DB. |
+    | `[HostType, mod_muc_light_Backend, get_blocking, count]` | counter   | Blocking data is fetched from a DB. |
+    | `[HostType, mod_muc_light_Backend, get_blocking, time]`  | histogram | Time to fetch blocking data from a DB. |
+    | `[HostType, mod_muc_light_Backend, set_blocking, count]` | counter   | Blocking data is updated in a DB. |
+    | `[HostType, mod_muc_light_Backend, set_blocking, time]`  | histogram | Time to update blocking data in a DB. |
+    | `[HostType, mod_muc_light_Backend, get_aff_users, count]` | counter   | Affiliated users list is fetched from a DB. |
+    | `[HostType, mod_muc_light_Backend, get_aff_users, time]`  | histogram | Time to fetch affiliated users list from a DB. |
+    | `[HostType, mod_muc_light_Backend, modify_aff_users, count]` | counter   | Affiliations in a room are updated in a DB. |
+    | `[HostType, mod_muc_light_Backend, modify_aff_users, time]`  | histogram | Time to update affiliations in a room in a DB. |

--- a/doc/modules/mod_offline.md
+++ b/doc/modules/mod_offline.md
@@ -46,9 +46,28 @@ to disable this error message.
 
 ## Metrics
 
+This module provides [backend metrics](../operation-and-maintenance/MongooseIM-metrics.md#backend-metrics).
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Backend action | Type | Description (when it gets incremented) |
-| ---- | ---- | -------------------------------------- |
-| `pop_messages` | histogram | Offline messages for a user are retrieved and deleted from a DB. |
-| `write_messages` | histogram | New offline messages to a user are written in a DB. |
+Prometheus metrics have a `host_type` and `function` labels associated with these metrics.
+Since Exometer doesn't support labels, the function as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+Backend in the action name can be either `rdbms` or `mnesia`.
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_last_Backend_count` | counter | `pop_messages` | Offline messages for a user are retrieved and deleted from a DB. |
+    | `mod_last_Backend_time` | histogram | `pop_messages` | Time spent retrieving and deleting offline messages for a user from a DB. |
+    | `mod_last_Backend_count` | counter | `write_messages` |  New offline messages to a user are written in a DB. |
+    | `mod_last_Backend_time` | histogram | `write_messages` | Time spent writing a new offline messages to a user in a DB. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_last_Backend, pop_messages, count]` | counter | Offline messages for a user are retrieved and deleted from a DB. |
+    | `[HostType, mod_last_Backend, pop_messages, time]` | histogram | Time spent retrieving and deleting offline messages for a user from a DB. |
+    | `[HostType, mod_last_Backend, write_messages, count]` | counter |  New offline messages to a user are written in a DB. |
+    | `[HostType, mod_last_Backend, write_messages, time]` | histogram | Time spent writing a new offline messages to a user in a DB. |

--- a/doc/modules/mod_ping.md
+++ b/doc/modules/mod_ping.md
@@ -53,8 +53,21 @@ Strategy to handle incoming stanzas. For details, please refer to
 
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Name | Type | Description (when it gets incremented) |
-| ---- | ---- | -------------------------------------- |
-| ``[HostType, mod_ping, ping_response]`` | spiral | Client responds to a ping. |
-| ``[HostType, mod_ping, ping_response_timeout]`` | spiral | Ping request timeouts without a response from client. |
-| ``[HostType, mod_ping, ping_response_time]`` | histogram | Response times (doesn't include timeouts). |
+Prometheus metrics have a `host_type` label associated with these metrics.
+Since Exometer doesn't support labels, the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+=== "Prometheus"
+
+    | Name | Type | Description (when it gets incremented) |
+    |------|------|----------------------------------------|
+    | `mod_ping_response_count` | counter | Client responds to a ping. |
+    | `mod_ping_response_time` | histogram | Ping request timeouts without a response from client. |
+    | `mod_ping_response_count` | counter | Response times (doesn't include timeouts). |
+
+=== "Exometer"
+
+    | Name | Type | Description (when it gets incremented) |
+    |------|------|----------------------------------------|
+    | `[HostType, mod_ping_response, count]` | spiral | Client responds to a ping. |
+    | `[HostType, mod_ping_response, time]` | histogram | Ping request timeouts without a response from client. |
+    | `[HostType, mod_ping_response_timeout, count]` | spiral | Response times (doesn't include timeouts). |

--- a/doc/modules/mod_ping.md
+++ b/doc/modules/mod_ping.md
@@ -61,13 +61,13 @@ Since Exometer doesn't support labels, the host types, or word `global`, are par
     | Name | Type | Description (when it gets incremented) |
     |------|------|----------------------------------------|
     | `mod_ping_response_count` | counter | Client responds to a ping. |
-    | `mod_ping_response_time` | histogram | Ping request timeouts without a response from client. |
-    | `mod_ping_response_count` | counter | Response times (doesn't include timeouts). |
+    | `mod_ping_response_time` | histogram | Response times (doesn't include timeouts). |
+    | `mod_ping_response_count` | counter | Ping request timeouts without a response from client. |
 
 === "Exometer"
 
     | Name | Type | Description (when it gets incremented) |
     |------|------|----------------------------------------|
     | `[HostType, mod_ping_response, count]` | spiral | Client responds to a ping. |
-    | `[HostType, mod_ping_response, time]` | histogram | Ping request timeouts without a response from client. |
-    | `[HostType, mod_ping_response_timeout, count]` | spiral | Response times (doesn't include timeouts). |
+    | `[HostType, mod_ping_response, time]` | histogram | Response times (doesn't include timeouts). |
+    | `[HostType, mod_ping_response_timeout, count]` | spiral | Ping request timeouts without a response from client. |

--- a/doc/modules/mod_privacy.md
+++ b/doc/modules/mod_privacy.md
@@ -19,14 +19,48 @@ This extension allows user to block IQs, messages, presences, or all, based on J
 
 ## Metrics
 
+This module provides [backend metrics](../operation-and-maintenance/MongooseIM-metrics.md#backend-metrics).
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Backend action | Description (when it gets incremented) |
-| ---- | -------------------------------------- |
-| `get_privacy_list` | A privacy list is retrieved from a DB. |
-| `get_list_names` | Names of user's privacy lists are fetched from a DB. |
-| `get_default_list` | A default privacy list for a user is fetched from a DB. |
-| `set_default_list` | A default list's name for a user is set in a DB. |
-| `forget_default_list` | A default list's name for a user is removed from a DB. |
-| `remove_privacy_list` | A privacy list is deleted from a DB. |
-| `replace_privacy_list` | A privacy list is updated (replaced) in a DB. |
+Prometheus metrics have a `host_type` and `function` labels associated with these metrics.
+Since Exometer doesn't support labels, the function as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+Backend in the action name can be either `rdbms` or `mnesia`.
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_privacy_Backend_count` | counter | `get_privacy_list` | A privacy list is retrieved from a database. |
+    | `mod_privacy_Backend_time` | histogram | `get_privacy_list` | Time spent retrieving a privacy list is retrieved from a database. |
+    | `mod_privacy_Backend_count` | counter | `get_list_names` | Names of user's privacy lists are fetched from a database. |
+    | `mod_privacy_Backend_time` | histogram | `get_list_names` | Time to fetch names of user's privacy lists from a database. |
+    | `mod_privacy_Backend_count` | counter | `get_default_list` | A default privacy list for a user is fetched from a database. |
+    | `mod_privacy_Backend_time` | histogram | `get_default_list` | Time to fetch a default privacy list for a user from a database. |
+    | `mod_privacy_Backend_count` | counter | `set_default_list` | A default list's name for a user is set in a database. |
+    | `mod_privacy_Backend_time` | histogram | `set_default_list` | Time to set a default list's name for a user in a database. |
+    | `mod_privacy_Backend_count` | counter | `forget_default_list` | A default list's name for a user is removed from a database. |
+    | `mod_privacy_Backend_time` | histogram | `forget_default_list` | Time to remove a default list's name for a user from a database. |
+    | `mod_privacy_Backend_count` | counter | `remove_privacy_list` | A privacy list is deleted from a database. |
+    | `mod_privacy_Backend_time` | histogram | `remove_privacy_list` | Time to delete a privacy list from a database. |
+    | `mod_privacy_Backend_count` | counter | `replace_privacy_list` | A privacy list is updated (replaced) in a database. |
+    | `mod_privacy_Backend_time` | histogram | `replace_privacy_list` | Time to update a privacy list is updated (replaced) in a database. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_privacy_Backend, get_privacy_list, count]` | spiral | A privacy list is retrieved from a database. |
+    | `[HostType, mod_privacy_Backend, get_privacy_list, time]` | histogram | Time spent retrieving a privacy list is retrieved from a database. |
+    | `[HostType, mod_privacy_Backend, get_list_names, count]` | spiral | Names of user's privacy lists are fetched from a database. |
+    | `[HostType, mod_privacy_Backend, get_list_names, time]` | histogram | Time to fetch names of user's privacy lists from a database. |
+    | `[HostType, mod_privacy_Backend, get_default_list, count]` | spiral | A default privacy list for a user is fetched from a database. |
+    | `[HostType, mod_privacy_Backend, get_default_list, time]` | histogram | Time to fetch a default privacy list for a user from a database. |
+    | `[HostType, mod_privacy_Backend, set_default_list, count]` | spiral | A default list's name for a user is set in a database. |
+    | `[HostType, mod_privacy_Backend, set_default_list, time]` | histogram | Time to set a default list's name for a user in a database. |
+    | `[HostType, mod_privacy_Backend, forget_default_list, count]` | spiral | A default list's name for a user is removed from a database. |
+    | `[HostType, mod_privacy_Backend, forget_default_list, time]` | histogram | Time to remove a default list's name for a user from a database. |
+    | `[HostType, mod_privacy_Backend, remove_privacy_list, count]` | spiral | A privacy list is deleted from a database. |
+    | `[HostType, mod_privacy_Backend, remove_privacy_list, time]` | histogram | Time to delete a privacy list from a database. |
+    | `[HostType, mod_privacy_Backend, replace_privacy_list, count]` | spiral | A privacy list is updated (replaced) in a database. |
+    | `[HostType, mod_privacy_Backend, replace_privacy_list, time]` | histogram | Time to update a privacy list is updated (replaced) in a database. |

--- a/doc/modules/mod_private.md
+++ b/doc/modules/mod_private.md
@@ -27,9 +27,28 @@ Database backend to use.
 
 ## Metrics
 
+This module provides [backend metrics](../operation-and-maintenance/MongooseIM-metrics.md#backend-metrics).
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Backend operation | Description (when it gets incremented) |
-| ---- | -------------------------------------- |
-| `multi_get_data` | XML data is fetched from a DB. |
-| `multi_set_data` | XML data is stored in a DB. |
+Prometheus metrics have a `host_type` and `function` labels associated with these metrics.
+Since Exometer doesn't support labels, the function as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+Backend in the action name can be either `rdbms` or `mnesia`.
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_private_Backend_count` | counter | `multi_get_data` | XML data is fetched from a database. |
+    | `mod_private_Backend_time`  | histogram | `multi_get_data` | Time to fetch XML data from a database. |
+    | `mod_private_Backend_count` | counter | `multi_set_data` | XML data is stored in a database. |
+    | `mod_private_Backend_time`  | histogram | `multi_set_data` | Time to store XML data in a database. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_private_Backend, multi_get_data,  count]` | spiral | XML data is fetched from a database. |
+    | `[HostType, mod_private_Backend, multi_get_data,  time]`  | histogram | Time to fetch XML data from a database. |
+    | `[HostType, mod_private_Backend, multi_set_data,  count]` | spiral | XML data is stored in a database. |
+    | `[HostType, mod_private_Backend, multi_set_data,  time]`  | histogram | Time to store XML data in a database. |

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -234,66 +234,198 @@ If you'd like to learn more about metrics in MongooseIM, please visit the [Mongo
 
 ### Overall PubSub action metrics
 
-For every PubSub action, like node creation, subscription, publication the following metrics are available:
+=== "Prometheus"
 
-* count - a spiral metric showing the number of given action invocations
-* errors - a spiral metric counting the errors for a given action
-* time - a histogram metric showing the time it took to finish the action in case of success
+    For every PubSub action, like node creation, subscription, publication the following metrics are available:
 
-Below there is a table describing all metrics related to PubSub actions
+    * count - a counter metric showing the number of given action invocations
+    * errors - a counter metric counting the errors for a given action
+    * time - a histogram metric showing the time it took to finish the action in case of success
 
-| Name | Description (when it gets incremented) |
-| ---- | -------------------------------------- |
-|`[HOST, pubsub, get, affiliations, TYPE]` | When node's affiliations are read |
-|`[HOST, pubsub, get, configure, TYPE]` | When node's configuration is read |
-|`[HOST, pubsub, get, default, TYPE]` | When node's defaults are read |
-|`[HOST, pubsub, get, items, TYPE]` | When node's items are read |
-|`[HOST, pubsub, get, options, TYPE]` | When node's options are read |
-|`[HOST, pubsub, get, subscriptions, TYPE]` | When node's subscriptions are read |
-|`[HOST, pubsub, set, affiliations, TYPE]` | When node's subscriptions are set |
-|`[HOST, pubsub, set, configure, TYPE]` | When node's configuration is set |
-|`[HOST, pubsub, set, create, TYPE]` | When node is created |
-|`[HOST, pubsub, set, delete, TYPE]` | When node is deleted |
-|`[HOST, pubsub, set, options, TYPE]` | When node's options are set |
-|`[HOST, pubsub, set, publish, TYPE]` | When an item is published |
-|`[HOST, pubsub, set, purge, TYPE]` | When node's items are purged |
-|`[HOST, pubsub, set, retract, TYPE]` | When node's items are retracted |
-|`[HOST, pubsub, set, subscribe, TYPE]` | When a subscriber subscribes to a node |
-|`[HOST, pubsub, set, subscriptions, TYPE]` | When a subscription is set (for instance accepted) |
-|`[HOST, pubsub, set, unsubscribe, TYPE]` | When a subscriber unsubscribes |
+    All PubSub metrics have a `host_type` label associated with them.
 
-Where:
+    Below there is a table describing all metrics related to PubSub actions
 
-* `HOST` is the XMPP host for which `mod_pubsub` is running. Can be set to `global` if all metrics are set to be global.
-* `TYPE` is one of the following `count`, `errors`, `time` (described above the table)
+    | Name | Description (when it gets incremented) |
+    | ---- | -------------------------------------- |
+    |`mod_pubsub_get_affiliations_TYPE` | When node's affiliations are read |
+    |`mod_pubsub_get_configure_TYPE` | When node's configuration is read |
+    |`mod_pubsub_get_default_TYPE` | When node's defaults are read |
+    |`mod_pubsub_get_items_TYPE` | When node's items are read |
+    |`mod_pubsub_get_options_TYPE` | When node's options are read |
+    |`mod_pubsub_get_subscriptions_TYPE` | When node's subscriptions are read |
+    |`mod_pubsub_set_affiliations_TYPE` | When node's subscriptions are set |
+    |`mod_pubsub_set_configure_TYPE` | When node's configuration is set |
+    |`mod_pubsub_set_create_TYPE` | When node is created |
+    |`mod_pubsub_set_delete_TYPE` | When node is deleted |
+    |`mod_pubsub_set_options_TYPE` | When node's options are set |
+    |`mod_pubsub_set_publish_TYPE` | When an item is published |
+    |`mod_pubsub_set_purge_TYPE` | When node's items are purged |
+    |`mod_pubsub_set_retract_TYPE` | When node's items are retracted |
+    |`mod_pubsub_set_subscribe_TYPE` | When a subscriber subscribes to a node |
+    |`mod_pubsub_set_subscriptions_TYPE` | When a subscription is set (for instance accepted) |
+    |`mod_pubsub_set_unsubscribe_TYPE` | When a subscriber unsubscribes |
+
+    Where:
+    
+    * `TYPE` is one of the following `count`, `errors`, `time` (described above the table)
+
+=== "Exometer"
+
+    For every PubSub action, like node creation, subscription, publication the following metrics are available:
+
+    * count - a spiral metric showing the number of given action invocations
+    * errors - a spiral metric counting the errors for a given action
+    * time - a histogram metric showing the time it took to finish the action in case of success
+
+    Below there is a table describing all metrics related to PubSub actions
+
+    | Name | Description (when it gets incremented) |
+    | ---- | -------------------------------------- |
+    |`[HOST, pubsub, get, affiliations, TYPE]` | When node's affiliations are read |
+    |`[HOST, pubsub, get, configure, TYPE]` | When node's configuration is read |
+    |`[HOST, pubsub, get, default, TYPE]` | When node's defaults are read |
+    |`[HOST, pubsub, get, items, TYPE]` | When node's items are read |
+    |`[HOST, pubsub, get, options, TYPE]` | When node's options are read |
+    |`[HOST, pubsub, get, subscriptions, TYPE]` | When node's subscriptions are read |
+    |`[HOST, pubsub, set, affiliations, TYPE]` | When node's subscriptions are set |
+    |`[HOST, pubsub, set, configure, TYPE]` | When node's configuration is set |
+    |`[HOST, pubsub, set, create, TYPE]` | When node is created |
+    |`[HOST, pubsub, set, delete, TYPE]` | When node is deleted |
+    |`[HOST, pubsub, set, options, TYPE]` | When node's options are set |
+    |`[HOST, pubsub, set, publish, TYPE]` | When an item is published |
+    |`[HOST, pubsub, set, purge, TYPE]` | When node's items are purged |
+    |`[HOST, pubsub, set, retract, TYPE]` | When node's items are retracted |
+    |`[HOST, pubsub, set, subscribe, TYPE]` | When a subscriber subscribes to a node |
+    |`[HOST, pubsub, set, subscriptions, TYPE]` | When a subscription is set (for instance accepted) |
+    |`[HOST, pubsub, set, unsubscribe, TYPE]` | When a subscriber unsubscribes |
+
+    Where:
+    
+    * `HOST` is the XMPP host for which `mod_pubsub` is running. Can be set to `global` if all metrics are set to be global.
+    * `TYPE` is one of the following `count`, `errors`, `time` (described above the table)
 
 ### Backend operations
 
-The are also more detailed metrics measuring execution time of backend operations.
+`mod_pubsub` also provides detailed [backend metrics](../operation-and-maintenance/MongooseIM-metrics.md#backend-metrics) measuring execution time of backend operations.
 
-Metrics for these actions may be found under `mod_pubsub_db` subkey.
+Prometheus metrics have a `host_type` and `function` labels associated with these metrics.
+Since Exometer doesn't support labels, the function as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
 
-| Backend action | Description (when it gets incremented) |
-| ---- | -------------------------------------- |
-| `get_state` |  User's state for a specific node is fetched. |
-| `get_states` | Node's states are fetched. |
-| `get_states_by_lus` | Nodes' states for user + domain are fetched. |
-| `get_states_by_bare` | Nodes' states for bare JID are fetched. |
-| `get_states_by_full` | Nodes' states for full JID are fetched. |
-| `get_own_nodes_states` | State data for user's nodes is fetched. |
-| `create_node` | A node's owner is set. |
-| `del_node` | All data related to a node is removed. |
-| `get_items` | Node's items are fetched. |
-| `get_item` | A specific item from a node is fetched. |
-| `add_item` | An item is upserted into a node. |
-| `set_item` | An item is updated in a node. |
-| `del_item` | An item is deleted from a node. |
-| `del_items` | Specified items are deleted from a node. |
-| `set_node` | A node is upserted. |
-| `find_node_by_id` | A node is fetched by its ID. |
-| `find_nodes_by_key` | Nodes are fetched by key. |
-| `find_node_by_name` | A node is fetched by its name. |
-| `del_node` | A node is deleted. |
-| `get_subnodes` | Subnodes of a node are fetched. |
-| `get_subnodes_tree` | Full tree of subnodes of a node is fetched. |
-| `get_parentnodes_tree` | All parents of a node are fetched. |
+Backend in the action name can be either `rdbms` or `mnesia`.
+
+#### Cache backend
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_pubsub_cache_Backend_count` | counter | `upsert_last_item` | Last item is upserted into a node. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `upsert_last_item` | Time to upsert last item into a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `delete_last_item` | Last item is deleted from a node. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `delete_last_item` | Time to delete last item from a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_last_item` | Last item from a node is fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_last_item` | Time to fetch the last item from a node. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_pubsub_cache_Backend, upsert_last_item, count]` | counter | Last item is upserted into a node. |
+    | `[HostType, mod_pubsub_cache_Backend, upsert_last_item, time]` | histogram | Time to upsert last item into a node. |
+    | `[HostType, mod_pubsub_cache_Backend, delete_last_item, count]` | counter | Last item is deleted from a node. |
+    | `[HostType, mod_pubsub_cache_Backend, delete_last_item, time]` | histogram | Time to delete last item from a node. |
+    | `[HostType, mod_pubsub_cache_Backend, get_last_item, count]` | counter | Last item from a node is fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_last_item, time]` | histogram | Time to fetch the last item from a node. |
+
+#### Database backend
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_state` | User's state for a specific node is fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_state` | Time to fetch user's state for a specific node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_states` | Node's states are fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_states` | Time to fetch node's states. |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_states_by_lus` | Nodes' states for user + domain are fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_states_by_lus` | Time to fetch the nodes' states for user + domain. |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_states_by_bare` | Nodes' states for bare JID are fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_states_by_bare` | Time to fetch nodes' states for bare JID. |
+    | `mod_pubsub_cache_Backend_count` | counter | `create_node` | A node's owner is set. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `create_node` | Time to set a node's owner. |
+    | `mod_pubsub_cache_Backend_count` | counter | `del_node` | All data related to a node is removed. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `del_node` | Time to remove all data related to a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_items` | Node's items are fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_items` | Time to fetch node's items. |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_item` | A specific item from a node is fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_item` | Time to fetch a specific item from a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `add_item` | An item is upserted into a node. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `add_item` | Time to upsert an item into a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `set_item` | An item is updated in a node. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `set_item` | Time to update an item in a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `del_item` | An item is deleted from a node. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `del_item` | Time to delete an item from a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `del_items` | Specified items are deleted from a node. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `del_items` | Time to delete specified items from a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `set_node` | A node is upserted. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `set_node` | Time to upsert a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `find_node_by_id` | A node is fetched by its ID. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `find_node_by_id` | Time to fetch a node by its ID. |
+    | `mod_pubsub_cache_Backend_count` | counter | `find_nodes_by_key` | Nodes are fetched by key. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `find_nodes_by_key` | Time to fetch nodes by key. |
+    | `mod_pubsub_cache_Backend_count` | counter | `find_node_by_name` | A node is fetched by its name. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `find_node_by_name` | Time to fetch a node by its name. |
+    | `mod_pubsub_cache_Backend_count` | counter | `delete_node` | A node is deleted. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `delete_node` | Time to delete a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_subnodes` | Subnodes of a node are fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_subnodes` | Time to fetch the subnodes of a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_subnodes_tree` | Full tree of subnodes of a node is fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_subnodes_tree` | Time to fetch the full tree of subnodes of a node. |
+    | `mod_pubsub_cache_Backend_count` | counter | `get_parentnodes_tree` | All parents of a node are fetched. |
+    | `mod_pubsub_cache_Backend_time` | histogram | `get_parentnodes_tree` | Time to fetch all parents of a node. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_pubsub_cache_Backend, get_state, count]` | counter | User's state for a specific node is fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_state, time]` | histogram | Time to fetch user's state for a specific node. |
+    | `[HostType, mod_pubsub_cache_Backend, get_states, count]` | counter | Node's states are fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_states, time]` | histogram | Time to fetch node's states. |
+    | `[HostType, mod_pubsub_cache_Backend, get_states_by_lus, count]` | counter | Nodes' states for user + domain are fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_states_by_lus, time]` | histogram | Time to fetch the nodes' states for user + domain. |
+    | `[HostType, mod_pubsub_cache_Backend, get_states_by_bare, count]` | counter | Nodes' states for bare JID are fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_states_by_bare, time]` | histogram | Time to fetch nodes' states for bare JID. |
+    | `[HostType, mod_pubsub_cache_Backend, create_node, count]` | counter | A node's owner is set. |
+    | `[HostType, mod_pubsub_cache_Backend, create_node, time]` | histogram | Time to set a node's owner. |
+    | `[HostType, mod_pubsub_cache_Backend, del_node, count]` | counter | All data related to a node is removed. |
+    | `[HostType, mod_pubsub_cache_Backend, del_node, time]` | histogram | Time to remove all data related to a node. |
+    | `[HostType, mod_pubsub_cache_Backend, get_items, count]` | counter | Node's items are fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_items, time]` | histogram | Time to fetch node's items. |
+    | `[HostType, mod_pubsub_cache_Backend, get_item, count]` | counter | A specific item from a node is fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_item, time]` | histogram | Time to fetch a specific item from a node. |
+    | `[HostType, mod_pubsub_cache_Backend, add_item, count]` | counter | An item is upserted into a node. |
+    | `[HostType, mod_pubsub_cache_Backend, add_item, time]` | histogram | Time to upsert an item into a node. |
+    | `[HostType, mod_pubsub_cache_Backend, set_item, count]` | counter | An item is updated in a node. |
+    | `[HostType, mod_pubsub_cache_Backend, set_item, time]` | histogram | Time to update an item in a node. |
+    | `[HostType, mod_pubsub_cache_Backend, del_item, count]` | counter | An item is deleted from a node. |
+    | `[HostType, mod_pubsub_cache_Backend, del_item, time]` | histogram | Time to delete an item from a node. |
+    | `[HostType, mod_pubsub_cache_Backend, del_items, count]` | counter | Specified items are deleted from a node. |
+    | `[HostType, mod_pubsub_cache_Backend, del_items, time]` | histogram | Time to delete specified items from a node. |
+    | `[HostType, mod_pubsub_cache_Backend, set_node, count]` | counter | A node is upserted. |
+    | `[HostType, mod_pubsub_cache_Backend, set_node, time]` | histogram | Time to upsert a node. |
+    | `[HostType, mod_pubsub_cache_Backend, find_node_by_id, count]` | counter | A node is fetched by its ID. |
+    | `[HostType, mod_pubsub_cache_Backend, find_node_by_id, time]` | histogram | Time to fetch a node by its ID. |
+    | `[HostType, mod_pubsub_cache_Backend, find_nodes_by_key, count]` | counter | Nodes are fetched by key. |
+    | `[HostType, mod_pubsub_cache_Backend, find_nodes_by_key, time]` | histogram | Time to fetch nodes by key. |
+    | `[HostType, mod_pubsub_cache_Backend, find_node_by_name, count]` | counter | A node is fetched by its name. |
+    | `[HostType, mod_pubsub_cache_Backend, find_node_by_name, time]` | histogram | Time to fetch a node by its name. |
+    | `[HostType, mod_pubsub_cache_Backend, delete_node, count]` | counter | A node is deleted. |
+    | `[HostType, mod_pubsub_cache_Backend, delete_node, time]` | histogram | Time to delete a node. |
+    | `[HostType, mod_pubsub_cache_Backend, get_subnodes, count]` | counter | Subnodes of a node are fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_subnodes, time]` | histogram | Time to fetch the subnodes of a node. |
+    | `[HostType, mod_pubsub_cache_Backend, get_subnodes_tree, count]` | counter | Full tree of subnodes of a node is fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_subnodes_tree, time]` | histogram | Time to fetch the full tree of subnodes of a node. |
+    | `[HostType, mod_pubsub_cache_Backend, get_parentnodes_tree, count]` | counter | All parents of a node are fetched. |
+    | `[HostType, mod_pubsub_cache_Backend, get_parentnodes_tree, time]` | histogram | Time to fetch all parents of a node. |

--- a/doc/modules/mod_register.md
+++ b/doc/modules/mod_register.md
@@ -81,12 +81,7 @@ Deny registration from network 10.20.0.0 with mask 255.255.0.0.
 
 ## Metrics
 
-If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
-
-| Name | Type | Description (when it gets incremented) |
-| ---- | ---- | -------------------------------------- |
-| `[Host, auth_register, count]` | spiral | A user registers via `mod_register` module. |
-| `[Host, auth_unregister, count]` | spiral | A user unregisters via `mod_register` module. |
+There are no metrics specific to this module.
 
 ## Entropy calculation algorithm
 

--- a/doc/modules/mod_roster.md
+++ b/doc/modules/mod_roster.md
@@ -43,17 +43,52 @@ Improves performance but should be disabled, when shared rosters are used.
 
 ## Metrics
 
-If you'd like to learn more about metrics in MongooseIM,
-please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
+This module provides [backend metrics](../operation-and-maintenance/MongooseIM-metrics.md#backend-metrics).
+If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Backend action | Description (when it gets incremented) |
-| ---- | -------------------------------------- |
-| `read_roster_version` | Version of a user's roster is retrieved. |
-| `write_roster_version` | Vversion of a user's roster is stored. |
-| `get_roster` | A user's roster is fetched. |
-| `get_roster_entry` | A specific roster entry is fetched. |
-| `get_roster_entry_t` | A specific roster entry is fetched inside a transaction. |
-| `get_subscription_lists` | A subscription list of a user is retrieved. |
-| `roster_subscribe_t` | A subscription status between users is updated inside a transaction. |
-| `update_roster_t` | A roster entry is updated in a transaction. |
-| `del_roster_t` | A roster entry is removed inside a transaction. |
+Prometheus metrics have a `host_type` and `function` labels associated with these metrics.
+Since Exometer doesn't support labels, the function as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+Backend in the action name can be either `rdbms` or `mnesia`.
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_private_Backend_count` | counter | `read_roster_version` | Version of a user's roster is retrieved. |
+    | `mod_private_Backend_time`  | histogram | `read_roster_version` | Time to retrieve the version of a user's roster. |
+    | `mod_private_Backend_count` | counter | `write_roster_version` | Version of a user's roster is stored. |
+    | `mod_private_Backend_time`  | histogram | `write_roster_version` | Time to store the version of a user's roster. |
+    | `mod_private_Backend_count` | counter | `get_roster` | A user's roster is fetched. |
+    | `mod_private_Backend_time`  | histogram | `get_roster` | Time to fetch user's roster. |
+    | `mod_private_Backend_count` | counter | `get_roster_entry` | A specific roster entry is fetched. |
+    | `mod_private_Backend_time`  | histogram | `get_roster_entry` | Time to fetch a specific roster entry. |
+    | `mod_private_Backend_count` | counter | `get_subscription_lists` | A subscription list of a user is retrieved. |
+    | `mod_private_Backend_time`  | histogram | `get_subscription_lists` | Time to retrieve a subscription list of a user. |
+    | `mod_private_Backend_count` | counter | `roster_subscribe_t` | A subscription status between users is updated inside a transaction. |
+    | `mod_private_Backend_time`  | histogram | `roster_subscribe_t` | Time to update a subscription status between users inside a transaction. |
+    | `mod_private_Backend_count` | counter | `update_roster_t` | A roster entry is updated in a transaction. |
+    | `mod_private_Backend_time`  | histogram | `update_roster_t` | Time to update a roster entry in a transaction. |
+    | `mod_private_Backend_count` | counter | `del_roster_t` | A roster entry is removed inside a transaction. |
+    | `mod_private_Backend_time`  | histogram | `del_roster_t` | Time to remove a roster entry inside a transaction. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_private_Backend, read_roster_version, count]` | spiral | Version of a user's roster is retrieved. |
+    | `[HostType, mod_private_Backend, read_roster_version, time]`  | histogram | Time to retrieve the version of a user's roster. |
+    | `[HostType, mod_private_Backend, write_roster_version, count]` | spiral | Version of a user's roster is stored. |
+    | `[HostType, mod_private_Backend, write_roster_version, time]`  | histogram | Time to store the version of a user's roster. |
+    | `[HostType, mod_private_Backend, get_roster, count]` | spiral | A user's roster is fetched. |
+    | `[HostType, mod_private_Backend, get_roster, time]`  | histogram | Time to fetch user's roster. |
+    | `[HostType, mod_private_Backend, get_roster_entry, count]` | spiral | A specific roster entry is fetched. |
+    | `[HostType, mod_private_Backend, get_roster_entry, time]`  | histogram | Time to fetch a specific roster entry. |
+    | `[HostType, mod_private_Backend, get_subscription_lists, count]` | spiral | A subscription list of a user is retrieved. |
+    | `[HostType, mod_private_Backend, get_subscription_lists, time]`  | histogram | Time to retrieve a subscription list of a user. |
+    | `[HostType, mod_private_Backend, roster_subscribe_t, count]` | spiral | A subscription status between users is updated inside a transaction. |
+    | `[HostType, mod_private_Backend, roster_subscribe_t, time]`  | histogram | Time to update a subscription status between users inside a transaction. |
+    | `[HostType, mod_private_Backend, update_roster_t, count]` | spiral | A roster entry is updated in a transaction. |
+    | `[HostType, mod_private_Backend, update_roster_t, time]`  | histogram | Time to update a roster entry in a transaction. |
+    | `[HostType, mod_private_Backend, del_roster_t, count]` | spiral | A roster entry is removed inside a transaction. |
+    | `[HostType, mod_private_Backend, del_roster_t, time]`  | histogram | Time to remove a roster entry inside a transaction. |

--- a/doc/modules/mod_vcard.md
+++ b/doc/modules/mod_vcard.md
@@ -127,10 +127,32 @@ An array of search fields, which values should be Base64-encoded by MongooseIM b
 
 ## Metrics
 
+This module provides [backend metrics](../operation-and-maintenance/MongooseIM-metrics.md#backend-metrics).
 If you'd like to learn more about metrics in MongooseIM, please visit [MongooseIM metrics](../operation-and-maintenance/MongooseIM-metrics.md) page.
 
-| Backend action | Description (when it gets incremented)   |
-|----------------|------------------------------------------|
-| `set_vcard`    | A vCard is set in a DB.                  |
-| `get_vcard`    | A specific vCard is retrieved from a DB. |
-| `search`       | A vCard search is performed.             |
+Prometheus metrics have a `host_type` and `function` labels associated with these metrics.
+Since Exometer doesn't support labels, the function as well as the host types, or word `global`, are part of the metric names, depending on the [`instrumentation.exometer.all_metrics_are_global`](../configuration/instrumentation.md#instrumentationexometerall_metrics_are_global) option.
+
+Backend in the action name can be either `rdbms`, `ldap` or `mnesia`.
+
+=== "Prometheus"
+
+    | Backend action | Type | Function | Description (when it gets incremented) |
+    | -------------- | ---- | -------- | -------------------------------------- |
+    | `mod_private_Backend_count` | counter | `set_vcard` | A vCard is set in a database. |
+    | `mod_private_Backend_time`  | histogram | `set_vcard` | Time to set a vCard in a database. |
+    | `mod_private_Backend_count` | counter | `get_vcard` | A specific vCard is retrieved from a database. |
+    | `mod_private_Backend_time`  | histogram | `get_vcard` | Time to retrieve a specific vCard from a database. |
+    | `mod_private_Backend_count` | counter | `search` | A vCard search is performed. |
+    | `mod_private_Backend_time`  | histogram | `search` | Time to search a vCard. |
+
+=== "Exometer"
+
+    | Backend action | Type | Description (when it gets incremented) |
+    | -------------- | ---- | -------------------------------------- |
+    | `[HostType, mod_private_Backend, set_vcard, count]` | spiral | A vCard is set in a database. |
+    | `[HostType, mod_private_Backend, set_vcard, time]`  | histogram | Time to set a vCard in a database. |
+    | `[HostType, mod_private_Backend, get_vcard, count]` | spiral | A specific vCard is retrieved from a database. |
+    | `[HostType, mod_private_Backend, get_vcard, time]`  | histogram | Time to retrieve a specific vCard from a database. |
+    | `[HostType, mod_private_Backend, search, count]` | spiral | A vCard search is performed. |
+    | `[HostType, mod_private_Backend, search, time]`  | histogram | Time to search a vCard. |

--- a/doc/operation-and-maintenance/Logging-&-monitoring.md
+++ b/doc/operation-and-maintenance/Logging-&-monitoring.md
@@ -59,19 +59,36 @@ Additionally, WombatOAM provides interfaces to feed the data to other OAM tools 
 
 For more information see: [WombatOAM](https://www.erlang-solutions.com/products/wombat-oam.html).
 
-### graphite-collectd
+### OS level metrics: graphite-collectd
 
-To monitor MongooseIM during load testing, we recommend the following open source applications:
+To monitor MongooseIM node during load testing, we recommend the following open source applications:
 
 - [Grafana](https://grafana.com/) is used for data presentation.
-- [Graphite](http://graphiteapp.org/) is a server used for metrics storage.
+- [Prometheus](https://prometheus.io) is a server used for metrics storage. Alternatively, MongooseIM also works with [Graphite](http://graphiteapp.org/).
 - [collectd](http://collectd.org/) is a daemon running on the monitored nodes capturing data related to CPU and Memory usage, IO etc.
 
-### Plug-in Exometer reporters
+### Application metrics
+
+MongooseIM uses [Prometheus](https://prometheus.io/) as the default metrics solution, but also supports Exometer with Graphite exporter.
+Enable the chosen one in the [instrumentation section](../configuration/instrumentation.md).
+
+#### Prometheus
+
+MongooseIM exposes metrics in the Prometheus format by default.
+More information about configuration can be found in [the HTTP listeners section](../listeners/listen-http.md#handler-types-prometheus-mongoose_prometheus_handler).
+
+#### Exometer
 
 MongooseIM uses [a fork of Exometer library](https://github.com/esl/exometer_core) for collecting metrics.
 Exometer has many plug-in reporters that can send metrics to external services. We maintain [exometer_report_graphite](https://github.com/esl/exometer_report_graphite) and [exometer_report_statsd](https://github.com/esl/exometer_report_statsd) for Graphite and StatsD respectively.
 It is possible to enable them in MongooseIM in the [instrumentation section of the configuration file](../configuration/instrumentation.md#exometer-reporter-options).
+
+Moreover, Exometer metrics can be accessed through the GraphQL API.
+
+#### GraphQL metrics endpoint
+
+When using Exometer, the metrics can be accessed through <a href="../admin-graphql-doc.html#query-metric" target="_blank" rel="noopener noreferrer">a GraphQL query</a>.
+With Prometheus, this query will not work, however, the metrics will be available in the Prometheus format from [the configured endpoint](../listeners/listen-http.md#listenhttphandlerspath).
 
 ### Run Graphite & Grafana in Docker - quick start
 

--- a/doc/operation-and-maintenance/Logging-&-monitoring.md
+++ b/doc/operation-and-maintenance/Logging-&-monitoring.md
@@ -71,33 +71,7 @@ To monitor MongooseIM during load testing, we recommend the following open sourc
 
 MongooseIM uses [a fork of Exometer library](https://github.com/esl/exometer_core) for collecting metrics.
 Exometer has many plug-in reporters that can send metrics to external services. We maintain [exometer_report_graphite](https://github.com/esl/exometer_report_graphite) and [exometer_report_statsd](https://github.com/esl/exometer_report_statsd) for Graphite and StatsD respectively.
-It is possible to enable them in MongooseIM via the `app.config` file.
-The file sits next to the `mongooseim.toml` file in the `rel/files` and `_REL_DIR_/etc` directories.
-
-Below you can find a sample configuration.
-It shows setting up a reporter connecting to graphite running on localhost.
-
-You can see an additional option not listed in the Exometer docs - `mongooseim_report_interval`, which sets the metrics' resolution, i.e. how often Exometer gathers and sends metrics through reporters.
-By default, the resolution is set to 60 seconds.
-
-```erlang
-...
-{exometer_core, [
-    {mongooseim_report_interval, 60000}, %% 60 seconds
-    {report, [
-        {reporters, [
-                     {exometer_report_graphite, [
-                                                 {prefix, "mongooseim"},
-                                                 {connect_timeout, 5000},
-                                                 {host, "127.0.0.1"},
-                                                 {port, 2003},
-                                                 {api_key, ""}
-                                                ]}
-                    ]}
-    ]}
-  ]}
-...
-```
+It is possible to enable them in MongooseIM in the [instrumentation section of the configuration file](../configuration/instrumentation.md#exometer-reporter-options).
 
 ### Run Graphite & Grafana in Docker - quick start
 

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -212,7 +212,7 @@ Since Exometer doesn't support labels, the host types are part of the metric nam
     | `[HostType, c2s_element_out, iq_error_count]` | spiral | An IQ error is sent to a client. |
     | `[HostType, c2s_element_out, message_error_count]` | spiral | A message error is sent to a client. |
     | `[HostType, c2s_element_out, presence_error_count]` | spiral | A presence error is sent to a client. |
-    | `[HostType, c2s_message_processing_time`] | histogram | Processing time for incomming c2s stanzas. |
+    | `[HostType, c2s_message_processing_time`] | histogram | Processing time for incoming c2s stanzas. |
     | `[HostType, sm_message_bounced, count]` | spiral | A `service-unavailable` error is sent, because the message recipient is offline. |
     | `[HostType, router_stanza_dropped, count]` | spiral | A stanza is dropped due to an AMP rule or a `filter_local_packet` processing flow. |
     | `[HostType, router_no_route_found, count]` | spiral | It is not possible to route a stanza (all routing handlers failed). |
@@ -446,7 +446,7 @@ Since Exometer doesn't support labels, the host types and backend actions are pa
     | Metric name | Type | Description |
     | ----------- | ---- | ----------- |
     | `[HostType, BackendModule, BackendAction, count]` | spiral | Number of calls (spiral metric), incremented for *every* call (even a failed one). |
-    | `[HostType, BackendModule, BackendAction, time]` | histogram | Successful operation times. |
+    | `[HostType, BackendModule, BackendAction, time]` | histogram | Times of successful operations. |
 
 
 Besides these, following authentication metrics are always available.
@@ -458,7 +458,7 @@ Since Exometer doesn't support labels, the host types are part of the metric nam
     | Metric name | Type | Description |
     | ----------- | ---- | ----------- |
     | `auth_register_user_count` | counter | A user registered successfully. |
-    | `auth_unregister_user_count` | counter | A user unregistered sucessfully. |
+    | `auth_unregister_user_count` | counter | A user unregistered successfully. |
     | `auth_authorize_count` | counter | A user tried to authorize. |
     | `auth_authorize_time` | histogram | Time it took to authorize a user. |
     | `auth_check_password_count` | counter | A password was checked. |
@@ -472,8 +472,8 @@ Since Exometer doesn't support labels, the host types are part of the metric nam
 
     | Metric name | Type | Description |
     | ----------- | ---- | ----------- |
-    | `[HostType, auth_register_user, count]` | spiral | A user registered sucessfully. |
-    | `[HostType, auth_unregister_user, count]` | spiral | A user unregistered sucessfully. |
+    | `[HostType, auth_register_user, count]` | spiral | A user registered successfully. |
+    | `[HostType, auth_unregister_user, count]` | spiral | A user unregistered successfully. |
     | `[HostType, auth_authorize, count]` | spiral | A user tried to authorize. |
     | `[HostType, auth_authorize, time]` | histogram | Time it took to authorize a user. |
     | `[HostType, auth_check_password, count]` | spiral | A password was checked. |

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -1,8 +1,12 @@
 # MongooseIM metrics
 
 MongooseIM by default collects many metrics showing the user behaviour and general system statistics.
-They are managed by [exometer](https://github.com/Feuerlabs/exometer).
-MongooseIM uses [ESL's fork of this project](https://github.com/esl/exometer/tree/1.2.1-patched).
+
+Metrics are exposed in the [Prometheus](https://prometheus.io/) format, or they are managed by [ESL's fork of the Exometer project](https://github.com/esl/exometer/tree/1.2.1-patched).
+Both can be configured in the [instrumentation](../configuration/instrumentation.md) section.
+There are some differences between the two systems, when it comes to conventions, naming and metric types.
+
+In the default configuration file, Prometheus metrics are enabled, and available at the <http://127.0.0.1:9091/metrics> endpoint.
 
 All metrics are divided into the following groups:
 

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -181,7 +181,7 @@ Since Exometer doesn't support labels, the host types are part of the metric nam
     | `c2s_element_out_iq_error_count` | counter | An IQ error is sent to a client. |
     | `c2s_element_out_message_error_count` | counter | A message error is sent to a client. |
     | `c2s_element_out_presence_error_count` | counter | A presence error is sent to a client. |
-    | `c2s_message_processed_time` | histogram | Processing time for incomming c2s stanzas. |
+    | `c2s_message_processed_time` | histogram | Processing time for incoming c2s stanzas. |
     | `sm_message_bounced_count` | counter | A `service-unavailable` error is sent, because the message recipient is offline. |
     | `router_stanza_dropped_count` | counter | A stanza is dropped due to an AMP rule or a `filter_local_packet` processing flow. |
     | `router_no_route_found_count` | counter | It is not possible to route a stanza (all routing handlers failed). |
@@ -439,7 +439,7 @@ Since Exometer doesn't support labels, the host types and backend actions are pa
     | Metric name | Type | Description |
     | ----------- | ---- | ----------- |
     | `BackendModule_count` | counter | Number of calls (spiral metric), incremented for *every* call (even a failed one). |
-    | `BackendModule_time` | histogram | Successful operation times. |
+    | `BackendModule_time` | histogram | Times of successful operations. |
 
 === "Exometer"
 
@@ -457,7 +457,7 @@ Since Exometer doesn't support labels, the host types are part of the metric nam
 
     | Metric name | Type | Description |
     | ----------- | ---- | ----------- |
-    | `auth_register_user_count` | counter | A user registered sucessfully. |
+    | `auth_register_user_count` | counter | A user registered successfully. |
     | `auth_unregister_user_count` | counter | A user unregistered sucessfully. |
     | `auth_authorize_count` | counter | A user tried to authorize. |
     | `auth_authorize_time` | histogram | Time it took to authorize a user. |

--- a/doc/rest-api/Administration-backend_swagger.yml
+++ b/doc/rest-api/Administration-backend_swagger.yml
@@ -794,7 +794,7 @@ paths:
           description: "Other errors."
   /metrics/:
     get:
-      description: Returns a list of host type names and metric names
+      description: Returns a list of host type names and metric names. Only works with Exometer enabled.
       tags:
         - "Metrics"
       responses:
@@ -831,7 +831,7 @@ paths:
                     - "sm_unique_sessions"
   /metrics/all:
     get:
-      description: Returns a list of metrics aggregated for all host types
+      description: Returns a list of metrics aggregated for all host types. Only works with Exometer enabled.
       tags:
         - "Metrics"
       responses:
@@ -850,7 +850,7 @@ paths:
     parameters:
       - $ref: '#/parameters/metric'
     get:
-      description: Returns the metric value aggregated for all host types
+      description: Returns the metric value aggregated for all host types. Only works with Exometer enabled.
       tags:
         - "Metrics"
       responses:
@@ -870,7 +870,7 @@ paths:
     parameters:
       - $ref: '#/parameters/hostType'
     get:
-      description: Returns the values of all host-type metrics
+      description: Returns the values of all host-type metrics. Only works with Exometer enabled.
       tags:
         - "Metrics"
       responses:
@@ -892,7 +892,7 @@ paths:
       - $ref: '#/parameters/hostType'
       - $ref: '#/parameters/metric'
     get:
-      description: Returns the value of a host-type metric
+      description: Returns the value of a host-type metric. Only works with Exometer enabled.
       tags:
         - "Metrics"
       responses:
@@ -910,7 +910,7 @@ paths:
           description: There is no such metric
   /metrics/global:
     get:
-      description: Returns the values of all global metrics
+      description: Returns the values of all global metrics. Only works with Exometer enabled.
       tags:
         - "Metrics"
       responses:
@@ -927,7 +927,7 @@ paths:
     parameters:
       - $ref: '#/parameters/metric'
     get:
-      description: Returns the value of a global metric
+      description: Returns the value of a global metric. Only works with Exometer enabled.
       tags:
         - "Metrics"
       responses:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - 'Options: Access': 'configuration/access.md'
       - 'Options: S2S': 'configuration/s2s.md'
       - 'Options: Host config': 'configuration/host_config.md'
+      - 'Options: Instrumentation': 'configuration/instrumentation.md'
       - 'Release Options': 'configuration/release-options.md'
       - 'Erlang Cookie Security': 'configuration/Erlang-cookie-security.md'
       - 'TLS Hardening': 'configuration/TLS-hardening.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
     - navigation.instant
     - navigation.instant.progress
     - navigation.top
+    - navigation.footer
     - content.tabs.link
     - toc.follow
 extra:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,8 @@ markdown_extensions:
   - admonition
   - pymdownx.tabbed:
       alternate_style: true
+  - toc:
+      permalink: true
 
 nav:
   - 'Home': 'index.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,9 @@ markdown_extensions:
   - admonition
   - pymdownx.tabbed:
       alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
   - toc:
       permalink: true
 

--- a/priv/graphql/schemas/admin/metric.gql
+++ b/priv/graphql/schemas/admin/metric.gql
@@ -98,7 +98,7 @@ type MetricNodeResult {
 }
 
 """
-Allow admin to get the metric values
+Allow admin to get the metric values. Only works with Exometer enabled.
 """
 type MetricAdminQuery @protected{
     """

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -86,8 +86,8 @@ instrumentation(global) ->
      {c2s_xmpp_element_size_in, #{},
       #{metrics => #{byte_size => histogram}}}];
 instrumentation(HostType) ->
-    [{c2s_message_processing_time, #{host_type => HostType},
-      #{metrics => #{byte_size => histogram}}},
+    [{c2s_message_processed, #{host_type => HostType},
+      #{metrics => #{time => histogram}}},
      {c2s_auth_failed, #{host_type => HostType},
       #{metrics => #{count => spiral}}},
      {c2s_element_in, #{host_type => HostType},
@@ -810,7 +810,7 @@ handle_stanza_from_client(#c2s_data{host_type = HostType}, HookParams, Acc, <<"m
     Acc1 = mongoose_c2s_hooks:user_send_message(HostType, Acc, HookParams),
     Acc2 = maybe_route(Acc1),
     TS1 = erlang:system_time(microsecond),
-    mongoose_instrument:execute(c2s_message_processing_time, #{host_type => HostType}, #{time => (TS1 - TS0)}),
+    mongoose_instrument:execute(c2s_message_processed, #{host_type => HostType}, #{time => (TS1 - TS0)}),
     Acc2;
 handle_stanza_from_client(#c2s_data{host_type = HostType}, HookParams, Acc, <<"iq">>) ->
     Acc1 = mongoose_c2s_hooks:user_send_iq(HostType, Acc, HookParams),


### PR DESCRIPTION
This PR adds documentation for instrumentation. There are also a number of small changes related with it that update the documentation and fix errors.
Instrumentation changes:
- Added `Instrumentation` page under `Configuration`, which documents the configuration options.
- Prometheus endpoint is documented in HTTP listeners.
- In `Logging and Monitoring`, Prometheus is described as an Exometer alternative, as well as GraphQL endpoint is mentioned. This file could be maybe revisited and updated later, maybe changed to a tutorial on setting up metrics/instrumentation.
- Metrics in `Operation and maintenance/Metrics` have been updated, mainly with the new Prometheus naming scheme.
- Update metrics descriptions in modules documentation.

Other changes:
- When clicking on a header, a link to this header is copied,
- Automatic links to next/previous pages is added at the bottom of the page. I think it makes sense, for example at the intrudactory sections. Sometimes it leads to a bit surprising links (for example from the `Configuration` page back to `MAM` page), but I think it's not a big issue, and the addition is worth it.
- Port syntax was incorrectly described in a few places.
- `c2s_message_processing_time` had an incorrect measurement declared - `byte_size`. It was supposed to be `time`, but then, the name would be `c2s_message_processing_time_time` for Exometer. So, the metric was renamed to `c2s_message_processed`, and the measurement fixed to `time`.
- Links to tabbed content now have more readable headers - the name of the tab, instead of numbers.

