### PR TITLE
Allow config processor to be a list of functions

### DIFF
--- a/include/mongoose_config_spec.hrl
+++ b/include/mongoose_config_spec.hrl
@@ -7,7 +7,7 @@
                   required = [] :: [mongoose_config_parser_toml:toml_key()] | all,
                   validate = any :: mongoose_config_validator:section_validator(),
                   format_items = map :: mongoose_config_spec:format_items(),
-                  process :: undefined | mongoose_config_parser_toml:list_processor(),
+                  process = [] :: mongoose_config_parser_toml:processor(),
                   defaults = #{} :: #{mongoose_config_parser_toml:toml_key() =>
                                          mongoose_config_parser_toml:config_part()},
                   wrap = default :: mongoose_config_spec:wrapper(),
@@ -16,12 +16,12 @@
 -record(list, {items :: mongoose_config_spec:config_node(),
                validate = any :: mongoose_config_validator:list_validator(),
                format_items = list :: mongoose_config_spec:format_items(),
-               process :: undefined | mongoose_config_parser_toml:list_processor(),
+               process = [] :: mongoose_config_parser_toml:processor(),
                wrap = default :: mongoose_config_spec:wrapper()}).
 
 -record(option, {type :: mongoose_config_spec:option_type(),
                  validate = any :: mongoose_config_validator:validator(),
-                 process :: undefined | mongoose_config_parser_toml:processor(),
+                 process = [] :: mongoose_config_parser_toml:processor(),
                  wrap = default :: mongoose_config_spec:wrapper()}).
 
 -endif.

--- a/src/config/mongoose_config_utils.erl
+++ b/src/config/mongoose_config_utils.erl
@@ -33,10 +33,4 @@ merge_sections(BasicSection, ExtraSection) ->
     BasicSection#section{items = maps:merge(Items1, Items2),
                          required = Required1 ++ Required2,
                          defaults = maps:merge(Defaults1, Defaults2),
-                         process = merge_process_functions(Process1, Process2)}.
-
-merge_process_functions(Process1, Process2) ->
-    fun(Path, V) ->
-            V1 = mongoose_config_parser_toml:process(Path, V, Process1),
-            mongoose_config_parser_toml:process(Path, V1, Process2)
-    end.
+                         process = lists:flatten([Process1, Process2])}.


### PR DESCRIPTION
This way, you can specify a list instead of having to merge functions.

Also: remove the `list_processor` type, because it was created when all sections would be formatted as lists. Now they are formatted as maps by default. What's more, if sections are merged, only the first processor gets a map/list as the argument, and it can pass anything to the subsequent processors.

The `processor` type covers all such cases.