### PR TITLE
Clear inbox after destroying muc light room

### DIFF
--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -726,7 +726,8 @@ destroy_room(Alice, Bob, Kate, Room, xmpp) ->
     AffUsersChanges = [{Alice, none}, {Bob, none}, {Kate, none}],
     muc_light_helper:verify_aff_bcast([], AffUsersChanges, [?NS_MUC_LIGHT_DESTROY]);
 destroy_room(_, _, _, Room, rest) ->
-    Path = <<"/muc-lights/muclight.localhost/", Room/binary, "/management">>,
+    Host = muc_light_helper:muc_host(),
+    Path = <<"/muc-lights/", Host/binary, "/", Room/binary, "/management">>,
     {{<<"204">>, <<"No Content">>}, <<"">>} = rest_helper:delete(admin, Path).
 
 advanced_groupchat_stored_in_all_inbox(Config) ->

--- a/big_tests/tests/inbox_SUITE.erl
+++ b/big_tests/tests/inbox_SUITE.erl
@@ -7,6 +7,7 @@
 -include_lib("exml/include/exml.hrl").
 -include_lib("jid/include/jid.hrl").
 -include_lib("inbox.hrl").
+-include("muc_light.hrl").
 
 %% tests
 -import(muc_light_helper, [room_bin_jid/1]).
@@ -97,7 +98,9 @@ groups() ->
        leave_and_remove_conversation,
        groupchat_markers_one_reset_room_created,
        groupchat_markers_all_reset_room_created,
-       inbox_does_not_trigger_does_user_exist
+       inbox_does_not_trigger_does_user_exist,
+       remove_muclight_messages_after_the_room_is_deleted_xmpp,
+       remove_muclight_messages_after_the_room_is_deleted_rest
       ]},
      {muclight_config, [sequence],
       [
@@ -677,6 +680,54 @@ simple_groupchat_stored_in_all_inbox(Config) ->
         check_inbox(Bob, [#conv{unread = 1, from = AliceRoomJid, to = BobJid, content = Msg}]),
         check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}])
       end).
+
+remove_muclight_messages_after_the_room_is_deleted_xmpp(Config) ->
+    remove_muclight_messages_after_the_room_is_deleted(Config, xmpp).
+
+remove_muclight_messages_after_the_room_is_deleted_rest(Config) ->
+    remove_muclight_messages_after_the_room_is_deleted(Config, rest).
+
+remove_muclight_messages_after_the_room_is_deleted(Config, ReqType) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+        Msg = <<"Hi Room!">>,
+        Id = <<"MyID">>,
+        Users = [Alice, Bob, Kate],
+        Room = inbox_helper:create_room(Alice, [Bob, Kate]),
+        AliceJid = inbox_helper:to_bare_lower(Alice),
+        KateJid = inbox_helper:to_bare_lower(Kate),
+        BobJid = inbox_helper:to_bare_lower(Bob),
+        RoomJid = room_bin_jid(Room),
+        AliceRoomJid = <<RoomJid/binary, "/", AliceJid/binary>>,
+        Stanza = escalus_stanza:set_id(
+                   escalus_stanza:groupchat_to(RoomJid, Msg), Id),
+        %% Alice sends message to a room
+        escalus:send(Alice, Stanza),
+        inbox_helper:wait_for_groupchat_msg(Users),
+        %% Alice has 0 unread messages
+        check_inbox(Alice, [#conv{unread = 0, from = AliceRoomJid, to = AliceJid, content = Msg}]),
+        %% Bob and Kate have one conv with 1 unread message
+        check_inbox(Bob, [#conv{unread = 1, from = AliceRoomJid, to = BobJid, content = Msg}]),
+        check_inbox(Kate, [#conv{unread = 1, from = AliceRoomJid, to = KateJid, content = Msg}]),
+
+        %% Remove the room
+        destroy_room(Alice, Bob, Kate, Room, ReqType),
+
+        %% Inbox entries are removed
+        check_inbox(Alice, []),
+        check_inbox(Bob, []),
+        check_inbox(Kate, [])
+      end).
+
+destroy_room(Alice, Bob, Kate, Room, xmpp) ->
+    Stanza = escalus_stanza:to(
+                escalus_stanza:iq_set(?NS_MUC_LIGHT_DESTROY, []),
+                room_bin_jid(Room)),
+    escalus:send(Alice, Stanza),
+    AffUsersChanges = [{Alice, none}, {Bob, none}, {Kate, none}],
+    muc_light_helper:verify_aff_bcast([], AffUsersChanges, [?NS_MUC_LIGHT_DESTROY]);
+destroy_room(_, _, _, Room, rest) ->
+    Path = <<"/muc-lights/muclight.localhost/", Room/binary, "/management">>,
+    {{<<"204">>, <<"No Content">>}, <<"">>} = rest_helper:delete(admin, Path).
 
 advanced_groupchat_stored_in_all_inbox(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -92,7 +92,7 @@ Only changes that affect the user directly will be stored in their inbox.
 
 Use this option when `muclight` is enabled.
 If true, the inbox conversation is removed for a user when they are removed from the groupchat.
-Enabling this option will also clear all inbox entries associated with the destroyed room.
+Enabling this option will also clear all inbox entries associated with a destroyed room.
 
 ### `modules.mod_inbox.iqdisc.type`
 * **Syntax:** string, one of `"one_queue"`, `"no_queue"`, `"queues"`, `"parallel"`

--- a/doc/modules/mod_inbox.md
+++ b/doc/modules/mod_inbox.md
@@ -92,6 +92,7 @@ Only changes that affect the user directly will be stored in their inbox.
 
 Use this option when `muclight` is enabled.
 If true, the inbox conversation is removed for a user when they are removed from the groupchat.
+Enabling this option will also clear all inbox entries associated with the destroyed room.
 
 ### `modules.mod_inbox.iqdisc.type`
 * **Syntax:** string, one of `"one_queue"`, `"no_queue"`, `"queues"`, `"parallel"`
@@ -121,7 +122,7 @@ Inbox currently supports the following DBs:
 ## Legacy MUC support
 Inbox comes with support for the legacy MUC as well. It stores all groupchat messages sent to
 room in each sender's and recipient's inboxes and private messages. Currently it is not possible to
-configure it to store system messages like [subject](https://xmpp.org/extensions/xep-0045.html#enter-subject) 
+configure it to store system messages like [subject](https://xmpp.org/extensions/xep-0045.html#enter-subject)
 or [affiliation](https://xmpp.org/extensions/xep-0045.html#affil) change.
 
 

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -11,12 +11,18 @@
 -include("jlib.hrl").
 -include("mongoose.hrl").
 
--export([handle_outgoing_message/5, handle_incoming_message/5]).
+-export([handle_outgoing_message/5, handle_incoming_message/5, handle_room_deletion/2]).
 
 -type role() :: r_member() | r_owner() | r_none().
 -type r_member() :: binary().
 -type r_owner() :: binary().
 -type r_none() :: binary().
+
+handle_room_deletion(HostType, RoomJID) ->
+    CheckRemove = mod_inbox_utils:get_option_remove_on_kicked(HostType),
+    {ok, AffList, _} = mod_muc_light_db_backend:get_aff_users(HostType, jid:to_lus(RoomJID)),
+    [maybe_remove_inbox_row(HostType, RoomJID, UserJID, CheckRemove) || {UserJID, _Aff} <- AffList],
+    ok.
 
 -spec handle_outgoing_message(HostType :: mongooseim:host_type(),
                               User :: jid:jid(),

--- a/src/inbox/mod_inbox_muclight.erl
+++ b/src/inbox/mod_inbox_muclight.erl
@@ -11,18 +11,12 @@
 -include("jlib.hrl").
 -include("mongoose.hrl").
 
--export([handle_outgoing_message/5, handle_incoming_message/5, handle_room_deletion/2]).
+-export([handle_outgoing_message/5, handle_incoming_message/5, handle_room_destruction/2]).
 
 -type role() :: r_member() | r_owner() | r_none().
 -type r_member() :: binary().
 -type r_owner() :: binary().
 -type r_none() :: binary().
-
-handle_room_deletion(HostType, RoomJID) ->
-    CheckRemove = mod_inbox_utils:get_option_remove_on_kicked(HostType),
-    {ok, AffList, _} = mod_muc_light_db_backend:get_aff_users(HostType, jid:to_lus(RoomJID)),
-    [maybe_remove_inbox_row(HostType, RoomJID, UserJID, CheckRemove) || {UserJID, _Aff} <- AffList],
-    ok.
 
 -spec handle_outgoing_message(HostType :: mongooseim:host_type(),
                               User :: jid:jid(),
@@ -112,9 +106,17 @@ maybe_store_system_message(HostType, Room, Remote, Packet, Acc) ->
             ok
     end.
 
+-spec handle_room_destruction(HostType :: mongooseim:host_type(),
+                              Room :: jid:jid()) -> ok.
+handle_room_destruction(HostType, RoomJID) ->
+    CheckRemove = mod_inbox_utils:get_option_remove_on_kicked(HostType),
+    {ok, AffList, _} = mod_muc_light_db_backend:get_aff_users(HostType, jid:to_lus(RoomJID)),
+    [maybe_remove_inbox_row(HostType, RoomJID, UserJID, CheckRemove) || {UserJID, _Aff} <- AffList],
+    ok.
+
 -spec maybe_remove_inbox_row(HostType :: mongooseim:host_type(),
                              Room :: jid:jid(),
-                             Remote :: jid:jid(),
+                             Remote :: jid:jid() | jid:simple_bare_jid(),
                              WriteAffChanges :: boolean()) -> ok.
 maybe_remove_inbox_row(_, _, _, false) ->
     ok;

--- a/src/muc_light/mod_muc_light_db_rdbms.erl
+++ b/src/muc_light/mod_muc_light_db_rdbms.erl
@@ -419,7 +419,7 @@ create_room_with_specified_name(HostType, RoomUS, Config, AffUsers, Version) ->
 destroy_room(HostType, RoomUS) ->
     case is_inbox_enabled(HostType) andalso room_exists(HostType, RoomUS) of
         true ->
-            mod_inbox_muclight:handle_room_deletion(HostType, RoomUS);
+            mod_inbox_muclight:handle_room_destruction(HostType, RoomUS);
         false ->
             ok
     end,
@@ -802,5 +802,6 @@ muc_server_to_host_type(MUCServer) ->
 
 %% ------------------------ Inbox ------------------------
 
+-spec is_inbox_enabled(mongooseim:host_type()) -> boolean().
 is_inbox_enabled(HostType) ->
     gen_mod:is_loaded(HostType, mod_inbox).


### PR DESCRIPTION
This PR adds functionality to clear inbox entries associated with a MUC Light room after it has been destroyed. The clearing will occur if the option `modules.mod_inbox.remove_on_kicked` is set to` true`.

For the original issue, look [here](https://github.com/esl/MongooseIM/issues/2497)