### PR TITLE
Port solution to run tests sequentially for mssql from the listeners branch

### DIFF
--- a/big_tests/tests/ct_helper.erl
+++ b/big_tests/tests/ct_helper.erl
@@ -6,7 +6,8 @@
          repeat_all_until_any_fail/2,
          groups_to_all/1,
          get_preset_var/3,
-         get_internal_database/0]).
+         get_internal_database/0,
+         add_params_to_list/3]).
 
 -type group_name() :: atom().
 
@@ -130,4 +131,17 @@ get_internal_database() ->
     case distributed_helper:lookup_config_opt([internal_databases, cets]) of
         {ok, _} -> cets;
         {error, not_found} -> mnesia
+    end.
+
+add_params_to_list(Groups, [], _IgnoreNames) ->
+    Groups;
+add_params_to_list(Groups, NewParams, IgnoreNames) ->
+    [add_params(Group, NewParams, IgnoreNames) || Group <- Groups].
+
+add_params({Name, Params, Tests} = Group, NewParams, IgnoreNames) ->
+    case lists:member(Name, IgnoreNames) of
+        true ->
+            Group;
+        false ->
+            {Name, NewParams ++ Params, Tests}
     end.

--- a/big_tests/tests/fast_auth_token_SUITE.erl
+++ b/big_tests/tests/fast_auth_token_SUITE.erl
@@ -21,7 +21,8 @@ all() ->
     [{group, Group} || {Group, _, _} <- groups()].
 
 groups() ->
-    [{Group, [parallel], tests()} || {Group, _Mech} <- mechanisms()].
+    Parallel = distributed_helper:maybe_parallel_group(),
+    [{Group, Parallel, tests()} || {Group, _Mech} <- mechanisms()].
 
 tests() ->
    [server_advertises_support_for_fast,

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -35,7 +35,7 @@ all() ->
     ].
 
 groups() ->
-    ParallelConfig = parallel_config(),
+    ParallelConfig = distributed_helper:maybe_parallel_group(),
     [
         {no_db, ParallelConfig, no_db_cases()},
         {db, [], [
@@ -61,14 +61,6 @@ groups() ->
         {rest_service_disabled, ParallelConfig, rest_service_disabled_cases()},
         {rest_db_fails, [], rest_db_fails_cases()}
     ].
-
-parallel_config() ->
-    %% These could be parallel but it seems like mssql CI can't handle the load
-    case distributed_helper:rpc(
-           distributed_helper:mim(), mongoose_rdbms, db_engine, [domain_helper:host_type()]) of
-        odbc -> [];
-        _ -> [parallel]
-    end.
 
 no_db_cases() -> [
     api_lookup_works,

--- a/test/common/distributed_helper.erl
+++ b/test/common/distributed_helper.erl
@@ -20,6 +20,18 @@ is_sm_distributed() ->
 is_sm_backend_distributed(ejabberd_sm_mnesia) -> true;
 is_sm_backend_distributed(Other) -> {false, Other}.
 
+db_engine() ->
+    rpc(mim(), mongoose_rdbms, db_engine, [domain_helper:host_type()]).
+
+%% To avoid DB timeouts, disables parallel execution for MSSQL
+maybe_parallel_group() ->
+    case catch db_engine() of
+        odbc ->
+            [];
+        _ ->
+            [parallel]
+    end.
+
 add_node_to_cluster(Config) ->
     Node2 = mim2(),
     add_node_to_cluster(Node2, Config).


### PR DESCRIPTION

This PR addresses "CI failures, and if we look at logs":

```
69 when=2025-03-07T17:21:14.838300+00:00 level=error what=rdbms_sql_execute_failed reason=timeout pid=<0.3477.0> at=mongoose_rdbms:sql_execute/4:872 stacktrace="eodbc:call/3:900 mongoose_rdbms_odbc:execute/4:107 timer:tc/4:649 mongoose_instrument:span/6:140 mongoose_rdbms:sql_execute/4:870 mongoose_rdbms:handle_call/3:680 wpool_process:handle_call/3:291 gen_server:try_handle_call/4:2381" statement_name=fast_upsert_and_set_current params="[<<\"domain.example.com\">>,<<\"alice_cannot_use_expired_token_in_the_current_slot_413\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"domain.example.com\">>,<<\"alice_cannot_use_expired_token_in_the_current_slot_413\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"verysecret\">>,1741454469,0,1,<<\"currentsecret\">>,1741367469,0,1,<<\"verysecret\">>,1741454469,0,1,<<\"currentsecret\">>,1741367469,0,1]" 
70 when=2025-03-07T17:21:17.820299+00:00 level=error what=rdbms_sql_execute_failed reason=timeout pid=<0.3479.0> at=mongoose_rdbms:sql_execute/4:872 stacktrace="eodbc:call/3:900 mongoose_rdbms_odbc:execute/4:107 timer:tc/4:649 mongoose_instrument:span/6:140 mongoose_rdbms:sql_execute/4:870 mongoose_rdbms:handle_call/3:680 wpool_process:handle_call/3:291 gen_server:try_handle_call/4:2381" statement_name=fast_upsert params="[<<\"domain.example.com\">>,<<\"alice_rerequest_token_with_initial_authentication_415\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"domain.example.com\">>,<<\"alice_rerequest_token_with_initial_authentication_415\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"3j7VWkbl9hAHtczW9fPHxkpwxNJLHYv2gg==\">>,1741627269,0,1,<<\"3j7VWkbl9hAHtczW9fPHxkpwxNJLHYv2gg==\">>,1741627269,0,1]" 
71 when=2025-03-07T17:21:17.826286+00:00 level=error what=rdbms_sql_execute_failed reason=timeout pid=<0.3481.0> at=mongoose_rdbms:sql_execute/4:872 stacktrace="eodbc:call/3:900 mongoose_rdbms_odbc:execute/4:107 timer:tc/4:649 mongoose_instrument:span/6:140 mongoose_rdbms:sql_execute/4:870 mongoose_rdbms:handle_call/3:680 wpool_process:handle_call/3:291 gen_server:try_handle_call/4:2381" statement_name=fast_upsert params="[<<\"domain.example.com\">>,<<\"alice_both_tokens_do_not_work_after_invalidation_417\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"domain.example.com\">>,<<\"alice_both_tokens_do_not_work_after_invalidation_417\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"T1mIVflsCP9klRedhuvJvPUrC1+mDDpGaA==\">>,1741627269,0,1,<<\"T1mIVflsCP9klRedhuvJvPUrC1+mDDpGaA==\">>,1741627269,0,1]" 
72 when=2025-03-07T17:21:17.831386+00:00 level=error reason="{timeout,[{eodbc,call,3,[{file,\"/home/circleci/project/_build/default/lib/eodbc/src/eodbc.erl\"},{line,900}]},{mongoose_rdbms_odbc,execute,4,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms_odbc.erl\"},{line,107}]},{timer,tc,4,[{file,\"timer.erl\"},{line,649}]},{mongoose_instrument,span,6,[{file,\"/home/circleci/project/src/instrument/mongoose_instrument.erl\"},{line,140}]},{mongoose_rdbms,sql_execute,4,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms.erl\"},{line,870}]},{mongoose_rdbms,handle_call,3,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms.erl\"},{line,680}]},{wpool_process,handle_call,3,[{file,\"/home/circleci/project/_build/default/lib/worker_pool/src/wpool_process.erl\"},{line,291}]},{gen_server,try_handle_call,4,[{file,\"gen_server.erl\"},{line,2381}]}]}" pid=<0.3485.0> at=gen_server:error_info/8:2646 client_info="{<0.7892.0>,{<0.7892.0>,[{gen,do_call,4,[{file,\"gen.erl\"},{line,260}]},{gen_server,call,3,[{file,\"gen_server.erl\"},{line,1218}]},{mod_fast_auth_token_rdbms,store_new_token,8,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token_rdbms.erl\"},{line,65}]},{timer,tc,4,[{file,\"timer.erl\"},{line,649}]},{mongoose_instrument,span,6,[{file,\"/home/circleci/project/src/instrument/mongoose_instrument.erl\"},{line,140}]},{mod_fast_auth_token,make_fast_token_response,6,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token.erl\"},{line,313}]},{mod_fast_auth_token,sasl2_success,3,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token.erl\"},{line,180}]},{gen_hook,apply_hook_function,3,[{file,\"/home/circleci/project/src/gen_hook.erl\"},{line,257}]}]}}" process_label=undefined last_message="{sql_cmd,{sql_execute,fast_upsert,[<<\"domain.example.com\">>,<<\"alice_request_token_with_initial_authentication_403\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"domain.example.com\">>,<<\"alice_request_token_with_initial_authentication_403\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"h/2AWlTl2ThvNByIbxAxVp5Ii0VbeyxXdA==\">>,1741627269,0,1,<<\"h/2AWlTl2ThvNByIbxAxVp5Ii0VbeyxXdA==\">>,1741627269,0,1]},-576460667398}" state="{state,'wpool_pool-mongoose_wpool$rdbms$global$default-5',{callback_cache,mongoose_rdbms,fun mongoose_rdbms:handle_call/3,fun mongoose_rdbms:handle_cast/2,fun mongoose_rdbms:handle_info/2},{state,<0.3486.0>,#{auth_get_password => {<<\"SELECT password, pass_details FROM users WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_add_user_scram => {<<\"INSERT INTO users(server, username, password, pass_details) VALUES (?, ?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_delete_user => {<<\"DELETE FROM users WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_list_users => {<<\"SELECT username FROM users WHERE server = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_list_users_range => {<<\"SELECT username FROM users WHERE server = ? ORDER BY username  OFFSET (?) ROWS FETCH NEXT (?) ROWS ONLY\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.0.27280070>]},auth_count_users => {<<\"SELECT COUNT(*) FROM users WHERE server = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_get => {<<\"SELECT jid, nick, subscription, ask, askmessage FROM rosterusers WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},fast_remove_user => {<<\"DELETE FROM fast_auth_token WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},insert_mam_message => {<<\"INSERT INTO mam_message (id, user_id, remote_bare_jid, remote_resource, direction, from_jid, origin_id, message, search_body, is_groupchat) VALUES (?, ?, ?, ?, \"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.3.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},mam_user_insert => {<<\"INSERT INTO mam_server_user (server, user_name) VALUES (?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},mam_user_select => {<<\"SELECT id FROM mam_server_user WHERE server=? AND user_name=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},offline_insert => {<<\"INSERT INTO offline_message (username, server, timestamp, expire, from_jid, packet, permanent_fields) VALUES (?, ?, ?, ?, ?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.3.27280070>]},offline_count_limit => {<<\"SELECT TOP (?) count(*) FROM offline_message WHERE server = ? AND username = ? \">>,[#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},offline_select => {<<\"SELECT timestamp, from_jid, packet, permanent_fields FROM offline_message WHERE server = ? AND username = ? AND (expire IS null OR expire > ?) ORDER BY timestam\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]},offline_delete => {<<\"DELETE FROM offline_message WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_get_id => {<<\"SELECT id FROM privacy_list WHERE server=? AND username=? AND name=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_get_names => {<<\"SELECT name FROM privacy_list WHERE server=? AND username=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_insert => {<<\"INSERT INTO privacy_list(server, username, name) VALUES (?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_default_get_name => {<<\"SELECT name FROM privacy_default_list WHERE server=? AND username=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_data_get_by_id => {<<\"SELECT ord, t, value, action, match_all, match_iq, match_message, match_presence_in, match_presence_out FROM privacy_list_data WHERE id=? ORDER BY ord\">>,[#Fun<mongoose_rdbms_odbc.4.27280070>]},privacy_data_insert => {<<\"INSERT INTO privacy_list_data(id, ord, t, value, action, match_all, match_iq, match_message, match_presence_in, match_presence_out) VALUES (?, ?, ?, ?, ?, ?, ?,\"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},privacy_default_upsert => {<<\"MERGE INTO privacy_default_list WITH (SERIALIZABLE) USING (SELECT  ? AS server,  ? AS username) AS source (server, username) ON (privacy_default_list.server = s\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_delete => {<<\"DELETE FROM rosterusers WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_group_delete => {<<\"DELETE FROM rostergroups WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_group_get => {<<\"SELECT jid, grp FROM rostergroups WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},vcard_remove => {<<\"DELETE FROM vcard WHERE username=? AND server=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},vcard_search_remove => {<<\"DELETE FROM vcard_search WHERE lusername=? AND server=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},domain_events_minmax => {<<\"SELECT MIN(id), MAX(id) FROM domain_events\">>,[]},mam_message_lookup_a_equ_limit => {<<\"SELECT TOP (?) id, from_jid, message FROM mam_message  WHERE user_id = ? ORDER BY id \">>,[#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]}},undefined,5000},#{worker => {mongoose_rdbms,#{driver => odbc,settings => \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\",query_timeout => 5000,max_start_interval => 30}},workers => 5,worker_opt => [],overrun_handler => {logger,warning},overrun_warning => infinity,pool_sup_shutdown => infinity,queue_type => fifo,time_checker => 'wpool_pool-mongoose_wpool$rdbms$global$default-time-checker',queue_manager => 'wpool_pool-mongoose_wpool$rdbms$global$default-queue-manager',max_overrun_warnings => infinity}}" log= name=wpool_pool-mongoose_wpool$rdbms$global$default-5 label={gen_server,terminate} 
73 when=2025-03-07T17:21:17.831163+00:00 level=error reason="{timeout,[{eodbc,call,3,[{file,\"/home/circleci/project/_build/default/lib/eodbc/src/eodbc.erl\"},{line,900}]},{mongoose_rdbms_odbc,execute,4,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms_odbc.erl\"},{line,107}]},{timer,tc,4,[{file,\"timer.erl\"},{line,649}]},{mongoose_instrument,span,6,[{file,\"/home/circleci/project/src/instrument/mongoose_instrument.erl\"},{line,140}]},{mongoose_rdbms,sql_execute,4,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms.erl\"},{line,870}]},{mongoose_rdbms,handle_call,3,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms.erl\"},{line,680}]},{wpool_process,handle_call,3,[{file,\"/home/circleci/project/_build/default/lib/worker_pool/src/wpool_process.erl\"},{line,291}]},{gen_server,try_handle_call,4,[{file,\"gen_server.erl\"},{line,2381}]}]}" pid=<0.3483.0> at=gen_server:error_info/8:2646 client_info="{<0.7915.0>,{<0.7915.0>,[{gen,do_call,4,[{file,\"gen.erl\"},{line,260}]},{gen_server,call,3,[{file,\"gen_server.erl\"},{line,1218}]},{mod_fast_auth_token_rdbms,store_new_token,8,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token_rdbms.erl\"},{line,65}]},{timer,tc,4,[{file,\"timer.erl\"},{line,649}]},{mongoose_instrument,span,6,[{file,\"/home/circleci/project/src/instrument/mongoose_instrument.erl\"},{line,140}]},{mod_fast_auth_token,make_fast_token_response,6,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token.erl\"},{line,313}]},{mod_fast_auth_token,sasl2_success,3,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token.erl\"},{line,180}]},{gen_hook,apply_hook_function,3,[{file,\"/home/circleci/project/src/gen_hook.erl\"},{line,257}]}]}}" process_label=undefined last_message="{sql_cmd,{sql_execute,fast_upsert,[<<\"domain.example.com\">>,<<\"alice_can_use_new_token_after_rerequest_token_with_initial_authentication_416\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"domain.example.com\">>,<<\"alice_can_use_new_token_after_rerequest_token_with_initial_authentication_416\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"oAYHgjVAUeUBXbr6RfWpTlsb9kL4eFOAcA==\">>,1741627269,0,1,<<\"oAYHgjVAUeUBXbr6RfWpTlsb9kL4eFOAcA==\">>,1741627269,0,1]},-576460667331}" state="{state,'wpool_pool-mongoose_wpool$rdbms$global$default-4',{callback_cache,mongoose_rdbms,fun mongoose_rdbms:handle_call/3,fun mongoose_rdbms:handle_cast/2,fun mongoose_rdbms:handle_info/2},{state,<0.3484.0>,#{domain_insert_event => {<<\"INSERT INTO domain_events (domain) VALUES (?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},offline_delete => {<<\"DELETE FROM offline_message WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},fast_remove_user => {<<\"DELETE FROM fast_auth_token WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},domain_events_minmax => {<<\"SELECT MIN(id), MAX(id) FROM domain_events\">>,[]},offline_insert => {<<\"INSERT INTO offline_message (username, server, timestamp, expire, from_jid, packet, permanent_fields) VALUES (?, ?, ?, ?, ?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.3.27280070>]},vcard_search_remove => {<<\"DELETE FROM vcard_search WHERE lusername=? AND server=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},offline_count_limit => {<<\"SELECT TOP (?) count(*) FROM offline_message WHERE server = ? AND username = ? \">>,[#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_data_insert => {<<\"INSERT INTO privacy_list_data(id, ord, t, value, action, match_all, match_iq, match_message, match_presence_in, match_presence_out) VALUES (?, ?, ?, ?, ?, ?, ?,\"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},fast_upsert => {<<\"MERGE INTO fast_auth_token WITH (SERIALIZABLE) USING (SELECT  ? AS server,  ? AS username,  ? AS user_agent_id) AS source (server, username, user_agent_id) ON (\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},privacy_list_get_id => {<<\"SELECT id FROM privacy_list WHERE server=? AND username=? AND name=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_get_names => {<<\"SELECT name FROM privacy_list WHERE server=? AND username=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_list_users_prefix_range => {<<\"SELECT username FROM users WHERE server = ? AND username LIKE ? ESCAPE '$' ORDER BY username  OFFSET (?) ROWS FETCH NEXT (?) ROWS ONLY\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.0.27280070>]},auth_delete_user => {<<\"DELETE FROM users WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_delete => {<<\"DELETE FROM rosterusers WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_list_users => {<<\"SELECT username FROM users WHERE server = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},insert_mam_message => {<<\"INSERT INTO mam_message (id, user_id, remote_bare_jid, remote_resource, direction, from_jid, origin_id, message, search_body, is_groupchat) VALUES (?, ?, ?, ?, \"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.3.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},domain_insert_settings => {<<\"INSERT INTO domain_settings (domain, host_type) VALUES (?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},mam_user_insert => {<<\"INSERT INTO mam_server_user (server, user_name) VALUES (?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_add_user_scram => {<<\"INSERT INTO users(server, username, password, pass_details) VALUES (?, ?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_count_users => {<<\"SELECT COUNT(*) FROM users WHERE server = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_group_delete => {<<\"DELETE FROM rostergroups WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_get => {<<\"SELECT jid, nick, subscription, ask, askmessage FROM rosterusers WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},domain_select => {<<\"SELECT host_type, status FROM domain_settings WHERE domain = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},mam_message_lookup_a_equ_limit => {<<\"SELECT TOP (?) id, from_jid, message FROM mam_message  WHERE user_id = ? ORDER BY id \">>,[#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]},privacy_data_get_by_id => {<<\"SELECT ord, t, value, action, match_all, match_iq, match_message, match_presence_in, match_presence_out FROM privacy_list_data WHERE id=? ORDER BY ord\">>,[#Fun<mongoose_rdbms_odbc.4.27280070>]},vcard_remove => {<<\"DELETE FROM vcard WHERE username=? AND server=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_insert => {<<\"INSERT INTO privacy_list(server, username, name) VALUES (?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_default_get_name => {<<\"SELECT name FROM privacy_default_list WHERE server=? AND username=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_default_upsert => {<<\"MERGE INTO privacy_default_list WITH (SERIALIZABLE) USING (SELECT  ? AS server,  ? AS username) AS source (server, username) ON (privacy_default_list.server = s\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_group_get => {<<\"SELECT jid, grp FROM rostergroups WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},mam_user_select => {<<\"SELECT id FROM mam_server_user WHERE server=? AND user_name=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},offline_select => {<<\"SELECT timestamp, from_jid, packet, permanent_fields FROM offline_message WHERE server = ? AND username = ? AND (expire IS null OR expire > ?) ORDER BY timestam\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]},auth_get_password => {<<\"SELECT password, pass_details FROM users WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]}},undefined,5000},#{worker => {mongoose_rdbms,#{driver => odbc,settings => \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\",query_timeout => 5000,max_start_interval => 30}},workers => 5,worker_opt => [],overrun_handler => {logger,warning},overrun_warning => infinity,pool_sup_shutdown => infinity,queue_type => fifo,time_checker => 'wpool_pool-mongoose_wpool$rdbms$global$default-time-checker',queue_manager => 'wpool_pool-mongoose_wpool$rdbms$global$default-queue-manager',max_overrun_warnings => infinity}}" log= name=wpool_pool-mongoose_wpool$rdbms$global$default-4 label={gen_server,terminate} 
74 when=2025-03-07T17:21:17.832299+00:00 level=error reason="{timeout,[{eodbc,call,3,[{file,\"/home/circleci/project/_build/default/lib/eodbc/src/eodbc.erl\"},{line,900}]},{mongoose_rdbms_odbc,execute,4,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms_odbc.erl\"},{line,107}]},{timer,tc,4,[{file,\"timer.erl\"},{line,649}]},{mongoose_instrument,span,6,[{file,\"/home/circleci/project/src/instrument/mongoose_instrument.erl\"},{line,140}]},{mongoose_rdbms,sql_execute,4,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms.erl\"},{line,870}]},{mongoose_rdbms,handle_call,3,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms.erl\"},{line,680}]},{wpool_process,handle_call,3,[{file,\"/home/circleci/project/_build/default/lib/worker_pool/src/wpool_process.erl\"},{line,291}]},{gen_server,try_handle_call,4,[{file,\"gen_server.erl\"},{line,2381}]}]}" pid=<0.3479.0> at=gen_server:error_info/8:2646 client_info="{<0.7918.0>,{<0.7918.0>,[{gen,do_call,4,[{file,\"gen.erl\"},{line,260}]},{gen_server,call,3,[{file,\"gen_server.erl\"},{line,1218}]},{mod_fast_auth_token_rdbms,store_new_token,8,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token_rdbms.erl\"},{line,65}]},{timer,tc,4,[{file,\"timer.erl\"},{line,649}]},{mongoose_instrument,span,6,[{file,\"/home/circleci/project/src/instrument/mongoose_instrument.erl\"},{line,140}]},{mod_fast_auth_token,make_fast_token_response,6,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token.erl\"},{line,313}]},{mod_fast_auth_token,sasl2_success,3,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token.erl\"},{line,180}]},{gen_hook,apply_hook_function,3,[{file,\"/home/circleci/project/src/gen_hook.erl\"},{line,257}]}]}}" process_label=undefined last_message="{sql_cmd,{sql_execute,fast_upsert,[<<\"domain.example.com\">>,<<\"alice_rerequest_token_with_initial_authentication_415\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"domain.example.com\">>,<<\"alice_rerequest_token_with_initial_authentication_415\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"3j7VWkbl9hAHtczW9fPHxkpwxNJLHYv2gg==\">>,1741627269,0,1,<<\"3j7VWkbl9hAHtczW9fPHxkpwxNJLHYv2gg==\">>,1741627269,0,1]},-576460667327}" state="{state,'wpool_pool-mongoose_wpool$rdbms$global$default-2',{callback_cache,mongoose_rdbms,fun mongoose_rdbms:handle_call/3,fun mongoose_rdbms:handle_cast/2,fun mongoose_rdbms:handle_info/2},{state,<0.3480.0>,#{offline_delete => {<<\"DELETE FROM offline_message WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},fast_remove_user => {<<\"DELETE FROM fast_auth_token WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},domain_events_minmax => {<<\"SELECT MIN(id), MAX(id) FROM domain_events\">>,[]},offline_insert => {<<\"INSERT INTO offline_message (username, server, timestamp, expire, from_jid, packet, permanent_fields) VALUES (?, ?, ?, ?, ?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.3.27280070>]},vcard_search_remove => {<<\"DELETE FROM vcard_search WHERE lusername=? AND server=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},offline_count_limit => {<<\"SELECT TOP (?) count(*) FROM offline_message WHERE server = ? AND username = ? \">>,[#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_data_insert => {<<\"INSERT INTO privacy_list_data(id, ord, t, value, action, match_all, match_iq, match_message, match_presence_in, match_presence_out) VALUES (?, ?, ?, ?, ?, ?, ?,\"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},fast_upsert => {<<\"MERGE INTO fast_auth_token WITH (SERIALIZABLE) USING (SELECT  ? AS server,  ? AS username,  ? AS user_agent_id) AS source (server, username, user_agent_id) ON (\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},cluster_insert_new => {<<\"INSERT INTO mongoose_cluster_id(k,v) VALUES ('cluster_id', ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_get_id => {<<\"SELECT id FROM privacy_list WHERE server=? AND username=? AND name=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_get_names => {<<\"SELECT name FROM privacy_list WHERE server=? AND username=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_list_users_prefix_range => {<<\"SELECT username FROM users WHERE server = ? AND username LIKE ? ESCAPE '$' ORDER BY username  OFFSET (?) ROWS FETCH NEXT (?) ROWS ONLY\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.0.27280070>]},auth_delete_user => {<<\"DELETE FROM users WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_delete => {<<\"DELETE FROM rosterusers WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_list_users => {<<\"SELECT username FROM users WHERE server = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},insert_mam_message => {<<\"INSERT INTO mam_message (id, user_id, remote_bare_jid, remote_resource, direction, from_jid, origin_id, message, search_body, is_groupchat) VALUES (?, ?, ?, ?, \"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.3.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},mam_user_insert => {<<\"INSERT INTO mam_server_user (server, user_name) VALUES (?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_add_user_scram => {<<\"INSERT INTO users(server, username, password, pass_details) VALUES (?, ?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_count_users => {<<\"SELECT COUNT(*) FROM users WHERE server = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_group_delete => {<<\"DELETE FROM rostergroups WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_list_users_prefix => {<<\"SELECT username FROM users WHERE server = ? AND username LIKE ? ESCAPE '$' ORDER BY username\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_get => {<<\"SELECT jid, nick, subscription, ask, askmessage FROM rosterusers WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},domain_select_events_between => {<<\"SELECT  domain_events.id, domain_events.domain, domain_settings.host_type  FROM domain_events  LEFT JOIN domain_settings ON (domain_settings.domain = domain_eve\"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]},mam_message_lookup_a_equ_limit => {<<\"SELECT TOP (?) id, from_jid, message FROM mam_message  WHERE user_id = ? ORDER BY id \">>,[#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]},privacy_data_get_by_id => {<<\"SELECT ord, t, value, action, match_all, match_iq, match_message, match_presence_in, match_presence_out FROM privacy_list_data WHERE id=? ORDER BY ord\">>,[#Fun<mongoose_rdbms_odbc.4.27280070>]},vcard_remove => {<<\"DELETE FROM vcard WHERE username=? AND server=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_insert => {<<\"INSERT INTO privacy_list(server, username, name) VALUES (?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_default_get_name => {<<\"SELECT name FROM privacy_default_list WHERE server=? AND username=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_default_upsert => {<<\"MERGE INTO privacy_default_list WITH (SERIALIZABLE) USING (SELECT  ? AS server,  ? AS username) AS source (server, username) ON (privacy_default_list.server = s\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_group_get => {<<\"SELECT jid, grp FROM rostergroups WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},mam_user_select => {<<\"SELECT id FROM mam_server_user WHERE server=? AND user_name=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},offline_select => {<<\"SELECT timestamp, from_jid, packet, permanent_fields FROM offline_message WHERE server = ? AND username = ? AND (expire IS null OR expire > ?) ORDER BY timestam\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]},auth_get_password => {<<\"SELECT password, pass_details FROM users WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]}},undefined,5000},#{worker => {mongoose_rdbms,#{driver => odbc,settings => \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\",query_timeout => 5000,max_start_interval => 30}},workers => 5,worker_opt => [],overrun_handler => {logger,warning},overrun_warning => infinity,pool_sup_shutdown => infinity,queue_type => fifo,time_checker => 'wpool_pool-mongoose_wpool$rdbms$global$default-time-checker',queue_manager => 'wpool_pool-mongoose_wpool$rdbms$global$default-queue-manager',max_overrun_warnings => infinity}}" log= name=wpool_pool-mongoose_wpool$rdbms$global$default-2 label={gen_server,terminate} 
75 when=2025-03-07T17:21:17.831768+00:00 level=error reason="{timeout,[{eodbc,call,3,[{file,\"/home/circleci/project/_build/default/lib/eodbc/src/eodbc.erl\"},{line,900}]},{mongoose_rdbms_odbc,execute,4,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms_odbc.erl\"},{line,107}]},{timer,tc,4,[{file,\"timer.erl\"},{line,649}]},{mongoose_instrument,span,6,[{file,\"/home/circleci/project/src/instrument/mongoose_instrument.erl\"},{line,140}]},{mongoose_rdbms,sql_execute,4,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms.erl\"},{line,870}]},{mongoose_rdbms,handle_call,3,[{file,\"/home/circleci/project/src/rdbms/mongoose_rdbms.erl\"},{line,680}]},{wpool_process,handle_call,3,[{file,\"/home/circleci/project/_build/default/lib/worker_pool/src/wpool_process.erl\"},{line,291}]},{gen_server,try_handle_call,4,[{file,\"gen_server.erl\"},{line,2381}]}]}" pid=<0.3477.0> at=gen_server:error_info/8:2646 client_info="{<0.7969.0>,{<0.7969.0>,[{gen,do_call,4,[{file,\"gen.erl\"},{line,260}]},{gen_server,call,3,[{file,\"gen_server.erl\"},{line,1218}]},{mod_fast_auth_token_rdbms,store_new_token,8,[{file,\"/home/circleci/project/src/fast_auth_token/mod_fast_auth_token_rdbms.erl\"},{line,79}]},{timer,tc,4,[{file,\"timer.erl\"},{line,649}]},{mongoose_instrument,span,6,[{file,\"/home/circleci/project/src/instrument/mongoose_instrument.erl\"},{line,140}]},{erpc,execute_call,4,[{file,\"erpc.erl\"},{line,1250}]}]}}" process_label=undefined last_message="{sql_cmd,{sql_execute,fast_upsert_and_set_current,[<<\"domain.example.com\">>,<<\"alice_cannot_use_expired_token_in_the_current_slot_413\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"domain.example.com\">>,<<\"alice_cannot_use_expired_token_in_the_current_slot_413\">>,<<\"d4565fa7-4d72-4749-b3d3-740edbf87770\">>,<<\"verysecret\">>,1741454469,0,1,<<\"currentsecret\">>,1741367469,0,1,<<\"verysecret\">>,1741454469,0,1,<<\"currentsecret\">>,1741367469,0,1]},-576460667388}" state="{state,'wpool_pool-mongoose_wpool$rdbms$global$default-1',{callback_cache,mongoose_rdbms,fun mongoose_rdbms:handle_call/3,fun mongoose_rdbms:handle_cast/2,fun mongoose_rdbms:handle_info/2},{state,<0.3478.0>,#{auth_get_password => {<<\"SELECT password, pass_details FROM users WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_set_password_scram => {<<\"UPDATE users SET password = ?, pass_details = ? WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_add_user_scram => {<<\"INSERT INTO users(server, username, password, pass_details) VALUES (?, ?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_delete_user => {<<\"DELETE FROM users WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_list_users => {<<\"SELECT username FROM users WHERE server = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_count_users_prefix => {<<\"SELECT COUNT(*) FROM users WHERE server = ? AND username LIKE ? ESCAPE '$'\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},auth_count_users => {<<\"SELECT COUNT(*) FROM users WHERE server = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_get => {<<\"SELECT jid, nick, subscription, ask, askmessage FROM rosterusers WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},fast_remove_user => {<<\"DELETE FROM fast_auth_token WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},fast_upsert => {<<\"MERGE INTO fast_auth_token WITH (SERIALIZABLE) USING (SELECT  ? AS server,  ? AS username,  ? AS user_agent_id) AS source (server, username, user_agent_id) ON (\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},insert_mam_message => {<<\"INSERT INTO mam_message (id, user_id, remote_bare_jid, remote_resource, direction, from_jid, origin_id, message, search_body, is_groupchat) VALUES (?, ?, ?, ?, \"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.3.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},mam_user_insert => {<<\"INSERT INTO mam_server_user (server, user_name) VALUES (?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},mam_user_select => {<<\"SELECT id FROM mam_server_user WHERE server=? AND user_name=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},offline_insert => {<<\"INSERT INTO offline_message (username, server, timestamp, expire, from_jid, packet, permanent_fields) VALUES (?, ?, ?, ?, ?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.3.27280070>]},offline_count_limit => {<<\"SELECT TOP (?) count(*) FROM offline_message WHERE server = ? AND username = ? \">>,[#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},offline_select => {<<\"SELECT timestamp, from_jid, packet, permanent_fields FROM offline_message WHERE server = ? AND username = ? AND (expire IS null OR expire > ?) ORDER BY timestam\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]},offline_delete => {<<\"DELETE FROM offline_message WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_get_id => {<<\"SELECT id FROM privacy_list WHERE server=? AND username=? AND name=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_get_names => {<<\"SELECT name FROM privacy_list WHERE server=? AND username=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_list_insert => {<<\"INSERT INTO privacy_list(server, username, name) VALUES (?, ?, ?)\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_default_get_name => {<<\"SELECT name FROM privacy_default_list WHERE server=? AND username=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},privacy_data_get_by_id => {<<\"SELECT ord, t, value, action, match_all, match_iq, match_message, match_presence_in, match_presence_out FROM privacy_list_data WHERE id=? ORDER BY ord\">>,[#Fun<mongoose_rdbms_odbc.4.27280070>]},privacy_data_insert => {<<\"INSERT INTO privacy_list_data(id, ord, t, value, action, match_all, match_iq, match_message, match_presence_in, match_presence_out) VALUES (?, ?, ?, ?, ?, ?, ?,\"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>,#Fun<mongoose_rdbms_odbc.5.27280070>]},privacy_default_upsert => {<<\"MERGE INTO privacy_default_list WITH (SERIALIZABLE) USING (SELECT  ? AS server,  ? AS username) AS source (server, username) ON (privacy_default_list.server = s\"...>>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_delete => {<<\"DELETE FROM rosterusers WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_group_delete => {<<\"DELETE FROM rostergroups WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},roster_group_get => {<<\"SELECT jid, grp FROM rostergroups WHERE server = ? AND username = ?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},vcard_remove => {<<\"DELETE FROM vcard WHERE username=? AND server=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},vcard_search_remove => {<<\"DELETE FROM vcard_search WHERE lusername=? AND server=?\">>,[#Fun<mongoose_rdbms_odbc.2.27280070>,#Fun<mongoose_rdbms_odbc.2.27280070>]},domain_select_events_between => {<<\"SELECT  domain_events.id, domain_events.domain, domain_settings.host_type  FROM domain_events  LEFT JOIN domain_settings ON (domain_settings.domain = domain_eve\"...>>,[#Fun<mongoose_rdbms_odbc.4.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]},mam_message_lookup_a_equ_limit => {<<\"SELECT TOP (?) id, from_jid, message FROM mam_message  WHERE user_id = ? ORDER BY id \">>,[#Fun<mongoose_rdbms_odbc.1.27280070>,#Fun<mongoose_rdbms_odbc.4.27280070>]}},undefined,5000},#{worker => {mongoose_rdbms,#{driver => odbc,settings => \"DSN=mongoose-mssql;UID=sa;PWD=mongooseim_secret+ESL123\",query_timeout => 5000,max_start_interval => 30}},workers => 5,worker_opt => [],overrun_handler => {logger,warning},overrun_warning => infinity,pool_sup_shutdown => infinity,queue_type => fifo,time_checker => 'wpool_pool-mongoose_wpool$rdbms$global$default-time-checker',queue_manager => 'wpool_pool-mongoose_wpool$rdbms$global$default-queue-manager',max_overrun_warnings => infinity}}" log= name=wpool_pool-mongoose_wpool$rdbms$global$default-1 label={gen_server,terminate} 
```

Proposed changes include:
* Port solution to run tests sequentially for mssql from the listeners branch (i.e. https://github.com/esl/MongooseIM/blob/feature/listeners/test/common/distributed_helper.erl#L23C1-L33C9)
* Issue is that test fail with odbc timeouts on CI due to high DB load

(Ported as is to avoid merging issues - the fix was already applied in the listeners branch, so we don't want to change helpers much probably)

