### PR TITLE
Migration guide for 6.4.0

### DIFF
--- a/doc/configuration/listen.md
+++ b/doc/configuration/listen.md
@@ -4,7 +4,7 @@ The `listen` section specifies how MongooseIM handles incoming connections.
 
     * [`c2s`](../listeners/listen-c2s.md) - client-to-server XMPP connections,
     * [`s2s`](../listeners/listen-s2s.md) - server-to-server XMPP connections,
-    * [`components`](../listeners/listen-components.md) - XMPP connections from external components,
+    * [`component`](../listeners/listen-components.md) - XMPP connections from external components,
     * [`http`](../listeners/listen-http.md) - HTTP connections from clients or other services.
 
 The double-bracket syntax is used because there can be multiple listeners of a given type, so for each listener type there is a TOML array of one or more tables (subsections).

--- a/doc/listeners/listen-c2s.md
+++ b/doc/listeners/listen-c2s.md
@@ -5,7 +5,7 @@ The recommended [port number](../configuration/listen.md#listenport) for a C2S l
 
 ## Configuration options
 
-The following options are supported for each C2S listener:
+For each C2S listener, all the [general](../configuration/listen.md#general-listener-options) and [XMPP](../configuration/listen.md#xmpp-listener-options) options are accepted. Additionally, the following options are supported:
 
 ### `listen.c2s.access`
 * **Syntax:** string, rule name or `"all"`

--- a/doc/listeners/listen-components.md
+++ b/doc/listeners/listen-components.md
@@ -9,10 +9,9 @@ According to [XEP-0114: Jabber Component Protocol](http://xmpp.org/extensions/xe
 
     Note the order of the routing modules: if a component is meant to supplant a domain served regularly by the MongooseIM server, the external routers should be ordered with higher priority.
 
-
 ## Configuration options
 
-The following options are supported for each component listener under `listen.component` subsection:
+For each component listener, all the [general](../configuration/listen.md#general-listener-options) and [XMPP](../configuration/listen.md#xmpp-listener-options) options are accepted. Additionally, the following options are supported:
 
 ### `listen.component.access`
 * **Syntax:** string, rule name or `"all"`
@@ -79,7 +78,7 @@ You can specify additional options of the TLS encryption in the `tls` subsection
 They have the same semantics as the corresponding [c2s options](listen-c2s.md#tls-options-for-c2s).
 The only difference is that the default value of `tls.mode` is `"tls"` instead of `"starttls"`.
 
-## Service listener configuration example
+## Component listener configuration example
 
 The following section configures a component listener, accepting connections from external components.
 The IP address is limited to loopback to prevent connections from different hosts.

--- a/doc/listeners/listen-http.md
+++ b/doc/listeners/listen-http.md
@@ -6,7 +6,7 @@ Recommended port number: 5280 for BOSH/WS.
 
 ## Configuration options
 
-Following configuration option is used to set up an HTTP handler:
+For each HTTP listener, all the [general](../configuration/listen.md#general-listener-options) options are accepted. Additionally, the following configuration option is used to set up HTTP handlers:
 
 ### `listen.http.handlers`
 * **Syntax:** each handler is specified in a subsection starting with `[[listen.http.handlers.type]]` where `type` is one of the allowed handler types, handling different connection types:

--- a/doc/listeners/listen-s2s.md
+++ b/doc/listeners/listen-s2s.md
@@ -6,9 +6,11 @@ The recommended port number for an S2S listener is 5269 [as registered in the XM
 !!! Note
     Many S2S options are configured in the [`s2s`](../configuration/s2s.md) section of the configuration file, and they apply to both incoming and outgoing connections.
 
-## TLS options for S2S
+## Configuration options
 
-To enable TLS, a TOML subsection called `tls` has to be present in the listener options.
+For each S2S listener, all the [general](../configuration/listen.md#general-listener-options) and [XMPP](../configuration/listen.md#xmpp-listener-options) options are accepted.
+
+Additionally, to enable TLS, a TOML subsection called `tls` has to be present in the listener options.
 To disable TLS, make sure that the section is not present, and no TLS options are set.
 You can specify additional options of the TLS encryption in the `tls` subsection.
 They have the same semantics as the corresponding [c2s options](listen-c2s.md#tls-options-for-c2s).

--- a/doc/migrations/6.3.3_6.4.0.md
+++ b/doc/migrations/6.3.3_6.4.0.md
@@ -1,0 +1,71 @@
+## Configuration options
+
+With the rework of connection handling for server-to-server (S2S) and component connections, we have updated several configuration options. Some of the changes affect client-to-server (C2S) connections as well.
+Some of the affected options were present in the default configuration file, and you might need to amend them even if you haven't changed them.
+
+### General
+
+The following options from the [general](../configuration/general.md) section were removed:
+
+* `general.max_fsm_queue`, used to limit the maximum number of incoming messages in the internal queues for S2S and component connections.
+  [Traffic shapers](../configuration/shaper.md) should be used instead, as they provide a more reliable protection, because they act at an earlier stage.
+* `general.domain_certfile`, used to specify distinct certificates for specific local XMPP domains. Instead, now you should specify the certificates in the configuration sections of your [C2S](../listeners/listen-c2s.md#listenc2stlscertfile) and [S2S](../listeners/listen-s2s.md#tls-options-for-s2s) listeners.
+
+### Shaper name validation
+
+When a referenced [traffic shaper](../configuration/shaper.md) does not exist, MongooseIM will now issue an error and refuse to start.
+In the previous version, it would silently disable the shaper instead.
+This means that your previous config might now cause an `undefined_shapers` error - in such case, you need to make sure the shaper is defined in the `shaper` section, or disable shaping by using the default `none` shaper.
+
+### Client-to-server (C2S) connections
+
+The `listen.c2s.shaper` option references the traffic shaper used for incoming C2S connections.
+This logic is unchanged, but there was an issue in the default configuration file - it referenced the `c2s_shaper` access rule (which had no effect) instead of the [`normal` shaper](../configuration/shaper.md#c2s-shaper).
+This is fixed in the new default configuration file, but you might need to update it in your configuration as well.
+It is recommended to also remove the obsolete `c2s_shaper` access rule to avoid confusion.
+Keep in mind that you might have several listeners configured.
+
+Another change is that the `listen.c2s.tls.module` option is removed, because `fast_tls` is not supported anymore.
+All listeners use the native Erlang/OTP TLS implementation instead (which was called `just_tls` before).
+
+### Server-to-server (S2S) connections
+
+The `listen.s2s.shaper` option references the traffic shaper used for incoming S2S connections.
+Previously, this option referenced an access rule name instead.
+In the default configuration file, the obsolete `s2s_shaper` rule was replaced by the corresponding [`fast` shaper](../configuration/shaper.md#s2s-shaper).
+You might need to apply this fix in your configuration file.
+Keep in mind that you might have several listeners configured.
+It is recommended to remove the `s2s_shaper` access rule as well to avoid confusion.
+
+!!! note "Shaper for outgoing S2S connections"
+    For outgoing connections, there is a new option [`s2s.outgoing.shaper`](../configuration/s2s.md#s2soutgoingshaper).
+    Together with `listen.s2s.shaper`, it allows you to shape the traffic from both connection types.
+
+Options from the [s2s](../configuration/s2s.md) section were reworked. All affected options are listed below:
+
+* `s2s.address` was renamed to [`s2s.outgoing.address`](../configuration/s2s.md#s2soutgoingaddress).
+* `s2s.certfile` was renamed to [`s2s.outgoing.tls.certfile`](../configuration/s2s.md#tls-options-for-outgoing-connections).
+* `s2s.ciphers` was renamed to [`s2s.outgoing.tls.ciphers`](../configuration/s2s.md#tls-options-for-outgoing-connections).
+* `s2s.dns` subsection was renamed to [`s2s.outgoing.dns`](../configuration/s2s.md#s2soutgoingdnsretries).
+* `s2s.max_retry_delay` was renamed to [`s2s.outgoing.max_retry_delay`](../configuration/s2s.md#s2soutgoingmax_retry_delay).
+* `s2s.use_starttls` was replaced with [`s2s.outgoing.tls.mode`](../configuration/s2s.md#s2soutgoingtlsmode). The default value `starttls` has the same meaning as the default value `optional` of the former option. You can use the [`s2s.outgoing.tls.verify_mode`](../configuration/s2s.md#tls-options-for-outgoing-connections) option to enable/disable certificate verification.
+
+You might need to amend these options in your configuration file.
+
+### External component connections
+
+The component listener section, previously called `listen.service`, was renamed to [`listen.component`](../listeners/listen-components.md).
+The `listen.service.shaper_rule` option, contrary to its name, was referencing the shaper directly.
+Now, this option has a more intuitive name `listen.component.shaper`, and its logic is unchanged.
+You might need to update these options in your configuration file.
+Keep in mind that you might have several listeners configured.
+
+## Metrics
+
+Metrics related to XMPP traffic were reworked from scratch. They are now more consistent and provide better coverage of the instrumented events. The table below summarizes the changes. The names presented in the table are assuming that Prometheus is used. For more information, e.g. about Prometheus labels or Exometer metrics, follow the links in the table.
+
+| Previous metrics | Current metrics  | More information |
+| ---------------- | ---------------- | ---------------- |
+| `c2s_tcp_data_in`, `c2s_tcp_data_out`,<br> `c2s_tls_data_in`, `c2s_tls_data_out`,<br> `s2s_tcp_data_in`, `s2s_tcp_data_out`,<br> `s2s_tls_data_in`, `s2s_tls_data_out`,<br> `component_tcp_data_in`, `component_tcp_data_out`,<br> `component_tls_data_in`, `component_tls_data_out` | `tcp_data_in`, `tcp_data_out`,<br> `tls_data_in`, `tls_data_out` | [Network data](../operation-and-maintenance/MongooseIM-metrics.md#network-data-metrics) |
+| `c2s_element_in_*`, `c2s_element_out_*` | `xmpp_element_in_*`, `xmpp_element_out_*` | [XMPP traffic](../operation-and-maintenance/MongooseIM-metrics.md#xmpp-traffic-metrics) |
+| `c2s_xmpp_element_size_in_byte_size`, `c2s_xmpp_element_size_out_byte_size`,<br> `s2s_xmpp_element_size_in_byte_size`, `s2s_xmpp_element_size_out_byte_size`,<br> `component_xmpp_element_size_in_byte_size`, `component_xmpp_element_size_out_byte_size` | `xmpp_element_in_byte_size`, `xmpp_element_out_byte_size` | [XMPP traffic](../operation-and-maintenance/MongooseIM-metrics.md#xmpp-traffic-metrics) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,7 @@ nav:
   - 'Listeners':
       - 'Client to server (C2S)': 'listeners/listen-c2s.md'
       - 'Server to server (S2S)': 'listeners/listen-s2s.md'
-      - 'XMPP components (service)': 'listeners/listen-components.md'
+      - 'XMPP components': 'listeners/listen-components.md'
       - 'HTTP-based services': 'listeners/listen-http.md'
   - 'Authentication Methods':
       - 'RDBMS': 'authentication-methods/rdbms.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,6 +217,7 @@ nav:
       - '6.2.1 to 6.3.0': 'migrations/6.2.1_6.3.0.md'
       - '6.3.0 to 6.3.1': 'migrations/6.3.0_6.3.1.md'
       - '6.3.1 to 6.3.2': 'migrations/6.3.1_6.3.2.md'
+      - '6.3.3 to 6.4.0': 'migrations/6.3.3_6.4.0.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - 'Contributions to the Ecosystem': 'Contributions.md'
   - 'MongooseIM History': 'History.md'

--- a/rel/vars-toml.config
+++ b/rel/vars-toml.config
@@ -16,7 +16,6 @@
   port = {{http_api_endpoint_port}}"}.
 {http_api_client_endpoint, "port = {{ http_api_client_endpoint_port }}"}.
 {http_prometheus_endpoint, "port = {{ http_prometheus_endpoint_port }}"}.
-{s2s_use_starttls, "\"optional\""}.
 {s2s_certfile, "\"priv/ssl/fake_server.pem\""}.
 {internal_databases, "[internal_databases.mnesia]"}.
 


### PR DESCRIPTION
The main goal of this PR is to describe the migration from version 6.3.2/6.3.3 to 6.4.0.

Main migration tasks for the user:
- Update options for S2S and components, but also C2S and some general options.
- Fix the shaper configuration after the default config was amended (see https://github.com/esl/MongooseIM/pull/4527).
- Update any dashboards to use the updated metrics.

Also changed in the PR:
- Remove unused variable `s2s_use_starttls` from config templating.
- Apply minor corrections to listener docs.
