### PR TITLE
MIM-2315 Always set `fail_if_no_peer_cert` for just_tls

### DIFF
--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -111,6 +111,7 @@ init_per_group(ca_signed, Config) ->
      {verify_mode, "\n  tls.verify_mode = \"peer\""} | Config];
 init_per_group(self_signed, Config) ->
     [{signed, self},
+     {ssl_options, "\n  tls.disconnect_on_failure = false"},
      {verify_mode, "\n  tls.verify_mode = \"selfsigned_peer\""} | Config];
 init_per_group(standard, Config) ->
     modify_config_and_restart("\"standard\"", Config),


### PR DESCRIPTION
 MIM-2315 Always set `fail_if_no_peer_cert` for just_tls when `verify_mode` is not none

The intention of this PR is to harden security by not accepting empty client certificate when MIM TLS is configured with  `verify_mode` of `peer` or `selfsigned_peer`.

In MongooseIM there are two implementations of TLS connectivity - `fast_tls` and `just_tls`.
`fast_tls` is imlemented in C and uses directly OpenSSL library.
`just_tls` is implemented in Erlang and uses OTP ssl library for connection or handshake.

This PR applies only to `just_tls`.
Some options (like `disconnect_on_failure`) are not implemented in `fast_tls` yet.

Certificate verification behaviour is governed by config setting `disconnect_on_failure`.

By default, when not configured, `disconnect_on_failure` is set to true. In this mode certificate verification is executed as part of the TLS handshake, and in case of failure the connection is closed by the MIM instance.
In this mode, to reject empty client certificate, we pass `fail_if_no_peer_cert` option to OTP SSL handshake.

When  `disconnect_on_failure` is set to false, we do not pass `fail_if_no_peer_cert` option to OTP SSL handshake, thus allowing empty client certificate and completing TLS handshake as normal.  This is so that certificate verification can be checked later, f. ex. in sasl authentication.