### PR TITLE
Reorganize S2S configuration options

### DIFF
--- a/doc/configuration/s2s.md
+++ b/doc/configuration/s2s.md
@@ -42,7 +42,7 @@ S2S shared secret used in the [Server Dialback](https://xmpp.org/extensions/xep-
 
 The options listed below affect only the outgoing S2S connections.
 
-### `s2s.address`
+### `s2s.outgoing.address`
 * **Syntax:** array of TOML tables with the following content:
     * `host` - string, mandatory, host name
     * `ip_address` - string, mandatory, IP address
@@ -51,34 +51,13 @@ The options listed below affect only the outgoing S2S connections.
 * **Example:**
 
 ```toml
-  address = [
+  outgoing.address = [
     {host = "my.xmpp.org", ip_address = "192.0.100.1"},
     {host = "your.xmpp.org", ip_address = "192.0.1.100", port = 5271}
   ]
 ```
 
 This option defines IP addresses and port numbers for specific non-local XMPP domains, allowing to override the DNS lookup for outgoing S2S connections.
-
-### `s2s.max_retry_delay`
-* **Syntax:** positive integer
-* **Default:** `300`
-* **Example:** `max_retry_delay = 300`
-
-Specifies the maximum time in seconds that MongooseIM will wait until the next attempt to connect to a remote XMPP server. The delays between consecutive attempts will be doubled until this limit is reached.
-
-### `s2s.outgoing.port`
-* **Syntax:** integer, port number
-* **Default:** `5269`
-* **Example:** `outgoing.port = 5270`
-
-Defines the port to be used for outgoing S2S connections.
-
-### `s2s.outgoing.ip_versions`
-* **Syntax:** array of integers (IP versions): `4` or `6`
-* **Default:** `[4, 6]`
-* **Example:** `outgoing.ip_versions = [6]`
-
-Specifies the order of IP address families to try when establishing an outgoing S2S connection.
 
 ### `s2s.outgoing.connection_timeout`
 * **Syntax:** positive integer or the string `"infinity"`
@@ -87,16 +66,87 @@ Specifies the order of IP address families to try when establishing an outgoing 
 
 Timeout (in milliseconds) for establishing an outgoing S2S connection.
 
-### `s2s.dns.timeout`
+### `s2s.outgoing.dns.retries`
+* **Syntax:** positive integer
+* **Default:** `2`
+* **Example:** `outgoing.dns.retries = 1`
+
+Number of DNS lookup attempts when opening an outgoing S2S connection.
+
+### `s2s.outgoing.dns.timeout`
 * **Syntax:** positive integer
 * **Default:** `10`
-* **Example:** `dns.timeout = 30`
+* **Example:** `outgoing.dns.timeout = 30`
 
 Timeout (in seconds) for DNS lookups when opening an outgoing S2S connection.
 
-### `s2s.dns.retries`
-* **Syntax:** positive integer
-* **Default:** `2`
-* **Example:** `dns.retries = 1`
+### `s2s.outgoing.ip_versions`
+* **Syntax:** array of integers (IP versions): `4` or `6`
+* **Default:** `[4, 6]`
+* **Example:** `outgoing.ip_versions = [6]`
 
-Number of DNS lookup attempts when opening an outgoing S2S connection.
+Specifies the order of IP address families to try when establishing an outgoing S2S connection.
+
+### `s2s.outgoing.max_retry_delay`
+* **Syntax:** positive integer
+* **Default:** `300`
+* **Example:** `outgoing.max_retry_delay = 300`
+
+Specifies the maximum time in seconds that MongooseIM will wait until the next attempt to connect to a remote XMPP server. The delays between consecutive attempts will be doubled until this limit is reached.
+
+### `s2s.outgoing.max_stanza_size`
+* **Syntax:** positive integer or the string `"infinity"`
+* **Default:** `"infinity"`
+* **Example:** `outgoing.max_stanza_size = 10_000`
+
+Maximum allowed incoming stanza size in bytes.
+!!! Warning
+    This limit is checked **after** the input data parsing, so it does not apply to the input data size itself.
+
+### `s2s.outgoing.port`
+* **Syntax:** integer, port number
+* **Default:** `5269`
+* **Example:** `outgoing.port = 5270`
+
+Defines the port to be used for outgoing S2S connections.
+
+### `s2s.outgoing.shaper`
+* **Syntax:** string, shaper name
+* **Default:** `"none"` (no shaper)
+* **Example:** `outgoing.shaper = "fast"`
+
+The shaper name that determines what traffic shaper is used to limit the incoming XMPP traffic to prevent the server from being flooded with incoming data.
+The shaper referenced here needs to be defined in the [`shaper`](shaper.md) configuration section.
+The value of the shaper name needs to be either the shaper name or the string `"none"`, which means no shaper.
+
+### `s2s.outgoing.state_timeout`
+* **Syntax:** non-negative integer or the string `"infinity"`
+* **Default:** `5000` (5 seconds)
+* **Example:** `outgoing.state_timeout = 10_000`
+
+Timeout value (in milliseconds) used by the state machine when waiting for the remote server to respond during stream negotiation and SASL authentication. After the timeout, the local server responds with the `connection-timeout` stream error and closes the connection.
+
+### `s2s.outgoing.stream_timeout`
+* **Syntax:** non-negative integer or the string `"infinity"`
+* **Default:** `600_000` (10 minutes)
+* **Example:** `outgoing.stream_timeout = 60_000`
+
+Timeout value (in milliseconds) used by the state machine for an established connection.
+When it passes without any sent or received data, the outgoing connection is closed due to inactivity.
+
+### TLS options for outgoing connections
+
+In order to enable TLS encryption, you need to ensure that the `s2s.outgoing.tls` subsection is present.
+It contains options with the same semantics as the corresponding options for [outgoing connection pools](outgoing-connections.md#tls-options).
+Additionally, the following options are supported:
+
+### `s2s.outgoing.tls.mode`
+* **Syntax:** string, one of `"tls"`, `"starttls"`, `"starttls_required"`
+* **Default:** `"starttls"`
+* **Example:** `outgoing.tls.mode = "starttls"`
+
+This option determines how the TLS encryption is set up.
+
+* `tls` - the local server initiates a TLS session immediately after connecting, before beginning the normal XML stream.
+* `starttls` - enables StartTLS, which upgrades the connection to TLS if supported by the remote server.
+* `starttls_required` - enables and enforces StartTLS usage. The connection is closed if StartTLS cannot be enabled.

--- a/rel/fed1.vars-toml.config
+++ b/rel/fed1.vars-toml.config
@@ -22,25 +22,25 @@
 {redis_database_number, "2"}.
 
 %% domain.example.com is for multitenancy preset, muc_SUITE:register_over_s2s
-{s2s_addr, "[[s2s.address]]
-    host = \"localhost\"
-    ip_address = \"127.0.0.1\"
+{s2s_addr, "[[s2s.outgoing.address]]
+        host = \"localhost\"
+        ip_address = \"127.0.0.1\"
 
-  [[s2s.address]]
-    host = \"pubsub.localhost\"
-    ip_address = \"127.0.0.1\"
+    [[s2s.outgoing.address]]
+      host = \"pubsub.localhost\"
+      ip_address = \"127.0.0.1\"
 
-  [[s2s.address]]
-    host = \"muc.localhost\"
-    ip_address = \"127.0.0.1\"
+    [[s2s.outgoing.address]]
+      host = \"muc.localhost\"
+      ip_address = \"127.0.0.1\"
 
-  [[s2s.address]]
-    host = \"localhost.bis\"
-    ip_address = \"127.0.0.1\"
+    [[s2s.outgoing.address]]
+      host = \"localhost.bis\"
+      ip_address = \"127.0.0.1\"
 
-  [[s2s.address]]
-    host = \"domain.example.com\"
-    ip_address = \"127.0.0.1\"
+    [[s2s.outgoing.address]]
+      host = \"domain.example.com\"
+      ip_address = \"127.0.0.1\"
 "}.
 
 {tls_config, "tls.verify_mode = \"none\"

--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -367,20 +367,22 @@
   ]
 
 [s2s]
-  {{#max_retry_delay}}
-  max_retry_delay = {{{max_retry_delay}}}
-  {{/max_retry_delay}}
   {{#s2s_default_policy}}
   default_policy = {{{s2s_default_policy}}}
   {{/s2s_default_policy}}
-  outgoing.port = {{{outgoing_s2s_port}}}
-  tls.mode = "starttls"
-  tls.verify_mode = "none"
-  tls.certfile = {{{s2s_certfile}}}
-  {{#s2s_addr}}
 
-  {{{s2s_addr}}}
-  {{/s2s_addr}}
+  [s2s.outgoing]
+    {{#max_retry_delay}}
+    max_retry_delay = {{{max_retry_delay}}}
+    {{/max_retry_delay}}
+    port = {{{outgoing_s2s_port}}}
+    tls.mode = "starttls"
+    tls.verify_mode = "none"
+    tls.certfile = {{{s2s_certfile}}}
+    {{#s2s_addr}}
+
+    {{{s2s_addr}}}
+    {{/s2s_addr}}
 
 {{#host_config}}
 {{{host_config}}}

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -57,9 +57,9 @@
 {auth_password_opts, "format = \"scram\"
     hash = [\"sha256\"]
     scram_iterations = 64"}.
-{s2s_addr, "[[s2s.address]]
-    host = \"fed1\"
-    ip_address = \"127.0.0.1\""}.
+{s2s_addr, "[[s2s.outgoing.address]]
+      host = \"fed1\"
+      ip_address = \"127.0.0.1\""}.
 
 {tls_config, "tls.verify_mode = \"none\"
   tls.certfile = \"priv/ssl/fake_server.pem\""}.

--- a/rel/mim2.vars-toml.config
+++ b/rel/mim2.vars-toml.config
@@ -21,9 +21,9 @@
 {default_server_domain, "\"localhost\""}.
 {cluster_name, "mim"}.
 {redis_database_number, "0"}.
-{s2s_addr, "[[s2s.address]]
-    host = \"localhost2\"
-    ip_address = \"127.0.0.1\""}.
+{s2s_addr, "[[s2s.outgoing.address]]
+      host = \"localhost2\"
+      ip_address = \"127.0.0.1\""}.
 
 {tls_config, "tls.verify_mode = \"none\"
   tls.certfile = \"priv/ssl/fake_server.pem\"

--- a/rel/mim3.vars-toml.config
+++ b/rel/mim3.vars-toml.config
@@ -25,9 +25,9 @@
 {cluster_name, "mim"}.
 {redis_database_number, "0"}.
 
-{s2s_addr, "[[s2s.address]]
-    host = \"localhost2\"
-    ip_address = \"127.0.0.1\""}.
+{s2s_addr, "[[s2s.outgoing.address]]
+      host = \"localhost2\"
+      ip_address = \"127.0.0.1\""}.
 {listen_component, ""}.
 
 {tls_config, "tls.verify_mode = \"none\"

--- a/rel/reg1.vars-toml.config
+++ b/rel/reg1.vars-toml.config
@@ -26,13 +26,13 @@
 {cluster_name, "reg"}.
 {redis_database_number, "1"}.
 
-{s2s_addr, "[[s2s.address]]
-    host = \"localhost\"
-    ip_address = \"127.0.0.1\"
+{s2s_addr, "[[s2s.outgoing.address]]
+      host = \"localhost\"
+      ip_address = \"127.0.0.1\"
 
-  [[s2s.address]]
-    host = \"localhost.bis\"
-    ip_address = \"127.0.0.1\""}.
+    [[s2s.outgoing.address]]
+      host = \"localhost.bis\"
+      ip_address = \"127.0.0.1\""}.
 {listen_component, "[[listen.component]]
   port = {{ component_port }}
   access = \"all\"

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -824,59 +824,9 @@ s2s() ->
                                             format_items = map},
                  <<"shared">> => #option{type = binary,
                                          validate = non_empty},
-                 <<"shaper">> => #option{type = atom,
-                                         validate = non_empty},
-                 <<"state_timeout">> => #option{type = int_or_infinity,
-                                                validate = non_negative},
-                 <<"stream_timeout">> => #option{type = int_or_infinity,
-                                                 validate = non_negative},
-                 <<"address">> => #list{items = s2s_address(),
-                                        format_items = map},
-                 <<"max_retry_delay">> => #option{type = integer,
-                                                  validate = positive},
-                 <<"max_stanza_size">> => #option{type = int_or_infinity,
-                                                  validate = positive,
-                                                  process = fun ?MODULE:process_infinity_as_zero/1},
-                 <<"outgoing">> => s2s_outgoing(),
-                 <<"dns">> => s2s_dns(),
-                 <<"tls">> => tls([client, xmpp])},
-       defaults = #{<<"default_policy">> => allow,
-                    <<"shaper">> => none,
-                    <<"max_stanza_size">> => 0,
-                    <<"max_retry_delay">> => 300,
-                    <<"state_timeout">> => timer:seconds(5),
-                    <<"stream_timeout">> => timer:minutes(10)},
+                 <<"outgoing">> => s2s_outgoing()},
+       defaults = #{<<"default_policy">> => allow},
        wrap = host_config
-      }.
-
-%% path: (host_config[].)s2s.dns
-s2s_dns() ->
-    #section{
-       items = #{<<"timeout">> => #option{type = integer,
-                                          validate = positive},
-                 <<"retries">> => #option{type = integer,
-                                          validate = positive}},
-       include = always,
-       defaults = #{<<"timeout">> => 10,
-                    <<"retries">> => 2}
-      }.
-
-%% path: (host_config[].)s2s.outgoing
-s2s_outgoing() ->
-    #section{
-       items = #{<<"port">> => #option{type = integer,
-                                       validate = port},
-                 <<"ip_versions">> =>
-                     #list{items = #option{type = integer,
-                                           validate = {enum, [4, 6]}},
-                           validate = unique_non_empty},
-                 <<"connection_timeout">> => #option{type = int_or_infinity,
-                                                     validate = positive}
-                },
-       include = always,
-       defaults = #{<<"port">> => 5269,
-                    <<"ip_versions">> => [4, 6], %% NOTE: we still prefer IPv4 first
-                    <<"connection_timeout">> => 10000}
       }.
 
 %% path: (host_config[].)s2s.host_policy[]
@@ -891,8 +841,46 @@ s2s_host_policy() ->
        process = fun ?MODULE:process_s2s_host_policy/1
       }.
 
-%% path: (host_config[].)s2s.address[]
-s2s_address() ->
+%% path: (host_config[].)s2s.outgoing
+s2s_outgoing() ->
+    #section{
+       items = #{<<"address">> => #list{items = s2s_outgoing_address(),
+                                        format_items = map},
+                 <<"connection_timeout">> => #option{type = int_or_infinity,
+                                                     validate = positive},
+                 <<"dns">> => s2s_outgoing_dns(),
+                 <<"ip_versions">> =>
+                     #list{items = #option{type = integer,
+                                           validate = {enum, [4, 6]}},
+                           validate = unique_non_empty},
+                 <<"max_retry_delay">> => #option{type = integer,
+                                                  validate = positive},
+                 <<"max_stanza_size">> => #option{type = int_or_infinity,
+                                                  validate = positive,
+                                                  process = fun ?MODULE:process_infinity_as_zero/1},
+                 <<"port">> => #option{type = integer,
+                                       validate = port},
+                 <<"shaper">> => #option{type = atom,
+                                         validate = non_empty},
+                 <<"state_timeout">> => #option{type = int_or_infinity,
+                                                validate = non_negative},
+                 <<"stream_timeout">> => #option{type = int_or_infinity,
+                                                 validate = non_negative},
+                 <<"tls">> => tls([client, xmpp])
+                },
+       include = always,
+       defaults = #{<<"connection_timeout">> => 10000,
+                    <<"ip_versions">> => [4, 6], %% NOTE: we still prefer IPv4 first
+                    <<"max_retry_delay">> => 300,
+                    <<"max_stanza_size">> => 0,
+                    <<"port">> => 5269,
+                    <<"shaper">> => none,
+                    <<"state_timeout">> => timer:seconds(5),
+                    <<"stream_timeout">> => timer:minutes(10)}
+      }.
+
+%% path: (host_config[].)s2s.outgoing.address[]
+s2s_outgoing_address() ->
     #section{
        items = #{<<"host">> => #option{type = binary,
                                        validate = non_empty},
@@ -905,6 +893,18 @@ s2s_address() ->
        required = [<<"host">>, <<"ip_address">>],
        process = fun ?MODULE:process_s2s_address/1,
        defaults = #{<<"tls">> => false}
+      }.
+
+%% path: (host_config[].)s2s.outgoing.dns
+s2s_outgoing_dns() ->
+    #section{
+       items = #{<<"timeout">> => #option{type = integer,
+                                          validate = positive},
+                 <<"retries">> => #option{type = integer,
+                                          validate = positive}},
+       include = always,
+       defaults = #{<<"timeout">> => 10,
+                    <<"retries">> => 2}
       }.
 
 %% Callbacks for 'process'

--- a/src/mongoose_addr_list.erl
+++ b/src/mongoose_addr_list.erl
@@ -189,7 +189,7 @@ ip_versions(HostType) ->
 -spec lookup_predefined_addresses(mongooseim:host_type(), jid:lserver()) ->
     {ok, pre_addr()} | {error, atom()}.
 lookup_predefined_addresses(HostType, LServer) ->
-    mongoose_config:lookup_opt([{s2s, HostType}, address, LServer]).
+    mongoose_config:lookup_opt([{s2s, HostType}, outgoing, address, LServer]).
 
 -spec outgoing_s2s_port(mongooseim:host_type()) -> inet:port_number().
 outgoing_s2s_port(HostType) ->
@@ -198,7 +198,7 @@ outgoing_s2s_port(HostType) ->
 -spec get_dns(mongooseim:host_type()) ->
     #{timeout := non_neg_integer(), retries := pos_integer()}.
 get_dns(HostType) ->
-    mongoose_config:get_opt([{s2s, HostType}, dns]).
+    mongoose_config:get_opt([{s2s, HostType}, outgoing, dns]).
 
 -spec prepare_addr
     ([inet:ip4_address()], inet:port_number(), with_tls(), hostname(), a) -> [addr()];

--- a/test/config_parser_SUITE_data/mongooseim-pgsql.toml
+++ b/test/config_parser_SUITE_data/mongooseim-pgsql.toml
@@ -298,11 +298,13 @@
 
 [s2s]
   default_policy = "allow"
-  outgoing.port = 5299
 
-  [[s2s.address]]
-    host = "fed1"
-    ip_address = "127.0.0.1"
+  [s2s.outgoing]
+    port = 5299
+
+    [[s2s.outgoing.address]]
+      host = "fed1"
+      ip_address = "127.0.0.1"
 
 [[host_config]]
   host = "localhost"

--- a/test/config_parser_SUITE_data/s2s_only.toml
+++ b/test/config_parser_SUITE_data/s2s_only.toml
@@ -8,14 +8,6 @@
 [s2s]
   default_policy = "allow"
   shared = "shared secret"
-  max_retry_delay = 30
-  outgoing.port = 5299
-  outgoing.connection_timeout = 4_000
-  outgoing.ip_versions = [6, 4]
-  dns.timeout = 30
-  dns.retries = 1
-  tls.cacertfile = "priv/ca.pem"
-  tls.server_name_indication.enabled = true
 
   [[s2s.host_policy]]
     host = "fed1"
@@ -25,11 +17,24 @@
     host = "reg1"
     policy = "deny"
 
-  [[s2s.address]]
-    host = "fed1"
-    ip_address = "127.0.0.1"
+  [s2s.outgoing]
+    connection_timeout = 4_000
+    dns.timeout = 30
+    dns.retries = 1
+    ip_versions = [6, 4]
+    max_retry_delay = 30
+    max_stanza_size = 10_000
+    port = 5299
+    state_timeout = 1_000
+    stream_timeout = 100_000
+    tls.cacertfile = "priv/ca.pem"
+    tls.server_name_indication.enabled = true
 
-  [[s2s.address]]
-    host = "fed2"
-    ip_address = "127.0.0.1"
-    port = 8765
+    [[s2s.outgoing.address]]
+      host = "fed1"
+      ip_address = "127.0.0.1"
+
+    [[s2s.outgoing.address]]
+      host = "fed2"
+      ip_address = "127.0.0.1"
+      port = 8765

--- a/test/mongoose_config_SUITE.erl
+++ b/test/mongoose_config_SUITE.erl
@@ -186,7 +186,7 @@ minimal_config_opts() ->
       {auth, <<"localhost">>} => config_parser_helper:default_auth(),
       {modules, <<"localhost">>} => #{},
       {replaced_wait_timeout, <<"localhost">>} => 2000,
-      {s2s, <<"localhost">>} => config_parser_helper:default_s2s(),
+      {s2s, <<"localhost">>} => config_parser_helper:default_config([s2s]),
       instrumentation => config_parser_helper:default_config([instrumentation])}.
 
 start_slave_node(Config) ->


### PR DESCRIPTION
After the rework of S2S options in `feature/listeners`, most options affect only outgoing connections, because incoming connections are configured with the S2S listeners. However, only three options were present in the `s2s.outgoing` subsection, making it confusing for the user. This PR moves all such options to `s2s.outgoing`. See the first commit for a complete list of options.

Additional changes:
- Improve documentation, because some S2S options were not described in the docs.
- Test all options in `config_parser_SUITE`.
- Correct multiple minor issues (see commit messages).

In the future, we have to update the migration guide with these changes.





