### PR TITLE
Fix mod_http_upload max_file_size

### DIFF
--- a/doc/modules/mod_http_upload.md
+++ b/doc/modules/mod_http_upload.md
@@ -44,9 +44,9 @@ Number of random bytes of a token that will be used in a generated URL.
 The text representation of the token will be twice as long as the number of bytes, e.g. for the default value the token in the URL will be 64 characters long.
 
 ### `modules.mod_http_upload.max_file_size`
-* **Syntax:** positive integer
-* **Default:** not set - no size limit
-* **Example:** `max_file_size = 10485760`
+* **Syntax:** positive integer or the string `"infinity"`
+* **Default:** `10485760`
+* **Example:** `max_file_size = "infinity"`
 
 Maximum file size (in bytes) accepted by the module.
 

--- a/src/http_upload/mod_http_upload.erl
+++ b/src/http_upload/mod_http_upload.erl
@@ -98,7 +98,7 @@ config_spec() ->
                                                    validate = positive},
                   <<"token_bytes">> => #option{type = integer,
                                                validate = positive},
-                  <<"max_file_size">> => #option{type = integer,
+                  <<"max_file_size">> => #option{type = int_or_infinity,
                                                  validate = positive},
                   <<"s3">> => s3_spec()
         },
@@ -258,7 +258,7 @@ token_bytes(HostType) ->
     gen_mod:get_module_opt(HostType, ?MODULE, token_bytes).
 
 
--spec max_file_size(mongooseim:host_type()) -> pos_integer() | undefined.
+-spec max_file_size(mongooseim:host_type()) -> pos_integer() | infinity.
 max_file_size(HostType) ->
     gen_mod:get_module_opt(HostType, ?MODULE, max_file_size).
 


### PR DESCRIPTION
Documentation says the default is not set, which is incorrect, the default was 10MB. This updates the code and clarifies the value in the documentation.
