### PR TITLE
Add building `arm64` packages to CI pipeline

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -707,6 +707,10 @@ jobs:
           name: Build package
           command: |
             ./tools/test.sh -p pkg -s false
+      - run:
+          name: Verify package architecture
+          command: |
+            ./tools/pkg/verify_arch.sh
       - when:
           condition:
             matches:
@@ -725,7 +729,7 @@ filters:
   - &all_tags_and_master
     <<: *all_tags
     branches:
-      only: master
+      only: ci-build-packages-for-arm64
 
 workflows:
   version: 2

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -730,7 +730,7 @@ filters:
   - &all_tags_and_master
     <<: *all_tags
     branches:
-      only: ci-build-packages-for-arm64
+      only: master
 
 workflows:
   version: 2

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -710,6 +710,7 @@ jobs:
       - run:
           name: Verify package architecture
           command: |
+            ./tools/circle-install-packages.sh rpm
             ./tools/pkg/verify_arch.sh
       - when:
           condition:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -750,8 +750,20 @@ workflows:
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
+          name: debian-bookworm-arm64
+          executor: otp_27_arm64
+          platform: debian-bookworm
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
           name: debian-bullseye
           executor: otp_27
+          platform: debian-bullseye
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
+          name: debian-bullseye-arm64
+          executor: otp_27_arm64
           platform: debian-bullseye
           context: mongooseim-org
           filters: *all_tags_and_master
@@ -762,8 +774,20 @@ workflows:
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
+          name: debian-buster-arm64
+          executor: otp_27_arm64
+          platform: debian-buster
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
           name: ubuntu-oracular
           executor: otp_27
+          platform: ubuntu-oracular
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
+          name: ubuntu-oracular-arm64
+          executor: otp_27_arm64
           platform: ubuntu-oracular
           context: mongooseim-org
           filters: *all_tags_and_master
@@ -774,8 +798,20 @@ workflows:
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
+          name: ubuntu-noble-arm64
+          executor: otp_27_arm64
+          platform: ubuntu-noble
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
           name: ubuntu-jammy
           executor: otp_27
+          platform: ubuntu-jammy
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
+          name: ubuntu-jammy-arm64
+          executor: otp_27_arm64
           platform: ubuntu-jammy
           context: mongooseim-org
           filters: *all_tags_and_master
@@ -786,8 +822,20 @@ workflows:
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
+          name: ubuntu-focal-arm64
+          executor: otp_27_arm64
+          platform: ubuntu-focal
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
           name: rockylinux-9
           executor: otp_27
+          platform: rockylinux-9
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
+          name: rockylinux-9-arm64
+          executor: otp_27_arm64
           platform: rockylinux-9
           context: mongooseim-org
           filters: *all_tags_and_master
@@ -798,14 +846,32 @@ workflows:
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
+          name: rockylinux-8-arm64
+          executor: otp_27_arm64
+          platform: rockylinux-8
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
           name: almalinux-9
           executor: otp_27
           platform: almalinux-9
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
+          name: almalinux-9-arm64
+          executor: otp_27_arm64
+          platform: almalinux-9
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
           name: almalinux-8
           executor: otp_27
+          platform: almalinux-8
+          context: mongooseim-org
+          filters: *all_tags_and_master
+      - package:
+          name: almalinux-8-arm64
+          executor: otp_27_arm64
           platform: almalinux-8
           context: mongooseim-org
           filters: *all_tags_and_master

--- a/tools/pkg/Dockerfile_deb
+++ b/tools/pkg/Dockerfile_deb
@@ -12,10 +12,15 @@ RUN apt-get install -y locales git make zlib1g-dev unixodbc-dev gcc g++ libssl-d
 
 # The signing script requires debsigs version 0.2 or higher, which is unavailable in
 # package repositories of Ubuntu versions earlier than 24.10 and Debian versions earlier than 13.
-# TODO: Switch to installing debsigs via apt once support for these older versions is dropped.
-RUN distro=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"') && \
+# TODO: Remove custom repo setup once older distro support ends.
+RUN arch=$(dpkg --print-architecture) && \
+    distro=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"') && \
     if [ "$distro" = "ubuntu" ]; then \
-        echo "deb http://archive.ubuntu.com/ubuntu oracular main restricted universe multiverse" >> /etc/apt/sources.list && \
+        if [ "$arch" = "arm64" ]; then \
+            echo "deb http://ports.ubuntu.com/ubuntu-ports oracular main restricted universe multiverse" >> /etc/apt/sources.list; \
+        else \
+            echo "deb http://archive.ubuntu.com/ubuntu oracular main restricted universe multiverse" >> /etc/apt/sources.list; \
+        fi && \
         printf "Package: debsigs\nPin: release n=oracular\nPin-Priority: 990\n" > /etc/apt/preferences.d/debsigs; \
     elif [ "$distro" = "debian" ]; then \
         echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list && \

--- a/tools/pkg/Dockerfile_deb
+++ b/tools/pkg/Dockerfile_deb
@@ -8,15 +8,23 @@ FROM $builder_image AS builder
 # Install build deps
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -y locales git make zlib1g-dev unixodbc-dev gcc g++ libssl-dev curl gpg wget gnupg
+RUN apt-get install -y locales git make zlib1g-dev unixodbc-dev gcc g++ libssl-dev curl gpg
 
 # The signing script requires debsigs version 0.2 or higher, which is unavailable in
 # package repositories of Ubuntu versions earlier than 24.10 and Debian versions earlier than 13.
 # TODO: Switch to installing debsigs via apt once support for these older versions is dropped.
-RUN wget http://ftp.de.debian.org/debian/pool/main/d/debsigs/debsigs_0.2.2-1_all.deb && \
-    dpkg -i debsigs_0.2.2-1_all.deb && \
-    rm debsigs_0.2.2-1_all.deb && \
-    which debsigs
+RUN distro=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"') && \
+    if [ "$distro" = "ubuntu" ]; then \
+        echo "deb http://archive.ubuntu.com/ubuntu oracular main restricted universe multiverse" >> /etc/apt/sources.list && \
+        printf "Package: debsigs\nPin: release n=oracular\nPin-Priority: 990\n" > /etc/apt/preferences.d/debsigs; \
+    elif [ "$distro" = "debian" ]; then \
+        echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list && \
+        printf "Package: debsigs\nPin: release n=trixie\nPin-Priority: 990\n" > /etc/apt/preferences.d/debsigs; \
+    fi && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends debsigs && \
+    sed -i '/oracular/d' /etc/apt/sources.list && \
+    sed -i '/trixie/d' /etc/apt/sources.list
 
 ARG erlang_version
 

--- a/tools/pkg/scripts/deb/build_package.sh
+++ b/tools/pkg/scripts/deb/build_package.sh
@@ -6,7 +6,6 @@ revision=$2
 otp_version=$3
 
 arch=$(dpkg --print-architecture)
-echo "Detected package architecture: $arch"
 
 cd ~/mongooseim
 
@@ -40,11 +39,6 @@ sed -i "s#@DATE@#${date}#g" mongooseim/DEBIAN/changelog
 
 chown $USER:$USER -R mongooseim
 dpkg --build mongooseim ./
-
-if [[ $(dpkg-deb -f mongooseim_*.deb Architecture) != $arch ]]; then
-  echo "Error: The package was not built for ${arch}."
-  exit 1
-fi
 
 source /etc/os-release
 os=$ID

--- a/tools/pkg/scripts/deb/build_package.sh
+++ b/tools/pkg/scripts/deb/build_package.sh
@@ -5,7 +5,8 @@ version=$1
 revision=$2
 otp_version=$3
 
-arch="amd64"
+arch=$(dpkg --print-architecture)
+echo "Detected package architecture: $arch"
 
 cd ~/mongooseim
 
@@ -39,6 +40,11 @@ sed -i "s#@DATE@#${date}#g" mongooseim/DEBIAN/changelog
 
 chown $USER:$USER -R mongooseim
 dpkg --build mongooseim ./
+
+if [[ $(dpkg-deb -f mongooseim_*.deb Architecture) != $arch ]]; then
+  echo "Error: The package was not built for ${arch}."
+  exit 1
+fi
 
 source /etc/os-release
 os=$ID

--- a/tools/pkg/scripts/rpm/build_package.sh
+++ b/tools/pkg/scripts/rpm/build_package.sh
@@ -20,21 +20,11 @@ case "$arch" in
     ;;
 esac
 
-echo "Detected architecture: $arch"
-echo "Package architecture: $package_name_arch"
-
-
 rpmbuild -bb \
     --define "version ${version}" \
     --define "release ${revision}" \
     --define "architecture ${arch}" \
     ~/rpmbuild/SPECS/mongooseim.spec
-
-if [[ $(rpm -qp --qf "%{ARCH}" \
-        ~/rpmbuild/RPMS/${arch}/mongooseim-${version}-${revision}.${arch}.rpm) != $arch ]]; then
-  echo "Error: The package was not built for ${arch}."
-  exit 1
-fi
 
 source /etc/os-release
 os=$ID

--- a/tools/pkg/scripts/rpm/build_package.sh
+++ b/tools/pkg/scripts/rpm/build_package.sh
@@ -5,8 +5,23 @@ version=$1
 revision=$2
 otp_version=$3
 
-arch="x86_64"
-package_name_arch="amd64"
+arch=$(uname -m)
+
+case "$arch" in
+  x86_64)
+    package_name_arch="amd64"
+    ;;
+  aarch64)
+    package_name_arch="arm64"
+    ;;
+  *)
+    echo "Unsupported architecture: $arch"
+    exit 1
+    ;;
+esac
+
+echo "Detected architecture: $arch"
+echo "Package architecture: $package_name_arch"
 
 
 rpmbuild -bb \
@@ -14,6 +29,12 @@ rpmbuild -bb \
     --define "release ${revision}" \
     --define "architecture ${arch}" \
     ~/rpmbuild/SPECS/mongooseim.spec
+
+if [[ $(rpm -qp --qf "%{ARCH}" \
+        ~/rpmbuild/RPMS/${arch}/mongooseim-${version}-${revision}.${arch}.rpm) != $arch ]]; then
+  echo "Error: The package was not built for ${arch}."
+  exit 1
+fi
 
 source /etc/os-release
 os=$ID

--- a/tools/pkg/verify_arch.sh
+++ b/tools/pkg/verify_arch.sh
@@ -1,0 +1,37 @@
+executor_arch=$(uname -m)
+case "$executor_arch" in
+  x86_64)
+    expected_arch="amd64"
+    ;;
+  aarch64)
+    expected_arch="arm64"
+    ;;
+  *)
+    echo "Unsupported executor architecture: $executor_arch"
+    exit 1
+    ;;
+esac
+
+echo "Executor architecture detected: $expected_arch"
+
+package_file=$(find tools/pkg/packages -name "*.deb" -o -name "*.rpm")
+if [ -z "$package_file" ]; then
+    echo "No package found in the output directory."
+    exit 1
+fi
+
+if [[ $package_file == *.deb ]]; then
+    actual_arch=$(dpkg --info "$package_file" | grep Architecture | awk '{print $2}')
+elif [[ $package_file == *.rpm ]]; then
+    actual_arch=$(rpm -q --info "$package_file" | grep Architecture | awk '{print $3}')
+else
+    echo "Unknown package type: $package_file"
+    exit 1
+fi
+
+if [ "$expected_arch" != "$actual_arch" ]; then
+    echo "Architecture mismatch: expected $expected_arch but got $actual_arch"
+    exit 1
+fi
+
+echo "Package architecture verified: $actual_arch"

--- a/tools/pkg/verify_arch.sh
+++ b/tools/pkg/verify_arch.sh
@@ -23,7 +23,15 @@ fi
 if [[ $package_file == *.deb ]]; then
     actual_arch=$(dpkg --info "$package_file" | grep Architecture | awk '{print $2}')
 elif [[ $package_file == *.rpm ]]; then
-    actual_arch=$(rpm -q --info "$package_file" | grep Architecture | awk '{print $3}')
+  actual_arch=$(rpm -qi "$package_file" | grep Architecture | awk '{print $2}')
+  if [ "$actual_arch" == "x86_64" ]; then
+    actual_arch="amd64"
+  elif [ "$actual_arch" == "aarch64" ]; then
+    actual_arch="arm64"
+  else
+    echo "Unable to determine architecture from file output."
+    exit 1
+  fi
 else
     echo "Unknown package type: $package_file"
     exit 1


### PR DESCRIPTION
This PR enables building packages with `arm64` executors and adds a verification script to ensure the package is built for the correct architecture. It also updates the installation method for the `debsigs` package in the Docker build process, addressing issues with the previous flaky approach.

CI run with passing package build: https://app.circleci.com/pipelines/github/esl/MongooseIM/13329/workflows/7f27f6ac-82f5-4951-a9f0-25cd788c44d0