### PR TITLE
Fix and update GraphiQL

### DIFF
--- a/big_tests/tests/graphql_SUITE.erl
+++ b/big_tests/tests/graphql_SUITE.erl
@@ -147,7 +147,7 @@ can_load_graphiql(Config) ->
     Ep = ?config(schema_endpoint, Config),
     {Status, Html} = get_graphiql_website(Ep),
     ?assertEqual({<<"200">>, <<"OK">>}, Status),
-    ?assertNotEqual(nomatch, binary:match(Html, <<"Loading...">>)).
+    ?assertNotEqual(nomatch, binary:match(Html, <<"MongooseIM GraphiQL">>)).
 
 user_checks_auth(Config) ->
     Ep = ?config(schema_endpoint, Config),

--- a/priv/graphql/wsite/index.html
+++ b/priv/graphql/wsite/index.html
@@ -1,84 +1,104 @@
 <!--
- *  Copyright (c) 2021 GraphQL Contributors
+ *  Copyright (c) 2025 GraphQL Contributors
  *  All rights reserved.
  *
- *  the original version of the file:
- *     https://github.com/graphql/graphiql/blob/graphiql@3.8.3/examples/graphiql-cdn/index.html
- *
- *  This source code is licensed under the license found at:
- *     https://github.com/graphql/graphiql/blob/graphiql@3.8.3/LICENSE
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
 -->
 <!doctype html>
 <html lang="en">
-  <head>
-    <title>GraphiQL</title>
-    <style>
-      body {
-        height: 100%;
-        margin: 0;
-        width: 100%;
-        overflow: hidden;
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GraphiQL 5 with React 19 and GraphiQL Explorer</title>
+  <style>
+    body {
+      margin: 0;
+    }
+
+    #graphiql {
+      height: 100dvh;
+    }
+
+    .loading {
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 4rem;
+    }
+  </style>
+  <link rel="stylesheet" href="https://esm.sh/graphiql/dist/style.css" />
+  <link rel="stylesheet" href="https://esm.sh/@graphiql/plugin-explorer/dist/style.css" />
+  <!-- Note: the ?standalone flag bundles the module along with all of its `dependencies`, excluding `peerDependencies`, into a single JavaScript file. -->
+  <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@19.1.0",
+          "react/jsx-runtime": "https://esm.sh/react@19.1.0/jsx-runtime",
+
+          "react-dom": "https://esm.sh/react-dom@19.1.0",
+          "react-dom/client": "https://esm.sh/react-dom@19.1.0/client",
+
+          "graphiql": "https://esm.sh/graphiql?standalone&external=react,react-dom,@graphiql/react,graphql",
+          "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer?standalone&external=react,@graphiql/react,graphql",
+          "@graphiql/react": "https://esm.sh/@graphiql/react?standalone&external=react,react-dom,graphql",
+
+          "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit?standalone&external=graphql",
+          "graphql": "https://esm.sh/graphql@16.11.0"
+        }
       }
-
-      #graphiql {
-        height: 100vh;
-      }
-    </style>
-    <!--
-      This GraphiQL example depends on Promise and fetch, which are available in
-      modern browsers, but can be "polyfilled" for older browsers.
-      GraphiQL itself depends on React DOM.
-      If you do not want to rely on a CDN, you can host these files locally or
-      include them directly in your favored resource bundler.
-    -->
-    <script
-      crossorigin
-      src="https://unpkg.com/react@18/umd/react.production.min.js"
-    ></script>
-    <script
-      crossorigin
-      src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
-    ></script>
-    <!--
-      These two files can be found in the npm module, however you may wish to
-      copy them directly into your environment, or perhaps include them in your
-      favored resource bundler.
-     -->
-    <script
-      src="https://unpkg.com/graphiql/graphiql.min.js"
-      type="application/javascript"
-    ></script>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
-    <!--
-      These are imports for the GraphIQL Explorer plugin.
-     -->
-    <script
-      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
-      crossorigin
-    ></script>
-
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
-    />
-  </head>
-
-  <body>
-    <div id="graphiql">Loading...</div>
-    <script>
-      const root = ReactDOM.createRoot(document.getElementById('graphiql'));
-      const fetcher = GraphiQL.createFetcher({
-        url: '/api/graphql/',
-        headers: { 'X-Example-Header': 'foo' },
-      });
-      const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
-      root.render(
-        React.createElement(GraphiQL, {
-          fetcher,
-          defaultEditorToolsVisibility: true,
-          plugins: [explorerPlugin],
-        }),
-      );
     </script>
-  </body>
+  <script type="module">
+    // Import React and ReactDOM
+    import React from 'react';
+    import ReactDOM from 'react-dom/client';
+    // Import GraphiQL and the Explorer plugin
+    import { GraphiQL, HISTORY_PLUGIN } from 'graphiql';
+    import { createGraphiQLFetcher } from '@graphiql/toolkit';
+    import { explorerPlugin } from '@graphiql/plugin-explorer';
+
+    import createJSONWorker from 'https://esm.sh/monaco-editor/esm/vs/language/json/json.worker.js?worker';
+    import createGraphQLWorker from 'https://esm.sh/monaco-graphql/esm/graphql.worker.js?worker';
+    import createEditorWorker from 'https://esm.sh/monaco-editor/esm/vs/editor/editor.worker.js?worker';
+
+    globalThis.MonacoEnvironment = {
+      getWorker(_workerId, label) {
+        console.info('MonacoEnvironment.getWorker', { label });
+        switch (label) {
+          case 'json':
+            return createJSONWorker();
+          case 'graphql':
+            return createGraphQLWorker();
+        }
+        return createEditorWorker();
+      },
+    };
+
+    const fetcher = createGraphiQLFetcher({
+      url: '/api/graphql',
+    });
+    const plugins = [HISTORY_PLUGIN, explorerPlugin()];
+
+    function App() {
+      return React.createElement(GraphiQL, {
+        fetcher,
+        plugins,
+        defaultEditorToolsVisibility: true,
+      });
+    }
+
+    const container = document.getElementById('graphiql');
+    const root = ReactDOM.createRoot(container);
+    root.render(React.createElement(App));
+  </script>
+</head>
+
+<body>
+  <div id="graphiql">
+    <div class="loading">Loading…</div>
+  </div>
+</body>
+
 </html>

--- a/priv/graphql/wsite/index.html
+++ b/priv/graphql/wsite/index.html
@@ -2,8 +2,11 @@
  *  Copyright (c) 2025 GraphQL Contributors
  *  All rights reserved.
  *
- *  This source code is licensed under the license found in the
- *  LICENSE file in the root directory of this source tree.
+ *  The original version of the file:
+ *     https://raw.githubusercontent.com/graphql/graphiql/8335433/examples/graphiql-cdn/index.html
+ *
+ *  This source code is licensed under the license found at:
+ *     https://raw.githubusercontent.com/graphql/graphiql/8335433/LICENSE
 -->
 <!doctype html>
 <html lang="en">
@@ -11,7 +14,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>GraphiQL 5 with React 19 and GraphiQL Explorer</title>
+  <title>MongooseIM GraphiQL</title>
   <style>
     body {
       margin: 0;


### PR DESCRIPTION
Recently, our GraphiQL website has become stuck at "Loading...".
Apparently the pinned version 3.8.3 stopped working with the latest browsers.

In this PR, I updated the version to the `main` branch of GraphiQL. This means that the JS libraries are downloaded from CDN in their latest versions. We can see how long this will work. If there are any issues, we could pin the versions again.

**Notes:**

- One of the reasons why I didn't use the latest release`5.0.0` is that it was referencing the JS libraries in "RC" versions.
- I verified that GraphiQL works manually. I used the UI to perform an admin query and checked the results. Unfortunately, I don't see an easy way to check that in big tests.