### PR TITLE
Don't create /usr/lib/mongooseim, because it already exists

### DIFF
--- a/tools/pkg/build.sh
+++ b/tools/pkg/build.sh
@@ -75,6 +75,7 @@ done
 builder_image="erlangsolutions/erlang:${platform}-${erlang_version}"
 target_image="${platform/-/:}"
 docker build -t mongooseim-${platform}:${version}-${revision} \
+    --progress=plain \
     --build-arg builder_image=${builder_image} \
     --build-arg target_image=${target_image} \
     --build-arg version=${version} \

--- a/tools/pkg/scripts/deb/debian/postinst
+++ b/tools/pkg/scripts/deb/debian/postinst
@@ -40,7 +40,7 @@ setup()
 
 case "$1" in
     configure)
-	useradd --system --shell /bin/sh --home-dir $PKG_ROOT --create-home $NAME
+	useradd --system --shell /bin/sh --home-dir $PKG_ROOT $NAME
 	setup "$@"
     ;;
 


### PR DESCRIPTION
This issue affected Debian/Ubuntu, resulting in warnings being printed out on installation.

- Don't create `/usr/lib/mongooseim`, because it already exists
- Don't truncate Docker logs - to be able to check the output.

I verified manually, that the issue was present for Debian/Ubuntu before the fix, and that it is gone after the fix (see the [CI workflow](https://app.circleci.com/pipelines/github/esl/MongooseIM/13363/workflows/e60f0474-90b9-4aac-9d8d-7209fed8650d) with packages enabled).

**Note:** I decided not to add automatic tests. We could add a condition to fail if anything is printed to `stderr`, but for me it might be too restrictive, i.e. there might be some unrelated output. I think we could add an automatic check later if we find any similar issue.
