### PR TITLE
Improve the consistency of just_tls helpers

### DIFF
--- a/big_tests/tests/sasl_external_SUITE_data/openssl-user.cnf
+++ b/big_tests/tests/sasl_external_SUITE_data/openssl-user.cnf
@@ -20,13 +20,25 @@ prompt              = no
 commonName                  = {{cn}}
 
 ####################################################################
-[ client_req_extensions ]
 
+[ client_req_extensions ]
 subjectKeyIdentifier        = hash
 basicConstraints            = CA:FALSE
 keyUsage                    = digitalSignature, keyEncipherment
 subjectAltName              = @alternate_names
 nsComment                   = "Fake Dev-Only Certificate for SASL EXTERNAL tests"
+
+[ self_signed_critical_extensions ]
+subjectKeyIdentifier        = hash
+basicConstraints            = CA:FALSE
+keyUsage                    = digitalSignature, keyEncipherment
+subjectAltName              = @alternate_names
+nsComment                   = "Fake Dev-Only Certificate for SASL EXTERNAL tests"
+1.2.3.4                     = critical, ASN1:UTF8String:Some random data
+
+[ critical_extensions ]
+1.2.3.4 = critical, ASN1:UTF8String:Some random data
+
 
 ###############################################################################################################
 ## subjectAltName sections, see 'man x509v3_config' for more information

--- a/src/c2s/mongoose_c2s_ranch.erl
+++ b/src/c2s/mongoose_c2s_ranch.erl
@@ -60,9 +60,9 @@ tcp_to_tls(#ranch_ssl{}, _) ->
 
 do_tcp_to_tls(TCPSocket, Options) ->
     inet:setopts(TCPSocket, [{active, false}]),
-    {Ref, SSLOpts} = just_tls:prepare_connection(Options),
+    SSLOpts = just_tls:make_server_opts(Options),
     Ret = ssl:handshake(TCPSocket, SSLOpts, 5000),
-    VerifyResults = just_tls:receive_verify_results(Ref),
+    VerifyResults = just_tls:receive_verify_results(),
     case Ret of
         {ok, SSLSocket} ->
             {ok, SSLSocket, VerifyResults};

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -155,7 +155,7 @@ do_start_cowboy(Ref, Opts) ->
 start_http_or_https(#{tls := TLSOpts, hibernate_after := HibernateAfter},
                     Ref, TransportOpts, ProtocolOpts) ->
     SocketOpts = maps:get(socket_opts, TransportOpts),
-    SSLOpts = just_tls:make_cowboy_ssl_opts(TLSOpts),
+    SSLOpts = just_tls:make_server_opts(TLSOpts),
     SocketOptsWithSSL = SocketOpts ++ SSLOpts ++ [{hibernate_after, HibernateAfter}],
     cowboy_start_https(Ref, TransportOpts#{socket_opts := SocketOptsWithSSL}, ProtocolOpts);
 start_http_or_https(#{}, Ref, TransportOpts, ProtocolOpts) ->

--- a/src/listeners/mongoose_listener.erl
+++ b/src/listeners/mongoose_listener.erl
@@ -264,7 +264,7 @@ transport_opts(#{port := Port,
 
 -spec maybe_tls_opts(map(), map()) -> map().
 maybe_tls_opts(#{tls := #{mode := tls} = TLSOpts}, #{socket_opts := SocketOpts} = TransportOpts) ->
-    SslSocketOpts = just_tls:make_cowboy_ssl_opts(TLSOpts),
+    SslSocketOpts = just_tls:make_server_opts(TLSOpts),
     TransportOpts#{socket_opts => SocketOpts ++ SslSocketOpts};
 maybe_tls_opts(_, TransportOpts) ->
     TransportOpts.

--- a/src/mongoose_ldap_worker.erl
+++ b/src/mongoose_ldap_worker.erl
@@ -77,7 +77,7 @@ connect_opts(State = #{port := Port,
                        password := Password}) ->
     AnonAuth = RootDN =:= <<>> andalso Password =:= <<>>,
     SSLConfig = case State of
-                    #{tls := TLSOptions} -> [{sslopts, just_tls:make_ssl_opts(TLSOptions)}];
+                    #{tls := TLSOptions} -> [{sslopts, just_tls:make_client_opts(TLSOptions)}];
                     #{} -> []
                 end,
     [{port, Port}, {anon_auth, AnonAuth}] ++ SSLConfig.

--- a/src/rdbms/mongoose_rdbms_mysql.erl
+++ b/src/rdbms/mongoose_rdbms_mysql.erl
@@ -78,7 +78,7 @@ db_opts(Options) ->
     FilteredOpts = maps:with([host, port, database, username, password, tls], Options),
     [{found_rows, true} | lists:map(fun process_opt/1, maps:to_list(FilteredOpts))].
 
-process_opt({tls, TLSOpts}) -> {ssl, just_tls:make_ssl_opts(TLSOpts)};
+process_opt({tls, TLSOpts}) -> {ssl, just_tls:make_client_opts(TLSOpts)};
 process_opt({username, UserName}) -> {user, UserName};
 process_opt(Opt) -> Opt.
 

--- a/src/rdbms/mongoose_rdbms_pgsql.erl
+++ b/src/rdbms/mongoose_rdbms_pgsql.erl
@@ -96,7 +96,7 @@ db_opts(Options) ->
 
 tls_opts(#{tls := TLSOpts}) ->
     #{ssl => ssl_mode(TLSOpts),
-      ssl_opts => just_tls:make_ssl_opts(maps:remove(required, TLSOpts))};
+      ssl_opts => just_tls:make_client_opts(maps:remove(required, TLSOpts))};
 tls_opts(#{}) ->
     #{}.
 

--- a/src/wpool/mongoose_wpool_cassandra.erl
+++ b/src/wpool/mongoose_wpool_cassandra.erl
@@ -58,7 +58,7 @@ cqerl_opts(auth, #{auth := #{plain := #{username := UserName, password := Passwo
 cqerl_opts(tcp, #{}) ->
     [{tcp_opts, [{keepalive, true}]}]; % always set
 cqerl_opts(tls, #{tls := TLSOpts}) ->
-    [{ssl, just_tls:make_ssl_opts(TLSOpts)}];
+    [{ssl, just_tls:make_client_opts(TLSOpts)}];
 cqerl_opts(_Opt, #{}) ->
     [].
 

--- a/src/wpool/mongoose_wpool_http.erl
+++ b/src/wpool/mongoose_wpool_http.erl
@@ -63,6 +63,6 @@ wpool_spec(WpoolOptsIn, #{host := Host} = ConnOpts) ->
     [{worker, Worker} | WpoolOptsIn].
 
 http_opts(#{tls := TLSOpts}) ->
-    just_tls:make_ssl_opts(TLSOpts);
+    just_tls:make_client_opts(TLSOpts);
 http_opts(#{}) ->
     [].


### PR DESCRIPTION
Note that now we can use `erlang:alias/1` to ensure that this message doesn't come from anywhere else, so the `Ref` parameter is not needed to ensure uniqueness. This allows us to unify the c2s preparing options from all other submodules preparing so, and we can fix naming convention by simply `make_client_opts` vs `make_server_opts`.

Note that the given `verify_fun` is just the default for the cases when `verify_mode` is `peer` or `none`, so only for `selfsigned_peer` it is needed to be provided explicitly. Also, the `verify_fun_wrapper` gets quite more readable this way.

We also here extend tests to ensure we are testing the case of unsupported critical extensions.