### PR TITLE
Muc create room ns

### DIFF
--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -5330,6 +5330,8 @@ was_room_destroyed(Query) ->
 was_room_created(Stanza) ->
     timer:sleep(?WAIT_TIME),
     has_status_codes(Stanza, [<<"201">>, <<"110">>]),
+    Namespaces = exml_query:paths(Stanza, [{element, <<"x">>}, {attr, <<"xmlns">>}]),
+    true = lists:member(?NS_MUC_USER, Namespaces),
     [<<"owner">>] = exml_query:paths(Stanza, [{element, <<"x">>},
                                               {element, <<"item">>},
                                               {attr, <<"affiliation">>}]),

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -2313,7 +2313,7 @@ send_new_presence_to_single(NJID, #user{jid = RealJID, nick = Nick, last_presenc
               end,
     Packet = jlib:append_subtags(
                Presence,
-               [#xmlel{name = <<"x">>, attrs = #{<<"xmlns">> => ?NS_MUC},
+               [#xmlel{name = <<"x">>, attrs = #{<<"xmlns">> => ?NS_MUC_USER},
                        children = [#xmlel{name = <<"item">>, attrs = ItemAttrs,
                                           children = ItemEls} | Status2]}]),
     ejabberd_router:route(jid:replace_resource(StateData#state.jid, Nick),


### PR DESCRIPTION
This PR fixes incorrect `xmlns` for a presence sent as a result of room creation in `muc`. Here is the example from XEP how the stanza should look like: https://xmpp.org/extensions/xep-0045.html#example-154.