### PR TITLE
Fixing GraphQL SSE crash with large stanza payloads

### DIFF
--- a/big_tests/tests/graphql_sse_SUITE.erl
+++ b/big_tests/tests/graphql_sse_SUITE.erl
@@ -145,6 +145,10 @@ sse_should_not_get_timeout(Config) ->
         timer:sleep(2000),
         escalus:send(Bob, escalus_stanza:chat(From, To, <<"Hello again!">>)),
         sse_helper:wait_for_event(Stream),
+        timer:sleep(2000),
+        Message = binary:copy(<<"0">>, 2000),
+        escalus:send(Bob, escalus_stanza:chat(From, To, Message)),
+        sse_helper:wait_for_event(Stream),
         sse_helper:stop_sse(Stream)
     end).
 

--- a/src/graphql/mongoose_graphql_response.erl
+++ b/src/graphql/mongoose_graphql_response.erl
@@ -3,10 +3,10 @@
 -export([term_to_json/1, term_to_pretty_json/1]).
 
 term_to_json(Term) ->
-    jiffy:encode(fixup(Term)).
+    iolist_to_binary(jiffy:encode(fixup(Term))).
 
 term_to_pretty_json(Term) ->
-    jiffy:encode(fixup(Term), [pretty]).
+    iolist_to_binary(jiffy:encode(fixup(Term), [pretty])).
 
 %% Ground types
 fixup(Term) when is_number(Term) -> Term;


### PR DESCRIPTION
**Fix**: Wrap jiffy:encode in iolist_to_binary to handle long messages.

**Issue**: When encoding a message to JSON that exceeds 2048 characters, jiffy:encode returns a list of binaries instead of a single binary.

**Solution**: By wrapping jiffy:encode in iolist_to_binary, we ensure that the encoded output is always a single binary, resolving the issue with long messages.