### PR TITLE
Skip every test suite if MIM is not running

### DIFF
--- a/big_tests/Makefile
+++ b/big_tests/Makefile
@@ -47,7 +47,7 @@ cover_test_clean: get-deps
 	$(MAKE) cover_test
 
 quicktest: $(PREPARE)
-	$(RUN) erl -noinput $(COMMON_OPTS) $(ADD_OPTS) \
+	$(RUN) erl -hidden -noinput $(COMMON_OPTS) $(ADD_OPTS) \
 			-s run_common_test main test=quick spec=$(TESTSPEC)
 
 cover_quicktest: $(PREPARE)

--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -135,7 +135,7 @@
             {ct_mongoose_log_hook, [{host, mim2}, {print_init_and_done_for_testcases, false}]},
             {ct_mongoose_log_hook, [{host, mim3}, {print_init_and_done_for_testcases, false}]},
             ct_progress_hook,
-            ct_markdown_errors_hook, ct_mongoose_log_hook]}.
+            ct_markdown_errors_hook, ct_mongoose_log_hook, ct_check_rpc_nodes]}.
 
 %% since test-runner.sh can be executed with the --one-node option,
 %% log collection is enabled by default for host mim1 only.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -174,8 +174,7 @@
 %% * ensure preset & mim_data_dir values are passed to ct Config
 %% * check server's purity after SUITE
 {ct_hooks, [ct_groups_summary_hook, ct_tty_hook, ct_mongoose_hook, ct_progress_hook,
-            ct_markdown_errors_hook,
-            ct_mongoose_log_hook,
+            ct_markdown_errors_hook, ct_mongoose_log_hook, ct_check_rpc_nodes,
             {ct_mongoose_log_hook, [{host, mim2}, {print_init_and_done_for_testcases, false}]},
             {ct_mongoose_log_hook, [{host, mim3}, {print_init_and_done_for_testcases, false}]}]}.
 

--- a/big_tests/failure_reporting_testing.spec
+++ b/big_tests/failure_reporting_testing.spec
@@ -32,3 +32,6 @@
 %%% is printed asynchronously by test.sh script using
 %%% 'tail -f /tmp/progress &' command.
 % {ct_hooks, [ct_progress_hook]}.
+
+%% This hook checks if nodes are up and running MongooseIM.
+{ct_hooks, [ct_check_rpc_nodes]}.

--- a/big_tests/src/ct_check_rpc_nodes.erl
+++ b/big_tests/src/ct_check_rpc_nodes.erl
@@ -21,7 +21,13 @@ pre_init_per_suite(_Suite, Config, State) ->
         ok ->
             {Config, State};
         {error, Reason} ->
-            {{fail, Reason}, State}
+            case os:getenv("SKIP_CHECK_RPC_NODES") of
+                "true" ->
+                    ct:pal("Skip failing with ~p in ct_check_rpc_nodes", [Reason]),
+                    {Config, State};
+                _ ->
+                    {{fail, Reason}, State}
+            end
     end.
 
 post_end_per_suite(Suite,_Config, Return, State) ->

--- a/big_tests/src/ct_check_rpc_nodes.erl
+++ b/big_tests/src/ct_check_rpc_nodes.erl
@@ -31,6 +31,9 @@ pre_init_per_suite(_Suite, Config, State) ->
     end.
 
 post_end_per_suite(Suite,_Config, Return, State) ->
+    %% To ensure users do not use `require_rpc_nodes' from the previous
+    %% suite accidentally
+    distributed_helper:require_rpc_nodes([], []),
     {Return, State}.
 
 terminate(State) ->

--- a/big_tests/src/ct_check_rpc_nodes.erl
+++ b/big_tests/src/ct_check_rpc_nodes.erl
@@ -1,0 +1,31 @@
+-module(ct_check_rpc_nodes).
+
+%% Callbacks
+-export([id/1]).
+-export([init/2]).
+
+-export([pre_init_per_suite/3]).
+-export([post_end_per_suite/4]).
+-export([terminate/1]).
+
+-record(state, {}).
+
+id(_Opts) ->
+    "ct_check_rpc_nodes_hook_001".
+
+init(_Id, _Opts) ->
+    {ok, #state{}}.
+
+pre_init_per_suite(_Suite, Config, State) ->
+    case distributed_helper:validate_nodes() of
+        ok ->
+            {Config, State};
+        {error, Reason} ->
+            {{fail, Reason}, State}
+    end.
+
+post_end_per_suite(Suite,_Config, Return, State) ->
+    {Return, State}.
+
+terminate(State) ->
+    ok.

--- a/big_tests/src/ct_mongoose_hook.erl
+++ b/big_tests/src/ct_mongoose_hook.erl
@@ -37,7 +37,10 @@ id(_Opts) ->
 %% @doc Always called before any other callback function. Use this to initiate
 %% any common state.
 init(_Id, _Opts) ->
+    NodeKeys = [NodeKey || {NodeKey, _Opts} <- ct:get_config(hosts)],
+    distributed_helper:require_rpc_nodes(NodeKeys, []),
     domain_helper:insert_configured_domains(),
+    distributed_helper:require_rpc_nodes([], []),
     {ok, #{}}.
 
 %% @doc Called before init_per_suite is called.
@@ -99,7 +102,9 @@ on_tc_skip(_TC, _Reason, State) ->
 
 %% @doc Called when the scope of the CTH is done
 terminate(_State) ->
+    distributed_helper:require_rpc_nodes([mim], []),
     domain_helper:delete_configured_domains(),
+    distributed_helper:require_rpc_nodes([], []),
     ok.
 
 check_server_purity(Suite, Config) ->

--- a/big_tests/src/ct_mongoose_hook.erl
+++ b/big_tests/src/ct_mongoose_hook.erl
@@ -37,10 +37,7 @@ id(_Opts) ->
 %% @doc Always called before any other callback function. Use this to initiate
 %% any common state.
 init(_Id, _Opts) ->
-    NodeKeys = [NodeKey || {NodeKey, _Opts} <- ct:get_config(hosts)],
-    distributed_helper:require_rpc_nodes(NodeKeys, []),
-    domain_helper:insert_configured_domains(),
-    distributed_helper:require_rpc_nodes([], []),
+    distributed_helper:with_all_nodes_allowed(fun domain_helper:insert_configured_domains/0),
     {ok, #{}}.
 
 %% @doc Called before init_per_suite is called.
@@ -102,9 +99,7 @@ on_tc_skip(_TC, _Reason, State) ->
 
 %% @doc Called when the scope of the CTH is done
 terminate(_State) ->
-    distributed_helper:require_rpc_nodes([mim], []),
-    domain_helper:delete_configured_domains(),
-    distributed_helper:require_rpc_nodes([], []),
+    distributed_helper:with_all_nodes_allowed(fun domain_helper:delete_configured_domains/0),
     ok.
 
 check_server_purity(Suite, Config) ->

--- a/big_tests/tests/acc_e2e_SUITE.erl
+++ b/big_tests/tests/acc_e2e_SUITE.erl
@@ -26,7 +26,7 @@
 -define(SLEEP_TIME, 50).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 %%--------------------------------------------------------------------
@@ -56,7 +56,7 @@ cache_test_cases() ->
     [ filter_local_packet_uses_recipient_values ].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -5,7 +5,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("exml/include/exml.hrl").
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(mongoose_helper, [wait_for_user/3]).
 -import(auth_helper, [assert_event/2]).
 -import(domain_helper, [domain/0, host_type/0]).
@@ -52,7 +52,7 @@ groups() ->
     ].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 change_password_tests() ->
     [change_password,

--- a/big_tests/tests/adhoc_SUITE.erl
+++ b/big_tests/tests/adhoc_SUITE.erl
@@ -53,7 +53,7 @@ visible_disco_cases() ->
      disco_items_sm_visible].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 init_per_suite(Config) ->
     escalus:init_per_suite(Config).

--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -12,13 +12,13 @@
 -include_lib("exml/include/exml.hrl").
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 -import(muc_light_helper, [lbin/1]).
 -import(domain_helper, [host_type/0, domain/0]).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, G} || G <- main_group_names(), is_enabled(G)].

--- a/big_tests/tests/anonymous_SUITE.erl
+++ b/big_tests/tests/anonymous_SUITE.erl
@@ -39,7 +39,7 @@ all_tests() ->
      messages_story].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/auth_methods_for_c2s_SUITE.erl
+++ b/big_tests/tests/auth_methods_for_c2s_SUITE.erl
@@ -28,7 +28,7 @@ groups() ->
     ].
 
 suite() ->
-    distributed_helper:require_rpc_nodes([mim]) ++ escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 init_per_suite(Config) ->
     escalus:init_per_suite(Config).

--- a/big_tests/tests/bind2_SUITE.erl
+++ b/big_tests/tests/bind2_SUITE.erl
@@ -17,6 +17,9 @@
 %% Suite configuration
 %%--------------------------------------------------------------------
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 all() ->
     [
      {group, basic}

--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -23,7 +23,7 @@
 -include_lib("exml/include/exml.hrl").
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 -import(domain_helper, [host_type/0, domain/0]).
 
@@ -62,7 +62,7 @@ groups() ->
     ].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 essential_test_cases() ->
     [create_and_terminate_session,

--- a/big_tests/tests/carboncopy_SUITE.erl
+++ b/big_tests/tests/carboncopy_SUITE.erl
@@ -11,6 +11,9 @@
 -import(mongoose_helper, [enable_carbons/1, disable_carbons/1]).
 -import(domain_helper, [domain/0]).
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 all() ->
     [{group, one2one},
      {group, muc}].

--- a/big_tests/tests/cets_disco_SUITE.erl
+++ b/big_tests/tests/cets_disco_SUITE.erl
@@ -37,7 +37,7 @@ rdbms_cases() ->
      address_please_returns_ip_127_0_0_1_from_db].
 
 suite() ->
-    distributed_helper:require_rpc_nodes([mim, mim2]).
+    distributed_helper:require_rpc_nodes([mim, mim2], []).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/cluster_commands_SUITE.erl
+++ b/big_tests/tests/cluster_commands_SUITE.erl
@@ -21,7 +21,7 @@
                              is_sm_distributed/0,
                              mim/0, mim2/0, mim3/0,
                              remove_node_from_cluster/2,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 -import(mongooseimctl_helper, [mongooseimctl/3, rpc_call/3]).
 -import(domain_helper, [host_type/1]).
@@ -46,7 +46,7 @@ groups() ->
      {clustering_three, [], clustering_three_tests()}].
 
 suite() ->
-    require_rpc_nodes([mim, mim2, mim3]) ++ escalus:suite().
+    require_rpc_nodes([mim, mim2, mim3], escalus:suite()).
 
 clustering_two_tests() ->
     [commands_without_args,

--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -26,7 +26,7 @@
 -import(distributed_helper, [add_node_to_cluster/1,
                              mim/0,
                              remove_node_from_cluster/1,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              start_node/2,
                              stop_node/2]).
 
@@ -60,7 +60,7 @@ groups() ->
                        ]}].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 xep0114_tests() ->
     [register_one_component,

--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -60,7 +60,7 @@ groups() ->
                        ]}].
 
 suite() ->
-    require_rpc_nodes([mim], escalus:suite()).
+    require_rpc_nodes([mim, mim2], escalus:suite()).
 
 xep0114_tests() ->
     [register_one_component,

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -35,7 +35,7 @@
 -import(distributed_helper, [mim/0,
                              mim2/0,
                              mim3/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 -import(domain_helper, [domain/0]).
 -import(config_parser_helper, [default_c2s_tls/1]).
@@ -127,7 +127,7 @@ cipher_test_cases() ->
     ].
 
 suite() ->
-    require_rpc_nodes([mim, mim2, mim3]) ++ escalus:suite().
+    require_rpc_nodes([mim, mim2, mim3], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/disco_and_caps_SUITE.erl
+++ b/big_tests/tests/disco_and_caps_SUITE.erl
@@ -7,6 +7,9 @@
 -import(domain_helper, [host_type/0, domain/0]).
 -import(config_parser_helper, [default_mod_config/1, mod_config/2, mod_config_with_auto_backend/1]).
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 all() ->
     [{group, disco_with_caps},
      {group, disco_with_caps_and_extra_features},

--- a/big_tests/tests/domain_isolation_SUITE.erl
+++ b/big_tests/tests/domain_isolation_SUITE.erl
@@ -4,12 +4,12 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -compile([export_all, nowarn_export_all]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4, subhost_pattern/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4, subhost_pattern/1]).
 -import(domain_helper, [host_type/0, secondary_host_type/0]).
 -import(config_parser_helper, [mod_config/2]).
 
 suite() ->
-    require_rpc_nodes([mim]).
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, two_domains}].

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -56,6 +56,10 @@ groups() ->
 %%%===================================================================
 %%% Overall setup/teardown
 %%%===================================================================
+
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 init_per_suite(Config) ->
     escalus:init_per_suite(Config).
 

--- a/big_tests/tests/domain_rest_helper.erl
+++ b/big_tests/tests/domain_rest_helper.erl
@@ -15,8 +15,6 @@
          delete_custom/4,
          patch_custom/4]).
 
--import(distributed_helper, [mim/0, mim2/0, require_rpc_nodes/1, rpc/4]).
-
 set_invalid_creds(Config) ->
     [{auth_creds, invalid}|Config].
 

--- a/big_tests/tests/dynamic_domains_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_SUITE.erl
@@ -5,7 +5,7 @@
 %% API
 -compile([export_all, nowarn_export_all]).
 -import(distributed_helper, [mim/0, mim2/0, rpc/4,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              subhost_pattern/1]).
 
 -define(TEST_NODES, [mim() | ?CLUSTER_NODES]).
@@ -14,7 +14,7 @@
 -define(HOST_TYPE, <<"dummy auth">>). %% preconfigured in the toml file
 
 suite() ->
-    require_rpc_nodes([mim, mim2]).
+    require_rpc_nodes([mim, mim2], escalus:suite()).
 
 all() ->
     [can_authenticate,

--- a/big_tests/tests/extdisco_SUITE.erl
+++ b/big_tests/tests/extdisco_SUITE.erl
@@ -62,6 +62,9 @@ tests() ->
 extdisco_required_elements_configured_tests() ->
     [external_service_required_elements_configured].
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 init_per_suite(Config) ->
     NewConfig = dynamic_modules:save_modules(host_type(), Config),
     escalus:init_per_suite(NewConfig).

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -68,7 +68,7 @@
 %% -------------------------------------------------------------
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim, mim2], escalus:suite()).
 
 all() ->
     [

--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -5,7 +5,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(graphql_helper, [execute/3, execute_auth/2, execute_user/3,
                          get_value/2, get_bad_request/1,
                          connect_to_tls/2, get_tls_data/1, send_tls_request/2,
@@ -20,7 +20,7 @@
                       <<"authStatus">> => atom_to_binary(Auth)}, Data)).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, cowboy_handler},

--- a/big_tests/tests/graphql_account_SUITE.erl
+++ b/big_tests/tests/graphql_account_SUITE.erl
@@ -6,7 +6,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_msg/1,
                          execute_domain_admin_command/4, get_unauthorized/1,
@@ -17,7 +17,7 @@
 -define(EMPTY_NAME_JID, <<"@", (domain_helper:domain())/binary>>).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user_account},

--- a/big_tests/tests/graphql_domain_SUITE.erl
+++ b/big_tests/tests/graphql_domain_SUITE.erl
@@ -4,7 +4,7 @@
 
  -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(graphql_helper, [execute_command/4, get_ok_value/2, get_err_msg/1, skip_null_fields/1,
                          execute_domain_admin_command/4, get_unauthorized/1, get_coercion_err_msg/1]).
 
@@ -15,7 +15,7 @@
 -define(DOMAIN_ADMIN_EXAMPLE_DOMAIN, <<"domain-admin.example.com">>).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
      [{group, domain_http},

--- a/big_tests/tests/graphql_gdpr_SUITE.erl
+++ b/big_tests/tests/graphql_gdpr_SUITE.erl
@@ -4,7 +4,7 @@
 
 -import(common_helper, [unprep/1]).
 -import(domain_helper, [host_type/0, domain/0]).
--import(distributed_helper, [mim/0, rpc/4, require_rpc_nodes/1]).
+-import(distributed_helper, [mim/0, rpc/4, require_rpc_nodes/2]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, user_to_bin/1,
                          get_ok_value/2, get_err_code/1, get_unauthorized/1]).
 
@@ -12,7 +12,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, admin_gdpr_http},

--- a/big_tests/tests/graphql_http_upload_SUITE.erl
+++ b/big_tests/tests/graphql_http_upload_SUITE.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2]).
 -import(domain_helper, [host_type/0, domain/0, secondary_domain/0]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, get_ok_value/2,
                          get_err_msg/1, get_err_code/1, get_coercion_err_msg/1, get_unauthorized/1]).
@@ -13,7 +13,7 @@
 -define(S3_HOSTNAME, <<"http://bucket.s3-eu-east-25.example.com">>).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user},

--- a/big_tests/tests/graphql_inbox_SUITE.erl
+++ b/big_tests/tests/graphql_inbox_SUITE.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(domain_helper, [host_type/0, domain/0]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, user_to_bin/1,
                          get_ok_value/2, get_err_msg/1, get_err_code/1, get_not_loaded/1,
@@ -17,7 +17,7 @@
 -define(assertErrCode(Res, Code), assert_err_code(Code, Res)).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     inbox_helper:skip_or_run_inbox_tests(tests()).

--- a/big_tests/tests/graphql_last_SUITE.erl
+++ b/big_tests/tests/graphql_last_SUITE.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, user_to_bin/1, user_to_jid/1,
                          get_ok_value/2, get_err_msg/1, get_err_code/1, get_unauthorized/1,
                          get_not_loaded/1, get_coercion_err_msg/1]).
@@ -21,7 +21,7 @@
 -define(NONEXISTENT_DOMAIN, <<"nonexistent">>).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user},

--- a/big_tests/tests/graphql_metric_SUITE.erl
+++ b/big_tests/tests/graphql_metric_SUITE.erl
@@ -10,9 +10,6 @@
 -import(domain_helper, [host_type/0]).
 
 suite() ->
-    MIM2NodeName = maps:get(node, distributed_helper:mim2()),
-    %% Ensure nodes are connected
-    mongoose_helper:successful_rpc(net_kernel, connect_node, [MIM2NodeName]),
     require_rpc_nodes([mim, mim2], escalus:suite()).
 
 all() ->
@@ -63,6 +60,9 @@ domain_admin_metrics_tests() ->
      domain_admin_get_cluster_metrics_as_dicts_for_nodes].
 
 init_per_suite(Config) ->
+    MIM2NodeName = maps:get(node, distributed_helper:mim2()),
+    %% Ensure nodes are connected
+    mongoose_helper:successful_rpc(net_kernel, connect_node, [MIM2NodeName]),
     Config1 = ejabberd_node_utils:init(mim(), Config),
     escalus:init_per_suite(Config1).
 

--- a/big_tests/tests/graphql_metric_SUITE.erl
+++ b/big_tests/tests/graphql_metric_SUITE.erl
@@ -4,7 +4,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(graphql_helper, [execute_command/4, get_ok_value/2, get_unauthorized/1,
                          get_err_msg/1, get_err_code/1]).
 -import(domain_helper, [host_type/0]).
@@ -13,7 +13,7 @@ suite() ->
     MIM2NodeName = maps:get(node, distributed_helper:mim2()),
     %% Ensure nodes are connected
     mongoose_helper:successful_rpc(net_kernel, connect_node, [MIM2NodeName]),
-    require_rpc_nodes([mim, mim2]) ++ escalus:suite().
+    require_rpc_nodes([mim, mim2], escalus:suite()).
 
 all() ->
      [{group, metrics_http},

--- a/big_tests/tests/graphql_mnesia_SUITE.erl
+++ b/big_tests/tests/graphql_mnesia_SUITE.erl
@@ -467,7 +467,8 @@ change_nodename(ChangeFrom, ChangeTo, Source, Target, Config) ->
     execute_command(<<"mnesia">>, <<"changeNodename">>, Vars, Config).
 
 set_master(Node, Config) ->
-    execute_command(<<"mnesia">>, <<"setMaster">>, Node, Config).
+    Vars = maps:with([node], Node),
+    execute_command(<<"mnesia">>, <<"setMaster">>, Vars, Config).
 
 mnesia_info_check() ->
     #{<<"access_module">> => check_binary,

--- a/big_tests/tests/graphql_mnesia_SUITE.erl
+++ b/big_tests/tests/graphql_mnesia_SUITE.erl
@@ -3,7 +3,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [require_rpc_nodes/1, mim/0, mim2/0, rpc/4]).
+-import(distributed_helper, [require_rpc_nodes/2, mim/0, mim2/0, rpc/4]).
 -import(domain_helper, [host_type/1]).
 -import(mongooseimctl_helper, [rpc_call/3]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, user_to_bin/1,
@@ -77,6 +77,9 @@ mnesia_not_configured_tests() ->
      set_master_not_configured_test,
      system_info_not_configured_test
     ].
+
+suite() ->
+    require_rpc_nodes([mim, mim2], escalus:suite()).
 
 init_per_suite(Config) ->
     application:ensure_all_started(jid),

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4, subhost_pattern/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4, subhost_pattern/1]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, get_ok_value/2, get_err_msg/1,
                          get_coercion_err_msg/1, user_to_bin/1, user_to_full_bin/1, user_to_jid/1,
                          get_unauthorized/1, get_not_loaded/1]).
@@ -14,7 +14,7 @@
 -include_lib("jid/include/jid.hrl").
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user},

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4, subhost_pattern/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4, subhost_pattern/1]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_msg/1,
                          get_coercion_err_msg/1, make_creds/1, get_unauthorized/1,
@@ -35,7 +35,7 @@
 -define(SET_BLOCKING_LIST_PATH, [data, muc_light, setBlockingList]).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user},

--- a/big_tests/tests/graphql_offline_SUITE.erl
+++ b/big_tests/tests/graphql_offline_SUITE.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2]).
 -import(domain_helper, [host_type/0, domain/0]).
 -import(graphql_helper, [execute_command/4, get_ok_value/2, get_err_code/1, user_to_bin/1,
                          get_unauthorized/1, get_not_loaded/1, get_coercion_err_msg/1]).
@@ -15,7 +15,7 @@
 -record(offline_msg, {us, timestamp, expire, from, to, packet, permanent_fields = []}).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, admin_http},

--- a/big_tests/tests/graphql_private_SUITE.erl
+++ b/big_tests/tests/graphql_private_SUITE.erl
@@ -2,7 +2,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, get_ok_value/2, get_err_code/1,
                          user_to_bin/1, get_unauthorized/1, get_not_loaded/1, get_coercion_err_msg/1]).
 -import(config_parser_helper, [mod_config_with_auto_backend/2]).
@@ -11,7 +11,7 @@
 -include_lib("exml/include/exml.hrl").
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user},

--- a/big_tests/tests/graphql_roster_SUITE.erl
+++ b/big_tests/tests/graphql_roster_SUITE.erl
@@ -2,7 +2,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_value/2, get_err_msg/1,
                          get_err_msg/2, get_bad_request/1, user_to_jid/1, user_to_bin/1,
@@ -12,7 +12,7 @@
 -include_lib("../../include/mod_roster.hrl").
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user_roster},

--- a/big_tests/tests/graphql_server_SUITE.erl
+++ b/big_tests/tests/graphql_server_SUITE.erl
@@ -13,7 +13,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    require_rpc_nodes([mim, mim2], escalus:suite()).
+    require_rpc_nodes([mim, mim2, mim3], escalus:suite()).
 
 all() ->
     [{group, admin_http},

--- a/big_tests/tests/graphql_server_SUITE.erl
+++ b/big_tests/tests/graphql_server_SUITE.erl
@@ -5,7 +5,7 @@
 -import(distributed_helper, [is_sm_distributed/0,
                              mim/0, mim2/0, mim3/0,
                              remove_node_from_cluster/2,
-                             require_rpc_nodes/1, rpc/4]).
+                             require_rpc_nodes/2, rpc/4]).
 -import(domain_helper, [host_type/0, domain/0]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4, get_ok_value/2,
                          get_err_msg/1, get_err_code/1, execute_command/5]).
@@ -13,7 +13,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, admin_http},

--- a/big_tests/tests/graphql_server_SUITE.erl
+++ b/big_tests/tests/graphql_server_SUITE.erl
@@ -13,7 +13,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    require_rpc_nodes([mim], escalus:suite()).
+    require_rpc_nodes([mim, mim2], escalus:suite()).
 
 all() ->
     [{group, admin_http},

--- a/big_tests/tests/graphql_session_SUITE.erl
+++ b/big_tests/tests/graphql_session_SUITE.erl
@@ -5,14 +5,14 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(domain_helper, [domain/0]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4,  get_listener_port/1,
                          get_listener_config/1, get_ok_value/2, get_err_msg/1, get_unauthorized/1,
                          get_coercion_err_msg/1]).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user_session},

--- a/big_tests/tests/graphql_sse_SUITE.erl
+++ b/big_tests/tests/graphql_sse_SUITE.erl
@@ -3,7 +3,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(graphql_helper, [get_bad_request/1, get_unauthorized/1, get_method_not_allowed/1,
                          build_request/4, make_creds/1, execute_auth/2,
                          execute_sse/3, execute_user_sse/3, execute_auth_sse/2]).
@@ -11,7 +11,7 @@
 %% common_test callbacks
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, admin},

--- a/big_tests/tests/graphql_stanza_SUITE.erl
+++ b/big_tests/tests/graphql_stanza_SUITE.erl
@@ -5,7 +5,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2]).
 -import(graphql_helper, [execute_user_command/5, execute_command/4,
                          execute_user_command_sse/5, execute_command_sse/4,
                          get_ok_value/2, get_value/2,
@@ -13,7 +13,7 @@
                          get_unauthorized/1, get_not_loaded/1]).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, admin_stanza_http},

--- a/big_tests/tests/graphql_stats_SUITE.erl
+++ b/big_tests/tests/graphql_stats_SUITE.erl
@@ -3,7 +3,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2]).
 -import(domain_helper, [host_type/0, domain/0, secondary_domain/0]).
 -import(graphql_helper, [execute_command/4, get_ok_value/2, get_unauthorized/1]).
 -import(mongooseimctl_helper, [mongooseimctl/3, rpc_call/3]).
@@ -12,7 +12,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, admin_stats_http},

--- a/big_tests/tests/graphql_token_SUITE.erl
+++ b/big_tests/tests/graphql_token_SUITE.erl
@@ -3,14 +3,14 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(common_helper, [unprep/1]).
--import(distributed_helper, [require_rpc_nodes/1, mim/0]).
+-import(distributed_helper, [require_rpc_nodes/2, mim/0]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5, user_to_bin/1,
                          get_ok_value/2, get_err_code/1, get_err_msg/1, get_unauthorized/1, get_not_loaded/1]).
 
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user},

--- a/big_tests/tests/graphql_vcard_SUITE.erl
+++ b/big_tests/tests/graphql_vcard_SUITE.erl
@@ -2,7 +2,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [require_rpc_nodes/1, mim/0]).
+-import(distributed_helper, [require_rpc_nodes/2, mim/0]).
 -import(graphql_helper, [execute_command/4, execute_user_command/5,
                          user_to_bin/1, get_ok_value/2, skip_null_fields/1, get_err_msg/1,
                          get_unauthorized/1, get_not_loaded/1, get_err_code/1]).
@@ -12,7 +12,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, user},

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -138,7 +138,9 @@ groups() ->
      {regular, [], test_groups()},
      {async_pools, [], [{group, bin} | test_groups()]}
     ],
-    inbox_helper:maybe_run_in_parallel(Gs).
+    distributed_helper:temporary_allow_nodes(fun() ->
+            inbox_helper:maybe_run_in_parallel(Gs)
+        end, [mim]).
 
 test_groups() ->
     [

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -157,7 +157,7 @@ test_groups() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -34,7 +34,10 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    inbox_helper:skip_or_run_inbox_tests(tests()).
+    Tests = tests(),
+    distributed_helper:temporary_allow_nodes(fun() ->
+            inbox_helper:skip_or_run_inbox_tests(Tests)
+        end, [mim]).
 
 tests() ->
     [

--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -125,7 +125,9 @@ groups() ->
         {group, muclight}
       ]}
     ],
-    inbox_helper:maybe_run_in_parallel(Gs).
+    distributed_helper:temporary_allow_nodes(fun() ->
+            inbox_helper:maybe_run_in_parallel(Gs)
+        end, [mim]).
 
 init_per_suite(Config) ->
     escalus:init_per_suite(Config).

--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -37,7 +37,7 @@ tests() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 groups() ->
     Gs = [

--- a/big_tests/tests/inbox_extensions_SUITE.erl
+++ b/big_tests/tests/inbox_extensions_SUITE.erl
@@ -25,7 +25,10 @@
          end_per_testcase/2]).
 
 all() ->
-    inbox_helper:skip_or_run_inbox_tests(tests()).
+    Tests = tests(),
+    distributed_helper:temporary_allow_nodes(fun() ->
+            inbox_helper:skip_or_run_inbox_tests(Tests)
+        end, [mim]).
 
 tests() ->
     [

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -145,6 +145,14 @@ skip_or_run_inbox_tests(TestCases) ->
 
 maybe_run_in_parallel(Gs) ->
     %% These could be parallel but it seems like mssql CI can't handle the load
+    case ct_helper:is_ct_running() of
+        true ->
+            maybe_run_in_parallel_when_ct_is_running(Gs);
+        false ->
+            Gs
+    end.
+
+maybe_run_in_parallel_when_ct_is_running(Gs) ->
     case distributed_helper:rpc(
            distributed_helper:without_assert_allowed_node(distributed_helper:mim()),
            mongoose_rdbms, db_engine, [domain_helper:host_type()]) of

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -153,8 +153,7 @@ maybe_run_in_parallel(Gs) ->
     end.
 
 maybe_run_in_parallel_when_ct_is_running(Gs) ->
-    case distributed_helper:rpc(
-           distributed_helper:without_assert_allowed_node(distributed_helper:mim()),
+    case distributed_helper:rpc(distributed_helper:mim(),
            mongoose_rdbms, db_engine, [domain_helper:host_type()]) of
         odbc -> Gs;
         _ -> insert_parallels(Gs)

--- a/big_tests/tests/inbox_helper.erl
+++ b/big_tests/tests/inbox_helper.erl
@@ -146,7 +146,8 @@ skip_or_run_inbox_tests(TestCases) ->
 maybe_run_in_parallel(Gs) ->
     %% These could be parallel but it seems like mssql CI can't handle the load
     case distributed_helper:rpc(
-           distributed_helper:mim(), mongoose_rdbms, db_engine, [domain_helper:host_type()]) of
+           distributed_helper:without_assert_allowed_node(distributed_helper:mim()),
+           mongoose_rdbms, db_engine, [domain_helper:host_type()]) of
         odbc -> Gs;
         _ -> insert_parallels(Gs)
     end.

--- a/big_tests/tests/jingle_SUITE.erl
+++ b/big_tests/tests/jingle_SUITE.erl
@@ -49,7 +49,7 @@ test_cases() ->
     ].
 
 suite() ->
-    require_rpc_nodes([mim], escalus:suite()).
+    require_rpc_nodes([mim, mim2], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/jingle_SUITE.erl
+++ b/big_tests/tests/jingle_SUITE.erl
@@ -6,7 +6,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -import(distributed_helper, [mim/0, mim2/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 -import(jingle_helper, [content/1,
@@ -49,7 +49,7 @@ test_cases() ->
     ].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/last_SUITE.erl
+++ b/big_tests/tests/last_SUITE.erl
@@ -48,7 +48,7 @@ valid_test_cases() -> [online_user_query,
 invalid_test_cases() -> [user_not_subscribed_receives_error].
 
 suite() ->
-    distributed_helper:require_rpc_nodes([mim, mim2]) ++ escalus:suite().
+    distributed_helper:require_rpc_nodes([mim, mim2], escalus:suite()).
 
 init_per_suite(Config0) ->
     mongoose_helper:inject_module(distributed_helper:mim2(), ?MODULE, reload),

--- a/big_tests/tests/local_iq_SUITE.erl
+++ b/big_tests/tests/local_iq_SUITE.erl
@@ -5,11 +5,11 @@
 -include_lib("exml/include/exml.hrl").
 
 -compile([export_all, nowarn_export_all]).
--import(distributed_helper, [mim/0, mim2/0, require_rpc_nodes/1, rpc/4, subhost_pattern/1]).
+-import(distributed_helper, [mim/0, mim2/0, require_rpc_nodes/2, rpc/4, subhost_pattern/1]).
 -import(domain_helper, [host_type/0, secondary_host_type/0]).
 
 suite() ->
-    require_rpc_nodes([mim, mim2]).
+    require_rpc_nodes([mim, mim2], escalus:suite()).
 
 all() ->
     [{group, iq_group}].

--- a/big_tests/tests/login_SUITE.erl
+++ b/big_tests/tests/login_SUITE.erl
@@ -21,7 +21,7 @@
 -include_lib("stdlib/include/assert.hrl").
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 -import(domain_helper, [host_type/0, domain/0]).
@@ -106,7 +106,7 @@ digest_tests() ->
      log_non_existent_digest].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -18,7 +18,7 @@
 -compile([export_all, nowarn_export_all]).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              subhost_pattern/1,
                              rpc/4]).
 
@@ -531,7 +531,7 @@ stream_management_cases() ->
      reconnect_no_ack_different_resource].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 init_per_suite(Config) ->
     PoolIds = [pm_mam, muc_mam],

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -713,7 +713,7 @@ prepare_for_suite(Config) ->
     [{mod_offline_loaded, Loaded}|Config].
 
 is_module_loaded(Mod) ->
-    rpc(unsafe_mim(), gen_mod, is_loaded, [host_type(), Mod]).
+    rpc(mim(), gen_mod, is_loaded, [host_type(), Mod]).
 
 clean_archives(Config) ->
     SUs = serv_users(Config),
@@ -1098,14 +1098,11 @@ is_mam_possible(Host) ->
 is_cassandra_enabled(_) ->
     is_cassandra_enabled().
 
-unsafe_mim() ->
-    distributed_helper:without_assert_allowed_node(mim()).
-
 is_cassandra_enabled() ->
-    rpc(unsafe_mim(), mongoose_wpool, is_configured, [cassandra]).
+    rpc(mim(), mongoose_wpool, is_configured, [cassandra]).
 
 is_elasticsearch_enabled(_Host) ->
-    case rpc(unsafe_mim(), mongoose_elasticsearch, health, []) of
+    case rpc(mim(), mongoose_elasticsearch, health, []) of
         {ok, _} ->
             true;
         {error, _} ->

--- a/big_tests/tests/mam_helper.erl
+++ b/big_tests/tests/mam_helper.erl
@@ -713,7 +713,7 @@ prepare_for_suite(Config) ->
     [{mod_offline_loaded, Loaded}|Config].
 
 is_module_loaded(Mod) ->
-    rpc(mim(), gen_mod, is_loaded, [host_type(), Mod]).
+    rpc(unsafe_mim(), gen_mod, is_loaded, [host_type(), Mod]).
 
 clean_archives(Config) ->
     SUs = serv_users(Config),
@@ -1098,11 +1098,14 @@ is_mam_possible(Host) ->
 is_cassandra_enabled(_) ->
     is_cassandra_enabled().
 
+unsafe_mim() ->
+    distributed_helper:without_assert_allowed_node(mim()).
+
 is_cassandra_enabled() ->
-    rpc(mim(), mongoose_wpool, is_configured, [cassandra]).
+    rpc(unsafe_mim(), mongoose_wpool, is_configured, [cassandra]).
 
 is_elasticsearch_enabled(_Host) ->
-    case rpc(mim(), mongoose_elasticsearch, health, []) of
+    case rpc(unsafe_mim(), mongoose_elasticsearch, health, []) of
         {ok, _} ->
             true;
         {error, _} ->

--- a/big_tests/tests/mam_proper_SUITE.erl
+++ b/big_tests/tests/mam_proper_SUITE.erl
@@ -4,13 +4,13 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 -import(domain_helper, [host_type/0]).
 
 %% Common Test init/teardown functions
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, async_writer}].

--- a/big_tests/tests/mam_send_message_SUITE.erl
+++ b/big_tests/tests/mam_send_message_SUITE.erl
@@ -1,7 +1,8 @@
 -module(mam_send_message_SUITE).
 
 %% API
--export([all/0,
+-export([suite/0,
+         all/0,
          groups/0,
          init_per_suite/1,
          end_per_suite/1,
@@ -21,7 +22,7 @@
          parse_forwarded_message/1]).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              subhost_pattern/1,
                              rpc/4]).
 -import(domain_helper, [host_type/0]).
@@ -41,6 +42,10 @@ groups() ->
 %%%===================================================================
 %%% Overall setup/teardown
 %%%===================================================================
+
+suite() ->
+    require_rpc_nodes([mim], escalus:suite()).
+
 init_per_suite(Config) ->
     escalus:init_per_suite(Config).
 

--- a/big_tests/tests/metrics_api_SUITE.erl
+++ b/big_tests/tests/metrics_api_SUITE.erl
@@ -55,6 +55,9 @@ groups() ->
                    cluster_size]}
     ].
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim, mim2], escalus:suite()).
+
 init_per_suite(Config) ->
     HostType = host_type(),
     Config1 = dynamic_modules:save_modules(HostType, Config),

--- a/big_tests/tests/metrics_c2s_SUITE.erl
+++ b/big_tests/tests/metrics_c2s_SUITE.erl
@@ -39,7 +39,8 @@ groups() ->
                            message_bounced]}].
 
 suite() ->
-    [{require, ejabberd_node} | escalus:suite()].
+    Config = [{require, ejabberd_node} | escalus:suite()],
+    distributed_helper:require_rpc_nodes([mim], Config).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/metrics_roster_SUITE.erl
+++ b/big_tests/tests/metrics_roster_SUITE.erl
@@ -17,7 +17,7 @@
 -module(metrics_roster_SUITE).
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 -import(domain_helper, [host_type/0]).
 -import(roster_helper, [assert_roster_event/2, assert_subscription_event/3]).
 
@@ -35,7 +35,7 @@ groups() ->
      {subscriptions, [parallel], subscription_tests()}].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 roster_tests() -> [get_roster,
                    add_contact,

--- a/big_tests/tests/metrics_session_SUITE.erl
+++ b/big_tests/tests/metrics_session_SUITE.erl
@@ -37,7 +37,8 @@ groups() ->
                                    session_node]}].
 
 suite() ->
-    [{require, ejabberd_node} | escalus:suite()].
+    Config = [{require, ejabberd_node} | escalus:suite()],
+    distributed_helper:require_rpc_nodes([mim], Config).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/mim_c2s_SUITE.erl
+++ b/big_tests/tests/mim_c2s_SUITE.erl
@@ -44,6 +44,10 @@ groups() ->
 %%--------------------------------------------------------------------
 %% Init & teardown
 %%--------------------------------------------------------------------
+
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 init_per_suite(Config) ->
     instrument_helper:start(instrumentation_events()),
     HostType = domain_helper:host_type(),

--- a/big_tests/tests/mod_blocking_SUITE.erl
+++ b/big_tests/tests/mod_blocking_SUITE.erl
@@ -88,7 +88,7 @@ notify_test_cases() ->
     [notify_blockee].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/mod_event_pusher_http_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_http_SUITE.erl
@@ -15,7 +15,7 @@
 -define(ETS_TABLE, mod_event_pusher_http).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 -import(push_helper, [http_notifications_port/0, http_notifications_host/0]).
@@ -29,7 +29,7 @@
 %%%===================================================================
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [

--- a/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
@@ -106,7 +106,7 @@ groups() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/mod_event_pusher_sns_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_sns_SUITE.erl
@@ -48,7 +48,7 @@ groups() ->
     ct_helper:repeat_all_until_all_ok(G).
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -107,11 +107,12 @@ groups() ->
     ].
 
 suite() ->
-    [{require, europe_node1, {hosts, mim, node}},
-     {require, europe_node2, {hosts, mim2, node}},
-     {require, asia_node, {hosts, reg, node}},
-     {require, c2s_port, {hosts, mim, c2s_port}} |
-     escalus:suite()].
+    distributed_helper:require_rpc_nodes([mim, mim2, reg],
+        [{require, europe_node1, {hosts, mim, node}},
+         {require, europe_node2, {hosts, mim2, node}},
+         {require, asia_node, {hosts, reg, node}},
+         {require, c2s_port, {hosts, mim, c2s_port}} |
+         escalus:suite()]).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/mod_http_upload_SUITE.erl
+++ b/big_tests/tests/mod_http_upload_SUITE.erl
@@ -75,7 +75,7 @@ groups() ->
                               ]}].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/mod_ping_SUITE.erl
+++ b/big_tests/tests/mod_ping_SUITE.erl
@@ -60,7 +60,7 @@ all_tests() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 ping_interval() ->
     timer:seconds(3).

--- a/big_tests/tests/mod_time_SUITE.erl
+++ b/big_tests/tests/mod_time_SUITE.erl
@@ -32,7 +32,7 @@ groups() ->
     [{mod_time, [parallel], [ask_for_time, time_service_discovery]}].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/mod_version_SUITE.erl
+++ b/big_tests/tests/mod_version_SUITE.erl
@@ -19,7 +19,7 @@ groups() ->
      {soft_version_with_os, [parallel], [version_service_discovery, ask_for_version_with_os]}].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/mongoose_cassandra_SUITE.erl
+++ b/big_tests/tests/mongoose_cassandra_SUITE.erl
@@ -21,7 +21,7 @@
 %%
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 %%.
@@ -51,10 +51,10 @@
 %%
 
 suite() ->
-    require_rpc_nodes([mim]) ++ [
+    require_rpc_nodes([mim], [
         {require, ejabberd_node},
         {require, ejabberd_cookie}
-    ].
+    ]).
 
 all() ->
     [

--- a/big_tests/tests/mongoose_elasticsearch_SUITE.erl
+++ b/big_tests/tests/mongoose_elasticsearch_SUITE.erl
@@ -26,9 +26,9 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{require, ejabberd_node},
-     {require, ejabberd_cookie} |
-     distributed_helper:require_rpc_nodes([mim])].
+     distributed_helper:require_rpc_nodes([mim],
+         [{require, ejabberd_node},
+          {require, ejabberd_cookie}]).
 
 all() ->
     [{group, all}].

--- a/big_tests/tests/mongooseimctl_SUITE.erl
+++ b/big_tests/tests/mongooseimctl_SUITE.erl
@@ -21,7 +21,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -import(mongooseimctl_helper, [mongooseimctl/3]).
--import(distributed_helper, [mim/0, require_rpc_nodes/1]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2]).
 -import(domain_helper, [domain/0]).
 
 %%--------------------------------------------------------------------
@@ -65,7 +65,7 @@ server() ->
      server_is_started].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 init_per_suite(Config) ->
     Node = mim(),

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -321,7 +321,7 @@ rsm_cases() ->
 rsm_cases_with_offline() ->
     [pagination_all_with_offline].
 suite() ->
-    distributed_helper:require_rpc_nodes([mim, fed]) ++ escalus:suite().
+    distributed_helper:require_rpc_nodes([mim, fed], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/muc_http_api_SUITE.erl
+++ b/big_tests/tests/muc_http_api_SUITE.erl
@@ -65,6 +65,9 @@ failure_response() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 init_per_suite(Config) ->
     muc_helper:load_muc(),
     escalus:init_per_suite(Config).

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -201,7 +201,7 @@ groups() ->
     ct_helper:repeat_all_until_all_ok(G).
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/muc_light_http_api_SUITE.erl
+++ b/big_tests/tests/muc_light_http_api_SUITE.erl
@@ -63,6 +63,9 @@ negative_response() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 init_per_suite(Config) ->
     Config1 = dynamic_modules:save_modules(host_type(), Config),
     dynamic_modules:ensure_modules(host_type(), required_modules()),

--- a/big_tests/tests/muc_light_legacy_SUITE.erl
+++ b/big_tests/tests/muc_light_legacy_SUITE.erl
@@ -92,7 +92,7 @@ groups() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/oauth_SUITE.erl
+++ b/big_tests/tests/oauth_SUITE.erl
@@ -23,7 +23,7 @@
 -include_lib("exml/include/exml.hrl").
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 -import(domain_helper, [domain/0]).
@@ -69,7 +69,7 @@ token_revocation_tests() ->
     ].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/offline_SUITE.erl
+++ b/big_tests/tests/offline_SUITE.erl
@@ -51,7 +51,7 @@ groups() ->
     ct_helper:repeat_all_until_all_ok(G).
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%%===================================================================
 %%% Init & teardown

--- a/big_tests/tests/offline_stub_SUITE.erl
+++ b/big_tests/tests/offline_stub_SUITE.erl
@@ -10,7 +10,7 @@ all() ->
      without_mod_offline_stub].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%%===================================================================
 %%% Init & teardown

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -44,7 +44,7 @@
         ]).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              subhost_pattern/1,
                              rpc/4]).
 -import(config_parser_helper, [mod_config/2]).
@@ -95,7 +95,7 @@ groups() ->
     ].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/persistent_cluster_id_SUITE.erl
+++ b/big_tests/tests/persistent_cluster_id_SUITE.erl
@@ -53,11 +53,14 @@ groups() ->
      {rdbms, [], tests()}
     ].
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], []).
+
 %%%===================================================================
 %%% Overall setup/teardown
 %%%===================================================================
 init_per_suite(Config) ->
-    distributed_helper:require_rpc_nodes([mim]) ++ Config.
+    Config.
 
 end_per_suite(_Config) ->
     ok.

--- a/big_tests/tests/persistent_cluster_id_SUITE.erl
+++ b/big_tests/tests/persistent_cluster_id_SUITE.erl
@@ -4,7 +4,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% API
--export([all/0,
+-export([suite/0,
+         all/0,
          groups/0,
          init_per_suite/1,
          end_per_suite/1,
@@ -54,7 +55,7 @@ groups() ->
     ].
 
 suite() ->
-    distributed_helper:require_rpc_nodes([mim], []).
+    distributed_helper:require_rpc_nodes([mim, mim2], []).
 
 %%%===================================================================
 %%% Overall setup/teardown

--- a/big_tests/tests/presence_SUITE.erl
+++ b/big_tests/tests/presence_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 -import(domain_helper, [host_type/0]).
@@ -66,7 +66,7 @@ groups() ->
                                     remove_unsubscribe]}].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/privacy_SUITE.erl
+++ b/big_tests/tests/privacy_SUITE.erl
@@ -89,7 +89,7 @@ allowing_test_cases() ->
      allow_subscription_both_message].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/private_SUITE.erl
+++ b/big_tests/tests/private_SUITE.erl
@@ -44,7 +44,7 @@ negative_test_cases() ->
      set_other_user].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 init_per_suite(Config0) ->
     HostType = domain_helper:host_type(),

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -50,17 +50,18 @@ group_is_compatible(hometree_specific, OnlyNodetreeTree) -> OnlyNodetreeTree =:=
 group_is_compatible(_, _) -> true.
 
 base_groups() ->
-    [{basic, parallel_props(), basic_tests()},
-     {service_config, parallel_props(), service_config_tests()},
-     {node_config, parallel_props(), node_config_tests()},
-     {node_affiliations, parallel_props(), node_affiliations_tests()},
-     {manage_subscriptions, parallel_props(), manage_subscriptions_tests()},
+    Props = distributed_helper:temporary_allow_nodes(fun parallel_props/0, [mim]),
+    [{basic, Props, basic_tests()},
+     {service_config, Props, service_config_tests()},
+     {node_config, Props, node_config_tests()},
+     {node_affiliations, Props, node_affiliations_tests()},
+     {manage_subscriptions, Props, manage_subscriptions_tests()},
      {collection, [sequence], collection_tests()},
-     {collection_config, parallel_props(), collection_config_tests()},
-     {debug_calls, parallel_props(), debug_calls_tests()},
-     {pubsub_item_publisher_option, parallel_props(), pubsub_item_publisher_option_tests()},
+     {collection_config, Props, collection_config_tests()},
+     {debug_calls, Props, debug_calls_tests()},
+     {pubsub_item_publisher_option, Props, pubsub_item_publisher_option_tests()},
      {hometree_specific, [sequence], hometree_specific_tests()},
-     {last_item_cache, parallel_props(), last_item_cache_tests()}].
+     {last_item_cache, Props, last_item_cache_tests()}].
 
 parallel_props() ->
     case rpc(mim(), mongoose_rdbms, db_engine, [host_type()]) of

--- a/big_tests/tests/pubsub_SUITE.erl
+++ b/big_tests/tests/pubsub_SUITE.erl
@@ -19,7 +19,7 @@
                        decode_group_name/1,
                        nodetree_to_mod/1]).
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              subhost_pattern/1,
                              rpc/4]).
 -import(domain_helper, [host_type/0]).
@@ -29,7 +29,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, GN} || {GN, _, _} <- groups()].

--- a/big_tests/tests/pubsub_s2s_SUITE.erl
+++ b/big_tests/tests/pubsub_s2s_SUITE.erl
@@ -22,7 +22,7 @@
          publish_without_node_attr_test/1
         ]).
 
--import(distributed_helper, [require_rpc_nodes/1,
+-import(distributed_helper, [require_rpc_nodes/2,
                              subhost_pattern/1]).
 -import(pubsub_tools, [
                        domain/0,
@@ -35,7 +35,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    require_rpc_nodes([mim, fed]) ++ escalus:suite().
+    require_rpc_nodes([mim, fed], escalus:suite()).
 
 all() ->
     [{group, GN} || {GN, _, _} <- groups()].

--- a/big_tests/tests/push_SUITE.erl
+++ b/big_tests/tests/push_SUITE.erl
@@ -77,7 +77,7 @@ notification_groups() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/push_http_SUITE.erl
+++ b/big_tests/tests/push_http_SUITE.erl
@@ -27,7 +27,7 @@ groups() ->
     ].
 
 suite() ->
-    distributed_helper:require_rpc_nodes([mim]) ++ escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -122,7 +122,7 @@ failure_cases() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -39,7 +39,7 @@ groups() ->
     ct_helper:repeat_all_until_all_ok(G).
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/race_conditions_SUITE.erl
+++ b/big_tests/tests/race_conditions_SUITE.erl
@@ -44,7 +44,7 @@ main_group_tests() ->
      ignore_iq_result_from_old_session].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 init_per_suite(Config) ->
     escalus:init_per_suite(Config).

--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -95,7 +95,7 @@ rdbms_queries_cases() ->
      pool_probe_metrics_are_updated].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/rest_SUITE.erl
+++ b/big_tests/tests/rest_SUITE.erl
@@ -100,7 +100,7 @@ roster_test_cases() ->
      delete_contact_errors].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/rest_client_SUITE.erl
+++ b/big_tests/tests/rest_client_SUITE.erl
@@ -132,6 +132,9 @@ security_test_cases() ->
      non_default_http_server_name_is_returned_if_configured
     ].
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim, mim2], escalus:suite()).
+
 init_per_suite(Config) ->
     Config1 = init_modules(Config),
     [{muc_light_host, muc_light_helper:muc_host()}

--- a/big_tests/tests/s2s_SUITE.erl
+++ b/big_tests/tests/s2s_SUITE.erl
@@ -87,7 +87,7 @@ connection_cases() ->
      auth_with_valid_cert_fails_for_other_mechanism_than_external].
 
 suite() ->
-    distributed_helper:require_rpc_nodes([mim, mim2, fed]) ++ escalus:suite().
+    distributed_helper:require_rpc_nodes([mim, mim2, fed], escalus:suite()).
 
 users() ->
     [alice2, alice, bob].

--- a/big_tests/tests/sasl2_SUITE.erl
+++ b/big_tests/tests/sasl2_SUITE.erl
@@ -57,6 +57,9 @@ groups() ->
 %% Init & teardown
 %%--------------------------------------------------------------------
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 init_per_suite(Config) ->
     Config1 = load_sasl_extensible(Config),
     escalus:init_per_suite(Config1).

--- a/big_tests/tests/sasl_SUITE.erl
+++ b/big_tests/tests/sasl_SUITE.erl
@@ -27,7 +27,7 @@
 -behaviour(cyrsasl).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 -import(domain_helper, [host_type/0]).
 
@@ -45,7 +45,7 @@ all_tests() ->
     [text_response].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -90,6 +90,9 @@ self_signed_certs_not_allowed_test_cases() ->
      ca_signed_cert_is_allowed_with_bosh,
      no_cert_fails_to_authenticate].
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 init_per_suite(Config) ->
     Config0 = escalus:init_per_suite(Config),
     Config1 = ejabberd_node_utils:init(Config0),

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -4,7 +4,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -compile([export_all, nowarn_export_all]).
--import(distributed_helper, [mim/0, mim2/0, mim3/0, require_rpc_nodes/1, rpc/4,
+-import(distributed_helper, [mim/0, mim2/0, mim3/0, require_rpc_nodes/2, rpc/4,
                              remove_node_from_cluster/2]).
 -import(graphql_helper, [execute_command/4]).
 
@@ -26,7 +26,7 @@
 -import(config_parser_helper, [config/2]).
 
 suite() ->
-    require_rpc_nodes([mim, mim2, mim3]).
+    require_rpc_nodes([mim, mim2, mim3], escalus:suite()).
 
 all() ->
     [

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -66,14 +66,19 @@ parallel_config() ->
     %% These could be parallel but it seems like mssql CI can't handle the load
     case ct_helper:is_ct_running() of
         true ->
-            Spec = distributed_helper:without_assert_allowed_node(distributed_helper:mim()),
-            case distributed_helper:rpc(Spec, mongoose_rdbms, db_engine, [domain_helper:host_type()]) of
+            case db_engine() of
                 odbc -> [];
                 _ -> [parallel]
             end;
         false ->
             []
     end.
+
+db_engine() ->
+    distributed_helper:temporary_allow_nodes(fun() ->
+            distributed_helper:rpc(distributed_helper:mim(),
+                    mongoose_rdbms, db_engine, [domain_helper:host_type()])
+        end, [mim]).
 
 
 no_db_cases() -> [

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -64,11 +64,17 @@ groups() ->
 
 parallel_config() ->
     %% These could be parallel but it seems like mssql CI can't handle the load
-    case distributed_helper:rpc(
-           distributed_helper:mim(), mongoose_rdbms, db_engine, [domain_helper:host_type()]) of
-        odbc -> [];
-        _ -> [parallel]
+    case ct_helper:is_ct_running() of
+        true ->
+            Spec = distributed_helper:without_assert_allowed_node(distributed_helper:mim()),
+            case distributed_helper:rpc(Spec, mongoose_rdbms, db_engine, [domain_helper:host_type()]) of
+                odbc -> [];
+                _ -> [parallel]
+            end;
+        false ->
+            []
     end.
+
 
 no_db_cases() -> [
     api_lookup_works,

--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -19,7 +19,7 @@
     app_secret = <<>>}).
 
 -import(distributed_helper, [mim/0, mim2/0, mim3/0, rpc/4,
-                             require_rpc_nodes/1
+                             require_rpc_nodes/2
                             ]).
 
 -import(component_helper, [connect_component/1,
@@ -30,7 +30,7 @@
 -import(config_parser_helper, [mod_config/2, config/2]).
 
 suite() ->
-    require_rpc_nodes([mim]).
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [

--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -30,7 +30,7 @@
 -import(config_parser_helper, [mod_config/2, config/2]).
 
 suite() ->
-    require_rpc_nodes([mim, mim2], escalus:suite()).
+    require_rpc_nodes([mim, mim2, mim3], escalus:suite()).
 
 all() ->
     [

--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -30,7 +30,7 @@
 -import(config_parser_helper, [mod_config/2, config/2]).
 
 suite() ->
-    require_rpc_nodes([mim], escalus:suite()).
+    require_rpc_nodes([mim, mim2], escalus:suite()).
 
 all() ->
     [

--- a/big_tests/tests/shared_roster_SUITE.erl
+++ b/big_tests/tests/shared_roster_SUITE.erl
@@ -20,7 +20,7 @@
 -define(USERS, [alice, bob]).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 -import(domain_helper, [host_type/0]).
@@ -40,7 +40,7 @@ groups() ->
     ct_helper:repeat_all_until_all_ok(G).
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/shutdown_SUITE.erl
+++ b/big_tests/tests/shutdown_SUITE.erl
@@ -17,6 +17,9 @@ cases() ->
     [shutdown,
      client_tries_to_connect_before_listener_stop].
 
+suite() ->
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
+
 init_per_suite(Config) ->
     mongoose_helper:inject_module(?MODULE),
     escalus:init_per_suite(Config).

--- a/big_tests/tests/sic_SUITE.erl
+++ b/big_tests/tests/sic_SUITE.erl
@@ -12,7 +12,7 @@
 -define(NS_SIC, <<"urn:xmpp:sic:1">>).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 -import(domain_helper, [host_type/0]).
@@ -31,7 +31,7 @@ groups() ->
     [{mod_sic_tests, [sequence], all_tests()}].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%%===================================================================
 %%% Init & teardown

--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -18,7 +18,7 @@
          filter_hook_handler_fn/3]).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 -import(domain_helper, [host_type/0]).
@@ -48,7 +48,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 all() ->
     [{group, ws_tests},

--- a/big_tests/tests/smart_markers_SUITE.erl
+++ b/big_tests/tests/smart_markers_SUITE.erl
@@ -16,7 +16,9 @@
 %%% Suite configuration
 all() ->
     case (not ct_helper:is_ct_running())
-         orelse mongoose_helper:is_rdbms_enabled(host_type()) of
+         orelse distributed_helper:temporary_allow_nodes(fun() ->
+                     mongoose_helper:is_rdbms_enabled(host_type())
+                 end, [mim]) of
         true -> all_cases();
         false -> {skip, require_rdbms}
     end.
@@ -79,7 +81,7 @@ groups2() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 init_per_suite(Config) ->
     escalus:init_per_suite(Config).

--- a/big_tests/tests/smart_markers_SUITE.erl
+++ b/big_tests/tests/smart_markers_SUITE.erl
@@ -28,7 +28,9 @@ all_cases() ->
     ].
 
 groups() ->
-    inbox_helper:maybe_run_in_parallel(groups1()) ++ groups2().
+    distributed_helper:temporary_allow_nodes(fun() ->
+            inbox_helper:maybe_run_in_parallel(groups1())
+        end, [mim]) ++ groups2().
 
 groups1() ->
     [

--- a/big_tests/tests/start_node_id_SUITE.erl
+++ b/big_tests/tests/start_node_id_SUITE.erl
@@ -18,7 +18,7 @@ cases() ->
     [cleaning_works].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/system_probes_SUITE.erl
+++ b/big_tests/tests/system_probes_SUITE.erl
@@ -5,7 +5,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, mim2/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, mim2/0, require_rpc_nodes/2, rpc/4]).
 -import(domain_helper, [host_type/1]).
 
 all() ->
@@ -32,13 +32,16 @@ system_cases() ->
      system_memory,
      system_dist_data].
 
+suite() ->
+    require_rpc_nodes([mim, mim2], escalus:suite()).
+
 init_per_suite(Config) ->
     mongoose_helper:inject_module(?MODULE),
     Config1 = mongoose_helper:backup_and_set_config_option(
                 Config, [instrumentation, probe_interval], 1),
     restart(mongoose_system_probes),
     instrument_helper:start(instrument_helper:declared_events(mongoose_system_probes, [])),
-    require_rpc_nodes([mim, mim2]) ++ Config1.
+    Config1.
 
 end_per_suite(Config) ->
     mongoose_helper:restore_config_option(Config, [instrumentation, probe_interval]),

--- a/big_tests/tests/tcp_listener_SUITE.erl
+++ b/big_tests/tests/tcp_listener_SUITE.erl
@@ -17,7 +17,7 @@
 -module(tcp_listener_SUITE).
 -compile([export_all, nowarn_export_all]).
 
--import(distributed_helper, [mim/0, require_rpc_nodes/1, rpc/4]).
+-import(distributed_helper, [mim/0, require_rpc_nodes/2, rpc/4]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -28,7 +28,7 @@ all() ->
      service_inet_sockname_returns_error].
 
 suite() ->
-    require_rpc_nodes([mim]).
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/tr_util_SUITE.erl
+++ b/big_tests/tests/tr_util_SUITE.erl
@@ -9,7 +9,7 @@ all() ->
     [c2s_hooks, c2s_elements].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 init_per_suite(Config) ->
     rpc(mim(), tr, start, []),

--- a/big_tests/tests/vcard_SUITE.erl
+++ b/big_tests/tests/vcard_SUITE.erl
@@ -41,7 +41,7 @@
 -define(PHOTO_BASE_64, <<"gsAhn8xWDD+EpA==">>). %% jlib:encode_base64(?PHOTO_BIN)
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              subhost_pattern/1,
                              rpc/4]).
 -import(ldap_helper, [get_ldap_base/1,
@@ -117,7 +117,7 @@ ldap_only_tests() ->
      return_photo_inserted_as_binary_by_3rd_party_service].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/vcard_simple_SUITE.erl
+++ b/big_tests/tests/vcard_simple_SUITE.erl
@@ -32,7 +32,7 @@
 -import(vcard_helper, [is_vcard_ldap/0]).
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              subhost_pattern/1,
                              rpc/4]).
 -import(domain_helper, [host_type/0,
@@ -66,7 +66,7 @@ all_tests() ->
      search_wildcard].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/websockets_SUITE.erl
+++ b/big_tests/tests/websockets_SUITE.erl
@@ -21,7 +21,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 -import(distributed_helper, [mim/0,
-                             require_rpc_nodes/1,
+                             require_rpc_nodes/2,
                              rpc/4]).
 
 %%--------------------------------------------------------------------
@@ -47,7 +47,7 @@ test_cases() ->
      too_big_stanza_is_rejected].
 
 suite() ->
-    require_rpc_nodes([mim]) ++ escalus:suite().
+    require_rpc_nodes([mim], escalus:suite()).
 
 %%--------------------------------------------------------------------
 %% Init & teardown

--- a/big_tests/tests/xep_0352_csi_SUITE.erl
+++ b/big_tests/tests/xep_0352_csi_SUITE.erl
@@ -32,7 +32,7 @@ all_tests() ->
     ].
 
 suite() ->
-    escalus:suite().
+    distributed_helper:require_rpc_nodes([mim], escalus:suite()).
 
 init_per_suite(Config) ->
     instrument_helper:start(instrument_helper:declared_events(mod_csi)),

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -40,7 +40,10 @@
 
 start(normal, _Args) ->
     try
-        do_start()
+        %% We want to print the starting progress if starting is too slow
+        %% (i.e. it would print the current stacktrace each several seconds
+        %%  during the startup)
+        cets_long:run_tracked(#{task => start_mongooseim}, fun do_start/0)
     catch Class:Reason:StackTrace ->
         %% Log a stacktrace because while proc_lib:crash_report/4 would report a crash reason,
         %% it would not report the stacktrace

--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -32,6 +32,9 @@
 -export([start_child/1, start_child/2, stop_child/1]).
 -export([create_ets_table/2]).
 
+-export([start_linked_child/2]).
+-ignore_xref([start_linked_child/2]).
+
 -include("mongoose_logger.hrl").
 
 start_link() ->
@@ -121,7 +124,17 @@ worker_spec(Mod) ->
     worker_spec(Mod, []).
 
 worker_spec(Mod, Args) ->
-    {Mod, {Mod, start_link, Args}, permanent, timer:seconds(5), worker, [Mod]}.
+    %% We use `start_linked_child' wrapper to log delays
+    %% in the slow init worker functions.
+    MFA = {?MODULE, start_linked_child, [Mod, Args]},
+    {Mod, MFA, permanent, timer:seconds(5), worker, [Mod]}.
+
+%% In case one of the workers takes long time to start
+%% we want the logging progress (to know which child got stuck).
+%% This could happend on CI during the node restarts.
+start_linked_child(Mod, Args) ->
+    F = fun() -> erlang:apply(Mod, start_link, Args) end,
+    cets_long:run_tracked(#{task => start_linked_child, child_module => Mod}, F).
 
 -spec create_ets_table(atom(), list()) -> ok.
 create_ets_table(TableName, TableOpts) ->

--- a/test/common/distributed_helper.erl
+++ b/test/common/distributed_helper.erl
@@ -133,7 +133,12 @@ cluster_op_timeout() ->
 -spec rpc(Spec, _, _, _) -> any() when
       Spec :: rpc_spec().
 rpc(#{} = RPCSpec, M, F, A) ->
-    assert_allowed_node(RPCSpec, {M, F, A}),
+    case RPCSpec of
+        #{without_assert_allowed_node := true} ->
+            ok;
+        _ ->
+            assert_allowed_node(RPCSpec, {M, F, A})
+    end,
     Node = maps:get(node, RPCSpec),
     Cookie = maps:get(cookie, RPCSpec, erlang:get_cookie()),
     TimeOut = maps:get(timeout, RPCSpec, timer:seconds(5)),
@@ -141,6 +146,9 @@ rpc(#{} = RPCSpec, M, F, A) ->
         {badrpc, Reason} -> error({badrpc, Reason}, [RPCSpec, M, F, A]);
         Result -> Result
     end.
+
+without_assert_allowed_node(Spec) ->
+    Spec#{without_assert_allowed_node => true}.
 
 %% @doc Require nodes defined in `test.config' for later convenient RPCing into.
 %%

--- a/test/common/distributed_helper.erl
+++ b/test/common/distributed_helper.erl
@@ -206,7 +206,7 @@ validate_nodes() ->
     end.
 
 validate_node(Spec = #{node := Node}) ->
-    try rpc(Spec, application, loaded_applications, []) of
+    try rpc(Spec, application, which_applications, []) of
         Loaded ->
             case lists:keymember(mongooseim, 1, Loaded) of
                 true -> ok;

--- a/test/common/distributed_helper.erl
+++ b/test/common/distributed_helper.erl
@@ -256,3 +256,9 @@ assert_allowed_node(#{node := Node}, MFA) ->
                     ct:fail(Reason)
             end
     end.
+
+with_all_nodes_allowed(F) ->
+    NodeKeys = [NodeKey || {NodeKey, _Opts} <- ct:get_config(hosts)],
+    require_rpc_nodes(NodeKeys, []),
+    F(),
+    require_rpc_nodes([], []).

--- a/test/common/distributed_helper.erl
+++ b/test/common/distributed_helper.erl
@@ -146,13 +146,13 @@ rpc(#{} = RPCSpec, M, F, A) ->
 %% The use case would be to require and import the same names in your suite like:
 %%
 %%  -import(distributed_helper, [mim/0, fed/0,
-%%                               require_rpc_nodes/1,
+%%                               require_rpc_nodes/2,
 %%                               rpc/4]).
 %%
 %%  ...
 %%
 %%  suite() ->
-%%      require_rpc_nodes([mim, fed]) ++ escalus:suite().
+%%      require_rpc_nodes([mim, fed], escalus:suite()).
 %%
 %%  ...
 %%
@@ -160,8 +160,8 @@ rpc(#{} = RPCSpec, M, F, A) ->
 %%      RPCResult = rpc(mim(), remote_mod, remote_fun, [arg1, arg2]),
 %%      ...
 %%
-require_rpc_nodes(Nodes) ->
-    [ {require, {hosts, Node, node}} || Node <- Nodes ].
+require_rpc_nodes(Nodes, Config) ->
+    [ {require, {hosts, Node, node}} || Node <- Nodes ] ++ Config.
 
 %% @doc Shorthand for hosts->mim->node from `test.config'.
 -spec mim() -> rpc_spec().

--- a/test/common/distributed_helper.erl
+++ b/test/common/distributed_helper.erl
@@ -243,5 +243,12 @@ assert_allowed_node(#{node := Node}) ->
     AllowedNodes = [get_or_fail({hosts, NodeKey, node}) || NodeKey <- Allowed],
     case lists:member(Node, AllowedNodes) of
         true -> ok;
-        false -> ct:fail({assert_allowed_node, Node, AllowedNodes})
+        false ->
+            case os:getenv("ALLOW_ANY_RPC") of
+                "true" ->
+                    %% Just log it instead of failing
+                    ct:pal("~p", [{assert_allowed_node, Node, AllowedNodes}]);
+                _ ->
+                    ct:fail({assert_allowed_node, Node, AllowedNodes})
+            end
     end.

--- a/tools/test-runner-complete.sh
+++ b/tools/test-runner-complete.sh
@@ -132,6 +132,8 @@ _run_all_tests() {
                           --show-small-reports \
                           --show-big-reports \
                           --rerun-big-tests \
+                          --allow-any-rpc \
+                          --skip-check-rpc-nodes \
                           --colors \
                           '"$SUGGESTIONS"' \
                           '"$SUITES"' \

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -117,8 +117,19 @@ Script examples:
     Sets dev-nodes and test-hosts to empty lists
     Reruns mam_SUITE
 
-./tools/test-runner.sh --skip-small-tests --skip-check-rpc-nodes --allow-any-rpc --one-node connect
-    Allows any RPCs in the tests, useful if not all nodes are running on the developer machine
+./tools/test-runner.sh --skip-small-tests --skip-check-rpc-nodes connect
+    Continues test execution even if some of nodes in require_rpc_nodes are not running.
+    Useful when you want to check what would be the behaviour when MongooseIM is not running on some nodes.
+
+./tools/test-runner.sh --skip-small-tests --allow-any-rpc connect
+    Allows any RPCs in the tests (and not just to nodes specified in require_rpc_nodes)
+    Useful when you want to have unrestricted access to any MongooseIM node during development
+
+./tools/test-runner.sh --skip-small-tests --one-node connect
+    Starts one node, checks that one node is running
+    Tests that do calls to mim2 and mim3 would fail with the badrpc reason
+    Warning that mim2 and mim3 are not running would be printed in init_per_suite/1
+    but the execution would continue
 
 ./tools/test-runner.sh --rerun-big-tests -- mam
     The same command as above

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -104,10 +104,10 @@ Script examples:
     CI MAM-only build job with elasticsearch_and_cassandra_mnesia
     Separator -- between presets and suites
 
-./tools/test-runner.sh --db redis pgsql --preset pgsql_mnesia
+./tools/test-runner.sh --db redis pgsql --preset pgsql_mnesia --skip-small-tests
     CI build job with pgsql_mnesia
 
-./tools/test-runner.sh --db redis pgsql --preset pgsql_mnesia --spec dynamic_domains.spec
+./tools/test-runner.sh --db redis pgsql --preset pgsql_mnesia --spec dynamic_domains.spec --skip-small-tests
     CI multi-tenancy build job with pgsql_mnesia
 
 ./tools/test-runner.sh --skip-small-tests --db pgsql --preset pgsql_mnesia --skip-stop-nodes -- mam

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -37,6 +37,8 @@ Options:
 --skip-start-nodes    -- do not start nodes before big tests
 --skip-stop-nodes     -- do not stop nodes after big tests
 --skip-setup-db       -- do not start any databases, the same as "--db --" option
+--skip-check-rpc-nodes -- do not fail if MongooseIM's node or application is not running
+--allow-any-rpc       -- do not fail when doing RPC to a non-required node
 --no-parallel         -- run most commands in sequence
 --tls-dist            -- enable encryption between nodes in big tests
 --verbose             -- print script output
@@ -114,6 +116,9 @@ Script examples:
 ./tools/test-runner.sh --skip-small-tests --skip-setup-db --dev-nodes --test-hosts --skip-cover --skip-preset -- mam
     Sets dev-nodes and test-hosts to empty lists
     Reruns mam_SUITE
+
+./tools/test-runner.sh --skip-small-tests --skip-check-rpc-nodes --allow-any-rpc --one-node connect
+    Allows any RPCs in the tests, useful if not all nodes are running on the developer machine
 
 ./tools/test-runner.sh --rerun-big-tests -- mam
     The same command as above
@@ -304,6 +309,8 @@ START_NODES=true
 STOP_NODES=true
 TLS_DIST=false
 PARALLEL_ENABLED=true
+SKIP_CHECK_RPC_NODES=false
+ALLOW_ANY_RPC=false
 
 SELECTED_TESTS=()
 STOP_SCRIPT=false
@@ -351,6 +358,16 @@ case $key in
         shift # past argument
         SKIP_DB_SETUP=true
         DB_FROM_PRESETS=false
+    ;;
+
+    --skip-check-rpc-nodes)
+        shift # past argument
+        SKIP_CHECK_RPC_NODES=true
+    ;;
+
+    --allow-any-rpc)
+        shift # past argument
+        ALLOW_ANY_RPC=true
     ;;
 
     # Similar how we parse --db option
@@ -635,6 +652,8 @@ export TESTSPEC="auto_big_tests.spec"
 export START_NODES="$START_NODES"
 export STOP_NODES="$STOP_NODES"
 export PAUSE_BEFORE_BIG_TESTS="$PAUSE_BEFORE_BIG_TESTS"
+export SKIP_CHECK_RPC_NODES="$SKIP_CHECK_RPC_NODES"
+export ALLOW_ANY_RPC="$ALLOW_ANY_RPC"
 
 # Debug printing
 echo "Variables:"
@@ -653,6 +672,8 @@ echo "    TESTSPEC=$TESTSPEC"
 echo "    TLS_DIST=$TLS_DIST"
 echo "    START_NODES=$START_NODES"
 echo "    STOP_NODES=$STOP_NODES"
+echo "    SKIP_CHECK_RPC_NODES=$SKIP_CHECK_RPC_NODES"
+echo "    ALLOW_ANY_RPC=$ALLOW_ANY_RPC"
 echo ""
 
 


### PR DESCRIPTION
This PR addresses MIM-2329.

Proposed changes include:
* Put in in the end of suite() callback
* Use require_rpc_nodes/2 instead of require_rpc_nodes/1

* Fail if MongoosIM is not running on required nodes. We have Common Test Hook doing it. Use `--skip-check-rpc-nodes` to disable.
* Fail if making an RPC to a non-required node. This is useful to ensure that the list or RPC nodes requested in the `suite()` callback is correct. Use `--allow-any-rpc` to disable the check.

* Added `cets_long:run_tracked` in a couple of places. `run_tracked` accepts a function and spawns a sidecar process, which would track the function execution. Each five seconds in will print time and current stacktrace.  Useful to debug MIM, which is stuck in starting.

