### PR TITLE
Increase default shaper

### DIFF
--- a/rel/files/mongooseim.toml
+++ b/rel/files/mongooseim.toml
@@ -271,7 +271,7 @@
 {{{instrumentation}}}
 
 [shaper.normal]
-  max_rate = 1000
+  max_rate = 16_384
 
 [shaper.fast]
   max_rate = 50_000


### PR DESCRIPTION
1Kb/s is very little and makes tests way way slower, even more prone to hit timeouts. I'm proposing here 16KB/s, considering that this includes all ad-hoc traffic like IQs, presences, read-receipts, and any other extension, and not just human text.