### PR TITLE
Migrated graphiql to v3

### DIFF
--- a/priv/graphql/wsite/index.html
+++ b/priv/graphql/wsite/index.html
@@ -2,12 +2,13 @@
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.
  *
- *  This source code is licensed under the license
- *  https://github.com/graphql/graphiql/blob/main/LICENSE.
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
 -->
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
+    <title>GraphiQL</title>
     <style>
       body {
         height: 100%;
@@ -15,125 +16,65 @@
         width: 100%;
         overflow: hidden;
       }
+
       #graphiql {
         height: 100vh;
       }
     </style>
-    <title>GraphiQL MongooseIM Api</title>
-    <link href="https://unpkg.com/graphiql@1.5.8/graphiql.min.css" rel="stylesheet" />
+    <!--
+      This GraphiQL example depends on Promise and fetch, which are available in
+      modern browsers, but can be "polyfilled" for older browsers.
+      GraphiQL itself depends on React DOM.
+      If you do not want to rely on a CDN, you can host these files locally or
+      include them directly in your favored resource bundler.
+    -->
+    <script
+      crossorigin
+      src="https://unpkg.com/react@18/umd/react.production.min.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
+    ></script>
+    <!--
+      These two files can be found in the npm module, however you may wish to
+      copy them directly into your environment, or perhaps include them in your
+      favored resource bundler.
+     -->
+    <script
+      src="https://unpkg.com/graphiql/graphiql.min.js"
+      type="application/javascript"
+    ></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+    <!-- 
+      These are imports for the GraphIQL Explorer plugin.
+     -->
+    <script
+      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
+      crossorigin
+    ></script>
+
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
+    />
   </head>
-  <body style="margin: 0;">
+
+  <body>
     <div id="graphiql">Loading...</div>
-    <script
-      crossorigin
-      src="https://unpkg.com/react/umd/react.production.min.js"></script>
-    <script
-      crossorigin
-      src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
-    <script
-      crossorigin
-      src="https://unpkg.com/graphiql@1.5.8/graphiql.min.js"></script>
     <script>
-
-      /**
-       * This GraphiQL example illustrates how to use some of GraphiQL's props
-       * in order to enable reading and updating the URL parameters, making
-       * link sharing of queries a little bit easier.
-       *
-       * This is only one example of this kind of feature, GraphiQL exposes
-       * various React params to enable interesting integrations.
-       */
-
-      // Parse the search string to get url parameters.
-      var search = window.location.search;
-      var parameters = {};
-      search.substr(1).split('&').forEach(function (entry) {
-        var eq = entry.indexOf('=');
-        if (eq >= 0) {
-          parameters[decodeURIComponent(entry.slice(0, eq))] =
-            decodeURIComponent(entry.slice(eq + 1));
-        }
+      const root = ReactDOM.createRoot(document.getElementById('graphiql'));
+      const fetcher = GraphiQL.createFetcher({
+        url: '/api/graphql/',
+        headers: { 'X-Example-Header': 'foo' },
       });
-
-      // if variables was provided, try to format it.
-      if (parameters.variables) {
-        try {
-          parameters.variables =
-            JSON.stringify(JSON.parse(parameters.variables), null, 2);
-        } catch (e) {
-          // Do nothing, we want to display the invalid JSON as a string, rather
-          // than present an error.
-        }
-      }
-
-      // When the query and variables string is edited, update the URL bar so
-      // that it can be easily shared
-      function onEditQuery(newQuery) {
-        parameters.query = newQuery;
-        updateURL();
-      }
-
-      function onEditVariables(newVariables) {
-        parameters.variables = newVariables;
-        updateURL();
-      }
-
-      function onEditOperationName(newOperationName) {
-        parameters.operationName = newOperationName;
-        updateURL();
-      }
-
-      function updateURL() {
-        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
-          return Boolean(parameters[key]);
-        }).map(function (key) {
-          return encodeURIComponent(key) + '=' +
-            encodeURIComponent(parameters[key]);
-        }).join('&');
-        history.replaceState(null, null, newSearch);
-      }
-
-      // Defines a GraphQL fetcher using the fetch API. You're not required to
-      // use fetch, and could instead implement graphQLFetcher however you like,
-      // as long as it returns a Promise or Observable.
-      function graphQLFetcher(graphQLParams, opts = {headers: {}}) {
-        // This example expects a GraphQL server at the path /graphql.
-        // Change this to point wherever you host your GraphQL server.
-        return fetch('/api/graphql/', {
-          method: 'post',
-          headers: Object.assign({
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'}, opts.headers),
-          body: JSON.stringify(graphQLParams),
-          credentials: 'include',
-        }).then(function (response) {
-          return response.text();
-        }).then(function (responseBody) {
-          try {
-            return JSON.parse(responseBody);
-          } catch (error) {
-            return responseBody;
-          }
-        });
-      }
-
-      // Render <GraphiQL /> into the body.
-      // See the README in the top level of this module to learn more about
-      // how you can customize GraphiQL by providing different values or
-      // additional child elements.
-      ReactDOM.render(
+      const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
+      root.render(
         React.createElement(GraphiQL, {
-          fetcher: graphQLFetcher,
-          query: parameters.query,
-          variables: parameters.variables,
-          operationName: parameters.operationName,
-          onEditQuery: onEditQuery,
-          onEditVariables: onEditVariables,
-	  headerEditorEnabled: true,
-	  headers: '{}',
-          onEditOperationName: onEditOperationName
+          fetcher,
+          defaultEditorToolsVisibility: true,
+          plugins: [explorerPlugin],
         }),
-        document.getElementById('graphiql')
       );
     </script>
   </body>


### PR DESCRIPTION
Current implemented GraphiQL version in this repo still uses React UMD build. This caused the IDE to be stuck at "Loading" since React 19 doesn't have UMD builds anymore: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#umd-builds-removed

Updated GraphiQL to v3 so it uses the latest tech stack.

Reference: https://github.com/graphql/graphiql/tree/main/examples/graphiql-cdn