### PR TITLE
Domain service test fix

### DIFF
--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -1211,7 +1211,7 @@ resume_service(Node) ->
     ok = rpc(Node, sys, resume, [service_domain_db]).
 
 sync_local(Node) ->
-    pong = rpc(Node, service_domain_db, sync_local, []).
+    pong = rpc(Node#{timeout => timer:seconds(30)}, service_domain_db, sync_local, []).
 
 force_check_for_updates(Node) ->
     ok = rpc(Node, service_domain_db, force_check_for_updates, []).

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -206,9 +206,11 @@ init_per_suite(Config) ->
     erase_database(mim()),
     Config2 = ejabberd_node_utils:init(mim(), Config1),
     mongoose_helper:inject_module(?MODULE),
+    enable_logging(),
     escalus:init_per_suite([{service_setup, per_testcase} | Config2]).
 
 end_per_suite(Config) ->
+    disable_logging(),
     [restart_domain_core(Node) || Node <- all_nodes()],
     dynamic_services:restore_services(Config),
     domain_helper:insert_configured_domains(),
@@ -1271,3 +1273,17 @@ dummy_auth_host_type() ->
 random_domain_name() ->
     Prefix = integer_to_binary(erlang:unique_integer([positive])),
     <<Prefix/binary, ".example.db">>.
+
+%% -----------------------------------------------------------------------
+%% Custom log levels for domain modules during the tests
+
+enable_logging() ->
+    mim_loglevel:enable_logging(test_hosts(), custom_loglevels()).
+
+disable_logging() ->
+    mim_loglevel:disable_logging(test_hosts(), custom_loglevels()).
+
+custom_loglevels() ->
+    [{mongoose_domain_sql, debug}].
+
+test_hosts() -> [mim, mim2, mim3].

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -206,11 +206,12 @@ init_per_suite(Config) ->
     erase_database(mim()),
     Config2 = ejabberd_node_utils:init(mim(), Config1),
     mongoose_helper:inject_module(?MODULE),
-    enable_logging(),
+    %% If there are CI issues, use this to debug SQL queries:
+%   mim_loglevel:enable_logging([mim, mim2, mim3], [{mongoose_domain_sql, debug}]),
     escalus:init_per_suite([{service_setup, per_testcase} | Config2]).
 
 end_per_suite(Config) ->
-    disable_logging(),
+%   mim_loglevel:disable_logging([mim, mim2, mim3], [{mongoose_domain_sql, debug}]),
     [restart_domain_core(Node) || Node <- all_nodes()],
     dynamic_services:restore_services(Config),
     domain_helper:insert_configured_domains(),
@@ -1273,17 +1274,3 @@ dummy_auth_host_type() ->
 random_domain_name() ->
     Prefix = integer_to_binary(erlang:unique_integer([positive])),
     <<Prefix/binary, ".example.db">>.
-
-%% -----------------------------------------------------------------------
-%% Custom log levels for domain modules during the tests
-
-enable_logging() ->
-    mim_loglevel:enable_logging(test_hosts(), custom_loglevels()).
-
-disable_logging() ->
-    mim_loglevel:disable_logging(test_hosts(), custom_loglevels()).
-
-custom_loglevels() ->
-    [{mongoose_domain_sql, debug}].
-
-test_hosts() -> [mim, mim2, mim3].

--- a/src/domain/mongoose_domain_loader.erl
+++ b/src/domain/mongoose_domain_loader.erl
@@ -106,6 +106,7 @@ check_for_updates({Min, Max},
 check_for_updates(MinMax = {Min, Max},
                   #{min_event_id := OldMin, max_event_id := OldMax})
   when is_integer(Min), is_integer(Max) ->
+    put(debug_last_check_for_updates_minmax, MinMax),
     {MinEventId, MaxEventId} = limit_max_id(OldMax, MinMax, 1000),
     check_if_id_is_still_relevant(OldMax, MinEventId),
     NewGapsFromBelow =
@@ -134,7 +135,9 @@ check_for_updates(MinMax = {Min, Max},
                 Ids = rows_to_ids(Rows),
                 ids_to_gaps(FromId, MaxEventId, Ids)
         end,
-    fix_gaps(NewGapsFromBelow ++ NewGapsFromThePage),
+    Gaps = NewGapsFromBelow ++ NewGapsFromThePage,
+    put(debug_last_gaps, list_to_tuple(Gaps)), %% Convert to a tuple so it could be printed
+    fix_gaps(Gaps),
     State2 = #{min_event_id => MinEventId, max_event_id => MaxEventId},
     mongoose_loader_state:set(State2),
     case MaxEventId < Max of

--- a/src/domain/mongoose_domain_loader.erl
+++ b/src/domain/mongoose_domain_loader.erl
@@ -266,7 +266,7 @@ fix_gaps(Gaps, Retries) when Retries > 0 ->
     %%
     %% There is no easy way to check for a reason.
     %%
-    %% fix_gaps tries to insert_dummy_event with a gap event id.
+    %% fix_gaps tries to insert_dummy_events with a gap event id.
     %% This makes the state of transaction for gap events obvious:
     %% - if this insert fails, this means the actual record finally
     %%   appears and we can read it.
@@ -277,7 +277,7 @@ fix_gaps(Gaps, Retries) when Retries > 0 ->
     %%
     %% RDBMS servers do not overwrite data when INSERT operation is used.
     %% i.e. only one insert for a key succeeded.
-    [catch mongoose_domain_sql:insert_dummy_event(Id) || Id <- Gaps],
+    catch mongoose_domain_sql:insert_dummy_events(Gaps),
     %% The gaps should be filled at this point
     Rows = lists:append([mongoose_domain_sql:select_updates_between(Id, Id) || Id <- Gaps]),
     ?LOG_WARNING(#{what => domain_fix_gaps, gaps => Gaps, rows => Rows}),

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -378,9 +378,11 @@ transaction(F, Retries, Errors) when Retries > 0 ->
     Result = rdbms_queries:sql_transaction(Pool, fun() -> F(Pool) end),
     case Result of
         {aborted, _} -> %% Restart any rolled back transaction
+            put(last_transaction_error, Result),
             timer:sleep(100), %% Small break before retry
             transaction(F, Retries - 1, [Result|Errors]);
         _ ->
+            erase(last_transaction_error),
             simple_result(Result)
     end.
 

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -384,11 +384,11 @@ transaction(F, Tries, Errors) when Tries > 0 ->
     Result = rdbms_queries:sql_transaction(Pool, fun() -> F(Pool) end),
     case Result of
         {aborted, _} -> %% Restart any rolled back transaction
-            put(last_transaction_error, Result),
+            put(debug_last_transaction_error, Result),
             timer:sleep(100), %% Small break before retry
             transaction(F, Tries - 1, [Result|Errors]);
         _ ->
-            erase(last_transaction_error),
+            erase(debug_last_transaction_error),
             simple_result(Result)
     end.
 

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -388,8 +388,9 @@ simple_result({atomic, Result}) -> Result;
 simple_result(Other) -> {error, {db_error, Other}}.
 
 execute_successfully(Pool, StatementName, Args) ->
-    Res = mongoose_rdbms:execute_successfully(Pool, StatementName, Args),
+    {Time, Res} = timer:tc(fun() -> mongoose_rdbms:execute_successfully(Pool, StatementName, Args) end),
     %% Convert args to tuple, because Erlang formats list as a string for domain_event_ids_between
     ?LOG_DEBUG(#{what => domain_sql_execute,
-                 statement_name => StatementName, args => list_to_tuple(Args), result => Res}),
+                 statement_name => StatementName, args => list_to_tuple(Args), result => Res,
+                 duration => round(Time / 1000)}),
     Res.

--- a/src/domain/mongoose_domain_sql.erl
+++ b/src/domain/mongoose_domain_sql.erl
@@ -30,7 +30,8 @@
 -ignore_xref([erase_database/1, prepare_test_queries/0, get_enabled_dynamic/0,
               insert_full_event/2, insert_domain_settings_without_event/2]).
 
--import(mongoose_rdbms, [prepare/4, execute_successfully/3]).
+-import(mongoose_rdbms, [prepare/4]).
+-include("mongoose_logger.hrl").
 
 -type event_id() :: non_neg_integer().
 -type domain() :: jid:lserver().
@@ -385,3 +386,10 @@ transaction(F, Retries, Errors) when Retries > 0 ->
 
 simple_result({atomic, Result}) -> Result;
 simple_result(Other) -> {error, {db_error, Other}}.
+
+execute_successfully(Pool, StatementName, Args) ->
+    Res = mongoose_rdbms:execute_successfully(Pool, StatementName, Args),
+    %% Convert args to tuple, because Erlang formats list as a string for domain_event_ids_between
+    ?LOG_DEBUG(#{what => domain_sql_execute,
+                 statement_name => StatementName, args => list_to_tuple(Args), result => Res}),
+    Res.

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -101,7 +101,12 @@ sync_local() ->
 
 -spec ping(pid()) -> pong.
 ping(Pid) ->
-    gen_server:call(Pid, ping).
+    try
+        gen_server:call(Pid, ping)
+    catch Class:Reason:Stacktrace ->
+        Info = rpc:pinfo(Pid, [current_stacktrace, dictionary]),
+        erlang:raise(Class, {Reason, Info}, Stacktrace)
+    end.
 
 %% ---------------------------------------------------------------------------
 %% Server callbacks

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -102,7 +102,7 @@ sync_local() ->
 -spec ping(pid()) -> pong.
 ping(Pid) ->
     try
-        gen_server:call(Pid, ping)
+        gen_server:call(Pid, ping, timer:seconds(15))
     catch Class:Reason:Stacktrace ->
         Info = rpc:pinfo(Pid, [current_stacktrace, dictionary]),
         erlang:raise(Class, {Reason, Info}, Stacktrace)

--- a/src/domain/service_domain_db.erl
+++ b/src/domain/service_domain_db.erl
@@ -95,7 +95,8 @@ sync_local() ->
     true = is_pid(LocalPid),
     Nodes = [node(Pid) || Pid <- all_members()],
     %% Ping from all nodes in the cluster
-    [pong = rpc:call(Node, ?MODULE, ping, [LocalPid]) || Node <- Nodes],
+    {Results, []} = rpc:multicall(Nodes, ?MODULE, ping, [LocalPid]),
+    [pong = Res || Res <- Results],
     pong.
 
 -spec ping(pid()) -> pong.


### PR DESCRIPTION
This PR addresses "MIM-2272 Fix flaky "service_domain_db" tests"

Example of the broken test timeout https://circleci-mim-results.s3.eu-central-1.amazonaws.com/PR/4357/235426/odbc_mssql_mnesia.27.0.1-amd64/big/ct_run.test%404f8408ead5c6.2024-08-14_09.06.15/big_tests.tests.service_domain_db_SUITE.logs/run.2024-08-14_09.27.28/service_domain_db_suite.rest_delete_domain_cleans_data_from_mam.283010.html

Proposed changes include:
* Higher timeouts when pinging domain service gen_server. It affects only the test code. 15 seconds for ping timeout, 30 seconds for the RPC timeout, so we can see what the server is doing, when the ping times out.
* Add debug logging for SQL queries which are done by the domain service.
* Do some stuff in parallel.
* There was slow code in fixing gaps because duplicate key error was causing the insert_dummy_event transaction to get restarted (i.e. 3*100 milliseconds for a gap). Sometimes test could create 20 gaps, so 20*300 = 6 seconds, and our timeout is default 5 seconds. So, we added catch there.
* Add `debug_` dictionary entries. Useful to figure out what the server is doing from the outside.
* Added info how to debug it.
* Repeated 30 times - no errors locally or on CI.

