### PR TITLE
Fix the description of log handler migration

### DIFF
--- a/doc/migrations/6.3.0_6.3.1.md
+++ b/doc/migrations/6.3.0_6.3.1.md
@@ -1,6 +1,7 @@
 ## Log Handler Configuration
 
-The shell log handler in `app.config` should be named either "default" to enable shell logs or "none" to suppress them.
+The shell log handler in `app.config` should be renamed from `shell_log` to `default`.
+Otherwise, there would be duplicate logs in the shell because of the [lager removal](https://github.com/esl/MongooseIM/pull/4393).
 
 ## CA Certificate Configuration
 


### PR DESCRIPTION
Setting the name to "none" would make no sense.
It is the log level that should be changed to "none", but this didn't change in the release, so there is no need to describe it.
