### PR TITLE
Add a custom separator to improve search results in the documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ extra:
 plugins:
   - include-markdown
   - search:
+      separator: '[\s\-_,:!=\[\]()"/<>]+|\.(?!\d)|&[lg]t;'
       lang: en
 extra_css: [css/custom.css]
 markdown_extensions:


### PR DESCRIPTION
This PR adds a custom separator regex to the MkDocs search plugin to improve how search works. It helps split text into searchable pieces, which is important for technical content like code, settings and XMPP stanzas.

How the Regex Works
- `[\s\-_,:!=\[\]()"/<>]+`: Matches spaces, punctuation, and special characters like underscores.
- `\.(?!\d)`: Splits at periods, but not if they’re part of a decimal number.
- `&[lg]t;`: Matches HTML entities like `&lt;` and `&gt;`.

It makes searching for configuration options easier. For example, you can now find `modules.mod_mam.pm.same_mam_id_for_peers` by searching for parts like `same_mam_id_for_peers`, `id_for_peers`, or even `mam peers`. Also, XMPP stanzas are now included in the results. So, if you search for `presence`, you’ll see results like `<presence/>` and `<presence type="unavailable"></presence>`.