### PR TITLE
Fix definition of the 'protected' GraphQL directive

### DIFF
--- a/priv/graphql/schemas/global/protected_dir.gql
+++ b/priv/graphql/schemas/global/protected_dir.gql
@@ -1,5 +1,8 @@
 "Marks the resource to be accessed only by authorized requests"
-directive @protected (type: String = DEFAULT, args: [String!] = []) on FIELD_DEFINITION | OBJECT | INTERFACE
+directive @protected (
+  type: ProtectedType = DEFAULT
+  args: [String!] = []
+) on FIELD_DEFINITION | OBJECT | INTERFACE
 
 enum ProtectedType{
   DEFAULT


### PR DESCRIPTION
The `type` argument had wrong type.
As a result, our docs started failing on the latest [spectaql@3.0.3](https://github.com/anvilco/spectaql/blob/main/CHANGELOG.md)