### PR TITLE
Refactor logging to use `c2s_data` consistently in log messages

### DIFF
--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -441,7 +441,7 @@ handle_sasl_success(StateData = #c2s_data{jid = MaybeInitialJid, info = Info}, S
                                             info = maps:merge(Info, #{auth_module => AuthMod})},
             El = mongoose_c2s_stanzas:sasl_success_stanza(MaybeServerOut),
             send_acc_from_server_jid(StateData1, SaslAcc, El),
-            ?LOG_INFO(#{what => auth_success, text => <<"Accepted SASL authentication">>, c2s_state => StateData1}),
+            ?LOG_INFO(#{what => auth_success, text => <<"Accepted SASL authentication">>, c2s_data => StateData1}),
             {next_state, {wait_for_stream, authenticated}, StateData1, state_timeout(StateData1)};
         false ->
             c2s_stream_error(StateData, mongoose_xmpp_errors:invalid_from())
@@ -548,7 +548,7 @@ verify_user(wait_for_session_establishment, _, _, Acc) ->
 verify_user(session_established, HostType, #{c2s_data := StateData} = HookParams, Acc) ->
     case mongoose_c2s_hooks:user_open_session(HostType, Acc, HookParams) of
         {ok, Acc1} ->
-            ?LOG_INFO(#{what => c2s_opened_session, c2s_state => StateData}),
+            ?LOG_INFO(#{what => c2s_opened_session, c2s_data => StateData}),
             {ok, Acc1};
         {stop, Acc1} ->
             Jid = StateData#c2s_data.jid,
@@ -686,7 +686,7 @@ verify_process_alive(StateData, C2SState, Pid) ->
         true ->
             ?LOG_WARNING(#{what => c2s_replaced_wait_timeout,
                            text => <<"Some processes are not responding when handling replace messages">>,
-                           replaced_pid => Pid, state_name => C2SState, c2s_state => StateData})
+                           replaced_pid => Pid, state_name => C2SState, c2s_data => StateData})
     end.
 
 -spec maybe_retry_state(state()) -> state() | {stop, term()}.
@@ -911,7 +911,7 @@ send_trailer(StateData) ->
 
 -spec c2s_stream_error(data(), exml:element()) -> fsm_res().
 c2s_stream_error(StateData, Error) ->
-    ?LOG_DEBUG(#{what => c2s_stream_error, xml_error => Error, c2s_state => StateData}),
+    ?LOG_DEBUG(#{what => c2s_stream_error, xml_error => Error, c2s_data => StateData}),
     send_element_from_server_jid(StateData, Error),
     send_xml(StateData, ?XML_STREAM_TRAILER),
     {stop, {shutdown, stream_error}, StateData}.

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -474,7 +474,7 @@ presence_broadcast_to_trusted(Acc, FromJid, Presences, Packet) ->
 
 -spec resend_offline_messages(mongoose_acc:t(), mongoose_c2s:data()) -> mongoose_acc:t().
 resend_offline_messages(Acc, StateData) ->
-    ?LOG_DEBUG(#{what => resend_offline_messages, acc => Acc, c2s_state => StateData}),
+    ?LOG_DEBUG(#{what => resend_offline_messages, acc => Acc, c2s_data => StateData}),
     Jid = mongoose_c2s:get_jid(StateData),
     Acc1 = mongoose_hooks:resend_offline_messages(Acc, Jid),
     Rs = mongoose_acc:get(offline, messages, [], Acc1),

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -454,7 +454,7 @@ handle_stream_mgmt(Acc, _Params, _El) ->
 handle_r(Acc, #{c2s_data := StateData}) ->
     case get_mod_state(StateData) of
         {error, not_found} ->
-            ?LOG_WARNING(#{what => unexpected_r, c2s_state => StateData,
+            ?LOG_WARNING(#{what => unexpected_r, c2s_data => StateData,
                            text => <<"received <r/> but stream management is off!">>}),
             {ok, Acc};
         #sm_state{counter_in = In} ->


### PR DESCRIPTION
**Refactor logging to use `c2s_data` consistently in log messages**

This PR standardizes the logging field names across the MongooseIM codebase by:

- **Replacing inconsistent `c2s_state` with `c2s_data`** in log messages across multiple modules (`mongoose_c2s.erl`, `mod_presence.erl`, `mod_stream_management.erl`)
- **Adding backward compatibility support** in `mongoose_log_filter.erl` to handle both `c2s_state` and `c2s_data` keys during the transition period
- **Improving log consistency** for better debugging and monitoring of C2S (client-to-server) connection states

