### PR TITLE
Update Debian release and minor OTP versions

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -5,9 +5,9 @@ references:
   # Available cimg-erlang images: https://hub.docker.com/r/erlangsolutions/erlang/tags?name=cimg
   # You could need to trigger a pipeline to create a Docker image:
   # https://github.com/esl/cimg-erlang#trigger-build-using-trigger-pipeline-on-circleci
-  - &LATEST_OTP_VERSION 28.0.1
-  - &OTP27 erlangsolutions/erlang:cimg-27.3.4.1
-  - &OTP28 erlangsolutions/erlang:cimg-28.0.1
+  - &LATEST_OTP_VERSION 28.0.2
+  - &OTP27 erlangsolutions/erlang:cimg-27.3.4.2
+  - &OTP28 erlangsolutions/erlang:cimg-28.0.2
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3
@@ -690,7 +690,7 @@ jobs:
         type: executor
       platform:
         type: enum
-        enum: [debian-bookworm, debian-bullseye, debian-buster, ubuntu-plucky, ubuntu-noble, ubuntu-jammy, ubuntu-focal, rockylinux-9, rockylinux-8, almalinux-9, almalinux-8]
+        enum: [debian-bookworm, debian-bullseye, debian-trixie, ubuntu-plucky, ubuntu-noble, ubuntu-jammy, ubuntu-focal, rockylinux-9, rockylinux-8, almalinux-9, almalinux-8]
         description: Platform type
       otp_version:
         type: string
@@ -768,15 +768,15 @@ workflows:
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
-          name: debian-buster
+          name: debian-trixie
           executor: otp_28
-          platform: debian-buster
+          platform: debian-trixie
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:
-          name: debian-buster-arm64
+          name: debian-trixie-arm64
           executor: otp_28_arm64
-          platform: debian-buster
+          platform: debian-trixie
           context: mongooseim-org
           filters: *all_tags_and_master
       - package:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         ## the full list of supported (prebuilt) OTP versions for ubuntu-22.04 runners
         ## can be found here:
         ##     https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
-        otp: [ '27.3.4.1', '28.0.1' ]
+        otp: [ '27.3.4.2', '28.0.2' ]
     runs-on: ubuntu-22.04
     env:
       PRESET: 'small_tests'
@@ -67,17 +67,17 @@ jobs:
       matrix:
         preset: [internal_mnesia, pgsql_mnesia, mysql_redis, odbc_mssql_mnesia,
                  ldap_mnesia, elasticsearch_and_cassandra_mnesia]
-        otp: [ '28.0.1' ]
+        otp: [ '28.0.2' ]
         include:
           - test-spec: "default.spec"
           - preset: elasticsearch_and_cassandra_mnesia
             test-spec: "mam.spec"
           - preset: ldap_mnesia
             test-spec: "default.spec"
-            otp: '27.3.4.1'
+            otp: '27.3.4.2'
           - preset: pgsql_mnesia
             test-spec: "default.spec"
-            otp: '27.3.4.1'
+            otp: '27.3.4.2'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -103,11 +103,11 @@ jobs:
       fail-fast: false
       matrix:
         preset: [pgsql_mnesia, mysql_redis, odbc_mssql_mnesia]
-        otp: [ '28.0.1' ]
+        otp: [ '28.0.2' ]
         test-spec: ["dynamic_domains.spec"]
         include:
           - preset: pgsql_mnesia
-            otp: '27.3.4.1'
+            otp: '27.3.4.2'
             test-spec: "dynamic_domains.spec"
     runs-on: ubuntu-22.04
     steps:
@@ -143,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '27.3.4.1' ]
+        otp: [ '27.3.4.2' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '27.3.4.1' ]
+        otp: [ '27.3.4.2' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '27.3.4.1' ]
+        otp: [ '27.3.4.2' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -197,7 +197,7 @@ jobs:
         pkg: [ubuntu-jammy]
     runs-on: ubuntu-22.04
     env:
-      pkg_OTP_VERSION: "28.0.1"
+      pkg_OTP_VERSION: "28.0.2"
       pkg_PLATFORM: ${{matrix.pkg}}
       GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
Replace debian buster with trixie
  - Buster is past its LTS support.
  - Trixie is the latest stable release.

Also update minor Erlang/OTP versions.

To check that the packages are built correctly, I temporarily enabled building them for this branch. You can check the [CI job](https://app.circleci.com/pipelines/github/esl/MongooseIM/14144/workflows/96624d3a-61d5-45fc-9949-f2a55d097012) - please ignore the flaky test. There was no need to rerun it, as that run was about the packages.

