### PR TITLE
Fix --rerun-big-tests not working with cth_validate_nodes

### DIFF
--- a/test/common/distributed_helper.erl
+++ b/test/common/distributed_helper.erl
@@ -231,7 +231,7 @@ get_node_keys() ->
             [NodeKey || {NodeKey, _Opts} <- ct:get_config(hosts)];
         EnvValue -> %% EnvValue examples are "mim" or "mim mim2"
             BinHosts = binary:split(iolist_to_binary(EnvValue), <<" ">>, [global]),
-            [binary_to_atom(Node, utf8) || Node <- BinHosts]
+            [binary_to_atom(Node, utf8) || Node <- BinHosts, Node =/= <<>>]
     end.
 
 validate_node(NodeKey) ->

--- a/tools/test-runner.sh
+++ b/tools/test-runner.sh
@@ -116,11 +116,11 @@ Script examples:
     Sets dev-nodes and test-hosts to empty lists
     Reruns mam_SUITE
 
-./tools/test-runner.sh --skip-small-tests --skip-start-nodes --skip-validate-nodes -- connect
-    Continues test execution even if MongooseIM is not running on all nodes
-
 ./tools/test-runner.sh --rerun-big-tests -- mam
     The same command as above
+
+./tools/test-runner.sh --skip-small-tests --skip-start-nodes --skip-validate-nodes -- connect
+    Continues test execution even if MongooseIM is not running on all nodes
 
 ./tools/test-runner.sh --help --examples --colors | more
     Display help using "more" command


### PR DESCRIPTION
This PR addresses "fixes after MIM-2329".

Proposed changes include:
* Fix in examples (wrong order)
* Properly parse `TEST_HOSTS=""`, used in `--rerun-big-tests`.

Fixes:
```
*** CT 2024-12-12 12:53:32.459 *** Suite Hook
[🔗](file:///Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/ct_report/ct_run.test@MikhailU.2024-12-12_12.53.31/big_tests.tests.private_SUITE.logs/run.2024-12-12_12.53.32/private_suite.init_per_suite.html#e-1)

Call to CTH failed: error:{{undefined,{hosts,'',node}},
                           [{distributed_helper,get_or_fail,1,
                                [{file,
                                     "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/../test/common/distributed_helper.erl"},
                                 {line,189}]},
                            {distributed_helper,rpc_spec,1,
                                [{file,
                                     "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/../test/common/distributed_helper.erl"},
                                 {line,185}]},
                            {distributed_helper,validate_node,1,
                                [{file,
                                     "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/../test/common/distributed_helper.erl"},
                                 {line,238}]},
                            {distributed_helper,
                                '-validate_nodes/1-lc$^0/1-0-',1,
                                [{file,
                                     "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/../test/common/distributed_helper.erl"},
                                 {line,214}]},
                            {distributed_helper,validate_nodes,1,
                                [{file,
                                     "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/../test/common/distributed_helper.erl"},
                                 {line,214}]},
                            {cth_validate_nodes,pre_init_per_suite,3,
                                [{file,
                                     "/Users/mikhailuvarov/erlang/esl/MongooseIM/big_tests/src/cth_validate_nodes.erl"},
                                 {line,22}]},
                            {ct_hooks,catch_apply,3,
                                [{file,"ct_hooks.erl"},{line,491}]},
                            {ct_hooks,do_call_generic,4,
                                [{file,"ct_hooks.erl"},{line,247}]}]}
```
