### PR TITLE
Fix cockroachdb consistency

### DIFF
--- a/big_tests/test.config
+++ b/big_tests/test.config
@@ -286,7 +286,7 @@
   workers = 10
 [outgoing_pools.rdbms.default]
   scope = \"global\"
-  workers = 1
+  workers = 5
   connection.driver = \"cockroachdb\"
   connection.host = \"localhost\"
   connection.port = 26257

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -22,6 +22,7 @@
                              require_rpc_nodes/1,
                              subhost_pattern/1,
                              rpc/4]).
+-import(domain_helper, [host_type/0]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -49,17 +50,26 @@ group_is_compatible(hometree_specific, OnlyNodetreeTree) -> OnlyNodetreeTree =:=
 group_is_compatible(_, _) -> true.
 
 base_groups() ->
-    [{basic, [parallel], basic_tests()},
-     {service_config, [parallel], service_config_tests()},
-     {node_config, [parallel], node_config_tests()},
-     {node_affiliations, [parallel], node_affiliations_tests()},
-     {manage_subscriptions, [parallel], manage_subscriptions_tests()},
+    [{basic, parallel_props(), basic_tests()},
+     {service_config, parallel_props(), service_config_tests()},
+     {node_config, parallel_props(), node_config_tests()},
+     {node_affiliations, parallel_props(), node_affiliations_tests()},
+     {manage_subscriptions, parallel_props(), manage_subscriptions_tests()},
      {collection, [sequence], collection_tests()},
-     {collection_config, [parallel], collection_config_tests()},
-     {debug_calls, [parallel], debug_calls_tests()},
-     {pubsub_item_publisher_option, [parallel], pubsub_item_publisher_option_tests()},
+     {collection_config, parallel_props(), collection_config_tests()},
+     {debug_calls, parallel_props(), debug_calls_tests()},
+     {pubsub_item_publisher_option, parallel_props(), pubsub_item_publisher_option_tests()},
      {hometree_specific, [sequence], hometree_specific_tests()},
-     {last_item_cache, [parallel], last_item_cache_tests()}].
+     {last_item_cache, parallel_props(), last_item_cache_tests()}].
+
+parallel_props() ->
+    case rpc(mim(), mongoose_rdbms, db_engine, [host_type()]) of
+        cockroachdb ->
+            %% Parallel pubsub tests are flaky on CockroachDB
+            [parallel, {repeat_until_all_ok, 5}];
+        _ ->
+            [parallel]
+    end.
 
 basic_tests() ->
     [

--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -104,8 +104,7 @@ init_per_suite(Config) ->
          orelse mongoose_helper:is_rdbms_enabled(host_type()) of
         false -> {skip, rdbms_or_ct_not_running};
         true ->
-            %% Warning: inject_module does not really work well with --rerun-big-tests flag
-            mongoose_helper:inject_module(?MODULE),
+            mongoose_helper:inject_module(?MODULE, reload),
             Config1 = mongoose_helper:backup_and_set_config_option(Config, [instrumentation, probe_interval], 1),
             escalus:init_per_suite(Config1)
     end.


### PR DESCRIPTION
The goal is to address flaky tests in `rdbms_SUITE` for CockroachDB.

The problem was caused by mocked `mongoose_rbdms_backend:execute/4`, which called `prepare` without the following `execute`. As a result, the`sync` message was missing in the protocol flow, and the subsequent query would receive stale data from the DB.

Main changes:
- Fix various issues with `rdbms_SUITE`.
- Add a test reproducing the issue reliably for CockroachDB (or for PostgreSQL with the `SERIALIZABLE` transaction isolation level).
- Fix the problem by adding missing `sync` after `prepare`, making it independent of the subsequent call to `execute`.
- Use 5 workers instead of 1 to re-enable testing concurrent queries. To address flaky pubsub tests, a repeat property is added.

There are more details in commit messages.

Additionally, I verified that:
- The new test case fails for CockroachDB before the fix, and it fails for PostgreSQL before the fix if the isolation level is changed to `SERIALIZABLE`. The new test case stops failing after the fix in both cases.
- The new test case fails with the expected message if there is only one worker, because the test doesn't make sense in this configuration.
- The whole suite passes with `{repeat_until_any_fail, 10}` - locally and on CI.
