### PR TITLE
Fast auth and channel bindings

### DIFF
--- a/big_tests/tests/fast_auth_token_SUITE.erl
+++ b/big_tests/tests/fast_auth_token_SUITE.erl
@@ -98,7 +98,13 @@ is_mech_supported(Mech, early_data) ->
     %% data)
     mech_to_cb_type(Mech) =:= none;
 is_mech_supported(Mech, ParentGroup) ->
-    true.
+    Ver = list_to_integer(erlang:system_info(otp_release)),
+    case mech_to_cb_type(Mech) of
+        expr ->
+            Ver >= 27;
+        _ ->
+            true
+    end.
 
 mech_to_cb_type(Mech) ->
     Type = lists:last(binary:split(Mech, <<"-">>, [global])),

--- a/src/fast_auth_token/mod_fast_auth_token_generic_mech.erl
+++ b/src/fast_auth_token/mod_fast_auth_token_generic_mech.erl
@@ -85,6 +85,21 @@ mech_to_cb_data(Mech, Socket) ->
         none ->
             <<>>;
         expr ->
+            %% The 'tls-exporter' Channel Binding Type
+            %% Descripbed in:
+            %% RFC 9266 Channel Bindings for TLS 1.3
+            %% https://www.ietf.org/rfc/rfc9266.html
+            %%
+            %% uses Exported Keying Material (EKM).
+            %% https://www.rfc-editor.org/rfc/rfc5705.html#section-4
+            %%
+            %% Arguments:
+            %% A disambiguating label string:
+            %%    The ASCII string "EXPORTER-Channel-Binding" with no terminating NUL.
+            %% Context value: Zero-length string (no_context).
+            %% Length: 32 bytes
+            %% Calls function with one label:
+            %% export_key_materials(Scoket, Labels, Contexts, WantedLengths, ConsumeSecret)
             case mongoose_xmpp_socket:export_key_materials(
                     Socket, [?CB_LABEL], [no_context], [32], true) of
                 {ok, [Msg | _]} when is_binary(Msg) ->

--- a/src/fast_auth_token/mod_fast_auth_token_generic_mech.erl
+++ b/src/fast_auth_token/mod_fast_auth_token_generic_mech.erl
@@ -10,26 +10,30 @@
 %% Called from cyrsasl
 -export([supports_sasl_module/2, sasl_modules/0]).
 
+-define(CB_LABEL, <<"EXPORTER-Channel-Binding">>).
+
 -record(fast_info, {
         creds :: mongoose_credentials:t(),
         agent_id :: mod_fast_auth_token:agent_id(),
         mechanism :: mod_fast_auth_token:mechanism(),
-        count :: mod_fast_auth_token:counter() | undefined
+        count :: mod_fast_auth_token:counter() | undefined,
+        socket :: mongoose_xmpp_socket:socket()
     }).
 -include("mongoose.hrl").
 -type fast_info() :: #fast_info{}.
+-type cb_data() :: binary().
 
 -spec mech_new(Host   :: jid:server(),
                Creds  :: mongoose_credentials:t(),
                SocketData :: term(),
                Mech :: mod_fast_auth_token:mechanism()) -> {ok, fast_info()} | {error, binary()}.
-mech_new(_Host, Creds, _SocketData = #{sasl_state := SaslState}, Mech) ->
+mech_new(_Host, Creds, _SocketData = #{sasl_state := SaslState, socket := Socket}, Mech) ->
     SaslModState = mod_sasl2:get_mod_state(SaslState),
     case SaslModState of
         #{encoded_id := AgentId} ->
             Count = mongoose_acc:get(mod_fast_auth_token, fast_count, undefined, SaslState),
             {ok, #fast_info{creds = Creds, agent_id = AgentId, mechanism = Mech,
-                            count = Count}};
+                            count = Count, socket = Socket}};
         _ ->
             {error, <<"not-sasl2">>}
     end;
@@ -39,7 +43,8 @@ mech_new(_Host, _Creds, _SocketData, _Mech) ->
 -spec mech_step(State :: fast_info(),
                 ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
                                        | {error, binary()}.
-mech_step(#fast_info{creds = Creds, agent_id = AgentId, mechanism = Mech, count = Count},
+mech_step(#fast_info{creds = Creds, agent_id = AgentId, mechanism = Mech,
+                     count = Count, socket = Socket},
           SerializedToken) ->
     %% SerializedToken is base64 decoded.
     Parts = binary:split(SerializedToken, <<0>>),
@@ -49,7 +54,7 @@ mech_step(#fast_info{creds = Creds, agent_id = AgentId, mechanism = Mech, count 
     LUser = jid:nodeprep(Username),
     case mod_fast_auth_token:read_tokens(HostType, LServer, LUser, AgentId) of
         {ok, TokenData} ->
-            CBData = <<>>,
+            CBData = mech_to_cb_data(LUser, Mech, Socket),
             case handle_auth(TokenData, InitiatorHashedToken, CBData, Mech, Count) of
                 {true, TokenSlot} ->
                     {ok, mongoose_credentials:extend(Creds,
@@ -64,6 +69,30 @@ mech_step(#fast_info{creds = Creds, agent_id = AgentId, mechanism = Mech, count 
             {error, <<"not-authorized">>}
     end.
 
+mech_to_cb_type(Mech) ->
+    Type = lists:last(binary:split(Mech, <<"-">>, [global])),
+    cb_type_to_atom(Type).
+
+cb_type_to_atom(<<"NONE">>) -> none;
+cb_type_to_atom(<<"EXPR">>) -> expr.
+
+-spec mech_to_cb_data(
+    LUser :: jid:luser(), 
+    Mech :: mod_fast_auth_token:mechanism(),
+    Socket :: mongoose_xmpp_socket:socket()) -> cb_data().
+mech_to_cb_data(LUser, Mech, Socket) ->
+    case mech_to_cb_type(Mech) of
+        none ->
+            <<>>;
+        expr ->
+            case mongoose_xmpp_socket:export_key_materials(
+                    Socket, [?CB_LABEL], [no_context], [32], true) of
+                {ok, [Msg | _]} when is_binary(Msg) ->
+                    Msg;
+                Other ->
+                    error({failed_to_get_channel_binding_data, LUser, Other})
+            end
+    end.
 
 %% For every client using FAST, have two token slots - 'current' and 'new'.
 %% Whenever generating a new token, always place it into the 'new' slot.
@@ -77,7 +106,7 @@ mech_step(#fast_info{creds = Creds, agent_id = AgentId, mechanism = Mech, count 
 %% in the 'current' slot (if any).
 -spec handle_auth(Data :: mod_fast_auth_token:tokens_data(),
                   InitiatorHashedToken :: binary(),
-                  CBData :: binary(),
+                  CBData :: cb_data(),
                   Mech :: mod_fast_auth_token:mechanism(),
                   Count :: mod_fast_auth_token:counter() | undefined) ->
       {true, Slot :: mod_fast_auth_token:token_slot()} | false.
@@ -152,6 +181,14 @@ mech_to_algo(<<"HT-SHA-3-256-NONE">>) -> sha3_256;
 mech_to_algo(<<"HT-SHA-3-384-NONE">>) -> sha3_384;
 mech_to_algo(<<"HT-SHA-3-512-NONE">>) -> sha3_512;
 
+mech_to_algo(<<"HT-SHA-256-EXPR">>) -> sha256;
+mech_to_algo(<<"HT-SHA-384-EXPR">>) -> sha384;
+mech_to_algo(<<"HT-SHA-512-EXPR">>) -> sha512;
+
+mech_to_algo(<<"HT-SHA-3-256-EXPR">>) -> sha3_256;
+mech_to_algo(<<"HT-SHA-3-384-EXPR">>) -> sha3_384;
+mech_to_algo(<<"HT-SHA-3-512-EXPR">>) -> sha3_512;
+
 mech_to_algo(_) -> unknown.
 
 -spec skip_announce_mechanism(mod_fast_auth_token:mechanism()) -> boolean().
@@ -169,7 +206,15 @@ mechanisms() ->
 
         <<"HT-SHA-3-256-NONE">>,
         <<"HT-SHA-3-384-NONE">>,
-        <<"HT-SHA-3-512-NONE">>
+        <<"HT-SHA-3-512-NONE">>,
+
+        <<"HT-SHA-256-EXPR">>,
+        <<"HT-SHA-384-EXPR">>,
+        <<"HT-SHA-512-EXPR">>,
+
+        <<"HT-SHA-3-256-EXPR">>,
+        <<"HT-SHA-3-384-EXPR">>,
+        <<"HT-SHA-3-512-EXPR">>
     ].
 
 -spec mech_id(mod_fast_auth_token:mechanism()) -> non_neg_integer().
@@ -179,7 +224,16 @@ mech_id(<<"HT-SHA-512-NONE">>) -> 8;
 
 mech_id(<<"HT-SHA-3-256-NONE">>) -> 10;
 mech_id(<<"HT-SHA-3-384-NONE">>) -> 11;
-mech_id(<<"HT-SHA-3-512-NONE">>) -> 12.
+mech_id(<<"HT-SHA-3-512-NONE">>) -> 12;
+
+%% Use ids from unassigned block
+mech_id(<<"HT-SHA-256-EXPR">>) -> 13;
+mech_id(<<"HT-SHA-384-EXPR">>) -> 14;
+mech_id(<<"HT-SHA-512-EXPR">>) -> 15;
+
+mech_id(<<"HT-SHA-3-256-EXPR">>) -> 16;
+mech_id(<<"HT-SHA-3-384-EXPR">>) -> 17;
+mech_id(<<"HT-SHA-3-512-EXPR">>) -> 18.
 
 -spec mech_name(non_neg_integer()) -> mod_fast_auth_token:mechanism().
 mech_name(1) -> <<"HT-SHA-256-NONE">>;
@@ -189,6 +243,14 @@ mech_name(8) -> <<"HT-SHA-512-NONE">>;
 mech_name(10) -> <<"HT-SHA-3-256-NONE">>;
 mech_name(11) -> <<"HT-SHA-3-384-NONE">>;
 mech_name(12) -> <<"HT-SHA-3-512-NONE">>;
+
+mech_name(13) -> <<"HT-SHA-256-EXPR">>;
+mech_name(14) -> <<"HT-SHA-384-EXPR">>;
+mech_name(15) -> <<"HT-SHA-512-EXPR">>;
+
+mech_name(16) -> <<"HT-SHA-3-256-EXPR">>;
+mech_name(17) -> <<"HT-SHA-3-384-EXPR">>;
+mech_name(18) -> <<"HT-SHA-3-512-EXPR">>;
 
 mech_name(_) -> <<"UNKNOWN-MECH">>. %% Just in case DB has an unknown mech_id
 
@@ -204,4 +266,12 @@ sasl_modules() ->
 
      cyrsasl_ht_sha3_256_none,
      cyrsasl_ht_sha3_384_none,
-     cyrsasl_ht_sha3_512_none].
+     cyrsasl_ht_sha3_512_none,
+
+     cyrsasl_ht_sha256_expr,
+     cyrsasl_ht_sha384_expr,
+     cyrsasl_ht_sha512_expr,
+
+     cyrsasl_ht_sha3_256_expr,
+     cyrsasl_ht_sha3_384_expr,
+     cyrsasl_ht_sha3_512_expr].

--- a/src/sasl/cyrsasl_ht_sha256_expr.erl
+++ b/src/sasl/cyrsasl_ht_sha256_expr.erl
@@ -1,0 +1,21 @@
+-module(cyrsasl_ht_sha256_expr).
+-behaviour(cyrsasl).
+
+-export([mechanism/0, mech_new/3, mech_step/2]).
+-ignore_xref([mech_new/3]).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"HT-SHA-256-EXPR">>.
+
+-spec mech_new(Host   :: jid:server(),
+               Creds  :: mongoose_credentials:t(),
+               SocketData :: term()) -> {ok, tuple()} | {error, binary()}.
+mech_new(Host, Creds, SocketData) ->
+    mod_fast_auth_token_generic_mech:mech_new(Host, Creds, SocketData, mechanism()).
+
+-spec mech_step(State :: tuple(),
+                ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
+                                       | {error, binary()}.
+mech_step(State, SerializedToken) ->
+    mod_fast_auth_token_generic_mech:mech_step(State, SerializedToken).

--- a/src/sasl/cyrsasl_ht_sha384_expr.erl
+++ b/src/sasl/cyrsasl_ht_sha384_expr.erl
@@ -1,0 +1,21 @@
+-module(cyrsasl_ht_sha384_expr).
+-behaviour(cyrsasl).
+
+-export([mechanism/0, mech_new/3, mech_step/2]).
+-ignore_xref([mech_new/3]).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"HT-SHA-384-EXPR">>.
+
+-spec mech_new(Host   :: jid:server(),
+               Creds  :: mongoose_credentials:t(),
+               SocketData :: term()) -> {ok, tuple()} | {error, binary()}.
+mech_new(Host, Creds, SocketData) ->
+    mod_fast_auth_token_generic_mech:mech_new(Host, Creds, SocketData, mechanism()).
+
+-spec mech_step(State :: tuple(),
+                ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
+                                       | {error, binary()}.
+mech_step(State, SerializedToken) ->
+    mod_fast_auth_token_generic_mech:mech_step(State, SerializedToken).

--- a/src/sasl/cyrsasl_ht_sha3_256_expr.erl
+++ b/src/sasl/cyrsasl_ht_sha3_256_expr.erl
@@ -1,0 +1,21 @@
+-module(cyrsasl_ht_sha3_256_expr).
+-behaviour(cyrsasl).
+
+-export([mechanism/0, mech_new/3, mech_step/2]).
+-ignore_xref([mech_new/3]).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"HT-SHA-3-256-EXPR">>.
+
+-spec mech_new(Host   :: jid:server(),
+               Creds  :: mongoose_credentials:t(),
+               SocketData :: term()) -> {ok, tuple()} | {error, binary()}.
+mech_new(Host, Creds, SocketData) ->
+    mod_fast_auth_token_generic_mech:mech_new(Host, Creds, SocketData, mechanism()).
+
+-spec mech_step(State :: tuple(),
+                ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
+                                       | {error, binary()}.
+mech_step(State, SerializedToken) ->
+    mod_fast_auth_token_generic_mech:mech_step(State, SerializedToken).

--- a/src/sasl/cyrsasl_ht_sha3_384_expr.erl
+++ b/src/sasl/cyrsasl_ht_sha3_384_expr.erl
@@ -1,0 +1,21 @@
+-module(cyrsasl_ht_sha3_384_expr).
+-behaviour(cyrsasl).
+
+-export([mechanism/0, mech_new/3, mech_step/2]).
+-ignore_xref([mech_new/3]).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"HT-SHA-3-384-EXPR">>.
+
+-spec mech_new(Host   :: jid:server(),
+               Creds  :: mongoose_credentials:t(),
+               SocketData :: term()) -> {ok, tuple()} | {error, binary()}.
+mech_new(Host, Creds, SocketData) ->
+    mod_fast_auth_token_generic_mech:mech_new(Host, Creds, SocketData, mechanism()).
+
+-spec mech_step(State :: tuple(),
+                ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
+                                       | {error, binary()}.
+mech_step(State, SerializedToken) ->
+    mod_fast_auth_token_generic_mech:mech_step(State, SerializedToken).

--- a/src/sasl/cyrsasl_ht_sha3_512_expr.erl
+++ b/src/sasl/cyrsasl_ht_sha3_512_expr.erl
@@ -1,0 +1,21 @@
+-module(cyrsasl_ht_sha3_512_expr).
+-behaviour(cyrsasl).
+
+-export([mechanism/0, mech_new/3, mech_step/2]).
+-ignore_xref([mech_new/3]).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"HT-SHA-3-512-EXPR">>.
+
+-spec mech_new(Host   :: jid:server(),
+               Creds  :: mongoose_credentials:t(),
+               SocketData :: term()) -> {ok, tuple()} | {error, binary()}.
+mech_new(Host, Creds, SocketData) ->
+    mod_fast_auth_token_generic_mech:mech_new(Host, Creds, SocketData, mechanism()).
+
+-spec mech_step(State :: tuple(),
+                ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
+                                       | {error, binary()}.
+mech_step(State, SerializedToken) ->
+    mod_fast_auth_token_generic_mech:mech_step(State, SerializedToken).

--- a/src/sasl/cyrsasl_ht_sha512_expr.erl
+++ b/src/sasl/cyrsasl_ht_sha512_expr.erl
@@ -1,0 +1,21 @@
+-module(cyrsasl_ht_sha512_expr).
+-behaviour(cyrsasl).
+
+-export([mechanism/0, mech_new/3, mech_step/2]).
+-ignore_xref([mech_new/3]).
+
+-spec mechanism() -> cyrsasl:mechanism().
+mechanism() ->
+    <<"HT-SHA-512-EXPR">>.
+
+-spec mech_new(Host   :: jid:server(),
+               Creds  :: mongoose_credentials:t(),
+               SocketData :: term()) -> {ok, tuple()} | {error, binary()}.
+mech_new(Host, Creds, SocketData) ->
+    mod_fast_auth_token_generic_mech:mech_new(Host, Creds, SocketData, mechanism()).
+
+-spec mech_step(State :: tuple(),
+                ClientIn :: binary()) -> {ok, mongoose_credentials:t()}
+                                       | {error, binary()}.
+mech_step(State, SerializedToken) ->
+    mod_fast_auth_token_generic_mech:mech_step(State, SerializedToken).


### PR DESCRIPTION
This PR addresses "XEP-0484 Channel bindings for mod_fast_token_auth MIM-2380"

Proposed changes include:
* New methods that support tls-exporter for channel binding
* tests
* 0rtt does not support channel binding with tls-exporter

