### PR TITLE
Zip MIM logs before uploading to S3

### DIFF
--- a/tools/circleci-prepare-log-dir.sh
+++ b/tools/circleci-prepare-log-dir.sh
@@ -31,12 +31,19 @@ EOL
 
 now=`date +'%Y-%m-%d_%H.%M.%S'`
 LOG_DIR_ROOT=${CT_REPORTS}/logs/${now}
+LOG_ZIP=${CT_REPORTS}/logs_${now}.zip
 for dev_node_logs_path in `find _build -name log -type d`; do
 	dev_node=$(basename $(dirname $(dirname $(dirname ${dev_node_logs_path}))))
-	LOG_DIR=${LOG_DIR_ROOT}/${dev_node}/log
+        LOG_DIR=${LOG_DIR_ROOT}/${dev_node}/
 	mkdir -p ${LOG_DIR}
 	cp ${dev_node_logs_path}/* ${LOG_DIR}
 done
 
 cp *.log ${LOG_DIR_ROOT}
 cp big_tests/*.log ${LOG_DIR_ROOT} || true
+
+# Zip to safe space
+zip -9 -r "$LOG_ZIP" "$LOG_DIR_ROOT"
+
+# Slightly faster than removing
+mv "$LOG_DIR_ROOT" /tmp/

--- a/tools/circleci-prepare-log-dir.sh
+++ b/tools/circleci-prepare-log-dir.sh
@@ -39,7 +39,7 @@ PREFIX="${CT_REPORTS//\//_}"
 # Optimize naming, so it is easy to extract on MacOS just by clicking it
 # and with reasonable directory names
 LOG_DIR_ROOT=${CT_REPORTS}/logs/${PREFIX}_${now}
-LOG_ZIP=${CT_REPORTS_FULL}/logs_${PREFIX}_${now}.zip
+LOG_ZIP=${CT_REPORTS_FULL}/logs_${PREFIX}_${now}.tar.gz
 for dev_node_logs_path in `find _build -name log -type d`; do
 	dev_node=$(basename $(dirname $(dirname $(dirname ${dev_node_logs_path}))))
         LOG_DIR=${LOG_DIR_ROOT}/${dev_node}/
@@ -56,7 +56,7 @@ OLD_DIR=$(pwd)
 cd "$LOG_DIR_ROOT/.."
 
 # Zip to safe space
-zip -9 -r "$LOG_ZIP" "$(basename "$LOG_DIR_ROOT")"
+tar -czvf "$LOG_ZIP" "$(basename "$LOG_DIR_ROOT")"
 
 cd "$OLD_DIR"
 

--- a/tools/circleci-prepare-log-dir.sh
+++ b/tools/circleci-prepare-log-dir.sh
@@ -5,6 +5,7 @@ source tools/circleci-helpers.sh
 set -euo pipefail
 IFS=$'\n\t'
 
+# Relative directory name
 CT_REPORTS=$(ct_reports_dir)
 mkdir -p ${CT_REPORTS}/small
 mkdir -p ${CT_REPORTS}/big
@@ -29,9 +30,16 @@ cat > ${CT_REPORTS}/index.html << EOL
 </html>
 EOL
 
+CT_REPORTS_FULL=$(cd "$CT_REPORTS" && pwd)
+
 now=`date +'%Y-%m-%d_%H.%M.%S'`
-LOG_DIR_ROOT=${CT_REPORTS}/logs/${now}
-LOG_ZIP=${CT_REPORTS}/logs_${now}.zip
+# Replace all occurrences of / with _
+PREFIX="${CT_REPORTS//\//_}"
+
+# Optimize naming, so it is easy to extract on MacOS just by clicking it
+# and with reasonable directory names
+LOG_DIR_ROOT=${CT_REPORTS}/logs/${PREFIX}_${now}
+LOG_ZIP=${CT_REPORTS_FULL}/logs_${PREFIX}_${now}.zip
 for dev_node_logs_path in `find _build -name log -type d`; do
 	dev_node=$(basename $(dirname $(dirname $(dirname ${dev_node_logs_path}))))
         LOG_DIR=${LOG_DIR_ROOT}/${dev_node}/
@@ -42,8 +50,15 @@ done
 cp *.log ${LOG_DIR_ROOT}
 cp big_tests/*.log ${LOG_DIR_ROOT} || true
 
+OLD_DIR=$(pwd)
+
+# cd so we don't include nested dirs in the archive (for example, PR/4366/236412)
+cd "$LOG_DIR_ROOT/.."
+
 # Zip to safe space
-zip -9 -r "$LOG_ZIP" "$LOG_DIR_ROOT"
+zip -9 -r "$LOG_ZIP" "$(basename "$LOG_DIR_ROOT")"
+
+cd "$OLD_DIR"
 
 # Slightly faster than removing
 mv "$LOG_DIR_ROOT" /tmp/


### PR DESCRIPTION
This PR addresses MIM-2284 - Compress MIM logs before uploading from CI

Proposed changes include:
* Safe space on s3
- tar.gz should compress even better.
- Check "Reports root" directory for the file like "logs_PR_4366_236711_odbc_mssql_mnesia.27.0.1-amd64_2024-08-28_14.22.50.tar.gz", download and double click to uncompress.