### PR TITLE
Improve migration guide for 6.3.2

### DIFF
--- a/doc/migrations/6.3.1_6.3.2.md
+++ b/doc/migrations/6.3.1_6.3.2.md
@@ -4,12 +4,15 @@ As of this release, usage of `fast_tls` for Client to Server connections (C2S) h
 `fast_tls` will be removed in a future release.
 
 From now on the default TLS library for C2S is `just_tls`, which uses TLS implementation from Erlang OTP.
-In our load tests `just_tls` is as performant as `fast_tls` and also has better standards compliance.
-
-This deprecation affects only C2S, `fast_tls` remains as a TLS implementation for S2S.
+In our load tests, `just_tls` is as performant as `fast_tls` and also has better standards compliance.
+This deprecation affects only C2S, and `fast_tls` remains as the TLS implementation for S2S.
 
 To continue using `fast_tls` for C2S in existing deployment after upgrade, make sure the
-option `tls.module` is set to `fast_tls` in `listen.c2s` section of your MongooseIM config.
+option [`tls.module`](../listeners/listen-c2s.md#listenc2stlsmodule) is set to `fast_tls` for each of your C2S listeners.
+
+If you leave `tls.module` unset, the TLS module will change from `fast_tls` to `just_tls` after the upgrade.
+One consequence is that the [`tls.protocol_options`](../listeners/listen-c2s.md#listenc2stlsprotocol_options-only-for-fast_tls) option, which you might have used, will be no longer valid.
+With `just_tls`, you need to use different options, e.g. [`tls.versions`](../listeners/listen-c2s.md#listenc2stlsversions-only-for-just_tls).
 
 ### Channel binding for TLS
 
@@ -19,67 +22,63 @@ We do plan to implement `channel binding` for `just_tls` (only for TLS 1.3) in t
 
 ### TLS handshake
 
-There is a difference between `fast_tls` and `just_tls` in client authentication behaviour during TLS handshake.
+There is a difference between `fast_tls` and `just_tls` in client authentication behaviour during TLS handshake:
 
-`fast_tls` doesn't verify client certificate during TLS handshake and relies on other mechanisms, like SASL,
-to authenticate client. It may involve client certificate, but is executed after TLS handshake succeeded,
-and in case of invalid certificate will result in an error reported in message stream.
-
-`just_tls` by default verifies client certificate during TLS handshake
-and aborts connection when client certificate is invalid. This is realised by the default settings in
-`just_tls` of `verify_mode` set to `peer` and `disconnect_on_failure` set to `true`.
+* `fast_tls` doesn't verify the client certificate during TLS handshake and relies on other mechanisms, like SASL, to authenticate the client.
+* `just_tls` by default verifies the client certificate during TLS handshake and aborts connection when the certificate is invalid. This is realised by the default settings in
+`just_tls`: `verify_mode` set to `peer` and `disconnect_on_failure` set to `true`.
 
 If you want to have the same behaviour for `just_tls` as it was in `fast_tls` regarding TLS handshake,
-set `tls.disconnect_on_failure` to `false`. This is required for example when using SASL for client authentication.
-
+set [`tls.disconnect_on_failure`](../listeners/listen-c2s.md#listenc2stlsdisconnect_on_failure-only-for-just_tls) to `false`. This is required for example when using [SASL EXTERNAL](../tutorials/client-certificate.md#enable-sasl-external-mechanism).
 It is also possible to completely disable client certificate verification during TLS
-handshake in `just_tls` by setting `tls.verify_mode` to `none`.
+handshake in `just_tls` by setting [`tls.verify_mode`](../listeners/listen-c2s.md#listenc2stlsverify_mode) to `none`.
 
-For more information regarding configuration of TLS for C2S see [Listener modules](../listeners/listen-c2s/#tls-options-for-c2s)
+For more information regarding configuration of TLS for C2S, see [C2S listener options](../listeners/listen-c2s.md#tls-options-for-c2s).
 
-## `exml` upgraded to 4.0
+## `exml` upgraded to 4.1.1
 
-### Change of internal format of XML messages affects the ways to upgrade MongooseIM cluster
+`exml` library used for parsing and encoding of XML messages was upgraded to version 4.1.1.
+In this new version, internal representation of XML elements has changed - element attributes are stored in a map (previously in a key-value list).
 
-`exml` library used for parsing and emitting of XML messages was upgraded to version 4.0.
-In this new version internal representation of XML elements changed - element attributes
-are stored in a map (previously in a key value list).
+### Impact on the upgrade procedure
 
-This is a disruptive change, and rollback to previous version is not possible.
+Parsed XML messages are being sent within MongooseIM cluster between Erlang nodes in internal representation, so to understand received messages (Erlang terms), all nodes must have the same code that handles XML elements.
+This makes a [rolling upgrade](../operation-and-maintenance/Rolling-upgrade.md) not viable for this release, as it would lead to multiple errors in the logs and clients being disconnected abruptly.
+There are following alternatives:
 
-Parsed XML messages are being sent within MongooseIM cluster between Erlang nodes in internal representation,
-so to understand received messages (Erlang terms), all nodes must have the same code that handle XML elements. This makes a rolling upgrade
-(an upgrade of a cluster node by node) not viable for this release.
+1. One solution is to stop the whole MongooseIM cluster, upgrade and start again.
 
-One solution is to stop the whole MongooseIM cluster, upgrade and start again.
-
-The second solution is to configure a new cluster running new version
+2. The second solution is to configure a new cluster running new version
 alongside the old cluster, and migrate traffic from the old one to the new one.
 
-There is a third solution, which allows to maintain service availability but not requiring building a full new cluster.
-In this solution, you upgrade nodes one by one (like in the rolling upgrade), but change configuration to not allow
-upgraded node to rejoin the old cluster, but instead run as a new cluster.
-That way all nodes are migrated one by one to the newly formed cluster. Both clusters have access the same database.
+3. There is a third solution, which allows to maintain service availability but not requiring building a full new cluster.
+  In this solution, you upgrade nodes one by one (like in the rolling upgrade), but change configuration to not allow the upgraded node to rejoin the old cluster, but instead run as a new cluster.
+  That way all nodes are migrated one by one to the newly formed cluster. Both clusters have to access the same database.
+  If you are using CETS, you can form a new cluster by changing [`internal_databases.cluster_name`](../configuration/internal-databases.md#internal_databasescetscluster_name).
 
-One warning regarding this solution: There is a corner case regarding access to archived messages only while both clusters
-are operating simultaneously. It may happen that users still connected to the old cluster try to retrieve newly archived messages.
-This will result in errors and possibly crashes as the old code doesn't recognise new internal representation.
-We just want to warn the operator about such possibility, the chance of it happening is slight, as we recommend the upgrade
-to be undertaken during the time of minimal traffic.
+### Archived XML - `mod_mam`
 
-### Archived XML - mod_mam
+The change of XML element representation could affect messages archived by `mod_mam`.
 
-Change of XML element representation also affects stored or archived messages, if they are stored in the internal Erlang term format.
+!!! question "Is my server affected?"
 
-There is a config setting `modules.mod_mam.db_message_format` which controls the message format for archived messages
-and its default is different depending on the database backend used.
-The default for RDBMS databases is `mam_message_compressed_eterm` (which is Erlang term format) while for Cassandra it is `mam_message_xml`.
+    There is a config setting [`modules.mod_mam.db_message_format`](../modules/mod_mam.md#modulesmod_mamdb_message_format), which controls the message format for archived messages, and its default is different depending on the database backend used.
 
-Messages stored in XML textual format (`mam_message_xml`) are not affected by `exml` version change.
+    * Messages stored in the XML textual format (`mam_message_xml`) are **not** affected.
+    * Messages stored in the Erlang term format (`mam_message_compressed_eterm` or `mam_message_eterm`) are affected.
 
-For messages stored as Erlang term (`mam_message_compressed_eterm` or `mam_message_eterm`), we provide transparent retrieval of the old format, while new messages will be written in the archive in
-the new format. This means that the change of the format is transparent in operations of MongooseIM.
-However if you have external tools accessing message archive, you may need to verify that they work correctly with the new internal XML element representation.
+For messages stored as Erlang terms, we provide transparent retrieval of the old format, while new messages will be written in the archive in the new format.
+However, a nonupgraded node would fail to read messages stored in the new format.
+This is not an issue unless you upgrade using method 2 or 3 from the list above (keeping two clusters running simultaneously), or you perform a rollback.
+To limit such issues, we recommend the upgrade to be undertaken during the time of minimal traffic.
+
+!!! info "What errors to expect?"
+    When a client connected to a nonupgraded node requests a message stored in the new format, you can expect:
+
+    * A warning log with `what=process_iq_error` on the MongooseIM node.
+    * An `internal-server-error` IQ stanza returned to the client.
+
+    Such issues would be transient during the upgrade, but if you attempt a rollback, they would persist until you upgrade again.
 
 ## Database migration
 


### PR DESCRIPTION
- Add explicit information about `protocol_options` being incompatible with `just_tls`
- Reword and reformat the migration guide for improved clarity
- Add more links to documentation
- Update `exml` version to 4.1.1
- Make it explicit that some issues are only possible with mod_mam
- Describe possible issues caused by a rollback or a "split-cluster" rolling upgrade
- Fix a broken link
