### PR TITLE
Deduplicate stream management buffer (solution 2+3)

### DIFF
--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -662,6 +662,12 @@ maybe_retry_state(StateData = #c2s_data{listener_opts = LOpts}, C2SState) ->
     end.
 
 -spec handle_cast(data(), state(), term()) -> fsm_res().
+handle_cast(StateData, _C2SState, {exit, {replaced, _} = Reason}) ->
+    ReasonText = <<"Replaced by new connection">>,
+    StreamConflict = mongoose_xmpp_errors:stream_conflict(StateData#c2s_data.lang, ReasonText),
+    send_element_from_server_jid(StateData, StreamConflict),
+    send_trailer(StateData),
+    {stop, {shutdown, Reason}};
 handle_cast(StateData, _C2SState, {exit, Reason}) when is_binary(Reason) ->
     StreamConflict = mongoose_xmpp_errors:stream_conflict(StateData#c2s_data.lang, Reason),
     send_element_from_server_jid(StateData, StreamConflict),
@@ -1131,7 +1137,7 @@ start_link(Params, ProcOpts) ->
 stop(Pid, Reason) ->
     gen_statem:cast(Pid, {stop, Reason}).
 
--spec exit(pid(), binary() | atom()) -> ok.
+-spec exit(pid(), binary() | atom() | {replaced, pid()}) -> ok.
 exit(Pid, Reason) ->
     gen_statem:cast(Pid, {exit, Reason}).
 

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -560,7 +560,7 @@ close_session_status(normal) ->
     <<>>;
 close_session_status({shutdown, retries}) ->
     <<"Too many attempts">>;
-close_session_status({shutdown, replaced}) ->
+close_session_status({shutdown, {replaced, _Pid}}) ->
     <<"Replaced by new connection">>;
 close_session_status({shutdown, Reason}) when is_atom(Reason) ->
     <<"Shutdown by reason: ", (atom_to_binary(Reason))/binary>>;

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -43,7 +43,6 @@
 -include("mongoose_config_spec.hrl").
 -define(STREAM_MGMT_H_MAX, (1 bsl 32 - 1)).
 -define(CONSTRAINT_CHECK_TIMEOUT, 5000).  %% 5 seconds
--define(IS_STREAM_MGMT_STOP(R), R =:= {shutdown, ?MODULE}; R =:= {shutdown, resumed}).
 -define(IS_ALLOWED_STATE(S), S =:= wait_for_session_establishment; S =:= session_established).
 
 -record(sm_state, {
@@ -381,44 +380,45 @@ notify_unacknowledged_msg(Acc, Jid) ->
 
 -spec reroute_unacked_messages(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
     mongoose_c2s_hooks:result().
-reroute_unacked_messages(Acc, #{c2s_data := StateData, reason := Reason}, #{host_type := HostType}) ->
+reroute_unacked_messages(Acc, #{c2s_state := C2SState, c2s_data := StateData, reason := Reason}, #{host_type := HostType}) ->
     MaybeSmState = get_mod_state(StateData),
-    maybe_handle_stream_mgmt_reroute(Acc, StateData, HostType, Reason, MaybeSmState).
+    maybe_handle_stream_mgmt_reroute(Acc, C2SState, StateData, HostType, Reason, MaybeSmState).
 
 -spec user_terminate(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
     mongoose_c2s_hooks:result().
-user_terminate(Acc, #{reason := Reason}, _Extra) when ?IS_STREAM_MGMT_STOP(Reason) ->
+user_terminate(Acc, #{c2s_state := ?EXT_C2S_STATE(resume_session)}, _Extra) ->
     {stop, Acc}; %% We stop here because this termination was triggered internally
 user_terminate(Acc, _Params, _Extra) ->
     {ok, Acc}.
 
 -spec maybe_handle_stream_mgmt_reroute(
-        mongoose_acc:t(), mongoose_c2s:data(), mongooseim:host_type(), term(), maybe_sm_state()) ->
+        mongoose_acc:t(), mongoose_c2s:state(), mongoose_c2s:data(), mongooseim:host_type(), term(), maybe_sm_state()) ->
     mongoose_c2s_hooks:result().
-maybe_handle_stream_mgmt_reroute(Acc, StateData, HostType, Reason, #sm_state{counter_in = H} = SmState)
-  when ?IS_STREAM_MGMT_STOP(Reason) ->
+maybe_handle_stream_mgmt_reroute(Acc, ?EXT_C2S_STATE(resume_session), StateData, HostType, Reason, #sm_state{counter_in = H} = SmState) ->
     Sid = mongoose_c2s:get_sid(StateData),
     do_remove_smid(HostType, Sid, H),
-    NewSmState = handle_user_terminate(SmState, StateData, HostType),
+    NewSmState = handle_user_terminate(SmState, StateData, HostType, Reason),
     {ok, mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewSmState})};
-maybe_handle_stream_mgmt_reroute(Acc, StateData, HostType, _Reason, #sm_state{} = SmState) ->
-    NewSmState = handle_user_terminate(SmState, StateData, HostType),
+maybe_handle_stream_mgmt_reroute(Acc, _C2SState, StateData, HostType, Reason, #sm_state{} = SmState) ->
+    NewSmState = handle_user_terminate(SmState, StateData, HostType, Reason),
     {ok, mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewSmState})};
-maybe_handle_stream_mgmt_reroute(Acc, _StateData, _HostType, _Reason, {error, not_found}) ->
+maybe_handle_stream_mgmt_reroute(Acc, _C2SState,_StateData, _HostType, _Reason, {error, not_found}) ->
     {ok, Acc}.
 
--spec handle_user_terminate(sm_state(), mongoose_c2s:data(), mongooseim:host_type()) -> sm_state().
-handle_user_terminate(#sm_state{counter_in = H} = SmState, StateData, HostType) ->
+-spec handle_user_terminate(sm_state(), mongoose_c2s:data(), mongooseim:host_type(), term()) -> sm_state().
+handle_user_terminate(#sm_state{counter_in = H} = SmState, StateData, HostType, Reason) ->
     Sid = mongoose_c2s:get_sid(StateData),
     do_remove_smid(HostType, Sid, H),
     FromServer = mongoose_c2s:get_lserver(StateData),
     NewState = add_delay_elements_to_buffer(SmState, FromServer),
-    reroute_buffer(StateData, NewState),
+    reroute_buffer(StateData, NewState, Reason),
     SmState#sm_state{buffer = [], buffer_size = 0}.
 
-reroute_buffer(StateData, #sm_state{buffer = Buffer, peer = {gen_statem, {Pid, _}}}) ->
+reroute_buffer(StateData, #sm_state{buffer = Buffer, peer = {gen_statem, {Pid, _}}}, _Reason) ->
     mongoose_c2s:reroute_buffer_to_pid(StateData, Pid, Buffer);
-reroute_buffer(StateData, #sm_state{buffer = Buffer}) ->
+reroute_buffer(StateData, #sm_state{buffer = Buffer}, {shutdown, {replaced, Pid}}) ->
+    mongoose_c2s:reroute_buffer_to_pid(StateData, Pid, Buffer);
+reroute_buffer(StateData, #sm_state{buffer = Buffer}, _Reason) ->
     mongoose_c2s:reroute_buffer(StateData, Buffer).
 
 add_delay_elements_to_buffer(#sm_state{buffer = Buffer} = SmState, FromServer) ->
@@ -429,7 +429,7 @@ add_delay_elements_to_buffer(#sm_state{buffer = Buffer} = SmState, FromServer) -
 terminate(Reason, C2SState, StateData) ->
     ?LOG_DEBUG(#{what => stream_mgmt_statem_terminate, reason => Reason,
                  c2s_state => C2SState, c2s_data => StateData}),
-    mongoose_c2s:terminate({shutdown, ?MODULE}, C2SState, StateData).
+    mongoose_c2s:terminate(Reason, C2SState, StateData).
 
 -spec handle_stream_mgmt(mongoose_acc:t(), mongoose_c2s_hooks:params(), exml:element()) ->
     mongoose_c2s_hooks:result().

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -366,7 +366,7 @@ too_many_sessions(_C) ->
     [given_session_opened(Sid, USR) || {Sid, USR} <- UserSessions],
 
     receive
-        {forwarded, _Sid, {'$gen_cast', {exit, <<"Replaced by new connection">>}}} ->
+        {forwarded, _Sid, {'$gen_cast', {exit, {replaced, _Pid}}}} ->
             ok;
         Message ->
             ct:fail("Unexpected message: ~p", [Message])


### PR DESCRIPTION
This PR solves the issue with duplicated stream management buffer - originally reported (and fixed) as a MAM issue, and then documented with tests in #4498. From the originally proposed [solutions](https://github.com/esl/MongooseIM/pull/4498#solutions), options 2 and 3 were chosen, but with a slightly different implementation for the latter.

Main changes:
- Prevent buffer duplication by adding `buffer_ref` to each newly buffered `Acc` and making sure they never duplicate in a single buffer. There is a need to perform a linear search of the buffer, but only if the incoming `Acc` already has `buffer_ref`.
- In case of session replacement, resend unacked messages to only to the replacing (new) session. This way, the duplication is completely avoided in case of session replacement (either because of the same resource or because the session limit was reached). This is done by putting the Pid of the new session in the termination reason.
- Update tests. There are also new `relay_*` tests for more than one reconnection in a row.

See commit messages for more information.