### PR TITLE
Adding support 'open_test_database_shell' for CockroachDB

### DIFF
--- a/tools/open-test-database-shell.sh
+++ b/tools/open-test-database-shell.sh
@@ -11,6 +11,9 @@ case $db in
     pgsql)
         $DOCKER exec -e PGPASSWORD=password -it mongooseim-pgsql psql -U postgres -d mongooseim -h 127.0.0.1
     ;;
+    cockroachdb)
+       $DOCKER exec -it mongooseim-cockroachdb cockroach sql --certs-dir=/cockroach/certs --host=127.0.0.1 --user=mongooseim
+    ;;
     mssql-sqlcmd)
         $DOCKER exec -it mongooseim-mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P mongooseim_secret+ESL123 -d mongooseim
     ;;


### PR DESCRIPTION
Updated the open-test-database-shell.sh script to include a shell command for accessing CockroachDB's shell within a running Docker container.

When running tests with the cockroachdb_cets preset, the latest OpenSSL version causes issues with certificates.
Temporary Workaround: Downgrade OpenSSL to version 3.0 to avoid these issues until a permanent fix is implemented.