### PR TITLE
MIM-2389 Fix wrong namespace when removing IQ handlers in mod_sic

### DIFF
--- a/src/mod_sic.erl
+++ b/src/mod_sic.erl
@@ -57,7 +57,7 @@ start(HostType, #{iqdisc := IQDisc}) ->
 
 -spec stop(mongooseim:host_type()) -> ok.
 stop(HostType) ->
-    [gen_iq_handler:remove_iq_handler_for_domain(HostType, ?NS_LAST, Component) ||
+    [gen_iq_handler:remove_iq_handler_for_domain(HostType, ?NS_SIC, Component) ||
         {Component, _Fn} <- iq_handlers()],
     ok.
 


### PR DESCRIPTION
`remove_iq_handler_for_domain` was called with wrong namespace in mod_sic.

The symptom for this bug was that, when mongooseim app was stopped, we were getting warnings about unregistering IQ handlers for `mod_last` which were not registered at all. It turned out that there was defect in mod_sic - when stopping `mod_sic` was unregistering `mod_last` handlers instead of its own.

The fix was tested manually in live MIM node.


