### PR TITLE
Properly handle Account Owner Service Discovery request

### DIFF
--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -680,8 +680,8 @@ disco_features(_Host, <<>>, _From) ->
     Acc :: mongoose_disco:item_acc(),
     Params :: map(),
     Extra :: gen_hook:extra().
-disco_sm_items(Acc = #{from_jid := From, to_jid := To, node := Node}, _, _) ->
-    Items = disco_items(jid:to_lower(jid:to_bare(To)), Node, From),
+disco_sm_items(Acc = #{from_jid := From, to_jid := To}, _, _) ->
+    Items = disco_items(jid:to_lower(jid:to_bare(To)), <<>>, From),
     {ok, mongoose_disco:add_items(Items, Acc)}.
 
 -spec disco_items(mod_pubsub:host(), mod_pubsub:nodeId(), jid:jid()) -> [mongoose_disco:item()].
@@ -707,20 +707,6 @@ disco_items(Host, <<>>, From) ->
      },
     case mod_pubsub_db_backend:dirty(NodeBloc, ErrorDebug) of
         {result, Items} -> Items;
-        _ -> []
-    end;
-disco_items(Host, Node, From) ->
-    Action = fun (#pubsub_node{id = Nidx, type = Type, options = Options, owners = Owners}) ->
-                     case get_allowed_items_call(Host, Nidx, From, Type, Options, Owners) of
-                         {result, Items} ->
-                             {result, [disco_item(Host, ItemId) ||
-                                          #pubsub_item{itemid = {ItemId, _}} <- Items]};
-                         _ ->
-                             {result, []}
-                     end
-             end,
-    case dirty(Host, Node, Action, ?FUNCTION_NAME) of
-        {result, {_, Result}} -> Result;
         _ -> []
     end.
 


### PR DESCRIPTION
This PR addresses [#2335](https://github.com/esl/MongooseIM/issues/2335) and updates the behavior of PEP discovery in line with the XEP's specification.  

Following the discussion in the original issue and XEP's ([examples 13 and 15](https://xmpp.org/extensions/xep-0060.html#entity-info)), if a node attribute is provided in a PEP discovery request, the server will now return the same identities and features as it does for the PEP account itself.  

Similarly this PR ensures that item discovery behaves consistently, matching with [examples 9 and 11](https://xmpp.org/extensions/xep-0060.html#entity-nodes) in the specification.