### PR TITLE
Check Exometer is loaded before calling it

### DIFF
--- a/src/system_metrics/mongoose_system_metrics_collector.erl
+++ b/src/system_metrics/mongoose_system_metrics_collector.erl
@@ -10,11 +10,11 @@
 
 -export_type([report_struct/0]).
 
--export([collect/1]).
+-export([collect/2]).
 
-collect(PrevReport) ->
+collect(PrevReport, ExometerEnabled) ->
     ReportResults = [ get_reports(RGetter) || RGetter <- report_getters()],
-    StanzasCount = get_xmpp_stanzas_count(PrevReport),
+    StanzasCount = get_xmpp_stanzas_count(PrevReport, ExometerEnabled),
     lists:flatten(ReportResults ++ StanzasCount).
 
 -spec get_reports(fun(() -> [report_struct()])) -> [report_struct()].
@@ -180,7 +180,9 @@ get_outgoing_pools() ->
     [#{name => outgoing_pool,
        params => #{value => Type}} || #{type := Type} <- OutgoingPools].
 
-get_xmpp_stanzas_count(PrevReport) ->
+get_xmpp_stanzas_count(_PrevReport, false = _ExometerEnabled) ->
+    [];
+get_xmpp_stanzas_count(PrevReport, true) ->
     StanzaTypes = [xmppMessageSent, xmppMessageReceived, xmppIqSent,
                    xmppIqReceived, xmppPresenceSent, xmppPresenceReceived],
     NewCount = [count_stanzas(StanzaType) || StanzaType <- StanzaTypes],

--- a/src/system_metrics/service_mongoose_system_metrics.erl
+++ b/src/system_metrics/service_mongoose_system_metrics.erl
@@ -36,6 +36,7 @@
         {report_after :: non_neg_integer(),
          reporter_monitor = none :: none | reference(),
          reporter_pid = none :: none | pid(),
+         exometer_enabled = false :: boolean(),
          prev_report = [] :: [mongoose_system_metrics_collector:report_struct()],
          tracking_ids :: [tracking_id()]}).
 
@@ -103,21 +104,24 @@ init(Opts) ->
             #{initial_report := InitialReport, periodic_report := PeriodicReport} = Opts,
             TrackingIds = tracking_ids(Opts),
             erlang:send_after(InitialReport, self(), spawn_reporter),
+            ExometerEnabled = exometer_loaded(),
             {ok, #system_metrics_state{report_after = PeriodicReport,
-                                       tracking_ids = TrackingIds}}
+                                       tracking_ids = TrackingIds,
+                                       exometer_enabled = ExometerEnabled}}
     end.
 
 handle_info(spawn_reporter, #system_metrics_state{report_after = ReportAfter,
                                                   reporter_monitor = none,
                                                   reporter_pid = none,
                                                   prev_report = PrevReport,
-                                                  tracking_ids = TrackingIds} = State) ->
+                                                  tracking_ids = TrackingIds,
+                                                  exometer_enabled = ExometerEnabled} = State) ->
     ServicePid = self(),
     case get_client_id() of
         {ok, ClientId} ->
             {Pid, Monitor} = spawn_monitor(
                 fun() ->
-                    Reports = mongoose_system_metrics_collector:collect(PrevReport),
+                    Reports = mongoose_system_metrics_collector:collect(PrevReport, ExometerEnabled),
                     mongoose_system_metrics_sender:send(ClientId, Reports, TrackingIds),
                     mongoose_system_metrics_file:save(Reports),
                     ServicePid ! {prev_report, Reports}
@@ -208,3 +212,7 @@ msg_accept_terms_and_conditions() ->
     "      https://esl.github.io/MongooseDocs/latest/operation-and-maintenance/System-Metrics-Privacy-Policy/ \n"
     "- MongooseIM GitHub page - https://github.com/esl/MongooseIM \n"
     "The last sent report is also written to a file ~s">>.
+
+-spec exometer_loaded() -> boolean().
+exometer_loaded() ->
+    lists:keymember(exometer, 1, application:loaded_applications()).


### PR DESCRIPTION
There is a crash in `mongoose_system_metrics_collector` when Exometer is not configured, and thus not started - reported in https://github.com/esl/MongooseIM/issues/4541. This PR should fix this issue. I've tested locally that the crash goes away - I'm not sure how to test this condition through big_tests though.
