### PR TITLE
Enable 'rerun failed tests' for big tests in CircleCI

### DIFF
--- a/tools/select_suites_to_run.erl
+++ b/tools/select_suites_to_run.erl
@@ -1,0 +1,28 @@
+%% Escript used to filter the test spec according to a list of allowed suites
+%% This is used to rerun failed tests on CircleCI
+%%
+%% Arguments: TEST_SPEC SUITE1 SUITE2 ..
+%% Example arguments: default.spec muc_SUITE rdbms_SUITE
+
+-module(select_suites_to_run).
+-export([main/1]).
+
+main([SpecFile | SuiteStrings]) ->
+    Suites = [list_to_atom(Str) || Str <- SuiteStrings],
+    io:format("Allowed suites: ~p~n", [Suites]),
+    {ok, OldTerms} = file:consult(SpecFile),
+    NewTerms = lists:filter(fun(Term) -> filter_term(Term, Suites) end, OldTerms),
+    write_terms(SpecFile, NewTerms),
+    ok.
+
+filter_term(Term, Suites) when element(1, Term) == suites;
+                               element(1, Term) == groups;
+                               element(1, Term) == cases ->
+    lists:member(element(3, Term), Suites);
+filter_term(_Term, _Suites) ->
+    true.
+
+write_terms(Filename, List) ->
+    Format = fun(Term) -> io_lib:format("~tp.~n", [Term]) end,
+    Text = lists:map(Format, List),
+    file:write_file(Filename, Text).

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -145,6 +145,7 @@ run_test_preset() {
   cd ${BASE}/big_tests
   local MAKE_RESULT=0
   TESTSPEC=${TESTSPEC:-default.spec}
+  maybe_select_suites
   if [ "$COVER_ENABLED" = "true" ]; then
     make cover_test_preset TESTSPEC=$TESTSPEC PRESET=$PRESET CT_HOOKS=$CT_HOOKS
     MAKE_RESULT=$?
@@ -155,6 +156,14 @@ run_test_preset() {
   cd -
   tools/print-dots.sh stop
   return ${MAKE_RESULT}
+}
+
+maybe_select_suites() {
+    if command -v circleci; then
+        circleci tests glob tests/*_SUITE.erl | \
+            circleci tests run --command=">selected_suites xargs -d' ' -I {} basename {} .erl"
+        escript ../tools/select_suites_to_run.erl $TESTSPEC $(<selected_suites)
+    fi
 }
 
 print_running_nodes() {


### PR DESCRIPTION
As described in the [CricleCI docs](https://circleci.com/docs/rerun-failed-tests), the "rerun failed tests" feature allows to rerun only failed test suites instead of all of them.

This PR makes use of this feature in big tests, because they fail the most, and there are substantial savings in terms of CI time and credits.

The steps needed were simple:
1. Use `circleci tests glob` and `circleci tests run` as described in https://circleci.com/docs/rerun-failed-tests/#output-test-files-only to have a list of test suites. For the first run, it will contain all files, but if you rerun tests, it will only contain failed suites.
2. Add a small escript to filter out the test suites in the test spec. This is similar to [selected_tests_to_test_spec.erl](https://github.com/esl/MongooseIM/blob/master/tools/test_runner/selected_tests_to_test_spec.erl), but the filtering is different:
    - Only suites from the original specs are allowed. This is to avoid running tests from outside of the current spec.
    - Filtering is only by suite (not by tests or groups).

### See it in action

Two presets failed - see https://github.com/esl/MongooseIM/pull/4403#issuecomment-2508134406. Then, on the [workflow page](https://app.circleci.com/pipelines/github/esl/MongooseIM/13223/workflows/06fd36f4-e023-4659-9602-c53fc8b6111a) I was able to click "Rerun failed tests":

 <img src="https://github.com/user-attachments/assets/f14a6244-597b-4eb0-bf71-1a5b04e01a9f" alt="Rerun failed tests" width="300">

Afterwards, all tests succeeded, running only the failed suites:

![image](https://github.com/user-attachments/assets/164ea0db-59d8-44fe-962e-dd0061df01ac)
 
New GitHub comments contain only the rerun tests, and the coverage seems to be correct. You can see in the logs, that CircleCI was choosing only the failed suites:

![image](https://github.com/user-attachments/assets/d67b7413-b942-4578-a5ea-ba3e2c9b92cb)

### Possible next steps

Do the same for small tests if needed.






