### PR TITLE
Replace last occurance of `EJABBERD_DIR` with `RUNNER_BASE_DIR`

### DIFF
--- a/rel/vars-toml.config
+++ b/rel/vars-toml.config
@@ -29,5 +29,5 @@
 %{mongooseim_log_dir, "log"}.
 %{mongooseim_mdb_dir, "$RUNNER_BASE_DIR/Mnesia.$NODE"}.
 %{mongooseim_mdb_dir_toggle, "%"}.
-%{mongooseim_lock_dir, "$EJABBERD_DIR/var/lock"}.
+%{mongooseim_lock_dir, "$RUNNER_BASE_DIR/var/lock"}.
 %{mongooseim_nodetool_etc_dir, "etc"}.


### PR DESCRIPTION
This PR replaces the last mention of the old `$EJABBERD_DIR` variable with `$RUNNER_BASE_DIR` in a commented-out line.