### PR TITLE
Bundle OpenSSL 3.x with packages for older systems

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -725,7 +725,7 @@ filters:
   - &all_tags_and_master
     <<: *all_tags
     branches:
-      only: master
+      only: bundle-openssl-for-older-systems
 
 workflows:
   version: 2

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -725,7 +725,7 @@ filters:
   - &all_tags_and_master
     <<: *all_tags
     branches:
-      only: bundle-openssl-for-older-systems
+      only: master
 
 workflows:
   version: 2

--- a/doc/getting-started/Installation.md
+++ b/doc/getting-started/Installation.md
@@ -25,16 +25,22 @@ The following sections describe the installation process for different operating
 === "CentOS compatible: AlmaLinux / Rocky Linux"
 
     An ODBC (RDBMS) driver must be installed on your machine to unpack and install from RPM packages. Enter the following command in a terminal window to install the latest unixODBC driver:
-    
+
     ```bash
     sudo yum install unixODBC
     ```
-    
+
     Once the RPM file is downloaded, open a terminal window and navigate to the directory containing the package. Use the following command to unpack and install MongooseIM:
-    
+
     ```bash
     sudo rpm -i mongooseim_[version here].rpm
     ```
+
+!!! info
+    Packages for older systems (Ubuntu Focal, Debian Bullseye, Debian Buster, AlmaLinux 8, Rocky Linux 8)
+    include a bundled OpenSSL 3.x, as this version is required for MongooseIM to function correctly,
+    but is not available in the official repositories for these distributions.
+    If your system already has OpenSSL 3.x installed, the package will detect and use the system version instead of the bundled one.
 
 ## Docker
 

--- a/tools/pkg/scripts/deb/build_package.sh
+++ b/tools/pkg/scripts/deb/build_package.sh
@@ -20,14 +20,17 @@ OS_ID=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
 OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
 if { [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" -lt 22 ]; } || \
    { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 11 ]; }; then
-    export PKG_CONFIG_PATH="/usr/local/ssl/lib64/pkgconfig"
     export LDFLAGS="-L/usr/local/ssl/lib64"
     export CFLAGS="-I/usr/local/ssl/include"
 
     # Copy essential OpenSSL 3.x runtime files to bundle with the app
     mkdir -p mongooseim/opt/mongooseim/openssl/etc
     mkdir -p mongooseim/opt/mongooseim/openssl/include
-    cp -a /usr/local/ssl/lib64 mongooseim/opt/mongooseim/openssl/
+    if [ -d /usr/local/ssl/lib64 ]; then
+        cp -a /usr/local/ssl/lib64 mongooseim/opt/mongooseim/openssl/
+    else
+        cp -a /usr/local/ssl/lib mongooseim/opt/mongooseim/openssl/
+    fi
     cp -a /usr/local/ssl/openssl.cnf mongooseim/opt/mongooseim/openssl/etc/
     cp -a /usr/local/ssl/include/openssl mongooseim/opt/mongooseim/openssl/include/
 fi

--- a/tools/pkg/scripts/deb/build_package.sh
+++ b/tools/pkg/scripts/deb/build_package.sh
@@ -25,7 +25,6 @@ if { [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" -lt 22 ]; } || \
     # Copy essential OpenSSL 3.x runtime files to bundle with the app
     mkdir -p mongooseim/opt/mongooseim/openssl/etc
     mkdir -p mongooseim/opt/mongooseim/openssl/include
-    cp -a /usr/local/ssl/openssl.cnf mongooseim/opt/mongooseim/openssl/etc/
     cp -a /usr/local/ssl/include/openssl mongooseim/opt/mongooseim/openssl/include/
 
     if [ -d /usr/local/ssl/lib64 ]; then

--- a/tools/pkg/scripts/deb/build_package.sh
+++ b/tools/pkg/scripts/deb/build_package.sh
@@ -16,6 +16,22 @@ apt-get update
 
 rm -rf /usr/lib/erlang/man/man3/cerff.3.gz /usr/lib/erlang/man/man3/cerfl.3.gz /usr/lib/erlang/man/man3/cerfcl.3.gz /usr/lib/erlang/man/man3/cerfcf.3.gz /usr/lib/erlang/man/man3/cerfcf.3.gz /usr/lib/erlang/man/man1/x86_64-linux-gnu-gcov-tool.1.gz  /usr/lib/erlang/man/man1/ocamlbuild.native.1.gz  /usr/lib/erlang/man/man1/gcov-tool.1.gz /usr/lib/erlang/man/man1/ocamlbuild.byte.1.gz
 
+OS_ID=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
+OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
+if { [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" -lt 22 ]; } || \
+   { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 11 ]; }; then
+    export PKG_CONFIG_PATH="/usr/local/ssl/lib64/pkgconfig"
+    export LDFLAGS="-L/usr/local/ssl/lib64"
+    export CFLAGS="-I/usr/local/ssl/include"
+
+    # Copy essential OpenSSL 3.x runtime files to bundle with the app
+    mkdir -p mongooseim/opt/mongooseim/openssl/etc
+    mkdir -p mongooseim/opt/mongooseim/openssl/include
+    cp -a /usr/local/ssl/lib64 mongooseim/opt/mongooseim/openssl/
+    cp -a /usr/local/ssl/openssl.cnf mongooseim/opt/mongooseim/openssl/etc/
+    cp -a /usr/local/ssl/include/openssl mongooseim/opt/mongooseim/openssl/include/
+fi
+
 make clean
 sed -i '1 s/^.*$/\#\!\/bin\/bash/' tools/install
 ./tools/configure with-all user=mongooseim prefix="" system=yes

--- a/tools/pkg/scripts/deb/build_package.sh
+++ b/tools/pkg/scripts/deb/build_package.sh
@@ -19,20 +19,22 @@ rm -rf /usr/lib/erlang/man/man3/cerff.3.gz /usr/lib/erlang/man/man3/cerfl.3.gz /
 OS_ID=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
 OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
 if { [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" -lt 22 ]; } || \
-   { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 11 ]; }; then
-    export LDFLAGS="-L/usr/local/ssl/lib64"
+   { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 12 ]; }; then
     export CFLAGS="-I/usr/local/ssl/include"
 
     # Copy essential OpenSSL 3.x runtime files to bundle with the app
     mkdir -p mongooseim/opt/mongooseim/openssl/etc
     mkdir -p mongooseim/opt/mongooseim/openssl/include
-    if [ -d /usr/local/ssl/lib64 ]; then
-        cp -a /usr/local/ssl/lib64 mongooseim/opt/mongooseim/openssl/
-    else
-        cp -a /usr/local/ssl/lib mongooseim/opt/mongooseim/openssl/
-    fi
     cp -a /usr/local/ssl/openssl.cnf mongooseim/opt/mongooseim/openssl/etc/
     cp -a /usr/local/ssl/include/openssl mongooseim/opt/mongooseim/openssl/include/
+
+    if [ -d /usr/local/ssl/lib64 ]; then
+        export LDFLAGS="-L/usr/local/ssl/lib64"
+        cp -a /usr/local/ssl/lib64 mongooseim/opt/mongooseim/openssl/
+    else
+        export LDFLAGS="-L/usr/local/ssl/lib"
+        cp -a /usr/local/ssl/lib mongooseim/opt/mongooseim/openssl/
+    fi
 fi
 
 make clean

--- a/tools/pkg/scripts/deb/debian/postinst
+++ b/tools/pkg/scripts/deb/debian/postinst
@@ -40,10 +40,14 @@ setup()
     OS_ID=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
     OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
     if { [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" -lt 22 ]; } || \
-       { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 11 ]; }; then
+       { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 12 ]; }; then
         SYSTEM_OPENSSL=$(ldconfig -p | grep "libssl.so.3" | awk '{print $NF}' | head -n 1)
         if [ -z "$SYSTEM_OPENSSL" ]; then
-            echo "/opt/mongooseim/openssl/lib64" > /etc/ld.so.conf.d/mongooseim-openssl.conf
+                if [ -d /opt/mongooseim/openssl/lib64 ]; then
+                    echo "/opt/mongooseim/openssl/lib64" > /etc/ld.so.conf.d/mongooseim-openssl.conf
+                else
+                    echo "/opt/mongooseim/openssl/lib" > /etc/ld.so.conf.d/mongooseim-openssl.conf
+                fi
             ldconfig
         fi
     fi

--- a/tools/pkg/scripts/deb/debian/postinst
+++ b/tools/pkg/scripts/deb/debian/postinst
@@ -36,6 +36,17 @@ setup()
 		chown -R $NAME:$NAME $PKG_ROOT $MIM_CTL $ETC_DIR $VAR_LIB $VAR_LOCK $VAR_LOG
 	fi
 	#sed -i -e "s*\(RUNNER_SCRIPT_DIR=\).\**\1${PKG_ROOT}bin*" /usr/sbin/mongooseimctl
+
+    OS_ID=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
+    OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
+    if { [ "$OS_ID" = "ubuntu" ] && [ "$OS_VERSION" -lt 22 ]; } || \
+       { [ "$OS_ID" = "debian" ] && [ "$OS_VERSION" -lt 11 ]; }; then
+        SYSTEM_OPENSSL=$(ldconfig -p | grep "libssl.so.3" | awk '{print $NF}' | head -n 1)
+        if [ -z "$SYSTEM_OPENSSL" ]; then
+            echo "/opt/mongooseim/openssl/lib64" > /etc/ld.so.conf.d/mongooseim-openssl.conf
+            ldconfig
+        fi
+    fi
 }
 
 case "$1" in

--- a/tools/pkg/scripts/rpm/build_package.sh
+++ b/tools/pkg/scripts/rpm/build_package.sh
@@ -24,7 +24,11 @@ OS_ID=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
 OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
 if { [ "$OS_ID" = "rocky" ] && [ "$OS_VERSION" -lt 9 ]; } || \
    { [ "$OS_ID" = "almalinux" ] && [ "$OS_VERSION" -lt 9 ]; }; then
-    export LDFLAGS="-L/usr/local/ssl/lib64"
+    if [ -d /usr/local/ssl/lib64 ]; then
+        export LDFLAGS="-L/usr/local/ssl/lib64"
+    else
+        export LDFLAGS="-L/usr/local/ssl/lib"
+    fi
     export CFLAGS="-I/usr/local/ssl/include"
 
     bundle_openssl=1

--- a/tools/pkg/scripts/rpm/build_package.sh
+++ b/tools/pkg/scripts/rpm/build_package.sh
@@ -20,10 +20,24 @@ case "$arch" in
     ;;
 esac
 
+OS_ID=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
+OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
+if { [ "$OS_ID" = "rocky" ] && [ "$OS_VERSION" -lt 9 ]; } || \
+   { [ "$OS_ID" = "almalinux" ] && [ "$OS_VERSION" -lt 9 ]; }; then
+    export PKG_CONFIG_PATH="/usr/local/ssl/lib64/pkgconfig"
+    export LDFLAGS="-L/usr/local/ssl/lib64"
+    export CFLAGS="-I/usr/local/ssl/include"
+
+    bundle_openssl=1
+else
+    bundle_openssl=0
+fi
+
 rpmbuild -bb \
     --define "version ${version}" \
     --define "release ${revision}" \
     --define "architecture ${arch}" \
+    --define "with_bundled_openssl ${bundle_openssl}" \
     ~/rpmbuild/SPECS/mongooseim.spec
 
 source /etc/os-release

--- a/tools/pkg/scripts/rpm/build_package.sh
+++ b/tools/pkg/scripts/rpm/build_package.sh
@@ -24,7 +24,6 @@ OS_ID=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"')
 OS_VERSION=$(grep ^VERSION_ID= /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
 if { [ "$OS_ID" = "rocky" ] && [ "$OS_VERSION" -lt 9 ]; } || \
    { [ "$OS_ID" = "almalinux" ] && [ "$OS_VERSION" -lt 9 ]; }; then
-    export PKG_CONFIG_PATH="/usr/local/ssl/lib64/pkgconfig"
     export LDFLAGS="-L/usr/local/ssl/lib64"
     export CFLAGS="-I/usr/local/ssl/include"
 

--- a/tools/pkg/scripts/rpm/mongooseim.spec
+++ b/tools/pkg/scripts/rpm/mongooseim.spec
@@ -37,6 +37,7 @@ cp %{SOURCE0} .
 
 %install
 %if %{with_bundled_openssl}
+# Copy essential OpenSSL 3.x runtime files to bundle with the app
 mkdir -p %{buildroot}/opt/mongooseim/openssl/etc
 mkdir -p %{buildroot}/opt/mongooseim/openssl/include
 cp -a /usr/local/ssl/lib64 %{buildroot}/opt/mongooseim/openssl/

--- a/tools/pkg/scripts/rpm/mongooseim.spec
+++ b/tools/pkg/scripts/rpm/mongooseim.spec
@@ -40,7 +40,6 @@ cp %{SOURCE0} .
 # Copy essential OpenSSL 3.x runtime files to bundle with the app
 mkdir -p %{buildroot}/opt/mongooseim/openssl/etc
 mkdir -p %{buildroot}/opt/mongooseim/openssl/include
-cp -a /usr/local/ssl/openssl.cnf %{buildroot}/opt/mongooseim/openssl/etc/
 cp -a /usr/local/ssl/include/openssl %{buildroot}/opt/mongooseim/openssl/include/
 if [ -d /usr/local/ssl/lib64 ]; then
     cp -a /usr/local/ssl/lib64 %{buildroot}/opt/mongooseim/openssl/
@@ -95,7 +94,6 @@ rm -rf %{buildroot}
 %ifarch aarch64
 /opt/mongooseim/openssl/lib/
 %endif
-/opt/mongooseim/openssl/etc/openssl.cnf
 /opt/mongooseim/openssl/include/openssl/
 %endif
 


### PR DESCRIPTION
This PR adds a bundled OpenSSL 3.x for systems where it is not available in official repositories. The bundled version is used only if no system-wide OpenSSL 3.x installation is detected at runtime. This provides a middle ground between requiring users to install OpenSSL 3.x themselves and risking conflicts with existing installations.

If you're looking for the source of the OpenSSL 3.x integration, please see this related PR: https://github.com/esl/cimg-erlang/pull/11

Successful package build workflow: https://app.circleci.com/pipelines/github/esl/MongooseIM/13932/workflows/346bd630-2447-47e3-beca-09095641d36a