### PR TITLE
Bump CI Erlang versions

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -5,9 +5,9 @@ references:
   # Available cimg-erlang images: https://hub.docker.com/r/erlangsolutions/erlang/tags?name=cimg
   # You could need to trigger a pipeline to create a Docker image:
   # https://github.com/esl/cimg-erlang#trigger-build-using-trigger-pipeline-on-circleci
-  - &LATEST_OTP_VERSION 27.1.2
-  - &OTP26 erlangsolutions/erlang:cimg-26.2.5.6
-  - &OTP27 erlangsolutions/erlang:cimg-27.1.2
+  - &LATEST_OTP_VERSION 27.3.3
+  - &OTP26 erlangsolutions/erlang:cimg-26.2.5.11
+  - &OTP27 erlangsolutions/erlang:cimg-27.3.3
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3
@@ -725,7 +725,7 @@ filters:
   - &all_tags_and_master
     <<: *all_tags
     branches:
-      only: master
+      only: bump-ci-erlang-versions
 
 workflows:
   version: 2

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -725,7 +725,7 @@ filters:
   - &all_tags_and_master
     <<: *all_tags
     branches:
-      only: bump-ci-erlang-versions
+      only: master
 
 workflows:
   version: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         ## the full list of supported (prebuilt) OTP versions for ubuntu-22.04 runners
         ## can be found here:
         ##     https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
-        otp: [ '26.2.5.2', '27.1.2' ]
+        otp: [ '26.2.5.11', '27.3.3' ]
     runs-on: ubuntu-22.04
     env:
       PRESET: 'small_tests'
@@ -67,17 +67,17 @@ jobs:
       matrix:
         preset: [internal_mnesia, pgsql_mnesia, mysql_redis, odbc_mssql_mnesia,
                  ldap_mnesia, elasticsearch_and_cassandra_mnesia]
-        otp: [ '27.1.2' ]
+        otp: [ '27.3.3' ]
         include:
           - test-spec: "default.spec"
           - preset: elasticsearch_and_cassandra_mnesia
             test-spec: "mam.spec"
           - preset: ldap_mnesia
             test-spec: "default.spec"
-            otp: '26.2.5.2'
+            otp: '26.2.5.11'
           - preset: pgsql_mnesia
             test-spec: "default.spec"
-            otp: '26.2.5.2'
+            otp: '26.2.5.11'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -103,11 +103,11 @@ jobs:
       fail-fast: false
       matrix:
         preset: [pgsql_mnesia, mysql_redis, odbc_mssql_mnesia]
-        otp: [ '27.1.2' ]
+        otp: [ '27.3.3' ]
         test-spec: ["dynamic_domains.spec"]
         include:
           - preset: pgsql_mnesia
-            otp: '26.2.5.2'
+            otp: '26.2.5.11'
             test-spec: "dynamic_domains.spec"
     runs-on: ubuntu-22.04
     steps:
@@ -143,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '26.2.5.2' ]
+        otp: [ '26.2.5.11' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '26.2.5.2' ]
+        otp: [ '26.2.5.11' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '26.2.5.2' ]
+        otp: [ '26.2.5.11' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -197,7 +197,7 @@ jobs:
         pkg: [ubuntu-jammy]
     runs-on: ubuntu-22.04
     env:
-      pkg_OTP_VERSION: "27.1.2"
+      pkg_OTP_VERSION: "27.3.3"
       pkg_PLATFORM: ${{matrix.pkg}}
       GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/big_tests/rebar.config
+++ b/big_tests/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info,
             {i, ["include"]}]}.
 
-{require_min_otp_vsn, "21"}.
+{require_min_otp_vsn, "26"}.
 
 {src_dirs, ["src", "tests", "../test/common"]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
     {httpd_util, integer_to_hexlist, 1}
 ]}.
 
-{require_min_otp_vsn, "21"}.
+{require_min_otp_vsn, "26"}.
 
 %% We agreed to use https:// for deps because of possible firewall issues.
 %%
@@ -211,7 +211,7 @@
    {override, cpool, [{deps, [{backoff, "1.1.6"}]}]},
    %% Remove test profile (pulling old proper) from `backoff`
    {override, backoff, [{profiles, [{test, []}]}]},
-   {override, worker_pool, [{minimum_otp_vsn, "24"}]}
+   {override, worker_pool, [{minimum_otp_vsn, "26"}]}
  ]}.
 
 {dialyzer, [


### PR DESCRIPTION
This PR updates the Erlang versions used in CircleCI and GitHub Actions. It also updates the relevant definitions in the `rebar.config` files.

Currently, there are three failing tests on GitHub Actions, but they are unrelated to the Erlang version update.

The packages are also building correctly on the new Erlang version: https://app.circleci.com/pipelines/github/esl/MongooseIM/14011/workflows/b21bceaa-a4bb-4b2c-a64d-5e2023a403dc