### PR TITLE
Generate package links

### DIFF
--- a/tools/pkg/publish.sh
+++ b/tools/pkg/publish.sh
@@ -18,11 +18,23 @@ aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
 aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
 aws configure set default.region $AWS_DEFAULT_REGION
 
+generate_link() {
+    local type=$1
+    local identifier=$2
+    local package_name=$3
+    local link_package_name=$(echo "$package_name" | sed 's/^mongooseim/mim/')
+    echo "Package link: https://esl.github.io/circleci-mim-results/s3_packages.html?prefix=${type}/${identifier}/${link_package_name}"
+}
+
 if [ -n "$CIRCLE_TAG" ]; then
     aws s3 cp "${PACKAGE_NAME}" "s3://mim-packages/tags/${CIRCLE_TAG}/${PACKAGE_NAME}" --acl public-read --quiet
 
     echo "$GH_RELEASE_TOKEN" | gh auth login --with-token
     gh release upload "${CIRCLE_TAG}" "${PACKAGE_NAME}" --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+
+    generate_link "tags" "$CIRCLE_TAG" "$PACKAGE_NAME"
 else
     aws s3 cp "${PACKAGE_NAME}" "s3://mim-packages/branches/${CIRCLE_BRANCH}/${prefix}/${PACKAGE_NAME}" --acl public-read --quiet
+
+    generate_link "branches" "$CIRCLE_BRANCH/$prefix" "$PACKAGE_NAME"
 fi


### PR DESCRIPTION
This PR adds a link to the published package after it is built, making it easy to access.

**How to test:**
1. Go to [this CircleCI pipeline](https://app.circleci.com/pipelines/github/esl/MongooseIM/13614/workflows/75dff9e0-b772-4fe2-ab13-063c67f261fc).
2. Click on any package job.
3. Check the "Publish package" step for the link.