### PR TITLE
Fix missing stream tag for connection-timeout errors

### DIFF
--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -188,6 +188,9 @@ handle_event(cast, Info, FsmState, StateData) ->
 handle_event({timeout, Name}, Payload, C2SState, StateData) ->
     handle_timeout(StateData, C2SState, Name, Payload);
 
+handle_event(state_timeout, state_timeout_termination, {wait_for_stream, stream_start}, StateData) ->
+    StreamError = mongoose_xmpp_errors:connection_timeout(),
+    stream_start_error(StateData, StreamError);
 handle_event(state_timeout, state_timeout_termination, _FsmState, StateData) ->
     StreamConflict = mongoose_xmpp_errors:connection_timeout(),
     send_element_from_server_jid(StateData, StreamConflict),


### PR DESCRIPTION
**Changes:**
- **Fixed stream error format**: Added proper `<stream:stream>` opening tag before sending connection-timeout errors during the `wait_for_stream` state
- **Added comprehensive test**: Created `disconnect_inactive_tcp_connection_after_timeout` test case to verify that inactive TCP connections receive proper XMPP stream error format and are closed after the configured `state_timeout`

**Problem:** Previously, when a client connected via TCP but didn't send any XMPP data within the `state_timeout` period, the server would send a malformed error response missing the required stream opening tag.

**Solution:** Handle the `state_timeout` event specifically during the `wait_for_stream` state to ensure proper XMPP stream error formatting with the correct `<stream:stream>` wrapper.

