### PR TITLE
Sid is always defined - reflect this in the type specs

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -186,7 +186,7 @@ make_new_sid() ->
 
 -spec open_session(HostType, SID, JID, Priority, Info) -> ReplacedPids when
       HostType :: binary(),
-      SID :: 'undefined' | sid(),
+      SID :: sid(),
       JID :: jid:jid(),
       Priority :: integer() | undefined,
       Info :: info(),
@@ -201,7 +201,7 @@ open_session(HostType, SID, JID, Priority, Info) ->
 
 -spec close_session(Acc, SID, JID, Reason, Info) -> Acc1 when
       Acc :: mongoose_acc:t(),
-      SID :: 'undefined' | sid(),
+      SID :: sid(),
       JID :: jid:jid(),
       Reason :: close_reason(),
       Info :: info(),
@@ -284,7 +284,7 @@ get_raw_sessions(#jid{luser = LUser, lserver = LServer}) ->
 -spec set_presence(Acc, SID, JID, Prio, Presence, Info) -> Acc1 when
       Acc :: mongoose_acc:t(),
       Acc1 :: mongoose_acc:t(),
-      SID :: 'undefined' | sid(),
+      SID :: sid(),
       JID :: jid:jid(),
       Prio :: 'undefined' | integer(),
       Presence :: any(),
@@ -297,7 +297,7 @@ set_presence(Acc, SID, JID, Priority, Presence, Info) ->
 -spec unset_presence(Acc, SID, JID, Status, Info) -> Acc1 when
       Acc :: mongoose_acc:t(),
       Acc1 :: mongoose_acc:t(),
-      SID :: 'undefined' | sid(),
+      SID :: sid(),
       JID :: jid:jid(),
       Status :: binary(),
       Info :: info().
@@ -585,7 +585,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 
 -spec set_session(SID, JID, Prio, Info) -> ok | {error, any()} when
-      SID :: sid() | 'undefined',
+      SID :: sid(),
       JID :: jid:jid(),
       Prio :: priority(),
       Info :: info().

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -651,7 +651,7 @@ sm_filter_offline_message(HostType, From, To, Packet) ->
 
 -spec sm_register_connection(HostType, SID, JID, Info) -> Result when
     HostType :: mongooseim:host_type(),
-    SID :: 'undefined' | ejabberd_sm:sid(),
+    SID :: ejabberd_sm:sid(),
     JID :: jid:jid(),
     Info :: ejabberd_sm:info(),
     Result :: ok.
@@ -661,7 +661,7 @@ sm_register_connection(HostType, SID, JID, Info) ->
 
 -spec sm_remove_connection(Acc, SID, JID, Info, Reason) -> Result when
     Acc :: mongoose_acc:t(),
-    SID :: 'undefined' | ejabberd_sm:sid(),
+    SID :: ejabberd_sm:sid(),
     JID :: jid:jid(),
     Info :: ejabberd_sm:info(),
     Reason :: ejabberd_sm:close_reason(),


### PR DESCRIPTION
The type specs suggested that the session identifier (Sid) could be `undefined`, while this is not the case anywhere in the code.

After checking the usage of Sid in calls to the changed functions, I couldn't find any place where it is `undefined`, because it is always created with `make_new_sid()`.

Assuming that Sid is always defined makes it easier to rework handling of session replacement in my upcoming PR.