### PR TITLE
Fix building packages on GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pkg: [ubuntu_xenial]
+        pkg: [ubuntu-jammy]
     runs-on: ubuntu-22.04
     env:
       pkg_OTP_VERSION: "27.0.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
         pkg: [ubuntu_xenial]
     runs-on: ubuntu-22.04
     env:
-      ESL_ERLANG_PKG_VER: "25.3.2"
+      pkg_OTP_VERSION: "27.0.1"
       pkg_PLATFORM: ${{matrix.pkg}}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         ## the full list of supported (prebuilt) OTP versions for ubuntu-22.04 runners
         ## can be found here:
         ##     https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
-        otp: [ '26.2.5.2', '27.0.1' ]
+        otp: [ '26.2.5.2', '27.1.2' ]
     runs-on: ubuntu-22.04
     env:
       PRESET: 'small_tests'
@@ -66,7 +66,7 @@ jobs:
       matrix:
         preset: [internal_mnesia, pgsql_mnesia, mysql_redis, odbc_mssql_mnesia,
                  ldap_mnesia, elasticsearch_and_cassandra_mnesia]
-        otp: [ '27.0.1' ]
+        otp: [ '27.1.2' ]
         include:
           - test-spec: "default.spec"
           - preset: elasticsearch_and_cassandra_mnesia
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         preset: [pgsql_mnesia, mysql_redis, odbc_mssql_mnesia]
-        otp: [ '27.0.1' ]
+        otp: [ '27.1.2' ]
         test-spec: ["dynamic_domains.spec"]
         include:
           - preset: pgsql_mnesia
@@ -191,7 +191,7 @@ jobs:
         pkg: [ubuntu-jammy]
     runs-on: ubuntu-22.04
     env:
-      pkg_OTP_VERSION: "27.0.1"
+      pkg_OTP_VERSION: "27.1.2"
       pkg_PLATFORM: ${{matrix.pkg}}
       GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,9 @@ jobs:
     env:
       pkg_OTP_VERSION: "27.0.1"
       pkg_PLATFORM: ${{matrix.pkg}}
+      GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASS: ${{ secrets.GPG_PASS }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR updates the package building workflow on GH Actions. `ubuntu_xenial package` job had 100% failure rate in the last month.

Changes:
- rename `ESL_ERLANG_PKG_VER` to `pkg_OTP_VERSION`, as in https://github.com/esl/MongooseIM/pull/4385.
- use GH Secrets to read GPG keys similarly to https://github.com/esl/MongooseIM/pull/4399. Packages require signing since that PR.
- since we now use https://hub.docker.com/r/erlangsolutions/erlangupdate to build packages, Ubuntu version has been updated: `_` was changed to `-`, and version number has been bumped.

Passing package building job for this PR (started manually): https://github.com/esl/MongooseIM/actions/runs/12237054902/job/34131909145