### PR TITLE
Fix GraphQL docs building

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -442,7 +442,7 @@ jobs:
       - run:
           name: Build GraphQL static docs
           command: |
-            npm install --prefix=$HOME/.local --global spectaql
+            npm install --global cheerio@1.0.0-rc.12 spectaql
             npx spectaql -t doc/graphql-api -f admin-graphql-doc.html doc/graphql-api/Admin-GraphQL_spectaql.yml
             npx spectaql -C -J -t doc/graphql-api -f user-graphql-doc.html doc/graphql-api/User-GraphQL_spectaql.yml
       - run:


### PR DESCRIPTION
There is an issue with spectaql dependency:
https://github.com/anvilco/spectaql/issues/979

Also, use preinstalled version of the package - npx would reinstall spectaql when using the prefix option
