### PR TITLE
Don't restart mongooseim as temporary

### DIFF
--- a/src/mongoose_cluster.erl
+++ b/src/mongoose_cluster.erl
@@ -218,7 +218,7 @@ with_app_stopped(App, F) ->
     try
         F()
     after
-        Running andalso application:start(App)
+        Running andalso application:start(App, permanent)
     end.
 
 node_trans(F) ->


### PR DESCRIPTION
It is started as a permanent app, and should stay this way to ensure that the node does not remain running without the app.

