### PR TITLE
Listeners/unification

### DIFF
--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -49,6 +49,15 @@ The protocol, which is TCP by default. Currently this is the only valid option.
 
 Allows to set the IP version to IPv6. Does not need to be set if `ip_address` is defined.
 
+### `listen.*.hibernate_after`
+* **Syntax:** non-negative integer or the string `"infinity"`
+* **Default:** `0`
+* **Example:** `hibernate_after = 10`
+
+Time in milliseconds after which a client process spawned by this listener will hibernate.
+Hibernation greatly reduces memory consumption of client processes, but *may* result in increased CPU consumption if a client is used *very* frequently.
+The default, recommended value of 0 means that the client processes will hibernate at every opportunity.
+
 ## XMPP listener options
 
 The options listed below can be set for the `c2s`, `s2s` and `component` listeners to adjust their parameters.
@@ -66,15 +75,6 @@ Overrides the default TCP backlog value.
 * **Example:** `proxy_protocol = true`
 
 When set to `true`, [Proxy Protocol](https://www.haproxy.com/blog/haproxy/proxy-protocol/) is enabled and each connecting client has to provide a proxy header. Use only with a proxy (or a load balancer) to allow it to provide the connection details (including the source IP address) of the original client. Versions 1 and 2 of the protocol are supported.
-
-### `listen.*.hibernate_after`
-* **Syntax:** non-negative integer or the string `"infinity"`
-* **Default:** `0`
-* **Example:** `hibernate_after = 10`
-
-Time in milliseconds after which a client process spawned by this listener will hibernate.
-Hibernation greatly reduces memory consumption of client processes, but *may* result in increased CPU consumption if a client is used *very* frequently.
-The default, recommended value of 0 means that the client processes will hibernate at every opportunity.
 
 ### `listen.*.max_stanza_size`
 * **Syntax:** positive integer or the string `"infinity"`

--- a/doc/listeners/listen-http.md
+++ b/doc/listeners/listen-http.md
@@ -82,7 +82,7 @@ Maximum allowed incoming stanza size in bytes.
 !!! Warning
     This limit is checked **after** the input data parsing, so it does not apply to the input data size itself.
 
-### `listen.http.handlers.mod_websockets.c2s_state_timeout`
+### `listen.http.handlers.mod_websockets.state_timeout`
 
 Same as the [C2S option](listen-c2s.md#listenc2sstate_timeout).
 

--- a/src/c2s/mongoose_c2s_listener.erl
+++ b/src/c2s/mongoose_c2s_listener.erl
@@ -58,7 +58,7 @@ start_listener(#{module := ?MODULE} = Opts) ->
 handle_user_open_session(Acc, #{c2s_data := StateData},
                          #{host_type := HostType, listener_id := ListenerId}) ->
     ListenerOpts = mongoose_c2s:get_listener_opts(StateData),
-    case mongoose_listener_config:listener_id(ListenerOpts) of
+    case mongoose_listener:listener_id(ListenerOpts) of
         ListenerId ->
             Jid = mongoose_c2s:get_jid(StateData),
             LServer = mongoose_c2s:get_lserver(StateData),

--- a/src/c2s/mongoose_c2s_listener.erl
+++ b/src/c2s/mongoose_c2s_listener.erl
@@ -41,14 +41,8 @@ instrumentation(HostType, Acc) when is_binary(HostType) ->
 %% mongoose_listener
 -spec start_listener(mongoose_listener:options()) -> {ok, supervisor:child_spec()}.
 start_listener(Opts) ->
-    HostTypes = ?ALL_HOST_TYPES,
-    TransportOpts = mongoose_listener:prepare_socket_opts(Opts),
-    ListenerId = mongoose_listener_config:listener_id(Opts),
-    maybe_add_access_check(HostTypes, Opts, ListenerId),
-    ChildSpec = ranch:child_spec(ListenerId, ranch_tcp, TransportOpts, ?MODULE, Opts),
-    ChildSpec1 = ChildSpec#{id := ListenerId, modules => [?MODULE, ranch_embedded_sup]},
     maybe_add_access_check_hooks(Opts),
-    {ok, ChildSpec1}.
+    {ok, mongoose_listener:child_spec(Opts)}.
 
 %% ranch_protocol
 -spec start_link(ranch:ref(), mongoose_listener:transport_module(), mongoose_listener:options()) ->

--- a/src/c2s/mongoose_c2s_listener.erl
+++ b/src/c2s/mongoose_c2s_listener.erl
@@ -49,7 +49,7 @@ start_listener(Opts) ->
     {ok, pid()}.
 start_link(Ref, Transport, Opts = #{hibernate_after := HibernateAfterTimeout}) ->
     ProcessOpts = [{hibernate_after, HibernateAfterTimeout}],
-    mongoose_c2s:start_link({mongoose_c2s_ranch, {Transport, Ref}, Opts}, ProcessOpts).
+    mongoose_c2s:start_link({mongoose_c2s_ranch, Ref, Transport, Opts}, ProcessOpts).
 
 %% Hooks and handlers
 -spec maybe_add_access_check_hooks(mongoose_listener:options()) -> ok.

--- a/src/c2s/mongoose_c2s_listener.erl
+++ b/src/c2s/mongoose_c2s_listener.erl
@@ -14,9 +14,6 @@
 -export([instrumentation/0]).
 -ignore_xref([instrumentation/0]).
 
--type options() :: #{module := ?MODULE,
-                     atom() => any()}.
-
 -spec instrumentation(_) -> [mongoose_instrument:spec()].
 instrumentation(_) ->
     lists:foldl(fun instrumentation/2, instrumentation(), ?ALL_HOST_TYPES).
@@ -42,17 +39,35 @@ instrumentation(HostType, Acc) when is_binary(HostType) ->
       #{metrics => maps:from_list([{Metric, spiral} || Metric <- mongoose_listener:element_spirals()])}} | Acc].
 
 %% mongoose_listener
--spec start_listener(options()) -> ok.
-start_listener(#{module := ?MODULE} = Opts) ->
+-spec start_listener(mongoose_listener:options()) -> {ok, supervisor:child_spec()}.
+start_listener(Opts) ->
     HostTypes = ?ALL_HOST_TYPES,
     TransportOpts = mongoose_listener:prepare_socket_opts(Opts),
     ListenerId = mongoose_listener_config:listener_id(Opts),
     maybe_add_access_check(HostTypes, Opts, ListenerId),
     ChildSpec = ranch:child_spec(ListenerId, ranch_tcp, TransportOpts, ?MODULE, Opts),
     ChildSpec1 = ChildSpec#{id := ListenerId, modules => [?MODULE, ranch_embedded_sup]},
-    mongoose_listener_sup:start_child(ChildSpec1).
+    maybe_add_access_check_hooks(Opts),
+    {ok, ChildSpec1}.
+
+%% ranch_protocol
+-spec start_link(ranch:ref(), mongoose_listener:transport_module(), mongoose_listener:options()) ->
+    {ok, pid()}.
+start_link(Ref, Transport, Opts = #{hibernate_after := HibernateAfterTimeout}) ->
+    ProcessOpts = [{hibernate_after, HibernateAfterTimeout}],
+    mongoose_c2s:start_link({mongoose_c2s_ranch, {Transport, Ref}, Opts}, ProcessOpts).
 
 %% Hooks and handlers
+-spec maybe_add_access_check_hooks(mongoose_listener:options()) -> ok.
+maybe_add_access_check_hooks(#{access := all}) ->
+    ok;
+maybe_add_access_check_hooks(Opts) ->
+    ListenerId = mongoose_listener:listener_id(Opts),
+    AclHooks = [ {user_open_session, HostType, fun ?MODULE:handle_user_open_session/3,
+                  #{listener_id => ListenerId}, 10}
+                 || HostType <- ?ALL_HOST_TYPES ],
+    gen_hook:add_handlers(AclHooks).
+
 -spec handle_user_open_session(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
     mongoose_c2s_hooks:result().
 handle_user_open_session(Acc, #{c2s_data := StateData},
@@ -75,18 +90,3 @@ handle_user_open_session(Acc, #{c2s_data := StateData},
         _Other ->
             {ok, Acc}
     end.
-
-%% ranch_protocol
--spec start_link(ranch:ref(), module(), mongoose_c2s:listener_opts()) -> {ok, pid()}.
-start_link(Ref, Transport, Opts = #{hibernate_after := HibernateAfterTimeout}) ->
-    ProcessOpts = [{hibernate_after, HibernateAfterTimeout}],
-    mongoose_c2s:start_link({mongoose_c2s_ranch, {Transport, Ref}, Opts}, ProcessOpts).
-
-%% supervisor
-maybe_add_access_check(_, #{access := all}, _) ->
-    ok;
-maybe_add_access_check(HostTypes, _, ListenerId) ->
-    AclHooks = [ {user_open_session, HostType, fun ?MODULE:handle_user_open_session/3,
-                  #{listener_id => ListenerId}, 10}
-                 || HostType <- HostTypes ],
-    gen_hook:add_handlers(AclHooks).

--- a/src/c2s/mongoose_c2s_listener.erl
+++ b/src/c2s/mongoose_c2s_listener.erl
@@ -3,7 +3,7 @@
 -include("mongoose.hrl").
 
 -behaviour(mongoose_listener).
--export([start_listener/1, instrumentation/1]).
+-export([listener_spec/1, instrumentation/1]).
 
 -behaviour(ranch_protocol).
 -export([start_link/3]).
@@ -39,10 +39,10 @@ instrumentation(HostType, Acc) when is_binary(HostType) ->
       #{metrics => maps:from_list([{Metric, spiral} || Metric <- mongoose_listener:element_spirals()])}} | Acc].
 
 %% mongoose_listener
--spec start_listener(mongoose_listener:options()) -> {ok, supervisor:child_spec()}.
-start_listener(Opts) ->
+-spec listener_spec(mongoose_listener:options()) -> supervisor:child_spec().
+listener_spec(Opts) ->
     maybe_add_access_check_hooks(Opts),
-    {ok, mongoose_listener:child_spec(Opts)}.
+    mongoose_listener:child_spec(Opts).
 
 %% ranch_protocol
 -spec start_link(ranch:ref(), mongoose_listener:transport_module(), mongoose_listener:options()) ->

--- a/src/c2s/mongoose_c2s_socket.erl
+++ b/src/c2s/mongoose_c2s_socket.erl
@@ -3,13 +3,13 @@
 -include_lib("public_key/include/public_key.hrl").
 -include("mongoose_logger.hrl").
 
--export([new/3,
+-export([new/4,
          handle_data/2,
          activate/1,
          close/1,
          is_channel_binding_supported/1,
          export_key_materials/5,
-         get_peer_certificate/2,
+         get_peer_certificate/1,
          has_peer_cert/2,
          tcp_to_tls/2,
          is_ssl/1,
@@ -19,9 +19,9 @@
          get_transport/1,
          get_conn_type/1]).
 
--callback socket_new(term(), mongoose_c2s:listener_opts()) -> state().
+-callback new(term(), term(), mongoose_listener:options()) -> state().
 -callback socket_peername(state()) -> {inet:ip_address(), inet:port_number()}.
--callback tcp_to_tls(state(), mongoose_c2s:listener_opts()) ->
+-callback tcp_to_tls(state(), mongoose_listener:options()) ->
     {ok, state()} | {error, term()}.
 -callback socket_handle_data(state(), {tcp | ssl, term(), iodata()}) ->
     iodata() | {raw, [exml:element()]} | {error, term()}.
@@ -29,8 +29,8 @@
 -callback socket_close(state()) -> ok.
 -callback socket_send_xml(state(), iodata() | exml_stream:element() | [exml_stream:element()]) ->
     ok | {error, term()}.
--callback get_peer_certificate(state(), mongoose_c2s:listener_opts()) -> peercert_return().
--callback has_peer_cert(state(), mongoose_c2s:listener_opts()) -> boolean().
+-callback get_peer_certificate(state()) -> peercert_return().
+-callback has_peer_cert(state(), mongoose_listener:options()) -> boolean().
 -callback is_channel_binding_supported(state()) -> boolean().
 -callback export_key_materials(state(), Labels, Contexts, WantedLengths, ConsumeSecret) ->
     {ok, ExportKeyMaterials} |
@@ -51,15 +51,16 @@
 -type peercert_return() :: no_peer_cert | {bad_cert, term()} | {ok, #'Certificate'{}}.
 -export_type([socket/0, state/0, conn_type/0, peercert_return/0]).
 
--spec new(module(), term(), mongoose_listener:options()) -> socket().
-new(Module, SocketOpts, LOpts) ->
-    State = Module:socket_new(SocketOpts, LOpts),
+-spec new(module(), ranch:ref(), mongoose_listener:transport_module(), mongoose_listener:options()) -> socket().
+new(Module, Ref, Transport, LOpts) ->
+    State = Module:new(Transport, Ref, LOpts),
     PeerIp = Module:socket_peername(State),
     verify_ip_is_not_blacklisted(PeerIp),
-    C2SSocket = #c2s_socket{
+    Socket = #c2s_socket{
         module = Module,
         state = State},
-    handle_socket_and_ssl_config(C2SSocket, LOpts).
+    activate(Socket),
+    Socket.
 
 verify_ip_is_not_blacklisted(PeerIp) ->
     case mongoose_hooks:check_bl_c2s(PeerIp) of
@@ -70,22 +71,6 @@ verify_ip_is_not_blacklisted(PeerIp) ->
         false ->
             ok
     end.
-
-handle_socket_and_ssl_config(C2SSocket, #{tls := #{mode := tls}} = LOpts) ->
-    case tcp_to_tls(C2SSocket, LOpts) of
-        {ok, TlsC2SSocket} ->
-            activate(TlsC2SSocket),
-            TlsC2SSocket;
-        {error, closed} ->
-            throw({stop, {shutdown, tls_closed}});
-        {error, timeout} ->
-            throw({stop, {shutdown, tls_timeout}});
-        {error, {tls_alert, TlsAlert}} ->
-            throw({stop, TlsAlert})
-    end;
-handle_socket_and_ssl_config(C2SSocket, _Opts) ->
-    activate(C2SSocket),
-    C2SSocket.
 
 -spec tcp_to_tls(socket(), mongoose_listener:options()) -> {ok, socket()} | {error, term()}.
 tcp_to_tls(#c2s_socket{module = Module, state = State} = C2SSocket, LOpts) ->
@@ -115,9 +100,9 @@ close(#c2s_socket{module = Module, state = State}) ->
 send_xml(#c2s_socket{module = Module, state = State}, XML) ->
     Module:socket_send_xml(State, XML).
 
--spec get_peer_certificate(socket(), mongoose_c2s:listener_opts()) -> peercert_return().
-get_peer_certificate(#c2s_socket{module = Module, state = State}, LOpts) ->
-    Module:get_peer_certificate(State, LOpts).
+-spec get_peer_certificate(socket()) -> peercert_return().
+get_peer_certificate(#c2s_socket{module = Module, state = State}) ->
+    Module:get_peer_certificate(State).
 
 -spec has_peer_cert(socket(), mongoose_listener:options()) -> boolean().
 has_peer_cert(#c2s_socket{module = Module, state = State}, LOpts) ->

--- a/src/component/mongoose_component_listener.erl
+++ b/src/component/mongoose_component_listener.erl
@@ -1,7 +1,7 @@
 -module(mongoose_component_listener).
 
 -behaviour(mongoose_listener).
--export([start_listener/1, instrumentation/1]).
+-export([listener_spec/1, instrumentation/1]).
 
 -behaviour(ranch_protocol).
 -export([start_link/3]).
@@ -22,9 +22,9 @@ instrumentation(_) ->
       #{metrics => maps:from_list([{Metric, spiral} || Metric <- mongoose_listener:element_spirals()])}}].
 
 %% mongoose_listener
--spec start_listener(mongoose_listener:options()) -> {ok, supervisor:child_spec()}.
-start_listener(Opts) ->
-    {ok, mongoose_listener:child_spec(Opts)}.
+-spec listener_spec(mongoose_listener:options()) -> supervisor:child_spec().
+listener_spec(Opts) ->
+    mongoose_listener:child_spec(Opts).
 
 %% ranch_protocol
 -spec start_link(ranch:ref(), mongoose_listener:transport_module(), mongoose_listener:options()) ->

--- a/src/component/mongoose_component_listener.erl
+++ b/src/component/mongoose_component_listener.erl
@@ -6,19 +6,6 @@
 -behaviour(ranch_protocol).
 -export([start_link/3]).
 
--type conflict_behaviour() :: disconnect | kick_old.
-
--type options() :: #{module := ?MODULE,
-                     access := atom(),
-                     shaper := atom(),
-                     password := binary(),
-                     check_from := boolean(),
-                     hidden_components := boolean(),
-                     conflict_behaviour := conflict_behaviour(),
-                     atom() => any()}.
-
--export_type([conflict_behaviour/0, options/0]).
-
 %% mongoose_listener
 -spec instrumentation(_) -> [mongoose_instrument:spec()].
 instrumentation(_) ->
@@ -35,13 +22,14 @@ instrumentation(_) ->
       #{metrics => maps:from_list([{Metric, spiral} || Metric <- mongoose_listener:element_spirals()])}}].
 
 %% mongoose_listener
--spec start_listener(options()) -> {ok, supervisor:child_spec()}.
+-spec start_listener(mongoose_listener:options()) -> {ok, supervisor:child_spec()}.
 start_listener(Opts) ->
     {ok, mongoose_listener:child_spec(Opts)}.
 
 %% ranch_protocol
--spec start_link(ranch:ref(), mongoose_listener:transport_module(), options()) ->
+-spec start_link(ranch:ref(), mongoose_listener:transport_module(), mongoose_listener:options()) ->
     {ok, pid()}.
 start_link(Ref, Transport, Opts = #{hibernate_after := HibernateAfterTimeout}) ->
     ProcessOpts = [{hibernate_after, HibernateAfterTimeout}],
-    mongoose_component_connection:start_link({mongoose_component_ranch, {Transport, Ref}, Opts}, ProcessOpts).
+    Params = {mongoose_component_ranch, Ref, Transport, Opts},
+    mongoose_component_connection:start_link(Params, ProcessOpts).

--- a/src/component/mongoose_component_ranch.erl
+++ b/src/component/mongoose_component_ranch.erl
@@ -13,13 +13,13 @@
 -record(ranch_tcp, {
           socket :: inet:socket(),
           ranch_ref :: ranch:ref(),
-          ip :: {inet:ip_address(), inet:port_number()}
+          ip :: mongoose_transport:peer()
          }).
 
 -record(ranch_ssl, {
           socket :: ssl:sslsocket(),
           ranch_ref :: ranch:ref(),
-          ip :: {inet:ip_address(), inet:port_number()}
+          ip :: mongoose_transport:peer()
          }).
 
 -type socket() :: #ranch_tcp{} | #ranch_ssl{}.
@@ -34,7 +34,7 @@ new(ranch_ssl, Ref, Opts) ->
     #{src_address := PeerIp, src_port := PeerPort} = ConnectionDetails,
     #ranch_ssl{socket = Socket, ranch_ref = Ref, ip = {PeerIp, PeerPort}}.
 
--spec peername(socket()) -> {inet:ip_address(), inet:port_number()}.
+-spec peername(socket()) -> mongoose_transport:peer().
 peername(#ranch_tcp{ip = Ip}) -> Ip;
 peername(#ranch_ssl{ip = Ip}) -> Ip.
 

--- a/src/component/mongoose_component_ranch.erl
+++ b/src/component/mongoose_component_ranch.erl
@@ -2,7 +2,7 @@
 
 -behaviour(mongoose_component_socket).
 
--export([new/2,
+-export([new/3,
          peername/1,
          handle_data/2,
          activate/1,
@@ -11,35 +11,28 @@
         ]).
 
 -record(ranch_tcp, {
-          ranch_ref :: ranch:ref(),
           socket :: inet:socket(),
+          ranch_ref :: ranch:ref(),
           ip :: {inet:ip_address(), inet:port_number()}
          }).
 
 -record(ranch_ssl, {
-          ranch_ref :: ranch:ref(),
           socket :: ssl:sslsocket(),
+          ranch_ref :: ranch:ref(),
           ip :: {inet:ip_address(), inet:port_number()}
          }).
 
 -type socket() :: #ranch_tcp{} | #ranch_ssl{}.
--type transport() :: ranch_tcp | ranch_ssl.
 
--spec new({transport(), ranch:ref()}, mongoose_listener:options()) -> socket().
-new({ranch_tcp, RanchRef}, _Opts) ->
-    {ok, Socket} = ranch:handshake(RanchRef),
-    {ok, Ip} = ranch_tcp:peername(Socket),
-    #ranch_tcp{
-       ranch_ref = RanchRef,
-       socket = Socket,
-       ip = Ip};
-new({ranch_ssl, RanchRef}, _Opts) ->
-    {ok, Socket} = ranch:handshake(RanchRef),
-    {ok, Ip} = ranch_ssl:peername(Socket),
-    #ranch_ssl{
-       ranch_ref = RanchRef,
-       socket = Socket,
-       ip = Ip}.
+-spec new(mongoose_listener:transport_module(), ranch:ref(), mongoose_listener:options()) -> socket().
+new(ranch_tcp, Ref, Opts) ->
+    {ok, Socket, ConnectionDetails} = mongoose_listener:read_connection_details(Ref, ranch_tcp, Opts),
+    #{src_address := PeerIp, src_port := PeerPort} = ConnectionDetails,
+    #ranch_tcp{socket = Socket, ranch_ref = Ref, ip = {PeerIp, PeerPort}};
+new(ranch_ssl, Ref, Opts) ->
+    {ok, Socket, ConnectionDetails} = mongoose_listener:read_connection_details(Ref, ranch_ssl, Opts),
+    #{src_address := PeerIp, src_port := PeerPort} = ConnectionDetails,
+    #ranch_ssl{socket = Socket, ranch_ref = Ref, ip = {PeerIp, PeerPort}}.
 
 -spec peername(socket()) -> {inet:ip_address(), inet:port_number()}.
 peername(#ranch_tcp{ip = Ip}) -> Ip;

--- a/src/component/mongoose_component_socket.erl
+++ b/src/component/mongoose_component_socket.erl
@@ -3,7 +3,7 @@
 -export([new/1, handle_data/2, activate/1, close/1, send_xml/2]).
 
 -callback new(mongoose_listener:transport_module(), ranch:ref(), mongoose_listener:options()) -> state().
--callback peername(state()) -> {inet:ip_address(), inet:port_number()}.
+-callback peername(state()) -> mongoose_transport:peer().
 -callback handle_data(state(), {tcp, term(), iodata()}) ->
     iodata() | {raw, [exml:element()]} | {error, term()}.
 -callback activate(state()) -> ok.

--- a/src/component/mongoose_component_socket.erl
+++ b/src/component/mongoose_component_socket.erl
@@ -1,8 +1,8 @@
 -module(mongoose_component_socket).
 
--export([new/3, handle_data/2, activate/1, close/1, send_xml/2]).
+-export([new/1, handle_data/2, activate/1, close/1, send_xml/2]).
 
--callback new(term(), mongoose_c2s:listener_opts()) -> state().
+-callback new(mongoose_listener:transport_module(), ranch:ref(), mongoose_listener:options()) -> state().
 -callback peername(state()) -> {inet:ip_address(), inet:port_number()}.
 -callback handle_data(state(), {tcp, term(), iodata()}) ->
     iodata() | {raw, [exml:element()]} | {error, term()}.
@@ -18,9 +18,9 @@
 -type conn_type() :: component.
 -export_type([socket/0, state/0, conn_type/0]).
 
--spec new(module(), term(), mongoose_listener:options()) -> socket().
-new(Module, SocketOpts, LOpts) ->
-    State = Module:new(SocketOpts, LOpts),
+-spec new(mongoose_listener:init_args()) -> socket().
+new({Module, Ref, Transport, LOpts}) ->
+    State = Module:new(Transport, Ref, LOpts),
     C2SSocket = #component_socket{
         module = Module,
         state = State},

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -986,7 +986,6 @@ listener_module(<<"s2s">>) -> mongoose_s2s_listener;
 listener_module(<<"http">>) -> ejabberd_cowboy;
 listener_module(<<"component">>) -> mongoose_component_listener.
 
-%% required for correct metrics reporting by mongoose_transport module
 connection_type(<<"c2s">>) -> c2s;
 connection_type(<<"s2s">>) -> s2s;
 connection_type(<<"http">>) -> http;

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -319,7 +319,7 @@ xmpp_listener_extra(<<"component">>) ->
                                                  validate = non_empty},
                        <<"state_timeout">> => #option{type = int_or_infinity,
                                                       validate = non_negative},
-                       <<"tls">> => tls([server, xmpp])},
+                       <<"tls">> => tls([server, xmpp_tls])},
              required = [<<"password">>],
              defaults = #{<<"access">> => all,
                           <<"check_from">> => true,
@@ -668,6 +668,11 @@ tls(xmpp) ->
     #section{items = #{<<"mode">> => #option{type = atom,
                                              validate = {enum, [tls, starttls, starttls_required]}}},
              defaults = #{<<"mode">> => starttls}
+            };
+tls(xmpp_tls) ->
+    #section{items = #{<<"mode">> => #option{type = atom,
+                                             validate = {enum, [tls, starttls, starttls_required]}}},
+             defaults = #{<<"mode">> => tls}
             }.
 
 server_name_indication() ->

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -254,10 +254,13 @@ listener_common() ->
                        <<"proto">> => #option{type = atom,
                                               validate = {enum, [tcp]}},
                        <<"ip_version">> => #option{type = integer,
-                                                   validate = {enum, [4, 6]}}
+                                                   validate = {enum, [4, 6]}},
+                       <<"hibernate_after">> => #option{type = int_or_infinity,
+                                                        validate = non_negative}
                       },
              required = [<<"port">>],
-             defaults = #{<<"proto">> => tcp},
+             defaults = #{<<"proto">> => tcp,
+                          <<"hibernate_after">> => 0},
              process = fun ?MODULE:process_listener/2
             }.
 
@@ -272,8 +275,6 @@ listener_extra(Type) ->
 
 xmpp_listener_common() ->
     #section{items = #{<<"backlog">> => #option{type = integer, validate = non_negative},
-                       <<"hibernate_after">> => #option{type = int_or_infinity,
-                                                        validate = non_negative},
                        <<"max_connections">> => #option{type = int_or_infinity,
                                                         validate = positive},
                        <<"max_stanza_size">> => #option{type = int_or_infinity,
@@ -286,7 +287,6 @@ xmpp_listener_common() ->
                        <<"shaper">> => #option{type = atom,
                                                validate = non_empty}},
              defaults = #{<<"backlog">> => 1024,
-                          <<"hibernate_after">> => 0,
                           <<"max_connections">> => infinity,
                           <<"max_stanza_size">> => 0,
                           <<"num_acceptors">> => 100,

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -44,27 +44,17 @@
 
 -include("mongoose.hrl").
 
--type listener_options() :: #{port := inet:port_number(),
-                              ip_tuple := inet:ip_address(),
-                              ip_address := string(),
-                              ip_version := inet:address_family(),
-                              proto := tcp,
-                              handlers := list(),
-                              transport := ranch:opts(),
-                              protocol := cowboy:opts(),
-                              atom() => any()}.
-
--record(cowboy_state, {ref :: atom(), opts :: listener_options()}).
+-record(cowboy_state, {ref :: atom(), opts :: mongoose_listener:options()}).
 
 %%--------------------------------------------------------------------
 %% mongoose_listener API
 %%--------------------------------------------------------------------
 
--spec instrumentation(listener_options()) -> [mongoose_instrument:spec()].
+-spec instrumentation(mongoose_listener:options()) -> [mongoose_instrument:spec()].
 instrumentation(#{handlers := Handlers}) ->
     [Spec || #{module := Module} <- Handlers, Spec <- mongoose_http_handler:instrumentation(Module)].
 
--spec start_listener(listener_options()) -> {ok, supervisor:child_spec()}.
+-spec start_listener(mongoose_listener:options()) -> {ok, supervisor:child_spec()}.
 start_listener(Opts) ->
     ListenerId = mongoose_listener:listener_id(Opts),
     Ref = ref(ListenerId),
@@ -125,11 +115,11 @@ execute(Req, Env) ->
 %% Internal Functions
 %%--------------------------------------------------------------------
 
--spec start_cowboy(atom(), listener_options()) -> {ok, pid()} | {error, any()}.
+-spec start_cowboy(atom(), mongoose_listener:options()) -> {ok, pid()} | {error, any()}.
 start_cowboy(Ref, Opts) ->
     start_cowboy(Ref, Opts, 20, 50).
 
--spec start_cowboy(atom(), listener_options(),
+-spec start_cowboy(atom(), mongoose_listener:options(),
                    Retries :: non_neg_integer(), SleepTime :: non_neg_integer()) ->
           {ok, pid()} | {error, any()}.
 start_cowboy(Ref, Opts, 0, _) ->
@@ -143,7 +133,7 @@ start_cowboy(Ref, Opts, Retries, SleepTime) ->
             Other
     end.
 
--spec do_start_cowboy(atom(), listener_options()) -> {ok, pid()} | {error, any()}.
+-spec do_start_cowboy(atom(), mongoose_listener:options()) -> {ok, pid()} | {error, any()}.
 do_start_cowboy(Ref, Opts) ->
     #{ip_tuple := IPTuple, port := Port, handlers := Handlers0,
       transport := TransportOpts0, protocol := ProtocolOpts0} = Opts,

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -41,7 +41,7 @@
 -export([start_cowboy/4, start_cowboy/2, stop_cowboy/1]).
 
 -ignore_xref([behaviour_info/1, process/1, ref/1, reload_dispatch/1, start_cowboy/2,
-              start_cowboy/4, start_link/1, start_listener/2, start_listener/1, stop/0, stop_cowboy/1]).
+              start_cowboy/4, start_link/1, start_listener/1, stop/0, stop_cowboy/1]).
 
 -include("mongoose.hrl").
 
@@ -67,7 +67,7 @@ instrumentation(#{handlers := Handlers}) ->
 
 -spec start_listener(listener_options()) -> ok.
 start_listener(Opts = #{proto := tcp}) ->
-    ListenerId = mongoose_listener_config:listener_id(Opts),
+    ListenerId = mongoose_listener:listener_id(Opts),
     Ref = ref(ListenerId),
     ChildSpec = #{id => ListenerId,
                   start => {?MODULE, start_link, [#cowboy_state{ref = Ref, opts = Opts}]},

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -33,7 +33,6 @@
          handle_call/3,
          handle_cast/2,
          handle_info/2,
-         code_change/3,
          terminate/2]).
 
 %% helper for internal use
@@ -100,9 +99,6 @@ handle_cast(_Request, State) ->
 
 handle_info(_Info, State) ->
     {noreply, State}.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 terminate(_Reason, State) ->
     stop_cowboy(State#cowboy_state.ref).

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -166,9 +166,11 @@ do_start_cowboy(Ref, Opts) ->
             Result
     end.
 
-start_http_or_https(#{tls := TLSOpts}, Ref, TransportOpts, ProtocolOpts) ->
+start_http_or_https(#{tls := TLSOpts, hibernate_after := HibernateAfter},
+                    Ref, TransportOpts, ProtocolOpts) ->
+    SocketOpts = maps:get(socket_opts, TransportOpts),
     SSLOpts = just_tls:make_cowboy_ssl_opts(TLSOpts),
-    SocketOptsWithSSL = maps:get(socket_opts, TransportOpts) ++ SSLOpts,
+    SocketOptsWithSSL = SocketOpts ++ SSLOpts ++ [{hibernate_after, HibernateAfter}],
     cowboy_start_https(Ref, TransportOpts#{socket_opts := SocketOptsWithSSL}, ProtocolOpts);
 start_http_or_https(#{}, Ref, TransportOpts, ProtocolOpts) ->
     cowboy_start_http(Ref, TransportOpts, ProtocolOpts).

--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -56,7 +56,7 @@ init([]) ->
     ShaperSup = mongoose_shaper:child_spec(),
     DomainSup = supervisor_spec(mongoose_domain_sup),
     ReceiverSupervisor =
-        template_supervisor_spec(mongoose_transport_sup, mongoose_transport),
+        template_supervisor_spec(mongoose_s2s_socket_out_sup, mongoose_s2s_socket_out),
     C2SSupervisor =
         template_supervisor_spec(mongoose_c2s_sup, mongoose_c2s),
     S2SOutSupervisor =

--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -55,7 +55,7 @@ init([]) ->
     Listener = supervisor_spec(mongoose_listener_sup),
     ShaperSup = mongoose_shaper:child_spec(),
     DomainSup = supervisor_spec(mongoose_domain_sup),
-    ReceiverSupervisor =
+    S2SReceiverSupervisor =
         template_supervisor_spec(mongoose_s2s_socket_out_sup, mongoose_s2s_socket_out),
     C2SSupervisor =
         template_supervisor_spec(mongoose_c2s_sup, mongoose_c2s),
@@ -74,10 +74,10 @@ init([]) ->
            ] ++ mongoose_cets_discovery:supervisor_specs() ++ [
            Router,
            S2S,
-           Local,
-           ReceiverSupervisor,
-           C2SSupervisor,
+           S2SReceiverSupervisor,
            S2SOutSupervisor,
+           Local,
+           C2SSupervisor,
            IQSupervisor,
            Listener,
            MucIQ,

--- a/src/global_distrib/mod_global_distrib_transport.erl
+++ b/src/global_distrib/mod_global_distrib_transport.erl
@@ -70,13 +70,13 @@ send(#?MODULE{transport = gen_tcp, socket = Socket}, Data) ->
 send(#?MODULE{transport = just_tls, socket = Socket}, Data) ->
     just_tls:send(Socket, Data).
 
--spec peername(t()) -> {inet:ip_address(), inet:port_number()} | unknown.
+-spec peername(t()) -> mongoose_transport:peer() | unknown.
 peername(#?MODULE{transport = gen_tcp, socket = Socket}) ->
     normalize_peername(inet:peername(Socket));
 peername(#?MODULE{transport = just_tls, socket = Socket}) ->
     normalize_peername(just_tls:peername(Socket)).
 
--spec normalize_peername({ok, {inet:ip_address(), inet:port_number()}} | any()) ->
-    {inet:ip_address(), inet:port_number()} | unknown.
+-spec normalize_peername({ok, mongoose_transport:peer()} | any()) ->
+    mongoose_transport:peer() | unknown.
 normalize_peername({ok, {IP, Port}}) when is_tuple(IP), is_integer(Port) -> {IP, Port};
 normalize_peername(_Other) -> unknown.

--- a/src/just_tls.erl
+++ b/src/just_tls.erl
@@ -48,11 +48,12 @@
          peername/1,
          setopts/2,
          get_peer_certificate/1,
-         export_key_materials/5,
          close/1]).
 
 % API
--export([make_ssl_opts/1, make_cowboy_ssl_opts/1]).
+-export([prepare_connection/1,
+         receive_verify_results/1, error_to_list/1,
+         make_ssl_opts/1, make_cowboy_ssl_opts/1]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% APIs
@@ -103,21 +104,14 @@ get_peer_certificate(#tls_socket{verify_results = [], ssl_socket = SSLSocket}) -
 get_peer_certificate(#tls_socket{verify_results = [Err | _]}) ->
     {bad_cert, error_to_list(Err)}.
 
--spec export_key_materials(tls_socket(), Labels, Contexts, WantedLengths, ConsumeSecret) ->
-    {ok, ExportKeyMaterials} |
-    {error, undefined_tls_material | exporter_master_secret_already_consumed | bad_input}
-      when
-      Labels :: [binary()],
-      Contexts :: [binary() | no_context],
-      WantedLengths :: [non_neg_integer()],
-      ConsumeSecret :: boolean(),
-      ExportKeyMaterials :: binary() | [binary()].
-export_key_materials(#tls_socket{ssl_socket = SslSocket},
-                     Labels, Contexts, WantedLengths, ConsumeSecret) ->
-    ssl:export_key_materials(SslSocket, Labels, Contexts, WantedLengths, ConsumeSecret).
-
 %% -callback close(tls_socket()) -> ok.
 close(#tls_socket{ssl_socket = SSLSocket}) -> ssl:close(SSLSocket).
+
+%% @doc Prepare SSL options for direct use of ssl:handshake/2 (server side)
+-spec prepare_connection(options()) -> {dummy_ref | reference(), [ssl:tls_server_option()]}.
+prepare_connection(Options) ->
+    FailIfNoPeerCert = fail_if_no_peer_cert_opt(Options),
+    format_opts_with_ref(Options, FailIfNoPeerCert).
 
 %% @doc Prepare SSL options for direct use of ssl:connect/2 (client side)
 %% The `disconnect_on_failure' option is expected to be unset or true

--- a/src/just_tls.erl
+++ b/src/just_tls.erl
@@ -83,15 +83,15 @@ tcp_to_tls(TCPSocket, Options) ->
         _ -> Ret
     end.
 
-%% -callback send(tls_socket(), binary()) -> ok | {error, any()}.
+-spec send(tls_socket(), binary()) -> ok | {error, any()}.
 send(#tls_socket{ssl_socket = SSLSocket}, Packet) -> ssl:send(SSLSocket, Packet).
 
-%% -callback peername(tls_socket()) -> {ok, {inet:ip_address(), inet:port_number()}} |
-%%                                     {error, any()}.
+-spec peername(tls_socket()) -> {ok, mongoose_transport:peer()} |
+                                     {error, any()}.
 peername(#tls_socket{ssl_socket = SSLSocket}) -> ssl:peername(SSLSocket).
 
 
-%% -callback setopts(tls_socket(), Opts::list()) -> ok | {error, any()}.
+-spec setopts(tls_socket(), Opts::list()) -> ok | {error, any()}.
 setopts(#tls_socket{ssl_socket = SSLSocket}, Opts) -> ssl:setopts(SSLSocket, Opts).
 
 get_peer_certificate(#tls_socket{verify_results = [], ssl_socket = SSLSocket}) ->
@@ -104,7 +104,7 @@ get_peer_certificate(#tls_socket{verify_results = [], ssl_socket = SSLSocket}) -
 get_peer_certificate(#tls_socket{verify_results = [Err | _]}) ->
     {bad_cert, error_to_list(Err)}.
 
-%% -callback close(tls_socket()) -> ok.
+-spec close(tls_socket()) -> ok.
 close(#tls_socket{ssl_socket = SSLSocket}) -> ssl:close(SSLSocket).
 
 %% @doc Prepare SSL options for direct use of ssl:handshake/2 (server side)

--- a/src/listeners/mongoose_listener.erl
+++ b/src/listeners/mongoose_listener.erl
@@ -26,11 +26,36 @@
                      module := module(),
                      connection_type := atom(),
                      hibernate_after := timeout(),
+                     tls => map(),
+                     %% HTTP
+                     handlers => list(),
+                     transport => ranch:opts(),
+                     protocol => cowboy:opts(),
+                     %% XMPP
+                     access => atom(),
+                     backlog => non_neg_integer(),
+                     max_connections => infinity | pos_integer(),
+                     max_stanza_size => non_neg_integer(),
+                     num_acceptors => pos_integer(),
+                     proxy_protocol => boolean(),
+                     reuse_port => boolean(),
+                     shaper => atom(),
+                     %% C2S
+                     allowed_auth_methods => list(),
+                     backwards_compatible_session => boolean(),
+                     state_timeout => non_neg_integer(),
+                     %% Components
+                     password => binary(),
+                     check_from => boolean(),
+                     hidden_components => boolean(),
+                     conflict_behaviour => disconnect | kick_old,
+                     %% Other maybe
                      atom() => any()}.
+
 -type id() :: {inet:port_number(), inet:ip_address(), tcp}.
--type transport_module() :: ranch_tcp | ranch_ssl.
+-type transport_module() :: ranch_tcp | ranch_ssl | undefined.
 -type typed_listeners() :: [{Type :: ranch | cowboy, Listener :: ranch:ref()}].
--type init_args() :: {ranch:ref(), transport_module(), options()}.
+-type init_args() :: {module(), ranch:ref(), transport_module(), options()}.
 
 -type connection_details() :: #{
         proxy        := boolean(),

--- a/src/listeners/mongoose_listener.erl
+++ b/src/listeners/mongoose_listener.erl
@@ -14,7 +14,7 @@
 %% Helpers
 -export([listener_id/1, prepare_socket_opts/1, element_spirals/0]).
 
--callback start_listener(options()) -> ok.
+-callback start_listener(options()) -> {ok, supervisor:child_spec()}.
 -callback instrumentation(options()) -> [mongoose_instrument:spec()].
 -optional_callbacks([instrumentation/1]).
 
@@ -57,7 +57,8 @@ stop() ->
 
 start_listener(Opts = #{module := Module}) ->
     try
-        Module:start_listener(Opts) % This function should call mongoose_listener_sup:start_child/1
+        {ok, ChildSpec} = Module:start_listener(Opts),
+        mongoose_listener_sup:start_child(ChildSpec)
     catch
         Class:Reason:Stacktrace ->
             ?LOG_CRITICAL(#{what => listener_failed_to_start,

--- a/src/listeners/mongoose_listener_config.erl
+++ b/src/listeners/mongoose_listener_config.erl
@@ -2,8 +2,7 @@
 -module(mongoose_listener_config).
 
 -export([ensure_ip_options/1,
-         verify_unique_listeners/1,
-         listener_id/1]).
+         verify_unique_listeners/1]).
 
 %% @doc Fill in IP-related options that can be calculated automatically.
 %% Apart from these options, the input should be a complete listener configuration.
@@ -30,15 +29,10 @@ ip_version(T) when tuple_size(T) =:= 8 -> inet6.
 -spec verify_unique_listeners([mongoose_listener:options()]) -> [mongoose_listener:options()].
 verify_unique_listeners(Listeners) ->
     Counts = lists:foldl(fun(L, Cts) ->
-                                 maps:update_with(listener_id(L), fun(Ct) -> Ct + 1 end, 1, Cts)
+                                 maps:update_with(mongoose_listener:listener_id(L), fun(Ct) -> Ct + 1 end, 1, Cts)
                          end, #{}, Listeners),
     case [K || {K, V} <- maps:to_list(Counts), V > 1] of
         [] -> Listeners;
         Dups -> error(#{what => duplicate_listeners, duplicates => Dups,
                         text => <<"Some listeners have duplicate listening socket addresses">>})
     end.
-
-%% @doc Create a unique ID based on the listening socket address
--spec listener_id(mongoose_listener:options()) -> mongoose_listener:id().
-listener_id(#{port := Port, ip_tuple := IPTuple, proto := Proto}) ->
-    {Port, IPTuple, Proto}.

--- a/src/listeners/mongoose_listener_config.erl
+++ b/src/listeners/mongoose_listener_config.erl
@@ -1,8 +1,7 @@
 %% @doc Utilities related to listener configuration options
 -module(mongoose_listener_config).
 
--export([ensure_ip_options/1,
-         verify_unique_listeners/1]).
+-export([ip_version/1, ensure_ip_options/1, verify_unique_listeners/1]).
 
 %% @doc Fill in IP-related options that can be calculated automatically.
 %% Apart from these options, the input should be a complete listener configuration.

--- a/src/mod_bosh_socket.erl
+++ b/src/mod_bosh_socket.erl
@@ -21,12 +21,12 @@
 
 %% mongoose_c2s_socket callbacks
 -export([new/3,
-         socket_peername/1,
+         peername/1,
          tcp_to_tls/2,
-         socket_handle_data/2,
-         socket_activate/1,
-         socket_send_xml/2,
-         socket_close/1,
+         handle_data/2,
+         activate/1,
+         send_xml/2,
+         close/1,
          get_peer_certificate/1,
          has_peer_cert/2,
          is_channel_binding_supported/1,
@@ -1051,8 +1051,8 @@ ignore_undefined(Map) ->
 new(_, Socket, _LOpts) ->
     Socket.
 
--spec socket_peername(mod_bosh:socket()) -> {inet:ip_address(), inet:port_number()}.
-socket_peername(#bosh_socket{peer = Peer}) ->
+-spec peername(mod_bosh:socket()) -> mongoose_transport:peer().
+peername(#bosh_socket{peer = Peer}) ->
     Peer.
 
 -spec tcp_to_tls(mod_bosh:socket(), mongoose_listener:options()) ->
@@ -1060,27 +1060,27 @@ socket_peername(#bosh_socket{peer = Peer}) ->
 tcp_to_tls(_Socket, _LOpts) ->
     {error, tls_not_allowed_on_bosh}.
 
--spec socket_handle_data(mod_bosh:socket(), {tcp | ssl, term(), iodata()}) ->
+-spec handle_data(mod_bosh:socket(), {tcp | ssl, term(), iodata()}) ->
   iodata() | {raw, [exml:element()]} | {error, term()}.
-socket_handle_data(_Socket, {_Kind, _Term, Packet}) ->
+handle_data(_Socket, {_Kind, _Term, Packet}) ->
     {raw, [Packet]}.
 
--spec socket_activate(mod_bosh:socket()) -> ok.
-socket_activate(_Socket) ->
+-spec activate(mod_bosh:socket()) -> ok.
+activate(_Socket) ->
     ok.
 
--spec socket_send_xml(mod_bosh:socket(),
+-spec send_xml(mod_bosh:socket(),
                       iodata() | exml_stream:element() | [exml_stream:element()]) ->
     ok | {error, term()}.
-socket_send_xml(#bosh_socket{pid = Pid}, XMLs) when is_list(XMLs) ->
+send_xml(#bosh_socket{pid = Pid}, XMLs) when is_list(XMLs) ->
     [Pid ! {send, XML} || XML <- XMLs],
     ok;
-socket_send_xml(#bosh_socket{pid = Pid}, XML) ->
+send_xml(#bosh_socket{pid = Pid}, XML) ->
     Pid ! {send, XML},
     ok.
 
--spec socket_close(mod_bosh:socket()) -> ok.
-socket_close(#bosh_socket{pid = Pid}) ->
+-spec close(mod_bosh:socket()) -> ok.
+close(#bosh_socket{pid = Pid}) ->
     Pid ! close,
     ok.
 

--- a/src/mod_bosh_socket.erl
+++ b/src/mod_bosh_socket.erl
@@ -196,7 +196,6 @@ init([{HostType, Sid, Peer, PeerCert, ListenerOpts}]) ->
     BoshSocket = #bosh_socket{sid = Sid, pid = self(), peer = Peer, peercert = PeerCert},
     C2SOpts = ListenerOpts#{access => all,
                             shaper => none,
-                            xml_socket => true,
                             max_stanza_size => 0,
                             hibernate_after => 0,
                             state_timeout => 5000,

--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -22,12 +22,12 @@
 
 %% mongoose_c2s_socket callbacks
 -export([new/3,
-         socket_peername/1,
+         peername/1,
          tcp_to_tls/2,
-         socket_handle_data/2,
-         socket_activate/1,
-         socket_close/1,
-         socket_send_xml/2,
+         handle_data/2,
+         activate/1,
+         close/1,
+         send_xml/2,
          get_peer_certificate/1,
          has_peer_cert/2,
          is_channel_binding_supported/1,
@@ -369,8 +369,8 @@ case_insensitive_match(_, []) ->
 new(_, Socket, _LOpts) ->
     Socket.
 
--spec socket_peername(socket()) -> {inet:ip_address(), inet:port_number()}.
-socket_peername(#websocket{peername = PeerName}) ->
+-spec peername(socket()) -> mongoose_transport:peer().
+peername(#websocket{peername = PeerName}) ->
     PeerName.
 
 -spec tcp_to_tls(socket(), mongoose_listener:options()) ->
@@ -378,26 +378,26 @@ socket_peername(#websocket{peername = PeerName}) ->
 tcp_to_tls(_Socket, _LOpts) ->
     {error, tls_not_allowed_on_websockets}.
 
--spec socket_handle_data(socket(), {tcp | ssl, term(), term()}) ->
+-spec handle_data(socket(), {tcp | ssl, term(), term()}) ->
   iodata() | {raw, [exml:element()]} | {error, term()}.
-socket_handle_data(_Socket, {_Kind, _Term, Packet}) ->
+handle_data(_Socket, {_Kind, _Term, Packet}) ->
     {raw, [Packet]}.
 
--spec socket_activate(socket()) -> ok.
-socket_activate(_Socket) ->
+-spec activate(socket()) -> ok.
+activate(_Socket) ->
     ok.
 
--spec socket_close(socket()) -> ok.
-socket_close(#websocket{pid = Pid}) ->
+-spec close(socket()) -> ok.
+close(#websocket{pid = Pid}) ->
     Pid ! stop,
     ok.
 
--spec socket_send_xml(socket(), iodata() | exml:element() | [exml:element()]) ->
+-spec send_xml(socket(), iodata() | exml:element() | [exml:element()]) ->
     ok | {error, term()}.
-socket_send_xml(#websocket{pid = Pid}, XMLs) when is_list(XMLs) ->
+send_xml(#websocket{pid = Pid}, XMLs) when is_list(XMLs) ->
     [Pid ! {send_xml, XML} || XML <- XMLs],
     ok;
-socket_send_xml(#websocket{pid = Pid}, XML) ->
+send_xml(#websocket{pid = Pid}, XML) ->
     Pid ! {send_xml, XML},
     ok.
 

--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -72,12 +72,12 @@ config_spec() ->
                                                   validate = positive},
                        <<"max_stanza_size">> => #option{type = int_or_infinity,
                                                         validate = positive},
-                       <<"c2s_state_timeout">> => #option{type = int_or_infinity,
+                       <<"state_timeout">> => #option{type = int_or_infinity,
                                                           validate = non_negative},
                        <<"backwards_compatible_session">> => #option{type = boolean}},
              defaults = #{<<"timeout">> => 60000,
                           <<"max_stanza_size">> => infinity,
-                          <<"c2s_state_timeout">> => 5000,
+                          <<"state_timeout">> => 5000,
                           <<"backwards_compatible_session">> => true}
             }.
 
@@ -214,13 +214,12 @@ send_to_fsm(FSM, Element) ->
 maybe_start_fsm([#xmlel{ name = <<"open">> }],
                 #ws_state{fsm_pid = undefined,
                           opts = #{ip_tuple := IPTuple, port := Port,
-                                   c2s_state_timeout := StateTimeout,
+                                   state_timeout := StateTimeout,
                                    backwards_compatible_session := BackwardsCompatible}} = State) ->
     Opts = #{
         access => all,
         shaper => none,
         max_stanza_size => 0,
-        xml_socket => true,
         state_timeout => StateTimeout,
         backwards_compatible_session => BackwardsCompatible,
         module => mongoose_c2s_listener,

--- a/src/mongoose_session_api.erl
+++ b/src/mongoose_session_api.erl
@@ -36,7 +36,7 @@
 
 -type session_info() :: {USR :: jid:jid(),
                          Conn :: atom(),
-                         Address :: {inet:ip_address(), inet:port_number()} | undefined,
+                         Address :: mongoose_transport:peer() | undefined,
                          Prio :: ejabberd_sm:priority(),
                          NodeS :: node(),
                          Uptime :: integer()}.

--- a/src/mongoose_transport.erl
+++ b/src/mongoose_transport.erl
@@ -1,0 +1,14 @@
+-module(mongoose_transport).
+-author('piotr.nosek@erlang-solutions.com').
+
+-include_lib("public_key/include/public_key.hrl").
+
+%%----------------------------------------------------------------------
+%% Types
+%%----------------------------------------------------------------------
+
+-type peer() :: {inet:ip_address(), inet:port_number()}.
+-type peername_return() :: {ok, peer()} | {error, inet:posix()}.
+-type peercert_return() :: no_peer_cert | {ok, #'Certificate'{}}.
+
+-export_type([peer/0, peername_return/0, peercert_return/0]).

--- a/src/s2s/mongoose_s2s_listener.erl
+++ b/src/s2s/mongoose_s2s_listener.erl
@@ -31,4 +31,4 @@ start_listener(Opts) ->
     {ok, pid()}.
 start_link(Ref, Transport, Opts = #{hibernate_after := HibernateAfterTimeout}) ->
     ProcessOpts = [{hibernate_after, HibernateAfterTimeout}],
-    mongoose_s2s_socket:start_link({mongoose_s2s_socket, Ref, Transport, Opts}, ProcessOpts).
+    mongoose_s2s_socket_in:start_link({mongoose_s2s_socket_in, Ref, Transport, Opts}, ProcessOpts).

--- a/src/s2s/mongoose_s2s_listener.erl
+++ b/src/s2s/mongoose_s2s_listener.erl
@@ -6,11 +6,7 @@
 -behaviour(ranch_protocol).
 -export([start_link/3]).
 
--type options() :: #{module := ?MODULE,
-                     atom() => any()}.
-
--export_type([options/0]).
-
+%% mongoose_listener
 -spec instrumentation(_) -> [mongoose_instrument:spec()].
 instrumentation(_) ->
     [{s2s_tcp_data_in, #{}, #{metrics => #{byte_size => spiral}}},
@@ -25,16 +21,19 @@ instrumentation(_) ->
      {s2s_element_out, #{},
       #{metrics => maps:from_list([{Metric, spiral} || Metric <- mongoose_listener:element_spirals()])}}].
 
--spec start_listener(options()) -> ok.
-start_listener(#{module := ?MODULE} = Opts) ->
+%% mongoose_listener
+-spec start_listener(mongoose_listener:options()) -> {ok, supervisor:child_spec()}.
+start_listener(Opts) ->
     TransportOpts0 = mongoose_listener:prepare_socket_opts(Opts),
     TransportOpts = TransportOpts0#{connection_type => supervisor},
     ListenerId = mongoose_listener_config:listener_id(Opts),
     ChildSpec0 = ranch:child_spec(ListenerId, ranch_tcp, TransportOpts, ?MODULE, Opts),
     ChildSpec1 = ChildSpec0#{id := ListenerId, modules => [?MODULE, ranch_embedded_sup]},
-    mongoose_listener_sup:start_child(ChildSpec1).
+    {ok, ChildSpec1}.
 
 %% ranch_protocol
--spec start_link(ranch:ref(), module(), map()) -> {ok, pid()}.
-start_link(Ref, Transport, Opts) ->
-    mongoose_s2s_socket:start_link(Ref, Transport, Opts).
+-spec start_link(ranch:ref(), mongoose_listener:transport_module(), mongoose_listener:options()) ->
+    {ok, pid()}.
+start_link(Ref, Transport, Opts = #{hibernate_after := HibernateAfterTimeout}) ->
+    ProcessOpts = [{hibernate_after, HibernateAfterTimeout}],
+    mongoose_s2s_socket:start_link({Ref, Transport, Opts}, ProcessOpts).

--- a/src/s2s/mongoose_s2s_listener.erl
+++ b/src/s2s/mongoose_s2s_listener.erl
@@ -31,4 +31,4 @@ start_listener(Opts) ->
     {ok, pid()}.
 start_link(Ref, Transport, Opts = #{hibernate_after := HibernateAfterTimeout}) ->
     ProcessOpts = [{hibernate_after, HibernateAfterTimeout}],
-    mongoose_s2s_socket:start_link({Ref, Transport, Opts}, ProcessOpts).
+    mongoose_s2s_socket:start_link({mongoose_s2s_socket, Ref, Transport, Opts}, ProcessOpts).

--- a/src/s2s/mongoose_s2s_listener.erl
+++ b/src/s2s/mongoose_s2s_listener.erl
@@ -24,12 +24,7 @@ instrumentation(_) ->
 %% mongoose_listener
 -spec start_listener(mongoose_listener:options()) -> {ok, supervisor:child_spec()}.
 start_listener(Opts) ->
-    TransportOpts0 = mongoose_listener:prepare_socket_opts(Opts),
-    TransportOpts = TransportOpts0#{connection_type => supervisor},
-    ListenerId = mongoose_listener_config:listener_id(Opts),
-    ChildSpec0 = ranch:child_spec(ListenerId, ranch_tcp, TransportOpts, ?MODULE, Opts),
-    ChildSpec1 = ChildSpec0#{id := ListenerId, modules => [?MODULE, ranch_embedded_sup]},
-    {ok, ChildSpec1}.
+    {ok, mongoose_listener:child_spec(Opts)}.
 
 %% ranch_protocol
 -spec start_link(ranch:ref(), mongoose_listener:transport_module(), mongoose_listener:options()) ->

--- a/src/s2s/mongoose_s2s_listener.erl
+++ b/src/s2s/mongoose_s2s_listener.erl
@@ -1,7 +1,7 @@
 -module(mongoose_s2s_listener).
 
 -behaviour(mongoose_listener).
--export([start_listener/1, instrumentation/1]).
+-export([listener_spec/1, instrumentation/1]).
 
 -behaviour(ranch_protocol).
 -export([start_link/3]).
@@ -22,9 +22,9 @@ instrumentation(_) ->
       #{metrics => maps:from_list([{Metric, spiral} || Metric <- mongoose_listener:element_spirals()])}}].
 
 %% mongoose_listener
--spec start_listener(mongoose_listener:options()) -> {ok, supervisor:child_spec()}.
-start_listener(Opts) ->
-    {ok, mongoose_listener:child_spec(Opts)}.
+-spec listener_spec(mongoose_listener:options()) -> supervisor:child_spec().
+listener_spec(Opts) ->
+    mongoose_listener:child_spec(Opts).
 
 %% ranch_protocol
 -spec start_link(ranch:ref(), mongoose_listener:transport_module(), mongoose_listener:options()) ->

--- a/src/s2s/mongoose_s2s_socket.erl
+++ b/src/s2s/mongoose_s2s_socket.erl
@@ -102,7 +102,7 @@ change_shaper(#socket_data{receiver = Receiver}, Shaper)  ->
 init(InitArgs) ->
     {ok, undefined, {continue, {do_handshake, InitArgs}}}.
 
-handle_continue({do_handshake, {Ref, Transport,
+handle_continue({do_handshake, {?MODULE, Ref, Transport,
                  #{shaper := Shaper,
                    max_stanza_size := MaxStanzaSize,
                    hibernate_after := HibernateAfter} = Opts}}, undefined) ->

--- a/src/s2s/mongoose_s2s_socket_in.erl
+++ b/src/s2s/mongoose_s2s_socket_in.erl
@@ -1,14 +1,10 @@
--module(mongoose_s2s_socket).
+-module(mongoose_s2s_socket_in).
 
 -behaviour(gen_server).
 
 -include("mongoose.hrl").
 -include("jlib.hrl").
 -include_lib("public_key/include/public_key.hrl").
-
--type peer() :: {inet:ip_address(), inet:port_number()}.
--type peername_return() :: {ok, peer()} | {error, inet:posix()}.
--type peercert_return() :: no_peer_cert | {ok, #'Certificate'{}}.
 
 -type stanza_size() :: pos_integer() | infinity.
 
@@ -32,7 +28,7 @@
                 hibernate_after = 0   :: non_neg_integer()}).
 -type state() :: #state{}.
 
--export_type([socket_data/0, peer/0, peername_return/0, peercert_return/0]).
+-export_type([socket_data/0]).
 
 %% transport API
 -export([close/1, send_text/2, send_element/2, peername/1, change_shaper/2,
@@ -86,7 +82,7 @@ get_peer_certificate(#socket_data{sockmod = just_tls, socket = Socket}) ->
 get_peer_certificate(_SocketData) ->
     no_peer_cert.
 
--spec peername(socket_data()) -> mongoose_transport:peername_return().
+-spec peername(socket_data()) -> {ok, mongoose_transport:peer()}.
 peername(#socket_data{connection_details = #{src_address := SrcAddr, src_port := SrcPort}}) ->
     {ok, {SrcAddr, SrcPort}}.
 

--- a/src/sasl/cyrsasl_external.erl
+++ b/src/sasl/cyrsasl_external.erl
@@ -44,8 +44,8 @@ mechanism() ->
 -spec mech_new(Host   :: jid:server(),
                Creds  :: mongoose_credentials:t(),
                Socket :: term()) -> {ok, sasl_external_state()}.
-mech_new(_Host, Creds, #{socket := Socket, listener_opts := LOpts}) ->
-    Cert = case mongoose_c2s_socket:get_peer_certificate(Socket, LOpts) of
+mech_new(_Host, Creds, #{socket := Socket}) ->
+    Cert = case mongoose_c2s_socket:get_peer_certificate(Socket) of
                {ok, C} -> C;
                _ -> no_cert
            end,

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -1136,7 +1136,7 @@ default_config([listen, http, handlers, mod_websockets]) ->
     #{timeout => 60000,
       max_stanza_size => infinity,
       module => mod_websockets,
-      c2s_state_timeout => 5000,
+      state_timeout => 5000,
       backwards_compatible_session => true};
 default_config([listen, http, handlers, mongoose_admin_api]) ->
     #{handlers => [contacts, users, sessions, messages, stanzas, muc_light, muc,

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -1090,7 +1090,6 @@ common_xmpp_listener_config() ->
                                 max_connections => infinity,
                                 reuse_port => false,
                                 shaper => none,
-                                hibernate_after => 0,
                                 max_stanza_size => 0,
                                 num_acceptors => 100}.
 
@@ -1098,7 +1097,8 @@ common_listener_config() ->
     #{ip_address => "0",
       ip_tuple => {0, 0, 0, 0},
       ip_version => inet,
-      proto => tcp}.
+      proto => tcp,
+      hibernate_after => 0}.
 
 extra_component_listener_config() ->
     #{access => all,

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -1176,7 +1176,7 @@ default_config([listen, component]) ->
     Extra = maps:merge(common_xmpp_listener_config(), extra_component_listener_config()),
     Extra#{module => mongoose_component_listener};
 default_config([listen, component, tls]) ->
-    default_xmpp_tls();
+    default_xmpp_tls_tls();
 default_config([modules, M]) ->
     default_mod_config(M);
 default_config([modules, mod_event_pusher, http]) ->
@@ -1325,6 +1325,9 @@ default_config(Path) when is_list(Path) ->
 
 default_xmpp_tls() ->
     (default_tls())#{mode => starttls}.
+
+default_xmpp_tls_tls() ->
+    (default_tls())#{mode => tls}.
 
 default_tls() ->
     #{verify_mode => peer,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -665,6 +665,8 @@ test_listen(P, T) ->
     ?cfg(P ++ [ip_address], "::", T(#{<<"ip_version">> => 6})),
     ?cfg(P ++ [ip_tuple], {0, 0, 0, 0, 0, 0, 0, 0}, T(#{<<"ip_version">> => 6})),
     ?cfg(P ++ [proto], tcp, T(#{<<"proto">> => <<"tcp">>})),
+    ?cfg(P ++ [hibernate_after], 10, T(#{<<"hibernate_after">> => 10})),
+    ?err(T(#{<<"hibernate_after">> => -10})),
     ?err(T(#{<<"ip_address">> => <<"192.168.1.999">>})),
     ?err(T(#{<<"port">> => <<"5222">>})),
     ?err(T(#{<<"port">> => 522222})),
@@ -676,7 +678,6 @@ test_listen_xmpp(P, T) ->
     ?cfg(P ++ [backlog], 10, T(#{<<"backlog">> => 10})),
     ?cfg(P ++ [proxy_protocol], true, T(#{<<"proxy_protocol">> => true})),
     ?cfg(P ++ [shaper], fast, T(#{<<"shaper">> => <<"fast">>})),
-    ?cfg(P ++ [hibernate_after], 10, T(#{<<"hibernate_after">> => 10})),
     ?cfg(P ++ [max_stanza_size], 10000, T(#{<<"max_stanza_size">> => 10000})),
     ?cfg(P ++ [max_stanza_size], 0, T(#{<<"max_stanza_size">> => <<"infinity">>})),
     ?cfg(P ++ [num_acceptors], 100, T(#{<<"num_acceptors">> => 100})),
@@ -687,7 +688,6 @@ test_listen_xmpp(P, T) ->
     ?err(T(#{<<"max_connections">> => 0})),
     ?err(T(#{<<"reuse_port">> => 0})),
     ?err(T(#{<<"proxy_protocol">> => <<"awesome">>})),
-    ?err(T(#{<<"hibernate_after">> => -10})),
     ?err(T(#{<<"max_stanza_size">> => <<"unlimited">>})),
     ?err(T(#{<<"num_acceptors">> => 0})).
 

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -552,7 +552,7 @@ listen_component_tls(_Config) ->
                                              <<"tls">> => Opts}) end,
     P = [listen, 1, tls],
     M = tls_ca_raw(),
-    ?cfg(P, maps:merge(default_xmpp_tls(), tls_ca()), T(M)),
+    ?cfg(P, maps:merge(config_parser_helper:default_xmpp_tls_tls(), tls_ca()), T(M)),
     test_just_tls_server(P, T).
 
 listen_http(_Config) ->

--- a/test/mod_websockets_SUITE.erl
+++ b/test/mod_websockets_SUITE.erl
@@ -25,12 +25,11 @@ timeout_tests() ->
      client_ping_frame_resets_idle_timeout].
 
 init_per_suite(C) ->
-    setup(),
+    setup(C),
     C.
 
-end_per_suite(_) ->
-    teardown(),
-    ok.
+end_per_suite(C) ->
+    teardown(C).
 
 init_per_testcase(_, C) ->
     C.
@@ -38,19 +37,15 @@ init_per_testcase(_, C) ->
 end_per_testcase(_, C) ->
     C.
 
-setup() ->
+setup(Config) ->
     meck:unload(),
     application:ensure_all_started(cowboy),
     application:ensure_all_started(jid),
     meck:new(supervisor, [unstick, passthrough, no_link]),
-    meck:new(gen_mod,[unstick, passthrough, no_link]),
+    meck:new(gen_mod, [unstick, passthrough, no_link]),
     %% Set ping rate
-    meck:expect(gen_mod,get_opt, fun(ping_rate, _, none) -> ?FAST_PING_RATE;
-                                    (A, B, C) -> meck:passthrough([A, B, C]) end),
-    meck:expect(supervisor, start_child,
-                fun(mongoose_listener_sup, _) -> {ok, self()};
-                   (A, B) -> meck:passthrough([A, B])
-                end),
+    meck:expect(gen_mod, get_opt, fun(ping_rate, _, none) -> ?FAST_PING_RATE;
+                                     (A, B, C) -> meck:passthrough([A, B, C]) end),
     mongoose_config:set_opts(#{default_server_name => <<"localhost">>}),
     %% Start websocket cowboy listening
     Handlers = [config([listen, http, handlers, mod_bosh],
@@ -58,25 +53,28 @@ setup() ->
                 config([listen, http, handlers, mod_websockets],
                        #{host => '_', path => "/ws-xmpp",
                          timeout => ?IDLE_TIMEOUT, ping_rate => ?FAST_PING_RATE})],
-    ejabberd_cowboy:start_listener(#{port => ?PORT,
-                                     ip_tuple => ?IP,
-                                     ip_address => "127.0.0.1",
-                                     ip_version => inet,
-                                     proto => tcp,
-                                     handlers => Handlers,
-                                     transport => default_config([listen, http, transport]),
-                                     protocol => default_config([listen, http, protocol])}).
+    Opts = #{module => ejabberd_cowboy,
+             port => ?PORT,
+             ip_tuple => ?IP,
+             ip_address => "127.0.0.1",
+             ip_version => inet,
+             proto => tcp,
+             handlers => Handlers,
+             transport => default_config([listen, http, transport]),
+             protocol => default_config([listen, http, protocol])},
+    {ok, #{start := {M, F, A}}} = ejabberd_cowboy:start_listener(Opts),
+    async_helper:start(Config, M, F, A).
 
-teardown() ->
+teardown(Config) ->
+    async_helper:stop_all(Config),
     meck:unload(),
     cowboy:stop_listener(ejabberd_cowboy:ref({?PORT, ?IP, tcp})),
     mongoose_config:erase_opts(),
     application:stop(cowboy),
-    %% Do not stop jid, Erlang 21 does not like to reload nifs
     ok.
 
 ping_test(_Config) ->
-    timer:sleep(500),
+    timer:sleep(5000),
     #{socket := Socket1} = ws_handshake(),
     %% When
     Resp = wait_for_ping(Socket1, 0, 5000),

--- a/test/mod_websockets_SUITE.erl
+++ b/test/mod_websockets_SUITE.erl
@@ -62,7 +62,7 @@ setup(Config) ->
              handlers => Handlers,
              transport => default_config([listen, http, transport]),
              protocol => default_config([listen, http, protocol])},
-    {ok, #{start := {M, F, A}}} = ejabberd_cowboy:start_listener(Opts),
+    #{start := {M, F, A}} = ejabberd_cowboy:listener_spec(Opts),
     async_helper:start(Config, M, F, A).
 
 teardown(Config) ->
@@ -74,7 +74,7 @@ teardown(Config) ->
     ok.
 
 ping_test(_Config) ->
-    timer:sleep(5000),
+    timer:sleep(500),
     #{socket := Socket1} = ws_handshake(),
     %% When
     Resp = wait_for_ping(Socket1, 0, 5000),


### PR DESCRIPTION
A step into unifying how listeners (c2s, s2s, components, and http) look like. These now all get similar config and behaviours from the common `mongoose_listener` module, and their `start_listener` callback looks almost identical. 

Sockets are also more uniform, the goal is that when S2S state machines are also reworked, more socket logic can be unified between the three XMPP socket modules (c2s, s2s, components). In the meantime we also rename and clean the division between incoming and outgoing s2s sockets.