### PR TITLE
Use the new docker image based on Ubuntu 24.10

### DIFF
--- a/tools/circleci-prepare-mongooseim-docker.sh
+++ b/tools/circleci-prepare-mongooseim-docker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 set -e
-# master from 2023-11-10
-MIM_DOCKER_VERSION=e46784fd44c5ec170d07adeead39755af9395d53
+# master from 2024-09-12
+MIM_DOCKER_VERSION=cde33527fab41b512ed0d83b50a1d088e99c4ea2
 
 # We use output of generate_vsn, because it does not contain illegal characters, returns
 # git tag when building from tag itself, and is unique in any other case


### PR DESCRIPTION
Update `mongooseim-docker` to the latest `master` with the new Ubuntu version. There is no change in performance, which is confirmed by a load test for 1-to-1 (PM) messaging with 100k users.

