### PR TITLE
Move the docker repo to the 'erlangsolutions' organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ It is brought to you by [Erlang Solutions](https://www.erlang-solutions.com/).
 
 For a quick start just download:
 
-* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
-* The [Docker image](https://hub.docker.com/r/mongooseim/mongooseim/): [https://hub.docker.com/r/mongooseim/mongooseim/](https://hub.docker.com/r/mongooseim/mongooseim/) (source code repository: [https://github.com/esl/mongooseim-docker](https://github.com/esl/mongooseim-docker))
+* The [Docker image](https://hub.docker.com/r/erlangsolutions/mongooseim/) ([source code repository](https://github.com/esl/mongooseim-docker))
 * The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
+* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
 
 ## Public testing
 

--- a/doc/getting-started/Installation.md
+++ b/doc/getting-started/Installation.md
@@ -41,14 +41,14 @@ The following sections describe the installation process for different operating
 In order to install MongooseIM using Docker, simply run the following command:
 
 ```bash
-docker pull mongooseim/mongooseim
+docker pull erlangsolutions/mongooseim
 ```
 
 This will download the latest release.
 You can use tags to download an exact version.
 
 We build Docker images for every release marked with a git tag, as well as for every Pull Request.
-You can see all of them on [DockerHub](https://hub.docker.com/r/mongooseim/mongooseim).
+You can see all of them on [DockerHub](https://hub.docker.com/r/erlangsolutions/mongooseim).
 In order to learn more about how the images are built, please visit the [source code repository](https://github.com/esl/mongooseim-docker).
 
 The `mongooseimctl` command is available in `/usr/lib/mongooseim/bin/mongooseimctl` in the container.

--- a/doc/index.md
+++ b/doc/index.md
@@ -59,7 +59,7 @@ We offer a set of additional server-side components:
 For a quick start just download:
 
 * The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
-* The [Docker image](https://hub.docker.com/r/mongooseim/mongooseim/) ([source code repository](https://github.com/esl/mongooseim-docker))
+* The [Docker image](https://hub.docker.com/r/erlangsolutions/mongooseim/) ([source code repository](https://github.com/esl/mongooseim-docker))
 * The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
 
 See the [installation guide](getting-started/Installation.md) for more details.

--- a/doc/operation-and-maintenance/Logging.md
+++ b/doc/operation-and-maintenance/Logging.md
@@ -260,7 +260,7 @@ Run MongooseIM daemon:
 
 ```bash
 docker run -d -t -h mongooseim -v mongooseim-logs:/usr/lib/mongooseim/log \
-    --network logging --name mongooseim -p 5222:5222 mongooseim/mongooseim:latest
+    --network logging --name mongooseim -p 5222:5222 erlangsolutions/mongooseim:latest
 ```
 
 The next part is based on [Filebeat's docs](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ extra:
     provider: mike
   social:
     - icon: fontawesome/brands/docker
-      link: https://hub.docker.com/r/mongooseim/mongooseim/
+      link: https://hub.docker.com/r/erlangsolutions/mongooseim/
     - icon: fontawesome/brands/github
       link: https://github.com/esl/MongooseIM
 plugins:

--- a/tools/circleci-prepare-mongooseim-docker.sh
+++ b/tools/circleci-prepare-mongooseim-docker.sh
@@ -23,7 +23,7 @@ fi
 
 echo "Tag: ${DOCKERHUB_TAG}"
 
-export IMAGE_TAG=${DOCKERHUB_REPO}/mongooseim:${DOCKERHUB_TAG}
+export IMAGE_TAG=${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${DOCKERHUB_TAG}
 
 git clone https://github.com/esl/mongooseim-docker.git
 cd mongooseim-docker


### PR DESCRIPTION
We are moving the docker image from [mongooseim/mongooseim](https://hub.docker.com/repository/docker/mongooseim/mongooseim/general) (free tier) to [erlangsolutions/mongooseim](https://hub.docker.com/repository/docker/erlangsolutions/mongooseim/general) (paid tier).

`DOCKERHUB_REPO` was used to name the organization. `DOCKERHUB_ORG` is now used instead, which is already set in CircleCI to `erlangsolutions`.