### PR TITLE
Fix dropped_client_doesnt_create_duplicate_carbons flaky test

### DIFF
--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -138,8 +138,10 @@ handle_user_terminate(Acc, StateData, Presences, Reason) ->
     PresenceUnavailable = presence_unavailable_stanza(Status),
     ParamsAcc = #{from_jid => Jid, to_jid => jid:to_bare(Jid), element => PresenceUnavailable},
     Acc1 = mongoose_acc:update_stanza(ParamsAcc, Acc),
+    Sid = mongoose_c2s:get_sid(StateData),
+    Info = mongoose_c2s:get_info(StateData),
+    ejabberd_sm:unset_presence(Acc1, Sid, Jid, Status, Info),
     presence_broadcast(Acc1, Presences),
-    mongoose_hooks:unset_presence(Acc1, Jid, Status),
     {ok, Acc}.
 
 -spec foreign_event(Acc, Params, Extra) -> Result when


### PR DESCRIPTION
`carboncopy_SUITE:dropped_client_doesnt_create_duplicate_carbons` is one of the flaky tests (failed run on GH Actions: https://github.com/esl/MongooseIM/actions/runs/12253944118/job/34183783884, failed run on CircleCI: https://app.circleci.com/pipelines/github/esl/MongooseIM/13363/workflows/761201e1-fae8-4792-a5df-051914a41ae6/jobs/248193).

The test:
1. Disconnects one of two user's resources,
2. waits for presence `unavailable` on the remaining resource,
3. after receiving the presence, sends a message from the remaining resource,
4. checks to make sure that the disconnected resource didn't get a carboncopy of the message.
However, sometimes the disconnected resource would actually get the stanza, resulting in a flaky test.

I think the issue comes from a race condition between sending the `unavailable` stanza on behalf of the user, and calling the `unset_presence` hook. To illustrate the point, I've tested a commit almost ensuring that the issue will appear by making MIM slower in the problematic place: https://github.com/esl/MongooseIM/commits/deab685f495bf73cec5409fc873f98ba75d168d0. The tests have failed as was suspected: https://github.com/esl/MongooseIM/runs/34035992149. I think that the `dropped_client_doesnt_create_duplicate_carbons` test is correct, and while it is unlikely that a user would notice this behaviour, it's probably still better to fix the implementation instead of changing the testcase.

The fix required changing the order: First, removing the session, and later broadcasting the `unavailable` presence. I also changed the direct hook call to a call through `ejabberd_sm`, which additionally sets priority for the disconnected resource to `undefined`. The session would be removed anyway by `mongoose_c2s`, but now there is less chance of a similar issue from different modules which would listen to `unset_presence` hook. `mod_presence:presence_update_to_unavailable/6` function also calls this hook through `ejabberd_sm`.
Perhaps it would be better to change the `ejabberd_sm:(un)set_presence/5` functions to be handlers of the `unset_presence` hook, and make sure only `mod_presence` is responsible for calling it, but I decided this rework was out of scope of this PR.

I've run the GH Actions manually for this PR, and there are still flaky tests, but the carboncopy case is not one of them: https://github.com/esl/MongooseIM/actions/runs/12278680395. Of course it is tricky to test that the test is not flaky any more, since it may pass by chance.