### PR TITLE
Fix MUC room crash when handling old protocol stanza

### DIFF
--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -1183,7 +1183,8 @@ handle_new_user(From, Nick, Packet, StateData, Attrs) ->
     case exml_query:path(Packet, [{element, <<"x">>}]) of
         undefined ->
             Response = kick_stanza_for_old_protocol(Attrs),
-            ejabberd_router:route(jid:replace_resource(StateData#state.jid, Nick), From, Response);
+            ejabberd_router:route(jid:replace_resource(StateData#state.jid, Nick), From, Response),
+            StateData;
         _ ->
             add_new_user(From, Nick, Packet, StateData)
     end.


### PR DESCRIPTION
With the changes done in https://github.com/esl/MongooseIM/pull/4054 the old "Groupchat 1.0" protocol is not supported. When receiving an old style presence, MIM would handle it correctly from the user's perspective, however, the MUC room process would crash loudly, as the Accumulator was passed instead of a Finite State Machine state. The fix is easy and analogous to the other `handle_new_user/5` branch.

I've checked locally, that the error is gone when running the `groupchat_user_enter_old_protocol` testcase from `muc_SUITE`.



