### PR TITLE
updating metrics documentation

### DIFF
--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -107,7 +107,7 @@ acks_test_cases() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    instrument_helper:start(instrumentation_events(), negative_instrumentation_events()),
+    instrument_helper:start(instrumentation_events()),
     Config1 = dynamic_modules:save_modules(host_type(), Config),
     escalus:init_per_suite([{escalus_user_db, {module, escalus_ejabberd}} | Config1]).
 
@@ -194,9 +194,6 @@ create_and_terminate_session(Config) ->
     % Assert that correct events have been executed
     [instrument_helper:assert(Event, Label, fun(#{byte_size := BS}) -> BS > 0 end)
      || {Event, Label} <- instrumentation_events(), Event =/= c2s_message_processed],
-
-    %% Verify C2S listener is not used
-    instrument_helper:assert_not_emitted(negative_instrumentation_events()),
 
     %% Assert the session was terminated.
     wait_for_zero_bosh_sessions().
@@ -954,11 +951,4 @@ instrumentation_events() ->
     instrument_helper:declared_events(mod_bosh, [])
     ++ [{c2s_message_processed, #{host_type => domain_helper:host_type()}},
         {xmpp_element_size_out, #{connection_type => c2s}, #{metrics => #{byte_size => histogram}}},
-        {xmpp_element_size_in, #{connection_type => c2s}, #{metrics => #{byte_size => histogram}}}]
-    -- negative_instrumentation_events().
-
-negative_instrumentation_events() ->
-    [{tcp_data_out, #{connection_type => c2s}},
-     {tcp_data_in, #{connection_type => c2s}},
-     {tls_data_out, #{connection_type => c2s}},
-     {tls_data_in, #{connection_type => c2s}}].
+        {xmpp_element_size_in, #{connection_type => c2s}, #{metrics => #{byte_size => histogram}}}].

--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -873,5 +873,7 @@ proxy_info() ->
      }.
 
 instrumentation_events() ->
-    [{c2s_message_processed, #{host_type => domain_helper:host_type()}}
-     | instrument_helper:declared_events(mongoose_c2s_listener, [])].
+    C2sGenericEvents =
+        [E || {_, Labels} = E <- instrument_helper:declared_events(mongoose_c2s, []),
+              not maps:is_key(host_type, Labels)],
+    [{c2s_message_processed, #{host_type => domain_helper:host_type()}} | C2sGenericEvents].

--- a/big_tests/tests/mim_c2s_SUITE.erl
+++ b/big_tests/tests/mim_c2s_SUITE.erl
@@ -236,8 +236,10 @@ escalus_start(Cfg, FlatCDs) ->
     Clients.
 
 instrumentation_events() ->
-    [{c2s_message_processed, #{host_type => domain_helper:host_type()}}
-     | instrument_helper:declared_events(mongoose_c2s_listener, [])].
+    C2sGenericEvents =
+        [E || {_, Labels} = E <- instrument_helper:declared_events(mongoose_c2s, []),
+              not maps:is_key(host_type, Labels)],
+    [{c2s_message_processed, #{host_type => domain_helper:host_type()}} | C2sGenericEvents].
 
 tcp_instrumentation_events() ->
     [{tcp_data_out, #{connection_type => c2s}},

--- a/big_tests/tests/websockets_SUITE.erl
+++ b/big_tests/tests/websockets_SUITE.erl
@@ -54,7 +54,7 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    instrument_helper:start(instrumentation_events(), negative_instrumentation_events()),
+    instrument_helper:start(instrumentation_events()),
     Config1 = escalus:init_per_suite(Config),
     Config2 = setup_listeners(Config1),
     escalus:create_users(Config2, escalus:get_users([alice, geralt, geralt_s, carol])).
@@ -116,8 +116,6 @@ metrics_test(Config) ->
                                                    (#{time := Time}) -> Time > 0 end)
          || {Event, Label} <- instrumentation_events()],
 
-        %% Verify C2S listener is not used
-        instrument_helper:assert_not_emitted(negative_instrumentation_events()),
         ok
         end).
 
@@ -172,11 +170,4 @@ instrumentation_events() ->
     instrument_helper:declared_events(mod_websockets, [])
     ++ [{c2s_message_processed, #{host_type => domain_helper:host_type()}},
         {xmpp_element_size_out, #{connection_type => c2s}, #{metrics => #{byte_size => histogram}}},
-        {xmpp_element_size_in, #{connection_type => c2s}, #{metrics => #{byte_size => histogram}}}]
-    -- negative_instrumentation_events().
-
-negative_instrumentation_events() ->
-    [{tcp_data_out, #{connection_type => c2s}},
-     {tcp_data_in, #{connection_type => c2s}},
-     {tls_data_out, #{connection_type => c2s}},
-     {tls_data_in, #{connection_type => c2s}}].
+        {xmpp_element_size_in, #{connection_type => c2s}, #{metrics => #{byte_size => histogram}}}].

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -296,22 +296,14 @@ All metrics are in bytes, and refer to unencrypted data (before encryption or af
     | ----------- | ---- | ----------- |
     | `xmpp_element_size_in_byte_size` | histogram | Size of an XML element received from a client, server or component. |
     | `xmpp_element_size_out_byte_size` | histogram | Size of an XML element sent to a client, server or component. |
-    | `c2s_tcp_data_in_byte_size` | counter | Amount of data received from a client via TCP channel. |
-    | `c2s_tcp_data_out_byte_size` | counter | Amount of data sent to a client via TCP channel. |
-    | `c2s_tls_data_in_byte_size` | counter | Amount of data received from a client via TLS channel. |
-    | `c2s_tls_data_out_byte_size` | counter | Amount of data sent to a client via TLS channel. |
+    | `tcp_data_in_byte_size` | counter | Amount of data received from a client, another XMPP server or component via TCP channel. |
+    | `tcp_data_out_byte_size` | counter | Amount of data sent to a client, another XMPP server or component via TCP channel. |
+    | `tls_data_in_byte_size` | counter | Amount of data received from a client, another XMPP server or component via TLS channel. |
+    | `tls_data_out_byte_size` | counter | Amount of data sent to a client, another XMPP server or component via TLS channel. |
     | `mod_bosh_data_received_byte_size` | counter | Amount of data received from a client via BOSH connection. |
     | `mod_bosh_data_sent_byte_size` | counter | Amount of data sent to a client via BOSH connection. |
     | `mod_websocket_data_received_byte_size` | counter | Amount of data received from a client via WebSocket connection. |
     | `mod_websocket_data_sent_byte_size` | counter | Amount of data sent to a client via WebSocket connection. |
-    | `s2s_tcp_data_in_byte_size` | counter | Amount of data received from another XMPP server via TCP channel. |
-    | `s2s_tcp_data_out_byte_size` | counter | Amount of data sent to another XMPP server via TCP channel. |
-    | `s2s_tls_data_in_byte_size` | counter | Amount of data received from another XMPP server via TLS channel. |
-    | `s2s_tls_data_out_byte_size` | counter | Amount of data sent to another XMPP server via TLS channel. |
-    | `component_tcp_data_in_byte_size` | counter | Amount of data received from a component via TCP channel. |
-    | `component_tcp_data_out_byte_size` | counter | Amount of data sent to a component via TCP channel. |
-    | `component_tls_data_in_byte_size` | counter | Amount of data received from a component via TLS channel. |
-    | `component_tls_data_out_byte_size` | counter | Amount of data sent to a component via TLS channel. |
 
 === "Exometer"
 
@@ -319,26 +311,26 @@ All metrics are in bytes, and refer to unencrypted data (before encryption or af
     | ----------- | ---- | ----------- |
     | `[global, xmpp_element_size_in, c2s, byte_size]` | histogram | Size of an XML element received from a client. |
     | `[global, xmpp_element_size_out, c2s, byte_size]` | histogram | Size of an XML element sent to a client. |
-    | `[global, c2s_tcp_data_in, byte_size]` | spiral | Amount of data received from a client via TCP channel. |
-    | `[global, c2s_tcp_data_out, byte_size]` | spiral | Amount of data sent to a client via TCP channel. |
-    | `[global, c2s_tls_data_in, byte_size]` | spiral | Amount of data received from a client via TLS channel. |
-    | `[global, c2s_tls_data_out, byte_size]` | spiral | Amount of data sent to a client via TLS channel. |
+    | `[global, tcp_data_in, c2s, byte_size]` | spiral | Amount of data received from a client via TCP channel. |
+    | `[global, tcp_data_out, c2s, byte_size]` | spiral | Amount of data sent to a client via TCP channel. |
+    | `[global, tls_data_in, c2s, byte_size]` | spiral | Amount of data received from a client via TLS channel. |
+    | `[global, tls_data_out, c2s, byte_size]` | spiral | Amount of data sent to a client via TLS channel. |
     | `[global, mod_bosh_data_received, byte_size]` | spiral | Amount of data received from a client via BOSH connection. |
     | `[global, mod_bosh_data_sent, byte_size]` | spiral | Amount of data sent to a client via BOSH connection. |
     | `[global, mod_websocket_data_received, byte_size]` | spiral | Amount of data received from a client via WebSocket connection. |
     | `[global, mod_websocket_data_sent, byte_size]` | spiral | Amount of data sent to a client via WebSocket connection. |
     | `[global, xmpp_element_size_in, s2s, byte_size]` | histogram | Size of an XML element received from another XMPP server. |
     | `[global, xmpp_element_size_out, s2s, byte_size]` | histogram | Size of an XML element sent to another XMPP server. |
-    | `[global, s2s_tcp_data_in, byte_size]` | spiral | Amount of data received from another XMPP server via TCP channel. |
-    | `[global, s2s_tcp_data_out, byte_size]` | spiral | Amount of data sent to another XMPP server via TCP channel. |
-    | `[global, s2s_tls_data_in, byte_size]` | spiral | Amount of data received from another XMPP server via TLS channel. |
-    | `[global, s2s_tls_data_out, byte_size]` | spiral | Amount of data sent to another XMPP server via TLS channel. |
+    | `[global, tcp_data_in, s2s, byte_size]` | spiral | Amount of data received from another XMPP server via TCP channel. |
+    | `[global, tcp_data_out, s2s, byte_size]` | spiral | Amount of data sent to another XMPP server via TCP channel. |
+    | `[global, tls_data_in, s2s, byte_size]` | spiral | Amount of data received from another XMPP server via TLS channel. |
+    | `[global, tls_data_out, s2s, byte_size]` | spiral | Amount of data sent to another XMPP server via TLS channel. |
     | `[global, xmpp_element_size_in, component, byte_size]` | histogram | Size of an XML element received from a component. |
     | `[global, xmpp_element_size_out, component, byte_size]` | histogram | Size of an XML element sent to a component. |
-    | `[global, component_tcp_data_in, byte_size]` | spiral | Amount of data received from a component via TCP channel. |
-    | `[global, component_tcp_data_out, byte_size]` | spiral | Amount of data sent to a component via TCP channel. |
-    | `[global, component_tls_data_in, byte_size]` | spiral | Amount of data received from a component via TLS channel. |
-    | `[global, component_tls_data_out, byte_size]` | spiral | Amount of data sent to a component via TLS channel. |
+    | `[global, tcp_data_in, component, byte_size]` | spiral | Amount of data received from a component via TCP channel. |
+    | `[global, tcp_data_out, component, byte_size]` | spiral | Amount of data sent to a component via TCP channel. |
+    | `[global, tls_data_in, component, byte_size]` | spiral | Amount of data received from a component via TLS channel. |
+    | `[global, tls_data_out, component, byte_size]` | spiral | Amount of data sent to a component via TLS channel. |
 
 ### CETS system metrics
 

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -54,12 +54,12 @@ All metrics are divided into the following groups:
 
     **Example:**
         ```
-        # TYPE c2s_xmpp_element_size_in_byte_size histogram
-        # HELP c2s_xmpp_element_size_in_byte_size Event: c2s_xmpp_element_size_in, Metric: byte_size
-        c2s_xmpp_element_size_in_byte_size_bucket{le="1"} 0
+        # TYPE xmpp_element_size_in_byte_size histogram
+        # HELP xmpp_element_size_in_byte_size Event: xmpp_element_size_in, Metric: byte_size
+        xmpp_element_size_in_byte_size_bucket{connection_type="c2s",le="1",} 0
         ...
-        c2s_xmpp_element_size_in_byte_size_bucket{le="1073741824"} 0
-        c2s_xmpp_element_size_in_byte_size_bucket{le="+Inf"} 0
+        xmpp_element_size_in_byte_size_bucket{connection_type="c2s",le="1073741824"} 0
+        xmpp_element_size_in_byte_size_bucket{connection_type="c2s",le="+Inf"} 0
         ```
 
 === "Exometer"
@@ -294,8 +294,8 @@ All metrics are in bytes, and refer to unencrypted data (before encryption or af
 
     | Metric name | Type | Description |
     | ----------- | ---- | ----------- |
-    | `c2s_xmpp_element_size_in_byte_size` | histogram | Size of an XML element received from a client. |
-    | `c2s_xmpp_element_size_out_byte_size` | histogram | Size of an XML element sent to a client. |
+    | `xmpp_element_size_in_byte_size` | histogram | Size of an XML element received from a client, server or component. |
+    | `xmpp_element_size_out_byte_size` | histogram | Size of an XML element sent to a client, server or component. |
     | `c2s_tcp_data_in_byte_size` | counter | Amount of data received from a client via TCP channel. |
     | `c2s_tcp_data_out_byte_size` | counter | Amount of data sent to a client via TCP channel. |
     | `c2s_tls_data_in_byte_size` | counter | Amount of data received from a client via TLS channel. |
@@ -304,14 +304,10 @@ All metrics are in bytes, and refer to unencrypted data (before encryption or af
     | `mod_bosh_data_sent_byte_size` | counter | Amount of data sent to a client via BOSH connection. |
     | `mod_websocket_data_received_byte_size` | counter | Amount of data received from a client via WebSocket connection. |
     | `mod_websocket_data_sent_byte_size` | counter | Amount of data sent to a client via WebSocket connection. |
-    | `s2s_xmpp_element_size_in_byte_size` | histogram | Size of an XML element received from another XMPP server. |
-    | `s2s_xmpp_element_size_out_byte_size` | histogram | Size of an XML element sent to another XMPP server. |
     | `s2s_tcp_data_in_byte_size` | counter | Amount of data received from another XMPP server via TCP channel. |
     | `s2s_tcp_data_out_byte_size` | counter | Amount of data sent to another XMPP server via TCP channel. |
     | `s2s_tls_data_in_byte_size` | counter | Amount of data received from another XMPP server via TLS channel. |
     | `s2s_tls_data_out_byte_size` | counter | Amount of data sent to another XMPP server via TLS channel. |
-    | `component_xmpp_element_size_in_byte_size` | histogram | Size of an XML element received from a component. |
-    | `component_xmpp_element_size_out_byte_size` | histogram | Size of an XML element sent to a component. |
     | `component_tcp_data_in_byte_size` | counter | Amount of data received from a component via TCP channel. |
     | `component_tcp_data_out_byte_size` | counter | Amount of data sent to a component via TCP channel. |
     | `component_tls_data_in_byte_size` | counter | Amount of data received from a component via TLS channel. |
@@ -321,8 +317,8 @@ All metrics are in bytes, and refer to unencrypted data (before encryption or af
 
     | Metric name | Type | Description |
     | ----------- | ---- | ----------- |
-    | `[global, c2s_xmpp_element_size_in, byte_size]` | histogram | Size of an XML element received from a client. |
-    | `[global, c2s_xmpp_element_size_out, byte_size]` | histogram | Size of an XML element sent to a client. |
+    | `[global, xmpp_element_size_in, c2s, byte_size]` | histogram | Size of an XML element received from a client. |
+    | `[global, xmpp_element_size_out, c2s, byte_size]` | histogram | Size of an XML element sent to a client. |
     | `[global, c2s_tcp_data_in, byte_size]` | spiral | Amount of data received from a client via TCP channel. |
     | `[global, c2s_tcp_data_out, byte_size]` | spiral | Amount of data sent to a client via TCP channel. |
     | `[global, c2s_tls_data_in, byte_size]` | spiral | Amount of data received from a client via TLS channel. |
@@ -331,14 +327,14 @@ All metrics are in bytes, and refer to unencrypted data (before encryption or af
     | `[global, mod_bosh_data_sent, byte_size]` | spiral | Amount of data sent to a client via BOSH connection. |
     | `[global, mod_websocket_data_received, byte_size]` | spiral | Amount of data received from a client via WebSocket connection. |
     | `[global, mod_websocket_data_sent, byte_size]` | spiral | Amount of data sent to a client via WebSocket connection. |
-    | `[global, s2s_xmpp_element_size_in, byte_size]` | histogram | Size of an XML element received from another XMPP server. |
-    | `[global, s2s_xmpp_element_size_out, byte_size]` | histogram | Size of an XML element sent to another XMPP server. |
+    | `[global, xmpp_element_size_in, s2s, byte_size]` | histogram | Size of an XML element received from another XMPP server. |
+    | `[global, xmpp_element_size_out, s2s, byte_size]` | histogram | Size of an XML element sent to another XMPP server. |
     | `[global, s2s_tcp_data_in, byte_size]` | spiral | Amount of data received from another XMPP server via TCP channel. |
     | `[global, s2s_tcp_data_out, byte_size]` | spiral | Amount of data sent to another XMPP server via TCP channel. |
     | `[global, s2s_tls_data_in, byte_size]` | spiral | Amount of data received from another XMPP server via TLS channel. |
     | `[global, s2s_tls_data_out, byte_size]` | spiral | Amount of data sent to another XMPP server via TLS channel. |
-    | `[global, component_xmpp_element_size_in, byte_size]` | histogram | Size of an XML element received from a component. |
-    | `[global, component_xmpp_element_size_out, byte_size]` | histogram | Size of an XML element sent to a component. |
+    | `[global, xmpp_element_size_in, component, byte_size]` | histogram | Size of an XML element received from a component. |
+    | `[global, xmpp_element_size_out, component, byte_size]` | histogram | Size of an XML element sent to a component. |
     | `[global, component_tcp_data_in, byte_size]` | spiral | Amount of data received from a component via TCP channel. |
     | `[global, component_tcp_data_out, byte_size]` | spiral | Amount of data sent to a component via TCP channel. |
     | `[global, component_tls_data_in, byte_size]` | spiral | Amount of data received from a component via TLS channel. |

--- a/src/c2s/mongoose_c2s_listener.erl
+++ b/src/c2s/mongoose_c2s_listener.erl
@@ -3,40 +3,13 @@
 -include("mongoose.hrl").
 
 -behaviour(mongoose_listener).
--export([listener_spec/1, instrumentation/1]).
+-export([listener_spec/1]).
 
 -behaviour(ranch_protocol).
 -export([start_link/3]).
 
 %% Hook handlers
 -export([handle_user_open_session/3]).
-
--export([instrumentation/0]).
--ignore_xref([instrumentation/0]).
-
--spec instrumentation(_) -> [mongoose_instrument:spec()].
-instrumentation(_) ->
-    lists:foldl(fun instrumentation/2, instrumentation(), ?ALL_HOST_TYPES).
-
--spec instrumentation() -> [mongoose_instrument:spec()].
-instrumentation() ->
-    [{tcp_data_in, #{connection_type => c2s}, #{metrics => #{byte_size => spiral}}},
-     {tcp_data_out, #{connection_type => c2s}, #{metrics => #{byte_size => spiral}}},
-     {tls_data_in, #{connection_type => c2s}, #{metrics => #{byte_size => spiral}}},
-     {tls_data_out, #{connection_type => c2s}, #{metrics => #{byte_size => spiral}}},
-     {xmpp_element_size_out, #{connection_type => c2s}, #{metrics => #{byte_size => histogram}}},
-     {xmpp_element_size_in, #{connection_type => c2s}, #{metrics => #{byte_size => histogram}}}].
-
--spec instrumentation(_, _) -> [mongoose_instrument:spec()].
-instrumentation(HostType, Acc) when is_binary(HostType) ->
-    [{c2s_message_processed, #{host_type => HostType},
-      #{metrics => #{time => histogram}}},
-     {c2s_auth_failed, #{host_type => HostType},
-      #{metrics => #{count => spiral}}},
-     {c2s_element_in, #{host_type => HostType},
-      #{metrics => maps:from_list([{Metric, spiral} || Metric <- mongoose_listener:element_spirals()])}},
-     {c2s_element_out, #{host_type => HostType},
-      #{metrics => maps:from_list([{Metric, spiral} || Metric <- mongoose_listener:element_spirals()])}} | Acc].
 
 %% mongoose_listener
 -spec listener_spec(mongoose_listener:options()) -> supervisor:child_spec().

--- a/src/ejabberd_cowboy.erl
+++ b/src/ejabberd_cowboy.erl
@@ -52,13 +52,8 @@
 
 -spec instrumentation(mongoose_listener:options()) -> [mongoose_instrument:spec()].
 instrumentation(#{handlers := Handlers}) ->
-    PerModule = [Spec || #{module := Module} <- Handlers,
-                         Spec <- mongoose_http_handler:instrumentation(Module)],
-    [{tcp_data_in, #{connection_type => http}, #{metrics => #{byte_size => spiral}}},
-     {tcp_data_out, #{connection_type => http}, #{metrics => #{byte_size => spiral}}},
-     {tls_data_in, #{connection_type => http}, #{metrics => #{byte_size => spiral}}},
-     {tls_data_out, #{connection_type => http}, #{metrics => #{byte_size => spiral}}}
-     | PerModule].
+    [Spec || #{module := Module} <- Handlers,
+             Spec <- mongoose_http_handler:instrumentation(Module)].
 
 -spec listener_spec(mongoose_listener:options()) -> supervisor:child_spec().
 listener_spec(Opts) ->

--- a/src/listeners/mongoose_listener.erl
+++ b/src/listeners/mongoose_listener.erl
@@ -110,7 +110,9 @@ stop_listener(Opts) ->
 %% Each listener module could be started more than once on different ports.
 -spec instrumentation([options()]) -> [mongoose_instrument:spec()].
 instrumentation(Listeners) ->
-    lists:usort([Spec || Listener <- Listeners, Spec <- listener_instrumentation(Listener)]).
+    %% c2s instrumentation is shared between Bosh, Websockets and TCP listeners
+    lists:usort([Spec || Listener <- Listeners, Spec <- listener_instrumentation(Listener)])
+    ++ mongoose_c2s:instrumentation().
 
 -spec listener_instrumentation(options()) -> [mongoose_instrument:spec()].
 listener_instrumentation(Opts = #{module := Module}) ->

--- a/src/listeners/mongoose_xmpp_socket.erl
+++ b/src/listeners/mongoose_xmpp_socket.erl
@@ -23,8 +23,6 @@
          get_transport/1,
          get_conn_type/1]).
 
--callback new(ranch:ref(), mongoose_listener:connection_type(), mongoose_listener:options()) ->
-    {state(), mongoose_listener:connection_type()}.
 -callback peername(state()) -> mongoose_transport:peer().
 -callback tcp_to_tls(state(), mongoose_listener:options(), side()) ->
     {ok, state()} | {error, term()}.
@@ -97,11 +95,10 @@ accept(ranch_ssl, Type, Ref, LOpts) ->
                              ranch_ref = Ref, ip = {PeerIp, PeerPort}},
     activate(SocketState),
     SocketState;
-accept(Module, Type, Ref, LOpts) ->
-    {State, NewType} = Module:new(Ref, Type, LOpts),
+accept(Module, Type, State, _LOpts) ->
     PeerIp = Module:peername(State),
     SocketState = #xmpp_socket{module = Module, state = State,
-                               connection_type = NewType, ip = PeerIp},
+                               connection_type = Type, ip = PeerIp},
     activate(SocketState),
     SocketState.
 

--- a/src/mod_bosh_socket.erl
+++ b/src/mod_bosh_socket.erl
@@ -20,8 +20,7 @@
          get_cached_responses/1]).
 
 %% mongoose_xmpp_socket callbacks
--export([new/3,
-         peername/1,
+-export([peername/1,
          tcp_to_tls/3,
          handle_data/2,
          activate/1,
@@ -1050,11 +1049,6 @@ ignore_undefined(Map) ->
     maps:filter(fun(_, V) -> V =/= undefined end, Map).
 
 %% mongoose_xmpp_socket callbacks
-
--spec new(mod_bosh:socket(), mongoose_listener:connection_type(), mongoose_listener:options()) ->
-    {mod_bosh:socket(), mongoose_listener:connection_type()}.
-new(Socket, _, _LOpts) ->
-    {Socket, http}.
 
 -spec peername(mod_bosh:socket()) -> mongoose_transport:peer().
 peername(#bosh_socket{peer = Peer}) ->

--- a/src/mod_websockets.erl
+++ b/src/mod_websockets.erl
@@ -21,8 +21,7 @@
          terminate/3]).
 
 %% mongoose_xmpp_socket callbacks
--export([new/3,
-         peername/1,
+-export([peername/1,
          tcp_to_tls/3,
          handle_data/2,
          activate/1,
@@ -366,11 +365,6 @@ case_insensitive_match(_, []) ->
     nomatch.
 
 %% mongoose_xmpp_socket callbacks
-
--spec new(socket(), mongoose_listener:connection_type(), mongoose_listener:options()) ->
-    {socket(), mongoose_listener:connection_type()}.
-new(Socket, _, _LOpts) ->
-    {Socket, http}.
 
 -spec peername(socket()) -> mongoose_transport:peer().
 peername(#websocket{peername = PeerName}) ->


### PR DESCRIPTION
this PR addresses the following things:
* updates description of the listeners' metrics.
* removes `connection_type => http` metrics since they duplicate existing mod_bosh_data_* and mod_websocket_data_* metrics and introduce inconsitency in `connection_type` label interpretation for various metrics.
* moves back c2s specific metrics definition into `mongoose_c2s` module, because it was impossible to configure websockets/bosh connection without tcp/tls c2s connection (even if tcp/tls c2s connection is not needed)