### PR TITLE
Use ubuntu-noble as the base docker image

### DIFF
--- a/tools/circleci-prepare-mongooseim-docker.sh
+++ b/tools/circleci-prepare-mongooseim-docker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 set -e
-# master from 2024-09-12
-MIM_DOCKER_VERSION=cde33527fab41b512ed0d83b50a1d088e99c4ea2
+# master from 2025-06-05
+MIM_DOCKER_VERSION=b2cf9273764632bcb1b1d1c8ab5b5047fa4ee27c
 
 # We use output of generate_vsn, because it does not contain illegal characters, returns
 # git tag when building from tag itself, and is unique in any other case


### PR DESCRIPTION
Noble has LTS, while Oracular is near its end of support (July 2025).

See the merged [PR](https://github.com/esl/mongooseim-docker/pull/58) for `mongooseim-docker` and the built [docker image](https://hub.docker.com/repository/docker/erlangsolutions/mongooseim/tags/PR-4537/sha256-72d67261d74c878781a9b125830d1d15f842e2de0c6c6b03c999bf9732e46aec).

Manual checks of the image:
- There are no critical vulnerabilities reported.
- The base OS is Ubuntu 24.04.


