### PR TITLE
Fix dynamic domains preset failing

### DIFF
--- a/big_tests/tests/domain_helper.erl
+++ b/big_tests/tests/domain_helper.erl
@@ -75,7 +75,11 @@ delete_domain_password(Node, Domain) ->
     {ok, _} = rpc(Node, mongoose_domain_api, delete_domain_password, [Domain]).
 
 for_each_configured_domain(F) ->
-    [for_each_configured_domain(F, Opts) || {_, Opts} <- ct:get_config(hosts)],
+    %% Skip nodes not specified in `--test-hosts'
+    Keys = distributed_helper:get_node_keys(),
+    [for_each_configured_domain(F, Opts)
+     || {Key, Opts} <- ct:get_config(hosts),
+        lists:member(Key, Keys)],
     ok.
 
 for_each_configured_domain(F, Opts) ->

--- a/test/common/distributed_helper.erl
+++ b/test/common/distributed_helper.erl
@@ -226,12 +226,15 @@ wait_for_nodes_to_start(NodeKeys) ->
                              name => wait_for_nodes_to_start}).
 
 get_node_keys() ->
+    Keys = [NodeKey || {NodeKey, _Opts} <- ct:get_config(hosts)],
     case os:getenv("TEST_HOSTS") of
         false ->
-            [NodeKey || {NodeKey, _Opts} <- ct:get_config(hosts)];
+            Keys;
         EnvValue -> %% EnvValue examples are "mim" or "mim mim2"
             BinHosts = binary:split(iolist_to_binary(EnvValue), <<" ">>, [global]),
-            [binary_to_atom(Node, utf8) || Node <- BinHosts, Node =/= <<>>]
+            EnvKeys = [binary_to_atom(Node, utf8) || Node <- BinHosts, Node =/= <<>>],
+            %% Check only configured nodes (through test.config)
+            [Key || Key <- EnvKeys, lists:member(Key, Keys)]
     end.
 
 validate_node(NodeKey) ->


### PR DESCRIPTION
This PR addresses a couple of bugs in MIM-2368:

```
commit 424fb5b4bfd748084bec2f61b588fc105db8a930 (HEAD -> fix-dyn-domains-test-runner, origin/fix-dyn-domains-test-runner)
Author: Mikhail Uvarov <arcusfelis@gmail.com>
Date:   Thu Dec 19 10:18:46 2024 +0100

    Skip service_domain_db:force_check_for_updates/0 for nodes which are not passed inside `--test-hosts`

    Fixes
    ./tools/test-runner.sh --preset pgsql_cets --db pgsql --skip-cover --skip-small-tests --spec dynamic_domains.spec --one-node

    Failed to start a CTH: error:{{badrpc,nodedown},
                                  [{distributed_helper,rpc,
                                    [#{node => mongooseim2@localhost},
                                     service_domain_db,force_check_for_updates,[]],
                                    [{file,
                                      "big_tests/../test/common/distributed_helper.erl"},
                                     {line,140}]},
                                   {domain_helper,for_each_configured_domain,2,
                                    [{file,"domain_helper.erl"},{line,89}]},
                                   {domain_helper,
                                    '-for_each_configured_domain/1-lc$^0/1-0-',2,
                                    [{file,"domain_helper.erl"},{line,78}]},
                                   {domain_helper,for_each_configured_domain,1,
                                    [{file,"domain_helper.erl"},{line,78}]},
                                   {ct_mongoose_hook,init,2,
                                    [{file,
                                      "big_tests/src/ct_mongoose_hook.erl"},
                                     {line,40}]},

commit 712a5043302720ac7414e85d326240d0dbbfbedb
Author: Mikhail Uvarov <arcusfelis@gmail.com>
Date:   Thu Dec 19 10:00:15 2024 +0100

    Only check configured nodes in cth_validate_nodes

    Fixes {undefined,{hosts,reg,node}} in
    ./tools/test-runner.sh --preset pgsql_cets --db pgsql --skip-cover --skip-small-tests --spec dynamic_domains.spec
```

Proposed changes include:
* Don't call mim2 if not required, don't call reg from dynamic tests
(TODO investigate if we should build `reg` for dynamic tests at all

