### PR TITLE
Fix event not registered on shutdown

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -121,6 +121,7 @@
 {suites, "tests", cets_disco_SUITE}.
 {suites, "tests", start_node_id_SUITE}.
 {suites, "tests", tr_util_SUITE}.
+{suites, "tests", shutdown_SUITE}.
 
 {config, ["test.config"]}.
 {logdir, "ct_report"}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -163,6 +163,7 @@
 {suites, "tests", cets_disco_SUITE}.
 {suites, "tests", start_node_id_SUITE}.
 {suites, "tests", tr_util_SUITE}.
+{suites, "tests", shutdown_SUITE}.
 
 {config, ["dynamic_domains.config", "test.config"]}.
 

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -198,6 +198,13 @@
         {server, <<"localhost">>},
         {password, <<"password">>},
         {port, 5252}]},
+    {adam, [ %% used in mod_global_distrib_SUITE, websockets
+        {username, <<"adam">>},
+        {server, <<"localhost">>},
+        {password, <<"password">>},
+        {transport, escalus_ws},
+        {port, 5272},
+        {wspath, <<"/ws-xmpp">>}]},
     {neustradamus, [
         {username, <<"neustradamus">>},
         {server, <<"localhost">>},

--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -348,6 +348,7 @@
   scope = \"global\"
   workers = 10
   strategy = \"random_worker\"
+  connection.database = {{redis_database_number}}
 [outgoing_pools.rdbms.default]
   scope = \"global\"
   workers = 5

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -697,7 +697,6 @@ test_location_disconnect(Config) ->
                   ok = rpc(asia_node, application, stop, [mongooseim]),
                   %% TODO: Stopping mongooseim alone should probably stop connections too
                   ok = rpc(asia_node, application, stop, [ranch]),
-
                   escalus_client:send(Alice, escalus_stanza:chat_to(Eve, <<"Hi again!">>)),
                   Error = escalus:wait_for_stanza(Alice),
                   escalus:assert(is_error, [<<"cancel">>, <<"service-unavailable">>], Error)
@@ -1433,10 +1432,14 @@ custom_loglevels() ->
      {mod_global_distrib_connection, debug},
     %% to check if gc or refresh is triggered
      {mod_global_distrib_server_mgr, info},
-   %% To debug incoming connections
+    %% To debug incoming connections
 %    {mod_global_distrib_receiver, info},
-   %% to debug global session set/delete
-     {mod_global_distrib_mapping, debug}
+    %% to debug global session set/delete
+     {mod_global_distrib_mapping, debug},
+    %% To log make_error_reply calls
+     {jlib, debug},
+    %% to log sm_route
+     {ejabberd_sm, debug}
     ].
 
 test_hosts() -> [mim, mim2, reg].

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -688,18 +688,26 @@ test_component_disconnect(Config) ->
 test_location_disconnect(Config) ->
     try
         escalus:fresh_story(
-          Config, [{alice, 1}, {eve, 1}],
-          fun(Alice, Eve) ->
+          Config, [{alice, 1}, {eve, 1}, {adam, 1}],
+          fun(Alice, Eve, Adam) ->
                   escalus_client:send(Alice, escalus_stanza:chat_to(Eve, <<"Hi from Europe1!">>)),
-
                   escalus_client:wait_for_stanza(Eve),
 
+                  escalus_client:send(Alice, escalus_stanza:chat_to(Adam, <<"Hi, Adam, from Europe1!">>)),
+                  escalus_client:wait_for_stanza(Adam),
+
+                  print_sessions_debug_info(asia_node),
                   ok = rpc(asia_node, application, stop, [mongooseim]),
                   %% TODO: Stopping mongooseim alone should probably stop connections too
                   ok = rpc(asia_node, application, stop, [ranch]),
+
                   escalus_client:send(Alice, escalus_stanza:chat_to(Eve, <<"Hi again!">>)),
                   Error = escalus:wait_for_stanza(Alice),
-                  escalus:assert(is_error, [<<"cancel">>, <<"service-unavailable">>], Error)
+                  escalus:assert(is_error, [<<"cancel">>, <<"service-unavailable">>], Error),
+
+                  escalus_client:send(Alice, escalus_stanza:chat_to(Adam, <<"Hi, Adam, again!">>)),
+                  Error2 = escalus:wait_for_stanza(Alice),
+                  escalus:assert(is_error, [<<"cancel">>, <<"service-unavailable">>], Error2)
           end)
     after
         rpc(asia_node, application, start, [ranch]),
@@ -1408,6 +1416,27 @@ can_connect_to_port(Port) ->
             ct:pal("can_connect_to_port port=~p result=~p", [Port, Other]),
             false
     end.
+
+%% Prints information about the active sessions
+print_sessions_debug_info(NodeName) ->
+    Node = rpc(NodeName, erlang, node, []),
+    Nodes = rpc(NodeName, erlang, nodes, []),
+    ct:log("name=~p, erlang_node=~p, other_nodes=~p", [NodeName, Node, Nodes]),
+
+    Children = rpc(NodeName, supervisor, which_children, [mongoose_c2s_sup]),
+    ct:log("C2S processes under a supervisour ~p", [Children]),
+
+    Sessions = rpc(NodeName, ejabberd_sm, get_full_session_list, []),
+    ct:log("C2S processes in the session manager ~p", [Sessions]),
+
+    Sids = [element(2, Session) || Session <- Sessions],
+    Pids = [Pid || {_, Pid} <- Sids],
+    PidNodes = [{Pid, node(Pid)} || Pid <- Pids],
+    ct:log("Pids on nodes ~p", [PidNodes]),
+
+    Info = [{Pid, rpc:call(Node, erlang, process_info, [Pid])} || {Pid, Node} <- PidNodes],
+    ct:log("Processes info ~p", [Info]),
+    ok.
 
 %% -----------------------------------------------------------------------
 %% Custom log levels for GD modules during the tests

--- a/big_tests/tests/shutdown_SUITE.erl
+++ b/big_tests/tests/shutdown_SUITE.erl
@@ -123,7 +123,10 @@ wait_for_down(Pid) ->
     MonRef = erlang:monitor(process, Pid),
     receive
         {'DOWN', MonRef, process, _, _} -> ok
-        after 5000 -> ct:fail(wait_for_down_timeout)
+        after 5000 ->
+            ct:pal("wait_for_down current_stacktrace ~p",
+                   [rpc:pinfo(Pid, current_stacktrace)]),
+            ct:fail(wait_for_down_timeout)
     end.
 
 %% Waits until the TCP socket is closed

--- a/big_tests/tests/shutdown_SUITE.erl
+++ b/big_tests/tests/shutdown_SUITE.erl
@@ -1,6 +1,7 @@
 -module(shutdown_SUITE).
 
 -compile([export_all, nowarn_export_all]).
+-import(distributed_helper, [mim/0, rpc/4]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -10,9 +11,14 @@ all() ->
     [{group, main}].
 
 groups() ->
-    [{main, [parallel], [shutdown]}].
+    [{main, [], cases()}].
+
+cases() ->
+    [shutdown,
+     client_tries_to_connect_before_listener_stop].
 
 init_per_suite(Config) ->
+    mongoose_helper:inject_module(?MODULE),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->
@@ -29,11 +35,16 @@ end_per_group(_, Config) ->
 init_per_testcase(shutdown = TC, Config) ->
     logger_ct_backend:start(),
     escalus:init_per_testcase(TC, Config);
+init_per_testcase(client_tries_to_connect_before_listener_stop = TC, Config) ->
+    escalus:init_per_testcase(TC, Config);
 init_per_testcase(Name, Config) ->
     escalus:init_per_testcase(Name, Config).
 
 end_per_testcase(shutdown = TC, Config) ->
     logger_ct_backend:stop(),
+    escalus:end_per_testcase(TC, Config);
+end_per_testcase(client_tries_to_connect_before_listener_stop = TC, Config) ->
+    rpc(mim(), meck, unload, []),
     escalus:end_per_testcase(TC, Config);
 end_per_testcase(Name, Config) ->
     escalus:end_per_testcase(Name, Config).
@@ -46,3 +57,75 @@ shutdown(Config) ->
     logger_ct_backend:stop_capture(),
     FilterFun = fun(_, WMsg) -> re:run(WMsg, "event_not_registered") /= nomatch end,
     [] = logger_ct_backend:recv(FilterFun).
+
+client_tries_to_connect_before_listener_stop(Config) ->
+    %% Ensures that user would not be able to connect while we are stopping
+    %% the listeners and other c2s processes
+    UserSpec = escalus_users:get_userspec(Config, geralt_s),
+    PortNum = proplists:get_value(port, UserSpec),
+    %% Ask MongooseIM to pause the stopping process
+    %% so we can check that listeners were suspended correctly
+    block_listener(),
+    %% Check that the listener is working
+    {ok, ConnPort} = gen_tcp:connect("127.0.0.1", PortNum, []),
+    %% Trigger the restarting logic in a separate parallel process
+    RestPid = restart_application_non_blocking(),
+    %% Wait until we are blocked in mongoose_listener:stop/0
+    Called = wait_for_called(),
+    {error, econnrefused} = gen_tcp:connect("127.0.0.1", PortNum, []),
+    %% Resume to stop the listeners
+    resume(Called),
+    %% Check that the old TCP connections are closed
+    receive_tcp_closed(ConnPort),
+    %% Wait till mongooseim is fully restarted
+    wait_for_down(RestPid).
+
+block_listener() ->
+    rpc(mim(), meck, new, [mongoose_listener, [no_link, passthrough]]),
+    Pid = self(),
+    F = fun() ->
+            wait_for_resume(Pid),
+            meck:passthrough([])
+        end,
+    rpc(mim(), meck, expect, [mongoose_listener, stop, F]).
+
+restart_application_non_blocking() ->
+    spawn_link(fun() -> ejabberd_node_utils:restart_application(mongooseim) end).
+
+wait_for_called() ->
+    receive
+        {called, Called} ->
+            Called
+        after 5000 ->
+            error(wait_for_called_timeout)
+    end.
+
+%% Blocks the mocked process until resume/1 is called
+wait_for_resume(Pid) ->
+    MonRef = erlang:monitor(process, Pid),
+    Called = {self(), MonRef},
+    Pid ! {called, Called},
+    receive
+        {'DOWN', MonRef, process, _, _} -> ok;
+        {resume, MonRef} -> ok
+    end.
+
+%% Command to the mocked process to resume the operation
+resume({Pid, MonRef}) ->
+    Pid ! {resume, MonRef}.
+
+wait_for_down(Pid) ->
+    MonRef = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', MonRef, process, _, _} -> ok
+        after 5000 -> ct:fail(wait_for_down_timeout)
+    end.
+
+%% Waits until the TCP socket is closed
+receive_tcp_closed(ConnPort) ->
+    receive
+        {tcp_closed, ConnPort} ->
+            ok
+        after 5000 ->
+            ct:fail(wait_for_tcp_close_timeout)
+    end.

--- a/big_tests/tests/shutdown_SUITE.erl
+++ b/big_tests/tests/shutdown_SUITE.erl
@@ -1,0 +1,48 @@
+-module(shutdown_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("exml/include/exml.hrl").
+
+all() ->
+    [{group, main}].
+
+groups() ->
+    [{main, [parallel], [shutdown]}].
+
+init_per_suite(Config) ->
+    escalus:init_per_suite(Config).
+
+end_per_suite(Config) ->
+    escalus:end_per_suite(Config).
+
+init_per_group(_, Config) ->
+    escalus:create_users(Config, escalus:get_users([geralt_s, alice])),
+    Config.
+
+end_per_group(_, Config) ->
+    escalus:delete_users(Config, escalus:get_users([geralt_s, alice])),
+    Config.
+
+init_per_testcase(shutdown = TC, Config) ->
+    logger_ct_backend:start(),
+    escalus:init_per_testcase(TC, Config);
+init_per_testcase(Name, Config) ->
+    escalus:init_per_testcase(Name, Config).
+
+end_per_testcase(shutdown = TC, Config) ->
+    logger_ct_backend:stop(),
+    escalus:end_per_testcase(TC, Config);
+end_per_testcase(Name, Config) ->
+    escalus:end_per_testcase(Name, Config).
+
+shutdown(Config) ->
+    UserSpec = escalus_users:get_userspec(Config, geralt_s),
+    {ok, _Alice, _} = escalus_connection:start(UserSpec),
+    logger_ct_backend:capture(error),
+    ejabberd_node_utils:restart_application(mongooseim),
+    logger_ct_backend:stop_capture(),
+    FilterFun = fun(_, WMsg) -> re:run(WMsg, "event_not_registered") /= nomatch end,
+    [] = logger_ct_backend:recv(FilterFun).

--- a/include/safely.hrl
+++ b/include/safely.hrl
@@ -4,7 +4,7 @@
 -define(SAFELY(F),
         try F catch
             error:R:S -> {exception, #{class => error, reason => R, stacktrace => S}};
-            throw:R -> {exception, #{class => throw, reason => R}};
+            throw:R:S -> {exception, #{class => throw, reason => R, stacktrace => S}};
             exit:R:S -> {exception, #{class => exit, reason => R, stacktrace => S}}
         end).
 

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -19,6 +19,7 @@
 {hosts, "\"fed1\", \"fed2\""}.
 {default_server_domain, "\"fed1\""}.
 {cluster_name, "fed"}.
+{redis_database_number, "2"}.
 
 %% domain.example.com is for multitenancy preset, muc_SUITE:register_over_s2s
 {s2s_addr, "[[s2s.address]]

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -22,6 +22,7 @@
 {host_types, "\"test type\", \"dummy auth\", \"anonymous\""}.
 {default_server_domain, "\"localhost\""}.
 {cluster_name, "mim"}.
+{redis_database_number, "0"}.
 
 {mod_amp, ""}.
 {host_config,

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -20,6 +20,7 @@
 {host_types, "\"test type\", \"dummy auth\""}.
 {default_server_domain, "\"localhost\""}.
 {cluster_name, "mim"}.
+{redis_database_number, "0"}.
 {s2s_addr, "[[s2s.address]]
     host = \"localhost2\"
     ip_address = \"127.0.0.1\""}.

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -23,6 +23,7 @@
 {hosts, "\"localhost\", \"anonymous.localhost\", \"localhost.bis\""}.
 {default_server_domain, "\"localhost\""}.
 {cluster_name, "mim"}.
+{redis_database_number, "0"}.
 
 {s2s_addr, "[[s2s.address]]
     host = \"localhost2\"

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -23,6 +23,8 @@
 {hosts, "\"reg1\", \"localhost\""}.
 {default_server_domain, "\"reg1\""}.
 {cluster_name, "reg"}.
+{cluster_name, "reg"}.
+{redis_database_number, "1"}.
 
 {s2s_addr, "[[s2s.address]]
     host = \"localhost\"

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -623,7 +623,8 @@ do_route(Acc, From, To, El) ->
                     do_route_offline(Name, mongoose_acc:stanza_type(Acc),
                                      From, To, Acc, El);
                 Pid when is_pid(Pid) ->
-                    ?LOG_DEBUG(#{what => sm_route_to_pid, session_pid => Pid, acc => Acc}),
+                    ?LOG_DEBUG(#{what => sm_route_to_pid, session_pid => Pid,
+                                 session_node => node(Pid), acc => Acc}),
                     mongoose_c2s:route(Pid, Acc),
                     Acc
             end

--- a/src/mongoose_listener.erl
+++ b/src/mongoose_listener.erl
@@ -10,6 +10,7 @@
 
 %% API
 -export([start/0, stop/0]).
+-export([suspend_listeners_and_shutdown_connections/0]).
 
 -callback start_listener(options()) -> ok.
 -callback instrumentation(options()) -> [mongoose_instrument:spec()].
@@ -23,6 +24,7 @@
                      any() => any()}.
 -type id() :: {inet:port_number(), inet:ip_address(), proto()}.
 -type proto() :: tcp.
+-type typed_listeners() :: [{Type :: ranch | cowboy, Listener :: ranch:ref()}].
 
 -export_type([options/0, id/0, proto/0]).
 
@@ -73,3 +75,67 @@ listener_instrumentation(Opts = #{module := Module}) ->
         false ->
             []
     end.
+
+-spec suspend_listeners_and_shutdown_connections() -> StoppedCount :: non_neg_integer().
+suspend_listeners_and_shutdown_connections() ->
+    TypedListeners = get_typed_listeners(),
+    suspend_listeners(TypedListeners),
+    broadcast_c2s_shutdown_sup() +
+        broadcast_c2s_shutdown_to_regular_c2s_connections(TypedListeners).
+
+-spec suspend_listeners(typed_listeners()) -> ok.
+suspend_listeners(TypedListeners) ->
+    [ranch:suspend_listener(Ref) || {_Type, Ref} <- TypedListeners],
+    ok.
+
+-spec get_typed_listeners() -> typed_listeners().
+get_typed_listeners() ->
+    Children = supervisor:which_children(mongoose_listener_sup),
+    Listeners1 = [{cowboy, ejabberd_cowboy:ref(Listener)}
+                  || {Listener, _, _, [ejabberd_cowboy]} <- Children],
+    Listeners2 = [{ranch, Ref}
+                  || {Ref, _, _, [mongoose_c2s_listener]} <- Children],
+    Listeners1 ++ Listeners2.
+
+-spec broadcast_c2s_shutdown_sup() -> StoppedCount :: non_neg_integer().
+broadcast_c2s_shutdown_sup() ->
+    %% Websocket c2s connections have two processes per user:
+    %% - one is websocket Cowboy process.
+    %% - one is under mongoose_c2s_sup.
+    %%
+    %% Regular XMPP connections are not under mongoose_c2s_sup,
+    %% they are under the Ranch listener, which is a child of mongoose_listener_sup.
+    %%
+    %% We could use ejabberd_sm to get both Websocket and regular XMPP sessions,
+    %% but waiting till the list size is zero is much more computationally
+    %% expensive in that case.
+    Children = supervisor:which_children(mongoose_c2s_sup),
+    lists:foreach(
+        fun({_, Pid, _, _}) ->
+            mongoose_c2s:exit(Pid, system_shutdown)
+        end,
+        Children),
+    mongoose_lib:wait_until(
+        fun() ->
+              Res = supervisor:count_children(mongoose_c2s_sup),
+              proplists:get_value(active, Res)
+        end,
+        0),
+    length(Children).
+
+%% Based on https://ninenines.eu/docs/en/ranch/2.1/guide/connection_draining/
+-spec broadcast_c2s_shutdown_to_regular_c2s_connections(typed_listeners()) ->
+    non_neg_integer().
+broadcast_c2s_shutdown_to_regular_c2s_connections(TypedListeners) ->
+    Refs = [Ref || {ranch, Ref} <- TypedListeners],
+    StoppedCount = lists:foldl(
+        fun(Ref, Count) ->
+            Conns = ranch:procs(Ref, connections),
+            [mongoose_c2s:exit(Pid, system_shutdown) || Pid <- Conns],
+            length(Conns) + Count
+        end, 0, Refs),
+    lists:foreach(
+        fun(Ref) ->
+            ok = ranch:wait_for_connections(Ref, '==', 0)
+        end, Refs),
+    StoppedCount.


### PR DESCRIPTION
This PR addresses "MIM-2316 event_not_registered for c2s_xmpp_element_size_out when stopping the node error".

When we call `mongooseimctl stop` (and there are some websocket connections), we see this error in logs:
`{error,#{what => event_not_registered,labels => #{},event_name => c2s_xmpp_element_size_out} .`

Code in question is this one in mongoose_listener:
```
stop() ->
    Listeners = mongoose_config:get_opt(listen),
    lists:foreach(fun stop_listener/1, Listeners),
    mongoose_instrument:tear_down(instrumentation(Listeners)).
```

So, basically it looks like there are some c2s processes alive on the node after we call tear_down. So, metric c2s_xmpp_element_size_out was there, but not here anymore.

Proposed changes include:
- **Try to reproduce the bug, most likely you will need websocket connections when you stop the server (or stop the listener?).** - Done. Just having a websocket connection is enough.

- **Try to fix the bug by ensuring that there are no c2s processes after the listener is stopped. Make sure no processes could spawn up.** - there was already logic for it, it was using ranch and c2s supervisor. Moving stopping based on the supervisor above before stopping the listeners fixes the issue. But there still a chance that new connections would be established. So, we 1) - disable acceptors. 2) - stop c2s processes. 3) - stop listeners completely. instead.

Global distribution:
- mysql_redis preset was using the same redis for both reg and mim clusters. This means that session from reg was visible in mim cluster over ejabberd_sm_redis. So, eve pid was visible in ejabberd_sm on the mim cluster too. We use different redis database numbers for different clusters now.
- added a test with a websocket client to global distribution too.
- added debug logging into make_error_reply.


Shutdown:
- mongoose_c2s_sup only contains websocket clients sessions (maybe bosh too).
- ranch contains regular XMPP connections.


Shutdown logic now is:
- suspend all ranch acceptors.
- drain connections from both ranch and c2s supervisor - could take some time.
- shotdown listeners and remove instrimentation metrics.

Use `ranch:wait_for_connections(Ref, '==', 0)`, because it is more optimized, than just pulling a list of pids and checking its length in the loop.

Ideas for future:
- can we use websocket process as a c2s process? so we have one process in the system per user. Could be nice savings in Websocket oriented setups.
- Move this code around a bit, so we can have `mongooseimctl suspend_listener` and `mongooseimctl drain` commands, which could be useful for implementing graceful shutdowns in k8s or ansible scripts.