### PR TITLE
Start CT node as hidden to avoid global doing netsplits

### DIFF
--- a/big_tests/Makefile
+++ b/big_tests/Makefile
@@ -47,7 +47,7 @@ cover_test_clean: get-deps
 	$(MAKE) cover_test
 
 quicktest: $(PREPARE)
-	$(RUN) erl -noinput $(COMMON_OPTS) $(ADD_OPTS) \
+	$(RUN) erl -hidden -noinput $(COMMON_OPTS) $(ADD_OPTS) \
 			-s run_common_test main test=quick spec=$(TESTSPEC)
 
 cover_quicktest: $(PREPARE)


### PR DESCRIPTION
mim, mim2 gets connected to fed1
Which should not happen, but global would connect it It reduces the chance of a netsplit a bit

This PR addresses "".

Proposed changes include:
* It helps with that:

```
26 when=2024-12-05T15:57:29.709626+00:00 level=error pid=<0.3532.0> at=: unstructured_log="** Connection attempt from node reg1@localhost rejected. Invalid challenge reply. **\
27 " 
28 when=2024-12-05T15:57:29.709940+00:00 level=warning pid=<0.3529.0> at=: unstructured_log="'global' at mongooseim@localhost failed to connect to reg1@localhost\
29 " 
30 when=2024-12-05T15:57:29.710974+00:00 level=warning pid=<0.59.0> at=: unstructured_log="'global' at node mongooseim@localhost disconnected node mongooseim2@localhost in order to prevent overlapping partitions" 
31 when=2024-12-05T15:57:29.711431+00:00 level=warning pid=<0.59.0> at=: unstructured_log="'global' at node mongooseim@localhost disconnected node mongooseim3@localhost in order to prevent overlapping partitions" 
32 when=2024-12-05T15:57:29.711756+00:00 level=warning pid=<0.59.0> at=: unstructured_log="'global' at node mongooseim@localhost disconnected node fed1@localhost in order to prevent overlapping partitions" 
```

Log:
https://esl.github.io/html-zip-reader/PR/4413/247303/ldap_mnesia.26.2.5.4-amd64/big.tar.gz//ct_run.test@1e3d8eb53586.2024-12-05_15.57.32/mongooseim@localhost.log.html#L4084
Fail:
https://esl.github.io/html-zip-reader/PR/4413/247303/ldap_mnesia.26.2.5.4-amd64/big.tar.gz//ct_run.test%401e3d8eb53586.2024-12-05_15.57.32/big_tests.tests.cluster_commands_SUITE.logs/run.2024-12-05_15.58.21/cluster_commands_suite.init_per_group.html

