### PR TITLE
Listeners/improve instrumentation

### DIFF
--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -111,17 +111,17 @@ register_one_component(Config) ->
                  end,
     CheckBytes = fun(#{byte_size := S}) -> S > 0 end,
     CheckServer = fun(#{lserver := S}) -> S =:= ComponentAddr end,
-    % start stream reply
+
+    %% Expect events for handshake, but not for 'start stream'.
     instrument_helper:assert(xmpp_element_size_out, #{connection_type => component}, FullCheckF,
-        #{expected_count => 2, min_timestamp => TS}),
-    % 1. start stream, 2. component handshake
-    instrument_helper:assert(component_auth_failed, #{}, FullCheckF,
-        #{expected_count => 0, min_timestamp => TS}),
+        #{expected_count => 1, min_timestamp => TS}),
     instrument_helper:assert(xmpp_element_size_in, #{connection_type => component}, FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
+
+    instrument_helper:assert(component_auth_failed, #{}, FullCheckF,
+        #{expected_count => 0, min_timestamp => TS}),
     instrument_helper:assert(tcp_data_in, #{connection_type => component}, CheckBytes,
         #{min_timestamp => TS}),
-    % 1. start stream reply, 2. handshake reply
     instrument_helper:assert(tcp_data_out, #{connection_type => component}, CheckBytes,
         #{min_timestamp => TS}),
 

--- a/big_tests/tests/metrics_c2s_SUITE.erl
+++ b/big_tests/tests/metrics_c2s_SUITE.erl
@@ -195,7 +195,7 @@ assert_events(Dir, CheckElFun) ->
     instrument_helper:assert(
       event_name(Dir), #{host_type => host_type()},
       fun(M = #{element := El}) ->
-               maps:remove(element, M) =:= #{count => 1} andalso CheckElFun(El)
+               maps:remove(element, M) =:= #{jid => undefined, count => 1} andalso CheckElFun(El)
       end).
 
 assert_event(Dir, ClientOrJid, Measurements, CheckElFun) ->

--- a/big_tests/tests/s2s_SUITE.erl
+++ b/big_tests/tests/s2s_SUITE.erl
@@ -571,9 +571,9 @@ assert_events(TS, Config) ->
     Filter = fun(#{byte_size := S}) -> S > 0 end,
 
     instrument_helper:assert(xmpp_element_size_in, Labels, Filter,
-        #{expected_count => element_count(in, TLS), min_timestamp => TS}),
+        #{expected_count => element_count(TLS), min_timestamp => TS}),
     instrument_helper:assert(xmpp_element_size_out, Labels, Filter,
-        #{expected_count => element_count(out, TLS), min_timestamp => TS}),
+        #{expected_count => element_count(TLS), min_timestamp => TS}),
     case TLS of
         true ->
             instrument_helper:assert(tls_data_out, Labels, Filter, #{min_timestamp => TS}),
@@ -588,51 +588,49 @@ assert_events(TS, Config) ->
 % and receiving (and authoritative) server in the dialback procedure.
 %
 % We also test that both users on each side of federation can text each other,
-% hence both server will run the dialback each.
+% hence both servers will run the dialback each.
 %
 % When a user in mim1 writes to a user in fed1, from the perspective of mim1:
 % - Open an outgoing connection from mim1 to fed1:
-%   1. Outgoing stream starts
-%   2. Incoming stream starts
-%   3. Incoming stream features
-%   4. Outgoing dialback key (step 1)
+%   Outgoing stream starts - skipped
+%   Incoming stream starts - skipped
+%   1. Incoming stream features
+%   2. Outgoing dialback key (step 1)
 % - Open an incoming connection from fed1 to mim1:
-%   5. Incoming stream starts
-%   6. Outgoing stream starts
-%   7. Outgoing stream features
-%   8. Incoming dialback verification request (step 2, as authoritative server)
-%   9. Outgoing dialback verification response (step 3, as receiving server)
+%   Incoming stream starts
+%   Outgoing stream starts
+%   3. Outgoing stream features
+%   4. Incoming dialback verification request (step 2, as authoritative server)
+%   5. Outgoing dialback verification response (step 3, as receiving server)
 % - Original outgoing connection
-%  10. Incoming dialback result (step 4, as initiating server)
-%  11. Outgoing message from user in mim1 to user in fed1
+%   6. Incoming dialback result (step 4, as initiating server)
+%   7. Outgoing message from user in mim1 to user in fed1
 %
 % Likewise, when a user in fed1 writes to a user in mim1, from the perspective of mim1:
 % - Open an incoming connection from fed1 to mim1:
-%   1. Incoming stream starts
-%   2. Outgoing stream starts
-%   3. Outgoing stream features
-%   4. Incoming dialback key (step 1)
+%   Incoming stream starts
+%   Outgoing stream starts
+%   1. Outgoing stream features
+%   2. Incoming dialback key (step 1)
 % - Open an outgoing connection from mim1 to fed1:
-%   5. Outgoing stream starts
-%   6. Incoming stream starts
-%   7. Incoming stream features
-%   8. Outgoing dialback verification request (step 2, as authoritative server)
-%   9. Incoming dialback verification response (step 3, as receiving server)
+%   Outgoing stream starts
+%   Incoming stream starts
+%   3. Incoming stream features
+%   4. Outgoing dialback verification request (step 2, as authoritative server)
+%   5. Incoming dialback verification response (step 3, as receiving server)
 % - Original incoming connection
-%  10. Outgoing dialback result (step 4, as initiating server)
-%  11. Incoming message from user in fed1 to user in mim1
+%   6. Outgoing dialback result (step 4, as initiating server)
+%   7. Incoming message from user in fed1 to user in mim1
 %
 % The number can be seen as the sum of all arrows from the dialback diagram, since mim
 % acts as all three roles in the two dialback procedures that occur:
 % https://xmpp.org/extensions/xep-0220.html#intro-howitworks
-% (6 arrows) + one for stream header response + one for the actual message
-element_count(_Dir, true) ->
+% (6 arrows) + one for the actual message
+element_count(true) ->
     % TLS tests are not checking a specific number of events, because the numbers are flaky
     positive;
-element_count(in, false) ->
-    11;
-element_count(out, false) ->
-    11.
+element_count(false) ->
+    7.
 
 group_with_tls(both_tls_optional) -> true;
 group_with_tls(both_tls_required) -> true;

--- a/big_tests/tests/s2s_SUITE.erl
+++ b/big_tests/tests/s2s_SUITE.erl
@@ -592,8 +592,8 @@ assert_events(TS, Config) ->
 %
 % When a user in mim1 writes to a user in fed1, from the perspective of mim1:
 % - Open an outgoing connection from mim1 to fed1:
-%   Outgoing stream starts - skipped
-%   Incoming stream starts - skipped
+%   Outgoing stream starts
+%   Incoming stream starts
 %   1. Incoming stream features
 %   2. Outgoing dialback key (step 1)
 % - Open an incoming connection from fed1 to mim1:

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -27,9 +27,6 @@
 
 -ignore_xref([get_ip/1, get_socket/1]).
 
-%% The pattern 'undefined' can never match the type binary()
--dialyzer({no_match, patch_attr_value/1}).
-
 -record(c2s_data, {
           host_type :: undefined | mongooseim:host_type(),
           lserver = ?MYNAME :: jid:lserver(),
@@ -130,7 +127,6 @@ handle_event(internal, #xmlstreamerror{name = <<"element too big">> = Err}, _, S
 handle_event(internal, #xmlstreamerror{name = Err}, _, StateData) ->
     c2s_stream_error(StateData, mongoose_xmpp_errors:xml_not_well_formed(StateData#c2s_data.lang, Err));
 handle_event(internal, #xmlel{name = <<"starttls">>} = El, {wait_for_feature_before_auth, SaslAcc, Retries}, StateData) ->
-    execute_element_event(c2s_element_in, El, StateData),
     case exml_query:attr(El, <<"xmlns">>) of
         ?NS_TLS ->
             handle_starttls(StateData, El, SaslAcc, Retries);
@@ -138,7 +134,6 @@ handle_event(internal, #xmlel{name = <<"starttls">>} = El, {wait_for_feature_bef
             c2s_stream_error(StateData, mongoose_xmpp_errors:invalid_namespace())
     end;
 handle_event(internal, #xmlel{name = <<"auth">>} = El, {wait_for_feature_before_auth, SaslAcc, Retries}, StateData) ->
-    execute_element_event(c2s_element_in, El, StateData),
     case exml_query:attr(El, <<"xmlns">>) of
         ?NS_SASL ->
             handle_auth_start(StateData, El, SaslAcc, Retries);
@@ -146,7 +141,6 @@ handle_event(internal, #xmlel{name = <<"auth">>} = El, {wait_for_feature_before_
             c2s_stream_error(StateData, mongoose_xmpp_errors:invalid_namespace())
     end;
 handle_event(internal, #xmlel{name = <<"response">>} = El, {wait_for_sasl_response, SaslAcc, Retries}, StateData) ->
-    execute_element_event(c2s_element_in, El, StateData),
     case exml_query:attr(El, <<"xmlns">>) of
         ?NS_SASL ->
             handle_auth_continue(StateData, El, SaslAcc, Retries);
@@ -154,7 +148,6 @@ handle_event(internal, #xmlel{name = <<"response">>} = El, {wait_for_sasl_respon
             c2s_stream_error(StateData, mongoose_xmpp_errors:invalid_namespace())
     end;
 handle_event(internal, #xmlel{name = <<"abort">>} = El, {wait_for_sasl_response, SaslAcc, Retries}, StateData) ->
-    execute_element_event(c2s_element_in, El, StateData),
     case exml_query:attr(El, <<"xmlns">>) of
         ?NS_SASL ->
             handle_sasl_abort(StateData, SaslAcc, Retries);
@@ -162,7 +155,6 @@ handle_event(internal, #xmlel{name = <<"abort">>} = El, {wait_for_sasl_response,
             c2s_stream_error(StateData, mongoose_xmpp_errors:invalid_namespace())
     end;
 handle_event(internal, #xmlel{name = <<"iq">>} = El, {wait_for_feature_after_auth, _} = C2SState, StateData) ->
-    execute_element_event(c2s_element_in, El, StateData),
     case jlib:iq_query_info(El) of
         #iq{type = set, xmlns = ?NS_BIND} = IQ ->
             handle_bind_resource(StateData, C2SState, El, IQ);
@@ -172,7 +164,6 @@ handle_event(internal, #xmlel{name = <<"iq">>} = El, {wait_for_feature_after_aut
             maybe_retry_state(StateData, C2SState)
     end;
 handle_event(internal, #xmlel{name = <<"iq">>} = El, wait_for_session_establishment = C2SState, StateData) ->
-    execute_element_event(c2s_element_in, El, StateData),
     case jlib:iq_query_info(El) of
         #iq{type = set, xmlns = ?NS_SESSION} = IQ ->
             handle_session_establishment(StateData, C2SState, El, IQ);
@@ -180,7 +171,6 @@ handle_event(internal, #xmlel{name = <<"iq">>} = El, wait_for_session_establishm
             handle_foreign_packet(StateData, C2SState, El)
     end;
 handle_event(internal, #xmlel{} = El, session_established = C2SState, StateData) ->
-    execute_element_event(c2s_element_in, El, StateData),
     case verify_from(El, StateData#c2s_data.jid) of
         false ->
             c2s_stream_error(StateData, mongoose_xmpp_errors:invalid_from());
@@ -265,30 +255,14 @@ handle_socket_packet(StateData = #c2s_data{parser = Parser}, Packet) ->
     end.
 
 -spec handle_socket_elements(data(), [exml:element()], non_neg_integer()) -> fsm_res().
-handle_socket_elements(StateData = #c2s_data{lserver = LServer, shaper = Shaper}, Elements, Size) ->
+handle_socket_elements(StateData = #c2s_data{shaper = Shaper}, Elements, Size) ->
+    [execute_element_events(Element, StateData, c2s_element_in, xmpp_element_size_in)
+     || Element = #xmlel{} <- Elements],
     {NewShaper, Pause} = mongoose_shaper:update(Shaper, Size),
-    [mongoose_instrument:execute(
-       xmpp_element_size_in, labels(), #{byte_size => elem_size(El), lserver => LServer})
-     || El <- Elements],
     NewStateData = StateData#c2s_data{shaper = NewShaper},
     StreamEvents0 = [ {next_event, internal, XmlEl} || XmlEl <- Elements ],
     StreamEvents1 = maybe_add_pause(NewStateData, StreamEvents0, Pause),
     {keep_state, NewStateData, StreamEvents1}.
-
-elem_size(#xmlstreamerror{name = Name}) ->
-    byte_size(Name);
-elem_size(El) ->
-    exml:xml_size(patch_element(El)).
-
-patch_element(El = #xmlstreamstart{attrs = Attrs}) ->
-    Attrs2 = #{Name => patch_attr_value(Value) || Name := Value <- Attrs},
-    El#xmlstreamstart{attrs = Attrs2};
-patch_element(El) ->
-    El.
-
--spec patch_attr_value(undefined | binary()) -> binary().
-patch_attr_value(undefined) -> <<>>;
-patch_attr_value(Bin) -> Bin.
 
 -spec maybe_add_pause(data(), [gen_statem:action()], integer()) -> [gen_statem:action()].
 maybe_add_pause(_, StreamEvents, Pause) when Pause > 0 ->
@@ -1080,18 +1054,15 @@ do_send_element(StateData = #c2s_data{host_type = undefined}, Acc, El) ->
 do_send_element(StateData = #c2s_data{host_type = HostType}, Acc, #xmlel{} = El) ->
     Res = send_xml(StateData, El),
     Acc1 = mongoose_acc:set(c2s, send_result, Res, Acc),
-    execute_element_event(c2s_element_out, El, StateData),
     mongoose_hooks:xmpp_send_element(HostType, Acc1, El).
 
 -spec send_xml(data(), exml_stream:element() | [exml_stream:element()]) -> maybe_ok().
 send_xml(Data, XmlElement) when is_tuple(XmlElement) ->
     send_xml(Data, [XmlElement]);
-send_xml(#c2s_data{socket = Socket}, XmlElements) when is_list(XmlElements) ->
-    [mongoose_instrument:execute(
-       xmpp_element_size_out, labels(), #{byte_size => exml:xml_size(El)})
-      || El <- XmlElements],
+send_xml(#c2s_data{socket = Socket} = StateData, XmlElements) when is_list(XmlElements) ->
+    [execute_element_events(Element, StateData, c2s_element_out, xmpp_element_size_out)
+     || Element = #xmlel{} <- XmlElements],
     mongoose_xmpp_socket:send_xml(Socket, XmlElements).
-
 
 state_timeout(#c2s_data{listener_opts = LOpts}) ->
     state_timeout(LOpts);
@@ -1269,32 +1240,19 @@ merge_states(S0 = #c2s_data{}, S1 = #c2s_data{}) ->
 
 %% Instrumentation helpers
 
--spec execute_element_event(mongoose_instrument:event_name(), exml:element(), data()) -> ok.
-execute_element_event(EventName, El, #c2s_data{host_type = HostType, jid = Jid}) ->
-    Metrics = measure_element(El#xmlel.name, exml_query:attr(El, <<"type">>)),
-    Measurements = case Jid of
-                       undefined -> Metrics#{element => El};
-                       _ -> Metrics#{element => El, jid => Jid}
-                   end,
-    mongoose_instrument:execute(EventName, #{host_type => HostType}, Measurements).
-
--spec measure_element(binary(), binary() | undefined) -> mongoose_instrument:measurements().
-measure_element(<<"message">>, <<"error">>) ->
-    #{count => 1, stanza_count => 1, error_count => 1, message_error_count => 1};
-measure_element(<<"iq">>, <<"error">>) ->
-    #{count => 1, stanza_count => 1, error_count => 1, iq_error_count => 1};
-measure_element(<<"presence">>, <<"error">>) ->
-    #{count => 1, stanza_count => 1, error_count => 1, presence_error_count => 1};
-measure_element(<<"message">>, _Type) ->
-    #{count => 1, stanza_count => 1, message_count => 1};
-measure_element(<<"iq">>, _Type) ->
-    #{count => 1, stanza_count => 1, iq_count => 1};
-measure_element(<<"presence">>, _Type) ->
-    #{count => 1, stanza_count => 1, presence_count => 1};
-measure_element(<<"stream:error">>, _Type) ->
-    #{count => 1, error_count => 1};
-measure_element(_Name, _Type) ->
-    #{count => 1}.
+-spec execute_element_events(exml:element(), data(), mongoose_instrument:event_name(),
+                             mongoose_instrument:event_name()) -> ok.
+execute_element_events(Element, C2SData = #c2s_data{jid = Jid}, EventName, SizeEventName) ->
+    case C2SData#c2s_data.host_type of
+        undefined ->
+            ok;
+        HostType ->
+            Measurements = mongoose_measurements:measure_element(Element),
+            mongoose_instrument:execute(EventName, #{host_type => HostType},
+                                        Measurements#{jid => Jid})
+    end,
+    mongoose_instrument:execute(SizeEventName, labels(),
+                                #{byte_size => exml:xml_size(Element), jid => Jid}).
 
 -spec labels() -> mongoose_instrument:labels().
 labels() ->

--- a/src/instrument/mongoose_measurements.erl
+++ b/src/instrument/mongoose_measurements.erl
@@ -1,0 +1,28 @@
+-module(mongoose_measurements).
+
+-export([measure_element/1]).
+
+-include_lib("exml/include/exml.hrl").
+
+-spec measure_element(exml:element()) -> mongoose_instrument:measurements().
+measure_element(#xmlel{name = Name} = Element) ->
+    Metrics = measure_element(Name, exml_query:attr(Element, <<"type">>)),
+    Metrics#{element => Element}.
+
+-spec measure_element(binary(), binary() | undefined) -> mongoose_instrument:measurements().
+measure_element(<<"message">>, <<"error">>) ->
+    #{count => 1, stanza_count => 1, error_count => 1, message_error_count => 1};
+measure_element(<<"iq">>, <<"error">>) ->
+    #{count => 1, stanza_count => 1, error_count => 1, iq_error_count => 1};
+measure_element(<<"presence">>, <<"error">>) ->
+    #{count => 1, stanza_count => 1, error_count => 1, presence_error_count => 1};
+measure_element(<<"message">>, _Type) ->
+    #{count => 1, stanza_count => 1, message_count => 1};
+measure_element(<<"iq">>, _Type) ->
+    #{count => 1, stanza_count => 1, iq_count => 1};
+measure_element(<<"presence">>, _Type) ->
+    #{count => 1, stanza_count => 1, presence_count => 1};
+measure_element(<<"stream:error">>, _Type) ->
+    #{count => 1, error_count => 1};
+measure_element(_Name, _Type) ->
+    #{count => 1}.

--- a/src/s2s/mongoose_s2s_in.erl
+++ b/src/s2s/mongoose_s2s_in.erl
@@ -103,16 +103,12 @@ handle_event(internal, #xmlstreamerror{name = <<"element too big">> = Err}, _, D
 handle_event(internal, #xmlstreamerror{name = Err}, _, Data) ->
     stream_error(Data, mongoose_xmpp_errors:xml_not_well_formed(Data#s2s_data.lang, Err));
 handle_event(internal, #xmlel{name = <<"starttls">>} = El, wait_for_feature_before_auth, Data) ->
-    execute_element_event(Data, El, s2s_element_in),
     handle_starttls(Data, El);
 handle_event(internal, #xmlel{name = <<"auth">>} = El, wait_for_feature_before_auth, Data) ->
-    execute_element_event(Data, El, s2s_element_in),
     handle_auth_start(Data, El);
 handle_event(internal, #xmlel{name = <<"db:", _/binary>>} = El, State, Data) ->
-    execute_element_event(Data, El, s2s_element_in),
     handle_dialback(Data, El, State);
 handle_event(internal, #xmlel{} = El, stream_established, Data) ->
-    execute_element_event(Data, El, s2s_element_in),
     handle_session_established(Data, El);
 handle_event(info, {Tag, _, _} = SocketData, _, Data) when Tag =:= tcp; Tag =:= ssl ->
     handle_socket_data(Data, SocketData);
@@ -404,11 +400,9 @@ handle_socket_packet(#s2s_data{parser = Parser} = Data, Packet) ->
 
 -spec handle_socket_elements(data(), [exml_stream:element()], non_neg_integer()) -> fsm_res().
 handle_socket_elements(#s2s_data{myname = LServer, shaper = Shaper} = Data, Elements, Size) ->
+    [execute_element_events(Element, LServer, s2s_element_in, xmpp_element_size_in)
+     || Element = #xmlel{} <- Elements],
     {NewShaper, Pause} = mongoose_shaper:update(Shaper, Size),
-    [mongoose_instrument:execute(
-       xmpp_element_size_in, labels(),
-       #{byte_size => exml:xml_size(Elem), lserver => LServer, pid => self(), module => ?MODULE})
-     || Elem <- Elements],
     NewData = Data#s2s_data{shaper = NewShaper},
     StreamEvents0 = [ {next_event, internal, XmlEl} || XmlEl <- Elements ],
     StreamEvents1 = maybe_add_pause(NewData, StreamEvents0, Pause),
@@ -518,36 +512,11 @@ stream_error(Data, Error) ->
 
 -spec send_xml(data(), exml_stream:element()) -> maybe_ok().
 send_xml(#s2s_data{myname = LServer, socket = Socket}, Elem) ->
-    mongoose_instrument:execute(
-      xmpp_element_size_out, labels(),
-       #{byte_size => exml:xml_size(Elem), lserver => LServer, pid => self(), module => ?MODULE}),
+    case Elem of
+        #xmlel{} -> execute_element_events(Elem, LServer, s2s_element_out, xmpp_element_size_out);
+        _ -> ok
+    end,
     mongoose_xmpp_socket:send_xml(Socket, Elem).
-
--spec execute_element_event(data(), exml_stream:element(), mongoose_instrument:event_name()) -> ok.
-execute_element_event(#s2s_data{myname = LServer}, #xmlel{name = Name} = El, EventName) ->
-    Metrics = measure_element(Name, exml_query:attr(El, <<"type">>)),
-    Measurements = Metrics#{element => El, lserver => LServer},
-    mongoose_instrument:execute(EventName, #{}, Measurements);
-execute_element_event(_, _, _) ->
-    ok.
-
--spec measure_element(binary(), binary() | undefined) -> mongoose_instrument:measurements().
-measure_element(<<"message">>, <<"error">>) ->
-    #{count => 1, stanza_count => 1, error_count => 1, message_error_count => 1};
-measure_element(<<"iq">>, <<"error">>) ->
-    #{count => 1, stanza_count => 1, error_count => 1, iq_error_count => 1};
-measure_element(<<"presence">>, <<"error">>) ->
-    #{count => 1, stanza_count => 1, error_count => 1, presence_error_count => 1};
-measure_element(<<"message">>, _Type) ->
-    #{count => 1, stanza_count => 1, message_count => 1};
-measure_element(<<"iq">>, _Type) ->
-    #{count => 1, stanza_count => 1, iq_count => 1};
-measure_element(<<"presence">>, _Type) ->
-    #{count => 1, stanza_count => 1, presence_count => 1};
-measure_element(<<"stream:error">>, _Type) ->
-    #{count => 1, error_count => 1};
-measure_element(_Name, _Type) ->
-    #{count => 1}.
 
 check_auth_domain(error, _) ->
     false;
@@ -653,6 +622,17 @@ invalid_mechanism() ->
     #xmlel{name = <<"failure">>,
            attrs = #{<<"xmlns">> => ?NS_SASL},
            children = [#xmlel{name = <<"invalid-mechanism">>}]}.
+
+%% Instrumentation helpers
+
+-spec execute_element_events(exml:element(), jid:lserver(), mongoose_instrument:event_name(),
+                             mongoose_instrument:event_name()) -> ok.
+execute_element_events(Element, LServer, EventName, SizeEventName) ->
+    Measurements = mongoose_measurements:measure_element(Element),
+    mongoose_instrument:execute(EventName, #{}, Measurements#{lserver => LServer}),
+    mongoose_instrument:execute(SizeEventName, labels(),
+                                #{byte_size => exml:xml_size(Element), lserver => LServer,
+                                  pid => self(), module => ?MODULE}).
 
 -spec labels() -> mongoose_instrument:labels().
 labels() ->

--- a/src/s2s/mongoose_s2s_in.erl
+++ b/src/s2s/mongoose_s2s_in.erl
@@ -249,7 +249,11 @@ handle_auth_start(#s2s_data{socket = Socket} = Data,
         false ->
             send_xml(Data, sasl_failure()),
             send_xml(Data, ?XML_STREAM_TRAILER),
-            ?LOG_WARNING(#{what => s2s_in_auth_failed}),
+            ?LOG_WARNING(#{what => s2s_in_auth_failed, domain => AuthDomain}),
+            mongoose_instrument:execute(s2s_auth_failed, #{},
+                                        #{local_domain => Data#s2s_data.myname,
+                                          remote_domain => AuthDomain,
+                                          direction => in, count => 1}),
             {stop, normal, Data}
     end;
 handle_auth_start(#s2s_data{} = Data,

--- a/src/s2s/mongoose_s2s_out.erl
+++ b/src/s2s/mongoose_s2s_out.erl
@@ -164,7 +164,11 @@ handle_event(internal, #xmlel{name = <<"success">>, attrs = #{<<"xmlns">> := ?NS
     send_xml(NewData, stream_header(NewData)),
     {next_state, {wait_for_stream, authenticated}, NewData, state_timeout(NewData)};
 handle_event(internal, #xmlel{name = <<"failure">>, attrs = #{<<"xmlns">> := ?NS_SASL}},
-             wait_for_auth_result, _Data) ->
+             wait_for_auth_result, #s2s_data{myname = LocalDomain, remote_server = RemoteDomain}) ->
+    mongoose_instrument:execute(s2s_auth_failed, #{},
+                                #{local_domain => LocalDomain,
+                                  remote_domain => RemoteDomain,
+                                  direction => out, count => 1}),
     {stop, s2s_sasl_failure};
 
 handle_event(internal,

--- a/src/s2s/mongoose_s2s_out.erl
+++ b/src/s2s/mongoose_s2s_out.erl
@@ -468,9 +468,10 @@ bounce_one(Error, Acc) ->
 
 -spec send_xml(data(), exml_stream:element()) -> maybe_ok().
 send_xml(#s2s_data{myname = LServer, socket = Socket}, Elem) ->
-    mongoose_instrument:execute(
-      xmpp_element_size_out, labels(),
-      #{byte_size => exml:xml_size(Elem), lserver => LServer, pid => self(), module => ?MODULE}),
+    case Elem of
+        #xmlel{} -> execute_element_events(Elem, LServer, s2s_element_out, xmpp_element_size_out);
+        _ -> ok
+    end,
     mongoose_xmpp_socket:send_xml(Socket, Elem).
 
 -spec handle_socket_data(data(), {tcp | ssl, _, binary()}) -> fsm_res().
@@ -496,11 +497,9 @@ handle_socket_packet(#s2s_data{parser = Parser} = Data, Packet) ->
 
 -spec handle_socket_elements(data(), [exml_stream:element()], non_neg_integer()) -> fsm_res().
 handle_socket_elements(#s2s_data{myname = LServer, shaper = Shaper} = Data, Elements, Size) ->
+    [execute_element_events(Element, LServer, s2s_element_in, xmpp_element_size_in)
+     || Element = #xmlel{} <- Elements],
     {NewShaper, Pause} = mongoose_shaper:update(Shaper, Size),
-    [mongoose_instrument:execute(
-       xmpp_element_size_in, labels(),
-       #{byte_size => exml:xml_size(Elem), lserver => LServer, pid => self(), module => ?MODULE})
-     || Elem <- Elements],
     NewData = Data#s2s_data{shaper = NewShaper},
     StreamEvents0 = [ {next_event, internal, XmlEl} || XmlEl <- Elements ],
     StreamEvents1 = maybe_add_pause(NewData, StreamEvents0, Pause),
@@ -557,10 +556,6 @@ handle_get_state_info(#s2s_data{socket = Socket, opts = Opts} = Data, State) ->
       myname => Data#s2s_data.myname,
       process_type => Data#s2s_data.process_type}.
 
--spec labels() -> mongoose_instrument:labels().
-labels() ->
-    #{connection_type => s2s}.
-
 -spec get_s2s_out_config(mongooseim:host_type()) -> options().
 get_s2s_out_config(HostType) ->
     mongoose_config:get_opt([{s2s, HostType}, outgoing]).
@@ -588,3 +583,18 @@ stream_header(#s2s_data{myname = LServer, remote_server = Remote, streamid = Id,
 -spec starttls() -> exml:element().
 starttls() ->
     #xmlel{name = <<"starttls">>, attrs = #{<<"xmlns">> => ?NS_TLS}}.
+
+%% Instrumentation helpers
+
+-spec execute_element_events(exml:element(), jid:lserver(), mongoose_instrument:event_name(),
+                             mongoose_instrument:event_name()) -> ok.
+execute_element_events(Element, LServer, EventName, SizeEventName) ->
+    Measurements = mongoose_measurements:measure_element(Element),
+    mongoose_instrument:execute(EventName, #{}, Measurements#{lserver => LServer}),
+    mongoose_instrument:execute(SizeEventName, labels(),
+                                #{byte_size => exml:xml_size(Element), lserver => LServer,
+                                  pid => self(), module => ?MODULE}).
+
+-spec labels() -> mongoose_instrument:labels().
+labels() ->
+    #{connection_type => s2s}.

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -243,10 +243,9 @@ options("mongooseim-pgsql") ->
               #{port => 5269,
                 shaper => s2s_shaper,
                 max_stanza_size => 131072,
-                tls => (default_config([listen, s2s, tls]))#{
-                            cacertfile => "priv/ca.pem",
-                            certfile => "priv/cert.pem",
-                            dhfile => "priv/dh.pem"}
+                tls => #{cacertfile => "priv/ca.pem",
+                         certfile => "priv/cert.pem",
+                         dhfile => "priv/dh.pem"}
                })
       ]},
      {loglevel, warning},


### PR DESCRIPTION
This PR improves the consistency of reported instrumentation events for different types of connections:
- C2S - `mongoose_c2s`;
- Components - `mongoose_component_connection`;
- S2S - `mongoose_s2s_in`, `mongoose_s2s_out`.

**The following rules are applied:**
- Element events (i.e. `xmpp_element_size_in`/`out` and `*_element_in`/`out`) are always executed in pairs, e.g. `xmpp_element_size_in` with `s2s_element_in`.
  - Before, they were triggered in multiple places, missing some of the events and causing inconsistency.
  - The only exception is `c2s` before `host_type` is known, in which case `c2s_element_in`/`out` will be missing. We could introduce a host-type-less version of this event, but I didn't want to change too much in this PR.
- Incoming element events are executed as soon as the inbound element events are parsed.
- Outgoing element events are executed just before sending the outbound elements to the socket.
- Element events are only triggered for stream elements, and never for stream start/end tags.
  - Before, they would be triggered for some start/end tags as well - but not always.
- `*_auth_failed` events are triggered on each SASL authentication failure.

**Notes:**
- Tests for S2S are improved to cover `s2s_element_in`/`out` and `s2s_auth_failed`. 
- I left the metadata in the measurements as they were before, e.g. `jid` for `c2s` or `pid` and `module` for s2s. We could unify them as well, but I just wanted to limit the scope of the changes for now.

**Left for the future:**
- Test `s2s_auth_failed` event with `direction => in` on `fed1` in `s2s_SUITE`. This would require extending `instrument_helper` to work for `fed1`.
- Improve metric documentation to include all events of `s2s` and `components` (now only `c2s` is fully covered).
