### PR TITLE
Fix `probe_failed` error

### DIFF
--- a/src/wpool/mongoose_wpool_rdbms.erl
+++ b/src/wpool/mongoose_wpool_rdbms.erl
@@ -139,13 +139,14 @@ merge_stats_fun(send_max, V1, V2) ->
 merge_stats_fun(_, V1, V2) ->
     V1 + V2.
 
+-spec inet_stats(inet:port_number() | undefined) -> [{inet:stat_option(), integer()}].
 inet_stats(Port) ->
     try
         {ok, Stats} = inet:getstat(Port, inet_stats()),
         Stats
     catch C:R:S ->
         ?LOG_INFO(#{what => inet_stats_failed, class => C, reason => R, stacktrace => S}),
-        empty_inet_stats_measurements()
+        []
     end.
 
 inet_stats() ->


### PR DESCRIPTION
Sometimes, `mongoose_wpool_rdbms:inet_stats()` may fail, for example when the socket is closing. This is why it's surrounded in a `try...catch`. The stats are processed with the `merge_stats/1` function, and it expects them to be proplists, as returned from `inet:getstat/2`, not a map.

Before this fix, there would be a loud error in the logs, when the failure occured:
```
when=2024-12-16T11:36:49.894423+00:00 level=error what=probe_failed reason=badarg pid=<0.3480.0> at=safely:apply_and_log/4:58 stacktrace="maps:from_list/1:0 mongoose_wpool_rdbms:'-merge_stats/1-fun-0-'/2:129 lists:foldl/3:2146 mongoose_wpool_rdbms:get_rdbms_data_stats/2:69 safely:apply_and_log/4:58 mongoose_instrument_probe:call/3:20" probe_mod=mongoose_wpool_rdbms event_name=wpool_global_rdbms_stats labels_pool_tag=default stacktrace_args="[#{send_pend => 0,recv_cnt => 0,recv_max => 0,recv_oct => 0,send_cnt => 0,\
   send_max => 0,send_oct => 0}]"
```
With the fix, and with `info` loglevel enabled, only the expected log message is printed:
```
when=2024-12-16T12:21:53.187785+00:00 level=info what=inet_stats_failed reason=function_clause pid=<0.68061.0> at=mongoose_wpool_rdbms:inet_stats/1:147 stacktrace="prim_inet:getstat/2:0 mongoose_wpool_rdbms:inet_stats/1:144 mongoose_wpool_rdbms:'-get_rdbms_data_stats/2-lc$^3/1-3-'/1:67 mongoose_wpool_rdbms:get_rdbms_data_stats/2:67 safely:apply_and_log/4:58 mongoose_instrument_probe:call/3:20" stacktrace_args=[undefined,[recv_oct,recv_cnt,recv_max,send_oct,send_max,send_cnt,send_pend]] 
```
