### PR TITLE
Fix XML test report for CircleCI

### DIFF
--- a/big_tests/src/cth_surefire.erl
+++ b/big_tests/src/cth_surefire.erl
@@ -492,3 +492,108 @@ count_tcs([#testcase{result={auto_skipped,_}}|TCs],Ok,F,S) ->
     count_tcs(TCs,Ok,F,S+1);
 count_tcs([],Ok,F,S) ->
     {Ok+F+S,F,S}.
+
+-ifdef(EUNIT).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("exml/include/exml.hrl").
+
+%% Unit tests
+
+report_test() ->
+    GroupPath = [deeply_nested_test_group, nested_test_group, test_group],
+    TCs = run_ct_with_report([GroupPath]),
+    Expected = wrap_suite_report(wrap_nested_group_report(expected_group_report())),
+    verify_results(Expected, TCs).
+
+report_skipped_group_test() ->
+    SkippedGroupPath = [deeply_nested_test_group, nested_test_group, skipped_test_group],
+    TCs = run_ct_with_report([SkippedGroupPath]),
+    Expected = wrap_suite_report(wrap_nested_group_report(expected_skipped_group_report())),
+    verify_results(Expected, TCs).
+
+report_two_groups_test() ->
+    GroupPaths = [[deeply_nested_test_group, nested_test_group, test_group],
+                  [deeply_nested_test_group, nested_test_group, skipped_test_group]],
+    TCs = run_ct_with_report(GroupPaths),
+    Expected = wrap_suite_report([wrap_nested_group_report(expected_group_report()),
+                                  wrap_nested_group_report(expected_skipped_group_report())]),
+    verify_results(Expected, TCs).
+
+report_skipped_suite_test() ->
+    try
+        meck:new(test_SUITE, [passthrough]),
+        meck:expect(test_SUITE, init_per_suite, fun(_) -> {skip, suite_skipped} end),
+        GroupPath = [deeply_nested_test_group, nested_test_group, test_group],
+        TCs = run_ct_with_report([GroupPath]),
+        Expected = skip_all(wrap_suite_report(test_report(undefined))),
+        verify_results(Expected, TCs)
+    after
+        meck:unload()
+    end.
+
+%% Helpers for running common test
+
+run_ct_with_report(Groups) ->
+    ct:run_test([{suite, "tests/test_SUITE"}, {group, Groups},
+                 {ct_hooks, [cth_surefire]}, {logdir, "ct_report"}]),
+    ReportPath = string:strip(os:cmd("ls -t ct_report/ct_run.*/junit_report.xml | head -1"),
+                              right, $\n),
+    {ok, ReportXML} = file:read_file(ReportPath),
+    {ok, RootEl} = exml:parse(ReportXML),
+    exml_query:paths(RootEl, [{element, <<"testsuite">>}, {element, <<"testcase">>}]).
+
+%% Helpers for expected test reports
+
+expected_skipped_group_report() ->
+    Group = <<"deeply_nested_test_group.nested_test_group.skipped_test_group">>,
+    skip_all(expected_group_report(Group)).
+
+skip_all(Report) ->
+    [{Test, Group, skipped} || {Test, Group, _} <- lists:flatten(Report)].
+
+expected_group_report() ->
+    Group = <<"deeply_nested_test_group.nested_test_group.test_group">>,
+    expected_group_report(Group).
+
+expected_group_report(Group) ->
+    [{<<"init_per_group">>, Group, ok},
+     test_report(Group),
+     {<<"end_per_group">>, Group, ok}].
+
+test_report(Group) ->
+    [{<<"passing_tc">>, Group, ok},
+     {<<"skipped_tc">>, Group, skipped},
+     {<<"failing_tc_1">>, Group, failed},
+     {<<"failing_tc_2">>, Group, failed}, % init_per_testcase failed
+     {<<"failing_tc_3">>, Group, ok} % end_per_testcase failed, still ok
+    ].
+
+wrap_nested_group_report(Report) ->
+    [{<<"init_per_group">>, <<"deeply_nested_test_group">>, ok},
+     {<<"init_per_group">>, <<"deeply_nested_test_group.nested_test_group">>, ok},
+     Report,
+     {<<"end_per_group">>, <<"deeply_nested_test_group.nested_test_group">>, ok},
+     {<<"end_per_group">>, <<"deeply_nested_test_group">>, ok}].
+
+wrap_suite_report(Report) ->
+    [{<<"init_per_suite">>, undefined, ok},
+     Report,
+     {<<"end_per_suite">>, undefined, ok}].
+
+%% Assertions for test reports
+
+verify_results(ExpectedReport, TCs) ->
+    ?assertEqual([], lists:foldl(fun verify_result/2, TCs, lists:flatten(ExpectedReport))).
+
+verify_result({CName, GName, Result}, [TC = #xmlel{children = Children} | Rest]) ->
+    ?assertEqual(CName, exml_query:attr(TC, <<"name">>)),
+    ?assertEqual(GName, exml_query:attr(TC, <<"group">>)),
+    case Result of
+        ok -> ?assertEqual([], Children);
+        skipped -> ?assertMatch([#xmlel{name = <<"skipped">>}], Children);
+        failed -> ?assertMatch([#xmlel{name = <<"failure">>}], Children)
+    end,
+    Rest.
+
+-endif.


### PR DESCRIPTION
The goal of this PR is to fix the issues with the `cth_surefire` hook, which we are using to produce an XML test report for CIrcleCI used for:
- Listing failing tests in job reports.
- Test insights (failed tests, flaky tests, etc.)
- Rerunning failed tests instead of full presets.

There were two **main issues**:
- Automatically skipped tests, e.g. after a failed `init_per_testcase`, were reported as skipped, while they should have been reported as failed in order to rerun them with "Rerun failed tests".
- If a test is skipped, it would overwrite all previous tests with the same (e.g. from other groups), resulting in an incomplete report, and possibly causing failed tests to be marked as skipped.

Together with the fix, this PR contains **EUnit tests**, which check the correctness of `cth_surefire`. I focused on the issues mentioned above, and the goal was not to cover all possible cases - so the tests only check a few typical scenarios. I verified that the tests failed before the fixes. The tests are not run on CI on purpose, because we rarely change `cth_surefire`. Instead, you can run them from the `big_tests` directory:

```bash
rebar3 eunit -m cth_surefire -v
```

**Notes**:
- `cth_surefire` is taken from the OTP sources, but we have modified it to work with CircleCI reports. We could actually try to open a PR to OTP with the changes.
- I also added whole `test_SUITE` manually to `default.spec` and checked the resulting [report](https://app.circleci.com/pipelines/github/esl/MongooseIM/13335/workflows/89cb8771-254b-402a-8ddd-600627582980/jobs/247441/tests) in CircleCI.
 

