### PR TITLE
Replace Ubuntu Oracular with Plucky

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -690,7 +690,7 @@ jobs:
         type: executor
       platform:
         type: enum
-        enum: [debian-bookworm, debian-bullseye, debian-buster, ubuntu-oracular, ubuntu-noble, ubuntu-jammy, ubuntu-focal, rockylinux-9, rockylinux-8, almalinux-9, almalinux-8]
+        enum: [debian-bookworm, debian-bullseye, debian-buster, ubuntu-plucky, ubuntu-noble, ubuntu-jammy, ubuntu-focal, rockylinux-9, rockylinux-8, almalinux-9, almalinux-8]
         description: Platform type
       otp_version:
         type: string
@@ -780,15 +780,15 @@ workflows:
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
-          name: ubuntu-oracular
+          name: ubuntu-plucky
           executor: otp_27
-          platform: ubuntu-oracular
+          platform: ubuntu-plucky
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
-          name: ubuntu-oracular-arm64
+          name: ubuntu-plucky-arm64
           executor: otp_27_arm64
-          platform: ubuntu-oracular
+          platform: ubuntu-plucky
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -742,7 +742,7 @@ workflows:
           filters: &release_tags
             tags:
               only: /^\d+\.\d+\.\d+/
-#       # ============= PACKAGES =============
+      # ============= PACKAGES =============
       - package:
           name: debian-bookworm
           executor: otp_27

--- a/tools/pkg/Dockerfile_deb
+++ b/tools/pkg/Dockerfile_deb
@@ -17,18 +17,18 @@ RUN arch=$(dpkg --print-architecture) && \
     distro=$(grep ^ID= /etc/os-release | cut -d= -f2 | tr -d '"') && \
     if [ "$distro" = "ubuntu" ]; then \
         if [ "$arch" = "arm64" ]; then \
-            echo "deb http://ports.ubuntu.com/ubuntu-ports oracular main restricted universe multiverse" >> /etc/apt/sources.list; \
+            echo "deb http://ports.ubuntu.com/ubuntu-ports plucky main restricted universe multiverse" >> /etc/apt/sources.list; \
         else \
-            echo "deb http://archive.ubuntu.com/ubuntu oracular main restricted universe multiverse" >> /etc/apt/sources.list; \
+            echo "deb http://archive.ubuntu.com/ubuntu plucky main restricted universe multiverse" >> /etc/apt/sources.list; \
         fi && \
-        printf "Package: debsigs\nPin: release n=oracular\nPin-Priority: 990\n" > /etc/apt/preferences.d/debsigs; \
+        printf "Package: debsigs\nPin: release n=plucky\nPin-Priority: 990\n" > /etc/apt/preferences.d/debsigs; \
     elif [ "$distro" = "debian" ]; then \
         echo "deb http://deb.debian.org/debian trixie main" >> /etc/apt/sources.list && \
         printf "Package: debsigs\nPin: release n=trixie\nPin-Priority: 990\n" > /etc/apt/preferences.d/debsigs; \
     fi && \
     apt-get update && \
     apt-get install -y --no-install-recommends debsigs && \
-    sed -i '/oracular/d' /etc/apt/sources.list && \
+    sed -i '/plucky/d' /etc/apt/sources.list && \
     sed -i '/trixie/d' /etc/apt/sources.list
 
 ARG erlang_version


### PR DESCRIPTION
Oracular will end its support in July 2025. Plucky is the current interim release, and we support only one interim
release. See https://ubuntu.com/about/release-cycle for details

Also: get the `debsigs` package from Plucky, not from Oracular. Motivation: Plucky is the current release, and Oracular might disappear from the repos.

Also, tested the packages by temporarily enabling building them for this branch, see the [CI](https://app.circleci.com/pipelines/github/esl/MongooseIM/14075/workflows/f53f7ca3-50a0-4d10-9521-8a8171fbdcd4) pipeline. I didn't rerun the flaky tests, because the check was only for packages.

