### PR TITLE
Mim 2314 reject verify peer without cacertfile

### DIFF
--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -68,6 +68,7 @@
   shaper = \"c2s_shaper\"
   max_stanza_size = 65536
   tls.certfile = \"priv/ssl/fake_server.pem\"
+  tls.cacertfile = \"priv/ssl/cacert.pem\"
   tls.mode = \"tls\""}.
 {listen_service,
   "[[listen.service]]

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -156,7 +156,8 @@ options("mongooseim-pgsql") ->
                 access => c2s,
                 shaper => c2s_shaper,
                 max_stanza_size => 65536,
-                tls => #{certfile => "priv/dc1.pem", dhfile => "priv/dh.pem"}
+                tls => #{certfile => "priv/dc1.pem", dhfile => "priv/dh.pem",
+                         cacertfile => "priv/ca.pem"}
                }),
        config([listen, c2s],
               #{port => 5223,

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -86,6 +86,7 @@
   tls.mode = "starttls"
   tls.certfile = "priv/dc1.pem"
   tls.dhfile = "priv/dh.pem"
+  tls.cacertfile = "priv/ca.pem"
 
 [[listen.c2s]]
   port = 5223


### PR DESCRIPTION
TLS peer verification requires cacertificate, so it makes sense to reject config that misses cacertificate when verify_mode is set to verify_peer.
We have had this config validation for just_tls. This PR adds it for fast_tls.
Note that fast_tls currently skips certificate validation during TLS handshake but allows for certificate checks to happen later on during authentication.

