### PR TITLE
Changing links to MongooseIM packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 * [Getting started](https://esl.github.io/MongooseDocs/latest/getting-started/Installation/)
 * [Developer's guide](https://esl.github.io/MongooseDocs/latest/developers-guide/Testing-MongooseIM/)
-* [Packages](https://www.erlang-solutions.com/resources/download.html)
+* [Packages](https://github.com/esl/MongooseIM/releases/latest)
 * Product page: [https://www.erlang-solutions.com/products/mongooseim.html](https://www.erlang-solutions.com/products/mongooseim.html)
 * Documentation: [https://esl.github.io/MongooseDocs/](https://esl.github.io/MongooseDocs/latest/)
 * Try it now: [https://trymongoose.im](https://trymongoose.im)
@@ -45,7 +45,7 @@ For a quick start just download:
 
 * The [Docker image](https://hub.docker.com/r/erlangsolutions/mongooseim/) ([source code repository](https://github.com/esl/mongooseim-docker))
 * The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
-* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
+* The [pre-built packages](https://github.com/esl/MongooseIM/releases/latest) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
 
 ## Public testing
 

--- a/doc/getting-started/Installation.md
+++ b/doc/getting-started/Installation.md
@@ -10,7 +10,7 @@ Alternatively, check out our tutorial on [How to build MongooseIM from source co
 
 ## Packages
 
-Go to the [downloads](https://www.erlang-solutions.com/resources/download.html) section of the Erlang Solutions website, and choose the version of MongooseIM you want.
+Go to the [latest release](https://github.com/esl/MongooseIM/releases/latest) page and select the package compatible with your system version.
 The following sections describe the installation process for different operating systems.
 
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -58,7 +58,7 @@ We offer a set of additional server-side components:
 
 For a quick start just download:
 
-* The [pre-built packages](https://www.erlang-solutions.com/resources/download.html) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
+* The [pre-built packages](https://github.com/esl/MongooseIM/releases/latest) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
 * The [Docker image](https://hub.docker.com/r/erlangsolutions/mongooseim/) ([source code repository](https://github.com/esl/mongooseim-docker))
 * The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
 

--- a/doc/tutorials/How-to-build.md
+++ b/doc/tutorials/How-to-build.md
@@ -19,7 +19,6 @@ To compile MongooseIM you need:
       *   C and C++ compiler: `gcc`, `g++`,
       *   Erlang/OTP 26.0 or higher:
         * `erlang` EPEL package, or,
-        * `esl-erlang` from [Erlang Solutions website](https://www.erlang-solutions.com/resources/download.html), or,
         * install using [kerl](https://github.com/kerl/kerl),
       *   OpenSSL 0.9.8 or higher, for STARTTLS, SASL and SSL encryption: `openssl` and `openssl-devel`,
       *   ODBC library: `unixODBC-devel`,
@@ -31,7 +30,6 @@ To compile MongooseIM you need:
       *   C and C++ compiler: `gcc`, `g++`,
       *   Erlang/OTP 24.0 or higher:
         * `erlang` package, or,
-        * `esl-erlang` from [Erlang Solutions website](https://www.erlang-solutions.com/resources/download.html), or,
         * install using [kerl](https://github.com/kerl/kerl),
       *   OpenSSL 0.9.8 or higher, for STARTTLS, SASL and SSL encryption: `olibssl-dev`,
       *   ODBC library: `unixodbc-dev`,


### PR DESCRIPTION
Updating MongooseIM package URLs, replacing links to the ESL page with links to the latest release page on GitHub