### PR TITLE
Fix doubled messaged in MAM bug

### DIFF
--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -56,7 +56,7 @@
 % Strip with or without stanza replacement
 -export([strip/1, strip/2]).
 
--ignore_xref([delete/2, ref/1]).
+-ignore_xref([delete/2, ref/1, strip/1]).
 
 %% Note about 'undefined' to_jid and from_jid: these are the special cases when JID may be
 %% truly unknown: before a client is authorized.

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -352,8 +352,7 @@ maybe_notify_unacknowledged_msg(Acc, Jid) ->
 
 -spec notify_unacknowledged_msg(mongoose_acc:t(), jid:jid()) -> mongoose_acc:t().
 notify_unacknowledged_msg(Acc, Jid) ->
-    NewAcc = mongoose_hooks:unacknowledged_message(Acc, Jid),
-    mongoose_acc:strip(NewAcc).
+    mongoose_hooks:unacknowledged_message(Acc, Jid).
 
 -spec reroute_unacked_messages(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
     mongoose_c2s_hooks:result().


### PR DESCRIPTION
The doubled message in MAM issue comes from the fact that MAM looks for a `mam_id` field in the accumulator when trying to save a message, and in the re-routing case, it is being stripped just a moment before.

This happens, because re-routing uses the normal routing procedure, which strips the non-persistent accumulator fields, including the `mam_id`, in `mongoose_local_delivery`. Stripping is done, because in the usual routing case the perspective of the message processing changes at that point - sender processing is finished, and receiver processing starts.

When retransmitting a message, we would like to process it from the receiver perspective once more, but with accumulator fields saved from the last time it was processed. I decided to use the `filter_unacknowledged_messages` hook in `mod_mam_pm`, which is called before retransmitting messages to save the `mam_id` as a permanent field in the accumulator. The "filter" name is analogous to the `filter_local_packet hook`, which is also used for processing in the broader sense than only filtering.

I'm not certain if the retransmission itself is a correct behaviour, and if the stanza shouldn't contain a "delay" element, however I couldn't find a definitive answer in the [Stream Management XEP](https://xmpp.org/extensions/xep-0198.html#acking) or in the [XMPP Core RFC](https://datatracker.ietf.org/doc/html/rfc6120#section-10.2).

The tests are added to check that the bug has been fixed, as well as document the current retransmitting behaviour.