### PR TITLE
Publish packages on GitHub

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -715,6 +715,7 @@ jobs:
       - run:
           name: Publish package
           command: |
+            if [ -n "${CIRCLE_TAG}" ]; then tools/circle-install-packages.sh gh; fi
             ./tools/pkg/publish.sh
 
 filters:

--- a/tools/pkg/publish.sh
+++ b/tools/pkg/publish.sh
@@ -20,6 +20,9 @@ aws configure set default.region $AWS_DEFAULT_REGION
 
 if [ -n "$CIRCLE_TAG" ]; then
     aws s3 cp "${PACKAGE_NAME}" "s3://mim-packages/tags/${CIRCLE_TAG}/${PACKAGE_NAME}" --acl public-read --quiet
+
+    echo "$GH_RELEASE_TOKEN" | gh auth login --with-token
+    gh release upload "${CIRCLE_TAG}" "${PACKAGE_NAME}" --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
 else
     aws s3 cp "${PACKAGE_NAME}" "s3://mim-packages/branches/${CIRCLE_BRANCH}/${prefix}/${PACKAGE_NAME}" --acl public-read --quiet
 fi


### PR DESCRIPTION
This pull request updates the script to also publish built packages as release assets for tags.

The changes were tested with a test release and confirmed to work as expected.

CircleCI workflow: [here](https://app.circleci.com/pipelines/github/esl/MongooseIM/13533/workflows/715c75df-2400-46d6-b9f8-807573f367c2)

Test release on GH:
![test_release](https://github.com/user-attachments/assets/1cab9720-0b27-4406-9ac8-7d9c314da06a)