### PR TITLE
Include bbmustache in the release

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -24,7 +24,8 @@ BaseApps = [kernel, stdlib, sasl,
             {nksip, none},
             {nkservice, none},
             {nkpacket, none},
-            {nklib, none}
+            {nklib, none},
+            {bbmustache, none}
            ],
 
 Apps = case os:getenv("DEVNODE") of


### PR DESCRIPTION
It was missed during the app starting rework, leading to package building job failures.
It is required by the `mongooseimctl bootstrap` command.

Manual check (failed before the change and succeeded after it):

```
_build/prod/rel/mongooseim/bin/mongooseimctl bootstrap
```