### PR TITLE
Fix "no such file or directory" on startup

### DIFF
--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -17,9 +17,7 @@ export EJABBERD_PID_PATH="$EJABBERD_PID_PATH"
 EJABBERD_STATUS_PATH="{{mongooseim_status_dir}}/status"
 export EJABBERD_STATUS_PATH="$EJABBERD_STATUS_PATH"
 
-EJABBERD_SO_PATH=`ls -dt "$RUNNER_BASE_DIR"/lib/mongooseim-*/priv/lib | head -1`
 EJABBERD_CONFIG_PATH=${EJABBERD_CONFIG_PATH:-$RUNNER_ETC_DIR/mongooseim.${MONGOOSEIM_CONFIG_FORMAT:-toml}}
-export EJABBERD_SO_PATH
 export EJABBERD_CONFIG_PATH
 
 # Make sure this script is running as the appropriate user


### PR DESCRIPTION
Running this on 30e119170dd2d4b1ac44e2ea9279608826af0548 (a version of master that passes), shows that under
`_build/mim1/rel/mongooseim/lib/mongooseim-*/priv/lib` it is expected to find the `.so` objects of the recently removed native code files. This is explored when the env-var removed in this commit is attempted to be expanded. This was used until 087452273720d1f87186fda456c7e23d849c0e44 when it was removed.

This PR addresses MIM-2353.
