### PR TITLE
Skip summarise-ct-results in small tests

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -91,10 +91,9 @@ run_small_tests() {
   fi
   export REBAR_CT_EXTRA_ARGS="$REBAR_CT_EXTRA_ARGS"
   make ct
+  RESULT="$?"
   tools/print-dots.sh stop
-  SMALL_SUMMARIES_DIRS=( ${BASE}/_build/test/logs/ct_run* )
-  SMALL_SUMMARIES_DIR=$(choose_newest_directory "${SMALL_SUMMARIES_DIRS[@]}")
-  big_tests/_build/default/lib/ct_groups_summary_hook/priv/summarise-ct-results ${SMALL_SUMMARIES_DIR}
+  return "$RESULT"
 }
 
 run_eunit_tests() {


### PR DESCRIPTION
This PR addresses:

CI is failing from the recent PR merge: 
- https://github.com/esl/MongooseIM/pull/4357 
- https://github.com/esl/MongooseIM/actions/runs/10613811409/job/29418409098#step:6:26

Proposed changes include:
* Skip summarise-ct-results in small tests
* We use rebar3 for small tests, it is smart enough to fail properly. 
* We also need to pull ct_groups_summary_hook dependency to use summarise-ct-results.

Hook is not used in small tests, so only basic info printed from summarise-ct-results.
We loose printing the number of groups run, but it is ok, I think (not super useful anyway).
