### PR TITLE
Report long tasks

### DIFF
--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -43,7 +43,7 @@ start(normal, _Args) ->
         %% We want to print the starting progress if starting is too slow
         %% (i.e. it would print the current stacktrace each several seconds
         %%  during the startup)
-        cets_long:run_tracked(#{task => start_mongooseim}, fun do_start/0)
+        mongoose_task:run_tracked(#{task => start_mongooseim}, fun do_start/0)
     catch Class:Reason:StackTrace ->
         %% Log a stacktrace because while proc_lib:crash_report/4 would report a crash reason,
         %% it would not report the stacktrace

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -40,7 +40,10 @@
 
 start(normal, _Args) ->
     try
-        do_start()
+        %% We want to print the starting progress if starting is too slow
+        %% (i.e. it would print the current stacktrace each several seconds
+        %%  during the startup)
+        cets_long:run_tracked(#{task => start_mongooseim}, fun do_start/0)
     catch Class:Reason:StackTrace ->
         %% Log a stacktrace because while proc_lib:crash_report/4 would report a crash reason,
         %% it would not report the stacktrace

--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -32,6 +32,9 @@
 -export([start_child/1, start_child/2, stop_child/1]).
 -export([create_ets_table/2]).
 
+-export([start_linked_child/2]).
+-ignore_xref([start_linked_child/2]).
+
 -include("mongoose_logger.hrl").
 
 start_link() ->
@@ -121,7 +124,17 @@ worker_spec(Mod) ->
     worker_spec(Mod, []).
 
 worker_spec(Mod, Args) ->
-    {Mod, {Mod, start_link, Args}, permanent, timer:seconds(5), worker, [Mod]}.
+    %% We use `start_linked_child' wrapper to log delays
+    %% in the slow init worker functions.
+    MFA = {?MODULE, start_linked_child, [Mod, Args]},
+    {Mod, MFA, permanent, timer:seconds(5), worker, [Mod]}.
+
+%% In case one of the workers takes long time to start
+%% we want the logging progress (to know which child got stuck).
+%% This could happend on CI during the node restarts.
+start_linked_child(Mod, Args) ->
+    F = fun() -> erlang:apply(Mod, start_link, Args) end,
+    cets_long:run_tracked(#{task => start_linked_child, child_module => Mod}, F).
 
 -spec create_ets_table(atom(), list()) -> ok.
 create_ets_table(TableName, TableOpts) ->

--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -134,7 +134,7 @@ worker_spec(Mod, Args) ->
 %% This could happend on CI during the node restarts.
 start_linked_child(Mod, Args) ->
     F = fun() -> erlang:apply(Mod, start_link, Args) end,
-    cets_long:run_tracked(#{task => start_linked_child, child_module => Mod}, F).
+    mongoose_task:run_tracked(#{task => start_linked_child, child_module => Mod}, F).
 
 -spec create_ets_table(atom(), list()) -> ok.
 create_ets_table(TableName, TableOpts) ->

--- a/src/mongoose_cluster_id.erl
+++ b/src/mongoose_cluster_id.erl
@@ -24,8 +24,9 @@ start() ->
     PersistentBackend = which_persistent_backend_enabled(),
     VolatileBackend = which_volatile_backend_available(),
     maybe_prepare_queries(PersistentBackend),
-    cets_long:run_tracked(#{task => wait_for_any_backend,
-                            backend => PersistentBackend, volatile_backend => VolatileBackend},
+    mongoose_task:run_tracked(#{task => wait_for_any_backend,
+                                backend => PersistentBackend,
+                                volatile_backend => VolatileBackend},
                           fun() -> wait_for_any_backend(PersistentBackend, VolatileBackend) end),
     CachedRes = get_cached_cluster_id(VolatileBackend),
     BackendRes = get_backend_cluster_id(PersistentBackend),
@@ -80,7 +81,8 @@ wait_for_backend_promise(cets, Alias) ->
         end)];
 wait_for_backend_promise(rdbms, Alias) ->
     [spawn(fun() ->
-            cets_long:run_tracked(#{task => wait_for_rdbms}, fun() -> wait_for_rdbms() end),
+            mongoose_task:run_tracked(#{task => wait_for_rdbms},
+                                      fun wait_for_rdbms/0),
             Alias ! {ready, Alias}
         end)];
 wait_for_backend_promise(_, Alias) ->

--- a/src/mongoose_start_node_id.erl
+++ b/src/mongoose_start_node_id.erl
@@ -41,6 +41,9 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 init(_) ->
+    mongoose_task:run_tracked(#{task => mongoose_start_node_id_init}, fun do_init/0).
+
+do_init() ->
     net_kernel:monitor_nodes(true),
     StartId = mongoose_bin:gen_from_crypto(),
     persistent_term:put(mongoose_start_node_id, StartId),

--- a/src/mongoose_start_node_id.erl
+++ b/src/mongoose_start_node_id.erl
@@ -96,8 +96,15 @@ code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
 register_on_remote_node(RemoteNode, StartId) ->
+    Info = #{task => register_on_remote_node,
+             remote_node => RemoteNode,
+             start_id => StartId},
+    F = fun() -> do_register_on_remote_node(RemoteNode, StartId) end,
+    mongoose_task:run_tracked(Info, F).
+
+do_register_on_remote_node(RemoteNode, StartId) ->
     Res = rpc:call(RemoteNode, ?MODULE, register_on_remote_node_rpc,
-                   [node(), StartId, self()]),
+                   [node(), StartId, self()], timer:seconds(10)),
     case Res of
         ok ->
             ok;

--- a/src/mongoose_task.erl
+++ b/src/mongoose_task.erl
@@ -1,0 +1,12 @@
+%% @doc Helper module for slow tasks.
+-module(mongoose_task).
+-export([run_tracked/2]).
+
+%% @doc Run a task, log if it takes too long
+-spec run_tracked(Info :: map(), F :: fun(() -> Res)) -> Res
+    when Res :: term().
+run_tracked(Info, F) ->
+    %% Reuse code from CETS.
+    %% `cets_long' module does not use any CETS functionality and
+    %% can be used, even if CETS tables are not used.
+    cets_long:run_tracked(Info, F).


### PR DESCRIPTION
This PR addresses "MIM-2351 Better logging when something takes too long".

Proposed changes include:
* Use mongoose_task:run_tracked/2 to report slow progress in ejabberd_app and ejabberd_sup.


Question:
* We could move [cets_long](https://github.com/esl/cets/blob/main/src/cets_long.erl) into some repo like `long_task`. Do we want to do so though? The only issues I see: `cets_long` would be reported as a part of a stacktrace - possible confusion. `cets_long` behaviour could be changed someday - we control cets though.




New found bugs:

**Bug 1 -- pep_SUITE:pep_tests:h_ok_after_notify_test**
CI task [1](https://app.circleci.com/jobs/github/esl/MongooseIM/249166)

PEP could fail: [report](https://esl.github.io/html-zip-reader/PR/4430/250534/odbc_mssql_mnesia.27.1.2-amd64/big.tar.gz//ct_run.test%40d27a5d5556a2.2024-12-13_10.09.10/big_tests.tests.pep_SUITE.logs/run.2024-12-13_10.22.13/pep_suite.h_ok_after_notify_test.105988.html) [log](https://esl.github.io/html-zip-reader/PR/4430/250534/odbc_mssql_mnesia.27.1.2-amd64/big.tar.gz//ct_run.test%40d27a5d5556a2.2024-12-13_10.09.10/mongooseim@localhost.log.html#L3222)

EODBC timeout, not much we can do there (could be a deadlock, an issue with mssql or an issue with eodbc. could be CI machine):
```
callback failed:\
3233 ** Tab: caps_features\
3234 ** Owner: <0.16661.0>\
3235 ** Operation: insert\
3236 ** Args: [{<<\"http://www.chatopus.com\">>,<<\"fsTdKpAlqJVSSyAsVkE/LZjsQps=\">>},\
3237           1734085334]\
3238 ** Reason: {timeout,\
3239                {gen_server,call,\
3240                    ['wpool_pool-mongoose_wpool$rdbms$global$default-2',\
3241                     {sql_cmd,\
3242                         {sql_execute,caps_upsert,\
3243                             [<<\"http://www.chatopus.com\">>,\
3244                              <<\"fsTdKpAlqJVSSyAsVkE/LZjsQps=\">>,\
3245                              <<\"http://www.chatopus.com\">>,\
3246                              <<\"fsTdKpAlqJVSSyAsVkE/LZjsQps=\">>,\
3247                              <<\"1734085334\">>,<<\"1734085334\">>]},\
3248                         -576459923992},\
3249                     60000]}}\
```

**Bug 2 -- graphql_server_SUITE:admin_cli:clustering_tests:remove_dead_from_cluster (ldap_mnesia preset usually)**

CI tasks [1](https://app.circleci.com/jobs/github/esl/MongooseIM/249155) [2](https://circleci.com/gh/esl/MongooseIM/249261) [3](https://circleci.com/gh/esl/MongooseIM/249674) [4](https://circleci.com/gh/esl/MongooseIM/250165)

mongoose_start_node_id could stuck in init in erpc forever.
This RPC call does persistent term insert and a gen_server cast - so, it should not block in theory.

[first time](https://esl.github.io/html-zip-reader/PR/4430/249155/ldap_mnesia.26.2.5.4-amd64/big.tar.gz//ct_run.test%407efb37acefe3.2024-12-11_12.56.18/big_tests.tests.graphql_server_SUITE.logs/run.2024-12-11_13.01.23/graphql_server_suite.remove_dead_from_cluster.html)

```
623 when=2024-12-11T13:03:58.475773+00:00 level=warning what=long_task_progress pid=<0.49836.0> at=cets_long:monitor_loop/5:116 child_module=mongoose_start_node_id time_ms=90017 caller_pid=<0.49835.0> task=start_linked_child 
current_stacktrace="[{proc_lib,sync_start,2,[{file,\"proc_lib.erl\"},{line,309}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{supervisor,do_start_child_i,3,[{file,\"supervisor.erl\"},{line,420}]},{supervisor,do_start_child,2,[{file,\"supervisor.erl\"},{line,406}]},{supervisor,'-start_children/2-fun-0-',3,[{file,\"supervisor.erl\"},{line,390}]},{supervisor,children_map,4,[{file,\"supervisor.erl\"},{line,1275}]},{supervisor,init_children,2,[{file,\"supervisor.erl\"},{line,350}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,980}]}]" 

624 when=2024-12-11T13:04:03.107750+00:00 level=warning what=long_task_progress pid=<0.49755.0> at=cets_long:monitor_loop/5:116 time_ms=95018 caller_pid=<0.49754.0> task=start_mongooseim current_stacktrace="[{proc_lib,sync_start,2,[{file,\"proc_lib.erl\"},{line,309}]},
{ejabberd_app,do_start,0,[{file,\"/home/circleci/project/src/ejabberd_app.erl\"},{line,68}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{ejabberd_app,start,2,[{file,\"/home/circleci/project/src/ejabberd_app.erl\"},{line,46}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,293}]}]" 

625 when=2024-12-11T13:04:03.476973+00:00 level=warning what=long_task_progress pid=<0.49836.0> at=cets_long:monitor_loop/5:116 child_module=mongoose_start_node_id time_ms=95018 caller_pid=<0.49835.0> task=start_linked_child 
current_stacktrace="[{proc_lib,sync_start,2,[{file,\"proc_lib.erl\"},{line,309}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{supervisor,do_start_child_i,3,[{file,\"supervisor.erl\"},{line,420}]},{supervisor,do_start_child,2,[{file,\"supervisor.erl\"},{line,406}]},
{supervisor,'-start_children/2-fun-0-',3,[{file,\"supervisor.erl\"},{line,390}]},{supervisor,children_map,4,[{file,\"supervisor.erl\"},{line,1275}]},{supervisor,init_children,2,[{file,\"supervisor.erl\"},{line,350}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,980}]}]" 

626 when=2024-12-11T13:04:08.108731+00:00 level=warning what=long_task_progress pid=<0.49755.0> at=cets_long:monitor_loop/5:116 time_ms=100019 caller_pid=<0.49754.0> task=start_mongooseim current_stacktrace="[{proc_lib,sync_start,2,[{file,\"proc_lib.erl\"},{line,309}]},
{ejabberd_app,do_start,0,[{file,\"/home/circleci/project/src/ejabberd_app.erl\"},{line,68}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},
{ejabberd_app,start,2,[{file,\"/home/circleci/project/src/ejabberd_app.erl\"},{line,46}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,293}]}]" 
```


After adding extra code with the 10 seconds timeout for RPC and extra cets_long:run_tracked call,  we are getting timeout after 10 seconds `what=node_id_register_on_remote_node_failed reason={badrpc,timeout}` which is still bad, but at least it is not "Never finish starting MongooseIM application bad" [log](https://esl.github.io/html-zip-reader/PR/4430/250165/ldap_mnesia.26.2.5.4-amd64/big.tar.gz//ct_run.test%40c705e7058c97.2024-12-12_18.35.41/mongooseim2@localhost.log.html#L738):

```

768 when=2024-12-12T18:43:16.119002+00:00 level=warning what=long_task_progress pid=<0.53066.0> at=cets_long:monitor_loop/5:116 time_ms=5001 caller_pid=<0.53065.0> task=start_mongooseim current_stacktrace="[{proc_lib,sync_start,2,[{file,\"proc_lib.erl\"},{line,309}]},{ejabberd_app,do_start,0,[{file,\"/home/circleci/project/src/ejabberd_app.erl\"},{line,68}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{ejabberd_app,start,2,[{file,\"/home/circleci/project/src/ejabberd_app.erl\"},{line,46}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,293}]}]" 
769 when=2024-12-12T18:43:16.433944+00:00 level=warning what=long_task_progress pid=<0.53150.0> at=cets_long:monitor_loop/5:116 child_module=mongoose_start_node_id time_ms=5000 caller_pid=<0.53146.0> task=start_linked_child current_stacktrace="[{proc_lib,sync_start,2,[{file,\"proc_lib.erl\"},{line,309}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{supervisor,do_start_child_i,3,[{file,\"supervisor.erl\"},{line,420}]},{supervisor,do_start_child,2,[{file,\"supervisor.erl\"},{line,406}]},{supervisor,'-start_children/2-fun-0-',3,[{file,\"supervisor.erl\"},{line,390}]},{supervisor,children_map,4,[{file,\"supervisor.erl\"},{line,1275}]},{supervisor,init_children,2,[{file,\"supervisor.erl\"},{line,350}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,980}]}]" 
770 when=2024-12-12T18:43:16.433961+00:00 level=warning what=long_task_progress pid=<0.53152.0> at=cets_long:monitor_loop/5:116 time_ms=5000 caller_pid=<0.53151.0> task=mongoose_start_node_id_init current_stacktrace="[{erpc,call,5,[{file,\"erpc.erl\"},{line,146}]},{rpc,call,5,[{file,\"rpc.erl\"},{line,401}]},{mongoose_start_node_id,do_register_on_remote_node,2,[{file,\"/home/circleci/project/src/mongoose_start_node_id.erl\"},{line,106}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{mongoose_start_node_id,'-do_init/0-lc$^0/1-0-',2,[{file,\"/home/circleci/project/src/mongoose_start_node_id.erl\"},{line,50}]},{mongoose_start_node_id,do_init,0,[{file,\"/home/circleci/project/src/mongoose_start_node_id.erl\"},{line,51}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,980}]}]" 
771 when=2024-12-12T18:43:16.435936+00:00 level=warning what=long_task_progress pid=<0.53157.0> at=cets_long:monitor_loop/5:116 start_id=52480a0b94f48ad3 time_ms=5000 caller_pid=<0.53151.0> task=register_on_remote_node remote_node=mongooseim3@localhost current_stacktrace="[{erpc,call,5,[{file,\"erpc.erl\"},{line,146}]},{rpc,call,5,[{file,\"rpc.erl\"},{line,401}]},{mongoose_start_node_id,do_register_on_remote_node,2,[{file,\"/home/circleci/project/src/mongoose_start_node_id.erl\"},{line,106}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{mongoose_start_node_id,'-do_init/0-lc$^0/1-0-',2,[{file,\"/home/circleci/project/src/mongoose_start_node_id.erl\"},{line,50}]},{mongoose_start_node_id,do_init,0,[{file,\"/home/circleci/project/src/mongoose_start_node_id.erl\"},{line,51}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,980}]}]" 
772 when=2024-12-12T18:43:21.119974+00:00 level=warning what=long_task_progress pid=<0.53066.0> at=cets_long:monitor_loop/5:116 time_ms=10002 caller_pid=<0.53065.0> task=start_mongooseim current_stacktrace="[{proc_lib,sync_start,2,[{file,\"proc_lib.erl\"},{line,309}]},{ejabberd_app,do_start,0,[{file,\"/home/circleci/project/src/ejabberd_app.erl\"},{line,68}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{ejabberd_app,start,2,[{file,\"/home/circleci/project/src/ejabberd_app.erl\"},{line,46}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,293}]}]" 
773 when=2024-12-12T18:43:21.435013+00:00 level=warning what=long_task_progress pid=<0.53150.0> at=cets_long:monitor_loop/5:116 child_module=mongoose_start_node_id time_ms=10001 caller_pid=<0.53146.0> task=start_linked_child current_stacktrace="[{proc_lib,sync_start,2,[{file,\"proc_lib.erl\"},{line,309}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{supervisor,do_start_child_i,3,[{file,\"supervisor.erl\"},{line,420}]},{supervisor,do_start_child,2,[{file,\"supervisor.erl\"},{line,406}]},{supervisor,'-start_children/2-fun-0-',3,[{file,\"supervisor.erl\"},{line,390}]},{supervisor,children_map,4,[{file,\"supervisor.erl\"},{line,1275}]},{supervisor,init_children,2,[{file,\"supervisor.erl\"},{line,350}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,980}]}]" 
774 when=2024-12-12T18:43:21.434982+00:00 level=warning what=long_task_progress pid=<0.53152.0> at=cets_long:monitor_loop/5:116 time_ms=10001 caller_pid=<0.53151.0> task=mongoose_start_node_id_init current_stacktrace="[{erpc,call,5,[{file,\"erpc.erl\"},{line,146}]},{rpc,call,5,[{file,\"rpc.erl\"},{line,401}]},{mongoose_start_node_id,do_register_on_remote_node,2,[{file,\"/home/circleci/project/src/mongoose_start_node_id.erl\"},{line,106}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{mongoose_start_node_id,'-do_init/0-lc$^0/1-0-',2,[{file,\"/home/circleci/project/src/mongoose_start_node_id.erl\"},{line,50}]},{mongoose_start_node_id,do_init,0,[{file,\"/home/circleci/project/src/mongoose_start_node_id.erl\"},{line,51}]},{cets_long,run_tracked,2,[{file,\"/home/circleci/project/_build/default/lib/cets/src/cets_long.erl\"},{line,61}]},{gen_server,init_it,2,[{file,\"gen_server.erl\"},{line,980}]}]" 
775 when=2024-12-12T18:43:21.436166+00:00 level=error what=node_id_register_on_remote_node_failed reason={badrpc,timeout} pid=<0.53151.0> at=mongoose_start_node_id:do_register_on_remote_node/2:112 remote_node=mongooseim3@localhost 
```

 By the way, we cannot do this operation async, otherwise IQ related test would start failing.
 
 Guessing: this should not happen. The caller should receive `nodedown` on their monitor eventually and stop waiting for a call. Still, it waits for a call.
 Nothing particular interesting in logs, sometimes there is MIM-2354 (Avoid noproc error in mongoose_epmd if CETS is not configured) bug in logs.
 
 Could it be related to CETS and mongoose_epmd? Could it be stuck schedulers?
 Ideally we need a better logging based on heart to report non-responding nodes into logs. And start/**stop** times for each node.
 We can also have heartbeat for distributed connections to ensure they actually work and if not - log something.
 
 **Bug 3 - starting wpool manager times out - default is 5 seconds**
 
 CI task [1](https://circleci.com/gh/esl/MongooseIM/249717)
 
 Error on MIM side:
 ```
 {task_failed,{timeout,{gen_server,call,[mongoose_wpool_rdbms_mgr,{start_pool,global,default,[{worke
 ```

Error on CT side: 
 ```
 vcard_SUITE:init_per_suite
{fail,[{validate_node_failed,mongooseim_not_running,mongooseim2@localhost}]}
```

Logs [link](https://esl.github.io/html-zip-reader/PR/4430/249717/odbc_mssql_mnesia.27.1.2-amd64/big.tar.gz//ct_run.test@10d7c0e9e673.2024-12-12_15.29.40/mongooseim2@localhost.log.html#L30):
 ```
 958 when=2024-12-12T15:47:57.547520+00:00 level=error what=task_failed reason="{timeout,{gen_server,call,[mongoose_wpool_rdbms_mgr,{start_pool,global,default,[{workers,5}],#{driver => odbc,settings => \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\",query_timeout => 5000,max_start_interval => 30}}]}}" pid=<0.67166.0> at=cets_long:run_tracked/2:75 stacktrace="gen_server:call/2:1142 mongoose_wpool:start/7:164 mongoose_wpool:'-start_configured_pools/3-lc$^1/1-1-'/1:123 ejabberd_app:do_start/0:72 cets_long:run_tracked/2:61 ejabberd_app:start/2:46 application_master:start_it_old/4:295" long_ref=#Ref<0.687671701.3611295747.178154> caller_pid=<0.67166.0> task=start_mongooseim 
959 when=2024-12-12T15:47:57.547909+00:00 level=critical what=app_failed_to_start reason="{task_failed,{timeout,{gen_server,call,[mongoose_wpool_rdbms_mgr,{start_pool,global,default,[{workers,5}],#{driver => odbc,settings => \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\",query_timeout => 5000,max_start_interval => 30}}]}},#{task => start_mongooseim}}" pid=<0.67166.0> at=ejabberd_app:start/2:50 stacktrace="gen_server:call/2:1142 mongoose_wpool:start/7:164 mongoose_wpool:'-start_configured_pools/3-lc$^1/1-1-'/1:123 ejabberd_app:do_start/0:72 cets_long:run_tracked/2:61 ejabberd_app:start/2:46 application_master:start_it_old/4:295" 
960 when=2024-12-12T15:47:57.550290+00:00 level=error pid=<0.67246.0> at=supervisor:handle_info/2:1165 unstructured_log="Supervisor received unexpected message: {'ETS-TRANSFER',prepared_statements,\
961                                          <0.67166.0>,testing}\
962 " 
```

Solution: increase timeout to 30 seconds.