### PR TITLE
Do not persist credentials on GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: erlef/setup-beam@v1.16.0
         with:
           otp-version: ${{ matrix.otp }}
@@ -82,6 +83,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/big-tests
         with:
           otp: ${{matrix.otp}}
@@ -112,6 +114,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/big-tests
         with:
           otp: ${{matrix.otp}}
@@ -146,6 +149,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: erlef/setup-beam@v1.16.0
         with:
           otp-version: ${{matrix.otp}}
@@ -162,6 +166,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: erlef/setup-beam@v1.16.0
         with:
           otp-version: ${{matrix.otp}}
@@ -178,6 +183,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: erlef/setup-beam@v1.16.0
         with:
           otp-version: ${{matrix.otp}}
@@ -200,4 +206,5 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - run: tools/test.sh -p pkg


### PR DESCRIPTION
I ran a GH Actions safety checker called [Zizmor](https://woodruffw.github.io/zizmor/), which suggested that the "persist-credentials" option should be set to "false", so that git auth tokens cannot be leaked. The full rationale: https://woodruffw.github.io/zizmor/audits/#artipacked. It is not a big issue for us, as we don't upload artifacts from GH Actions, but using this option should add a bit of safety anyway.

Manually run GH Actions to see if the change doesn't break anything: https://github.com/esl/MongooseIM/actions/runs/12299291228
