### PR TITLE
Bump Erlang versions used on CIs

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -5,9 +5,9 @@ references:
   # Available cimg-erlang images: https://hub.docker.com/r/erlangsolutions/erlang/tags?name=cimg
   # You could need to trigger a pipeline to create a Docker image:
   # https://github.com/esl/cimg-erlang#trigger-build-using-trigger-pipeline-on-circleci
-  - &LATEST_OTP_VERSION 27.3.3
-  - &OTP26 erlangsolutions/erlang:cimg-26.2.5.11
-  - &OTP27 erlangsolutions/erlang:cimg-27.3.3
+  - &LATEST_OTP_VERSION 27.3.4
+  - &OTP26 erlangsolutions/erlang:cimg-26.2.5.12
+  - &OTP27 erlangsolutions/erlang:cimg-27.3.4
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         ## the full list of supported (prebuilt) OTP versions for ubuntu-22.04 runners
         ## can be found here:
         ##     https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
-        otp: [ '26.2.5.11', '27.3.3' ]
+        otp: [ '26.2.5.12', '27.3.4' ]
     runs-on: ubuntu-22.04
     env:
       PRESET: 'small_tests'
@@ -67,17 +67,17 @@ jobs:
       matrix:
         preset: [internal_mnesia, pgsql_mnesia, mysql_redis, odbc_mssql_mnesia,
                  ldap_mnesia, elasticsearch_and_cassandra_mnesia]
-        otp: [ '27.3.3' ]
+        otp: [ '27.3.4' ]
         include:
           - test-spec: "default.spec"
           - preset: elasticsearch_and_cassandra_mnesia
             test-spec: "mam.spec"
           - preset: ldap_mnesia
             test-spec: "default.spec"
-            otp: '26.2.5.11'
+            otp: '26.2.5.12'
           - preset: pgsql_mnesia
             test-spec: "default.spec"
-            otp: '26.2.5.11'
+            otp: '26.2.5.12'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -103,11 +103,11 @@ jobs:
       fail-fast: false
       matrix:
         preset: [pgsql_mnesia, mysql_redis, odbc_mssql_mnesia]
-        otp: [ '27.3.3' ]
+        otp: [ '27.3.4' ]
         test-spec: ["dynamic_domains.spec"]
         include:
           - preset: pgsql_mnesia
-            otp: '26.2.5.11'
+            otp: '26.2.5.12'
             test-spec: "dynamic_domains.spec"
     runs-on: ubuntu-22.04
     steps:
@@ -143,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '26.2.5.11' ]
+        otp: [ '26.2.5.12' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '26.2.5.11' ]
+        otp: [ '26.2.5.12' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '26.2.5.11' ]
+        otp: [ '26.2.5.12' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -197,7 +197,7 @@ jobs:
         pkg: [ubuntu-jammy]
     runs-on: ubuntu-22.04
     env:
-      pkg_OTP_VERSION: "27.3.3"
+      pkg_OTP_VERSION: "27.3.4"
       pkg_PLATFORM: ${{matrix.pkg}}
       GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
This PR bumps the Erlang versions used on both GH Actions and CircleCI.