### PR TITLE
Test MAM without prefs

### DIFF
--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -3666,7 +3666,7 @@ muc_prefs_set_request_not_an_owner(ConfigIn) ->
                                                                     [<<"montague@montague.net">>],
                                                                     mam_ns_binary()), Room)),
         escalus:assert(is_error, [<<"cancel">>, <<"not-allowed">>], escalus:wait_for_stanza(Bob)),
-        assert_no_event_with_jid(mod_mam_muc_get_prefs, RoomAddr)
+        assert_no_event_with_jid(mod_mam_muc_set_prefs, RoomAddr)
     end,
     RoomOpts = [{persistent, true}],
     UserSpecs = [{alice, 1}, {bob, 1}],


### PR DESCRIPTION
The goal is to ensure that MAM works correctly with user preferences disabled, which is actually the default setting.

Changes to `mam_SUITE`:
- Add a configuration without prefs for regression tests. Disable prefs-related tests when prefs are disabled.
- Add a test to check that disabling prefs is effective. It seems enough to just check PM (no MUC test). 
- Fix event name in a test.

Note:
- The prefs-related events are executed even if prefs are disabled. We could later add more data to the events if needed, e.g. the result. This isn't done now, because it's out of scope of this task.

