### PR TITLE
Implement support for blocking a user for any groupchat

### DIFF
--- a/big_tests/tests/mod_blocking_SUITE.erl
+++ b/big_tests/tests/mod_blocking_SUITE.erl
@@ -128,8 +128,8 @@ init_per_group(muc_light, Config0) ->
     HostType = domain_helper:host_type(),
     Config1 = dynamic_modules:save_modules(HostType, Config0),
     Backend = mongoose_helper:mnesia_or_rdbms_backend(),
-    dynamic_modules:ensure_modules(HostType,
-                                   [{mod_muc_light, config_parser_helper:mod_config(mod_muc_light, #{backend => Backend})}]),
+    MucLightConfig = config_parser_helper:mod_config(mod_muc_light, #{backend => Backend}),
+    dynamic_modules:ensure_modules(HostType, [{mod_muc_light, MucLightConfig}]),
     init_per_group(generic, Config1);
 init_per_group(_GroupName, Config) ->
     escalus_fresh:create_users(Config, escalus:get_users([alice, bob, kate, mike, john])).
@@ -273,9 +273,12 @@ messages_from_blocked_user_dont_arrive(Config) ->
 
 messages_from_blocked_user_dont_arrive_muc(ConfigIn) ->
     muc_helper:story_with_room(ConfigIn, [], [{alice, 1}, {bob, 1}], fun(Config, Alice, Bob) ->
-        escalus:send(Bob, muc_helper:stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Bob))),
+        RoomJid = ?config(room, Config),
+        BobNick = escalus_utils:get_username(Bob),
+        escalus:send(Bob, muc_helper:stanza_muc_enter_room(RoomJid, BobNick)),
         escalus:wait_for_stanzas(Bob, 2),
-        escalus:send(Alice, muc_helper:stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Alice))),
+        AliceNick = escalus_utils:get_username(Alice),
+        escalus:send(Alice, muc_helper:stanza_muc_enter_room(RoomJid, AliceNick)),
         escalus:wait_for_stanza(Bob),
         escalus:wait_for_stanzas(Alice, 3),
 

--- a/big_tests/tests/mod_blocking_SUITE.erl
+++ b/big_tests/tests/mod_blocking_SUITE.erl
@@ -17,6 +17,7 @@
 -module(mod_blocking_SUITE).
 -compile([export_all, nowarn_export_all]).
 
+-include_lib("common_test/include/ct.hrl").
 -include_lib("exml/include/exml.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("escalus/include/escalus_xmlns.hrl").
@@ -33,7 +34,9 @@ all() ->
         {group, effect},
         {group, offline},
         {group, errors},
-        {group, pushes}
+        {group, pushes},
+        {group, muc},
+        {group, muc_light}
     ].
 
 groups() ->
@@ -43,7 +46,9 @@ groups() ->
          {offline, [sequence], offline_test_cases()},
          {errors, [parallel], error_test_cases()},
          {pushes, [parallel], push_test_cases()},
-         {notify, [parallel], notify_test_cases()}
+         {notify, [parallel], notify_test_cases()},
+         {muc, [parallel], muc_test_cases()},
+         {muc_light, [parallel], muc_light_test_cases()}
     ].
 
 manage_test_cases() ->
@@ -81,11 +86,18 @@ offline_test_cases() ->
 
 error_test_cases() ->
     [blocker_cant_send_to_blockee].
+
 push_test_cases() ->
     [block_push_sent].
 
 notify_test_cases() ->
     [notify_blockee].
+
+muc_test_cases() ->
+    [messages_from_blocked_user_dont_arrive_muc].
+
+muc_light_test_cases() ->
+    [messages_from_blocked_user_dont_arrive_muc_light].
 
 suite() ->
     escalus:suite().
@@ -108,9 +120,28 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config),
     instrument_helper:stop().
 
+init_per_group(muc, Config) ->
+    muc_helper:load_muc(),
+    mongoose_helper:ensure_muc_clean(),
+    init_per_group(generic, Config);
+init_per_group(muc_light, Config0) ->
+    HostType = domain_helper:host_type(),
+    Config1 = dynamic_modules:save_modules(HostType, Config0),
+    Backend = mongoose_helper:mnesia_or_rdbms_backend(),
+    dynamic_modules:ensure_modules(HostType,
+                                   [{mod_muc_light, config_parser_helper:mod_config(mod_muc_light, #{backend => Backend})}]),
+    init_per_group(generic, Config1);
 init_per_group(_GroupName, Config) ->
     escalus_fresh:create_users(Config, escalus:get_users([alice, bob, kate, mike, john])).
 
+end_per_group(muc, Config) ->
+    mongoose_helper:ensure_muc_clean(),
+    muc_helper:unload_muc(),
+    Config;
+end_per_group(muc_light, Config) ->
+    muc_light_helper:clear_db(domain_helper:host_type()),
+    dynamic_modules:restore_modules(Config),
+    Config;
 end_per_group(_GroupName, Config) ->
     Config.
 
@@ -239,6 +270,44 @@ messages_from_blocked_user_dont_arrive(Config) ->
             privacy_helper:assert_privacy_check_packet_event(User2, #{dir => out}, TS),
             privacy_helper:assert_privacy_check_packet_event(User1, #{dir => in, blocked_count => 1}, TS)
         end).
+
+messages_from_blocked_user_dont_arrive_muc(ConfigIn) ->
+    muc_helper:story_with_room(ConfigIn, [], [{alice, 1}, {bob, 1}], fun(Config, Alice, Bob) ->
+        escalus:send(Bob, muc_helper:stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Bob))),
+        escalus:wait_for_stanzas(Bob, 2),
+        escalus:send(Alice, muc_helper:stanza_muc_enter_room(?config(room, Config), escalus_utils:get_username(Alice))),
+        escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanzas(Alice, 3),
+
+        user_blocks(Alice, [Bob], muc),
+        TS = instrument_helper:timestamp(),
+        Stanza = escalus_stanza:groupchat_to(muc_helper:room_address(?config(room, Config)), <<"Hello">>),
+        escalus:send(Bob, Stanza),
+        ct:sleep(100),
+        % We don't expect Bob to get an error from Alice as this would lead to
+        % her being kicked out of the room
+        escalus_assert:has_no_stanzas(Alice),
+        privacy_helper:assert_privacy_check_packet_event(Bob, #{dir => out}, TS),
+        privacy_helper:assert_privacy_check_packet_event(Alice, #{dir => in, blocked_count => 1}, TS)
+    end).
+
+messages_from_blocked_user_dont_arrive_muc_light(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        RoomName = <<"blocking-testroom">>,
+        muc_light_helper:create_room(RoomName, muc_light_helper:muc_host(),
+                                     Alice, [Bob], Config, muc_light_helper:ver(1)),
+
+        user_blocks(Alice, [Bob], muc_light),
+        TS = instrument_helper:timestamp(),
+        Stanza = escalus_stanza:groupchat_to(muc_light_helper:room_bin_jid(RoomName), <<"Hello">>),
+        escalus:send(Bob, Stanza),
+        ct:sleep(100),
+        % We don't expect Bob to get an error from Alice as this would lead to
+        % her being kicked out of the room
+        escalus_assert:has_no_stanzas(Alice),
+        privacy_helper:assert_privacy_check_packet_event(Bob, #{dir => out}, TS),
+        privacy_helper:assert_privacy_check_packet_event(Alice, #{dir => in, blocked_count => 1}, TS)
+    end).
 
 messages_from_unblocked_user_arrive_again(Config) ->
     escalus:fresh_story(
@@ -594,9 +663,12 @@ get_blocklist_items(Items) ->
                   maps:get(<<"jid">>, A)
               end, Items).
 
-user_blocks(Blocker, Blockees) when is_list(Blockees) ->
+user_blocks(Blocker, Blockees) ->
+    user_blocks(Blocker, Blockees, pm).
+
+user_blocks(Blocker, Blockees, ChatType) when is_list(Blockees) ->
     TS = instrument_helper:timestamp(),
-    BlockeeJIDs = [ escalus_utils:jid_to_lower(escalus_client:short_jid(B)) || B <- Blockees ],
+    BlockeeJIDs = blockee_jids(Blockees, ChatType),
     AddStanza = block_users_stanza(BlockeeJIDs),
     escalus_client:send(Blocker, AddStanza),
     Res = escalus:wait_for_stanzas(Blocker, 2),
@@ -604,6 +676,15 @@ user_blocks(Blocker, Blockees) when is_list(Blockees) ->
     Preds = [is_iq_result, CheckPush],
     escalus:assert_many(Preds, Res),
     privacy_helper:assert_privacy_set_event(Blocker, #{}, TS).
+
+blockee_jids(Blockees, pm) ->
+    [escalus_utils:jid_to_lower(escalus_client:short_jid(B)) || B <- Blockees];
+blockee_jids(Blockees, muc) ->
+    MucHost = muc_helper:muc_host(),
+    [<<MucHost/binary, "/", (escalus_client:username(B))/binary>> || B <- Blockees];
+blockee_jids(Blockees, muc_light) ->
+    MucHost = muc_light_helper:muc_host(),
+    [<<MucHost/binary, "/", (escalus_client:short_jid(B))/binary>> || B <- Blockees].
 
 blocklist_is_empty(BlockList) ->
     escalus:assert(is_iq_result, BlockList),

--- a/doc/modules/mod_blocking.md
+++ b/doc/modules/mod_blocking.md
@@ -24,3 +24,9 @@ If the user has other online resources which use privacy lists it may result in 
 Similar to privacy lists, a blocked contact sees the user as offline no matter what their real status is.
 
 If the contact being blocked is subscribed to the user's presence, they receive an "unavailable" presence; when unblocked, they receive the current status of the user.
+
+The user can be blocked in the context of groupchat by using `domain/resource` format of the jid, see [JID Matching](https://xmpp.org/extensions/xep-0191.html#matching).
+The `domain` part should be then a configured `muc` or `muclight` domain, e.g. `conference.localhost` or `muclight.localhost`.
+The resource is then respectively user's nickname in case of `muc` or user's bare jid in case of `muclight`.
+
+Note: When a blocked user sends a message to a room, the server does not respond with an error but silently ignores it, i.e. doesn't deliver it to the user that issued the blocking.

--- a/src/privacy/mod_privacy.erl
+++ b/src/privacy/mod_privacy.erl
@@ -166,7 +166,12 @@ handle_privacy_iq(Acc1, StateData, HostType, IQ) ->
 -spec user_receive_message(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
     mongoose_c2s_hooks:result().
 user_receive_message(Acc, #{c2s_data := StateData}, _Extra) ->
-    do_privacy_check_receive(Acc, StateData, send).
+    case mongoose_acc:stanza_type(Acc) of
+        <<"groupchat">> ->
+            do_privacy_check_receive(Acc, StateData, ignore);
+        _ ->
+            do_privacy_check_receive(Acc, StateData, send)
+    end.
 
 -spec user_receive_presence(mongoose_acc:t(), mongoose_c2s_hooks:params(), map()) ->
     mongoose_c2s_hooks:result().
@@ -673,6 +678,13 @@ is_type_match(jid, Value, JID, _Subscription, _Groups) ->
         {User, Server, <<>>} ->
             case JID of
                 {User, Server, _} ->
+                    true;
+                _ ->
+                    false
+            end;
+        {<<>>, Server, Resource} ->
+            case JID of
+                {_, Server, Resource} ->
                     true;
                 _ ->
                     false


### PR DESCRIPTION
Given that [XEP-0191: Blocking Command](https://xmpp.org/extensions/xep-0191.html#matching) allows to block a jid in a `domain/resource` format (which is compliant with XEP-0016: Privacy Lists), it could be leveraged to block any messages from a particular user in any groupchat. 

For it to work properly the server mustn't send error from blocking user when a blocked user send a message to a room. This is because we have an implementation of [this optional feature from MUC](https://xmpp.org/extensions/xep-0045.html#service-error-kick).
Example:
1. Alice blocked Bob
2. Bob sent a message to a groupchat where Alice is in
3. The server sends error to Bob (on behalf of Alice) - current feature of Blocking Command for PM
4. Alice gets kicked out from the room - current feature of MUC

Not sending an error message doesn't break the protocol as the XEP states that

> For message stanzas, the server SHOULD return an error, which SHOULD be \<service-unavailable/>.

see - https://xmpp.org/extensions/xep-0191.html#block.
Thus, in the case of groupchat it could block the message silently.
