### PR TITLE
Allow config section processor to be a list of functions

### DIFF
--- a/src/config/mongoose_config_parser_toml.erl
+++ b/src/config/mongoose_config_parser_toml.erl
@@ -30,8 +30,9 @@
 -type list_processor() :: fun((path(), [config_part()]) -> config_part())
                         | fun(([config_part()]) -> config_part()).
 
--type processor() :: fun((path(), config_part()) -> config_part())
-                   | fun((config_part()) -> config_part()).
+-type processor() :: processor_fun() | [processor_fun()].
+-type processor_fun() :: fun((path(), config_part()) -> config_part())
+                       | fun((config_part()) -> config_part()).
 
 -type step() ::
         parse        % Recursive processing (section/list) or type conversion (leaf option)
@@ -213,6 +214,8 @@ process_spec(#option{process = Process}) -> Process.
 
 -spec process(path(), config_part(), undefined | processor()) -> config_part().
 process(_Path, V, undefined) -> V;
+process(Path, V, Functions) when is_list(Functions) ->
+    lists:foldl(fun(F, Value) -> process(Path, Value, F) end, V, Functions);
 process(_Path, V, F) when is_function(F, 1) -> F(V);
 process(Path, V, F) when is_function(F, 2) -> F(Path, V).
 

--- a/src/config/mongoose_config_utils.erl
+++ b/src/config/mongoose_config_utils.erl
@@ -33,10 +33,4 @@ merge_sections(BasicSection, ExtraSection) ->
     BasicSection#section{items = maps:merge(Items1, Items2),
                          required = Required1 ++ Required2,
                          defaults = maps:merge(Defaults1, Defaults2),
-                         process = merge_process_functions(Process1, Process2)}.
-
-merge_process_functions(Process1, Process2) ->
-    fun(Path, V) ->
-            V1 = mongoose_config_parser_toml:process(Path, V, Process1),
-            mongoose_config_parser_toml:process(Path, V1, Process2)
-    end.
+                         process = lists:flatten([Process1, Process2])}.


### PR DESCRIPTION
This way, you can specify a list instead of having to merge functions.

The code is already tested, because it is used to merge sections.

