### PR TITLE
Fix documentation of mod_blocking

### DIFF
--- a/doc/modules/mod_blocking.md
+++ b/doc/modules/mod_blocking.md
@@ -4,17 +4,9 @@ This module implements [XEP-0191: Blocking command](http://xmpp.org/extensions/x
 The extension allows blocking the whole communication with a user (or a group of users) with a single command. 
 The protocol is much simpler than privacy lists.
 
-## Options
-
-None.
-
-## Example Configuration
-
-```toml
-[modules.mod_blocking]
-```
-
-The module is not configurable because internally it is an interface to privacy lists, so settings like storage backend apply to it automatically.
+!!! Info "Relation to `mod_privacy`"
+    This module uses [`mod_privacy`](./mod_privacy.md) as a dependency, because internally it is an interface to privacy lists.
+    If you configure `mod_blocking`, `mod_privacy` will be started automatically with the same options.
 
 Issuing a blocking command creates a privacy list named "blocking" (if it didn't exist), adds to it items being blocked and sets this list as the default.
 Unblocking contacts removes them from "blocking" privacy list.
@@ -30,3 +22,14 @@ The `domain` part should be then a configured `muc` or `muclight` domain, e.g. `
 The resource is then respectively user's nickname in case of `muc` or user's bare jid in case of `muclight`.
 
 Note: When a blocked user sends a message to a room, the server does not respond with an error but silently ignores it, i.e. doesn't deliver it to the user that issued the blocking.
+
+## Options
+
+Same as in [`mod_privacy`](./mod_privacy.md#options).
+
+## Example Configuration
+
+```toml
+[modules.mod_blocking]
+  backend = "rdbms"
+```

--- a/doc/modules/mod_privacy.md
+++ b/doc/modules/mod_privacy.md
@@ -8,7 +8,9 @@ This extension allows user to block IQs, messages, presences, or all, based on J
 ### `modules.mod_privacy.backend`
 * **Syntax:** string, one of `"mnesia"`, `"rdbms"`.
 * **Default:** `"mnesia"`
-* **Example:** `backend = "mnesia"`
+* **Example:** `backend = "rdbms"`
+
+Database backend used to store the privacy lists.
 
 ## Example Configuration
 


### PR DESCRIPTION
It was incorrectly described as non-configurable.
If fact, it is not only configurable, but also passes its options to mod_privacy.

