### PR TITLE
Remove SET SESSION query_cache_type=1 in MySQL

### DIFF
--- a/src/rdbms/mongoose_rdbms_mysql.erl
+++ b/src/rdbms/mongoose_rdbms_mysql.erl
@@ -44,7 +44,6 @@ connect(Options, QueryTimeout) ->
     case mysql:start_link([{query_timeout, QueryTimeout} | db_opts(Options)]) of
         {ok, Ref} ->
             mysql:query(Ref, <<"set names 'utf8mb4';">>),
-            mysql:query(Ref, <<"SET SESSION query_cache_type=1;">>),
             {ok, Ref};
         Error ->
             Error


### PR DESCRIPTION
This PR addresses MIM-2419

Proposed changes include:
* Remove SET SESSION query_cache_type=1 in MySQL
* It is not supported in MySQL 8
* It returns {error,{1193,<<"HY000">>,<<"Unknown system variable 'query_cache_type'">>} but connection keeps working

