### PR TITLE
Update cth_surefire to report errors in end_per_testcase

### DIFF
--- a/big_tests/src/cth_surefire.erl
+++ b/big_tests/src/cth_surefire.erl
@@ -208,6 +208,8 @@ pre_init_per_testcase(_Suite,_TC,Config,State) ->
 
 post_end_per_testcase(Suite,TC,Config,Result,Proxy) when is_pid(Proxy) ->
     {gen_server:call(Proxy,{?FUNCTION_NAME, [Suite, TC, Config, Result]}),Proxy};
+post_end_per_testcase(Suite, TC, Config, {failed, _} = Result, State) ->
+    {Result, do_tc_fail(Suite, Result, end_tc(TC, Config, Result, State))};
 post_end_per_testcase(_Suite,TC,Config,Result,State) ->
     {Result, end_tc(TC,Config, Result,State)}.
 
@@ -574,7 +576,7 @@ test_report(Group) ->
      {<<"skipped_tc">>, Group, skipped},
      {<<"failing_tc_1">>, Group, failed},
      {<<"failing_tc_2">>, Group, failed}, % init_per_testcase failed
-     {<<"failing_tc_3">>, Group, ok} % end_per_testcase failed, still ok
+     {<<"failing_tc_3">>, Group, failed} % end_per_testcase failed
     ].
 
 wrap_nested_group_report(Report) ->


### PR DESCRIPTION
Since the CI build fails if there is any fail in `end_per_testcase`, our `cth_surefire` plugin generating the report should behave the same way.

I ran the unit test manually to confirm that the change is working correctly:
```
big_tests $ rebar3 eunit -m cth_surefire -v
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling mongoose_tests
===> Performing EUnit tests...
======================== EUnit ========================
module 'cth_surefire'
  cth_surefire: report_test...[1.908 s] ok
  cth_surefire: report_skipped_group_test...[1.698 s] ok
  cth_surefire: report_two_groups_test...[1.906 s] ok
  cth_surefire: report_skipped_suite_test...[1.679 s] ok
  [done in 7.203 s]
=======================================================
  All 4 tests passed.
```
