### PR TITLE
Add config option for amqp virtual host

### DIFF
--- a/doc/configuration/outgoing-connections.md
+++ b/doc/configuration/outgoing-connections.md
@@ -318,6 +318,11 @@ Any other `Tag` can be used for other purposes.
 * **Default:** `"guest"`
 * **Example:** `password = "guest"`
 
+### `outgoing_pools.rabbit.*.connection.virtual_host`
+* **Syntax:** string
+* **Default:** `"/"`
+* **Example:** `virtual_host = "host_example"`
+
 ### `outgoing_pools.rabbit.*.connection.confirms_enabled`
 * **Syntax:** boolean
 * **Default:** `false`

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -534,6 +534,8 @@ outgoing_pool_connection(<<"rabbit">>) ->
                                            validate = non_empty},
                  <<"password">> => #option{type = binary,
                                            validate = non_empty},
+                 <<"virtual_host">> => #option{type = binary,
+                                       validate = non_empty},
                  <<"confirms_enabled">> => #option{type = boolean},
                  <<"max_worker_queue_len">> => #option{type = int_or_infinity,
                                                        validate = non_negative}
@@ -543,6 +545,7 @@ outgoing_pool_connection(<<"rabbit">>) ->
                     <<"port">> => 5672,
                     <<"username">> => <<"guest">>,
                     <<"password">> => <<"guest">>,
+                    <<"virtual_host">> => <<"/">>,
                     <<"confirms_enabled">> => false,
                     <<"max_worker_queue_len">> => 1000}
       };

--- a/src/mongoose_amqp.erl
+++ b/src/mongoose_amqp.erl
@@ -54,8 +54,8 @@
 %%%===================================================================
 
 -spec network_params(map()) -> #amqp_params_network{}.
-network_params(#{host := Host, port := Port, username := UserName, password := Password}) ->
-    #amqp_params_network{host = Host, port = Port, username = UserName, password = Password}.
+network_params(#{host := Host, port := Port, username := UserName, password := Password, virtual_host := VirtualHost}) ->
+    #amqp_params_network{host = Host, port = Port, username = UserName, password = Password, virtual_host = VirtualHost}.
 
 -spec exchange_declare(Exchange :: binary(), Type :: binary()) -> method().
 exchange_declare(Exchange, Type) ->

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -835,6 +835,7 @@ default_pool_conn_opts(rabbit) ->
       port => 5672,
       username => <<"guest">>,
       password => <<"guest">>,
+      virtual_host => <<"/">>,
       confirms_enabled => false,
       max_worker_queue_len => 1000};
 default_pool_conn_opts(redis) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1085,12 +1085,14 @@ pool_rabbit_connection(_Config) ->
     ?cfg(P ++ [port], 9999, T(#{<<"port">> => 9999})),
     ?cfg(P ++ [username], <<"user">>, T(#{<<"username">> => <<"user">>})),
     ?cfg(P ++ [password], <<"pass">>, T(#{<<"password">> => <<"pass">>})),
+    ?cfg(P ++ [virtual_host], <<"vh">>, T(#{<<"virtual_host">> => <<"vh">>})),
     ?cfg(P ++ [confirms_enabled], true, T(#{<<"confirms_enabled">> => true})),
     ?cfg(P ++ [max_worker_queue_len], 100, T(#{<<"max_worker_queue_len">> => 100})),
     ?err(T(#{<<"host">> => <<>>})),
     ?err(T(#{<<"port">> => 123456})),
     ?err(T(#{<<"username">> => <<>>})),
     ?err(T(#{<<"password">> => <<>>})),
+    ?err(T(#{<<"virtual_host">> => <<>>})),
     ?err(T(#{<<"confirms_enabled">> => <<"yes">>})),
     ?err(T(#{<<"max_worker_queue_len">> => -1})).
 


### PR DESCRIPTION
This PR adds the possibility to use non default `virtual_host`for outgoing rabbitmq pool connections.
I added the documentation and extend the tests suite `test/config_parser_SUITE.erl` accordingly. Changes are tested locally with the `rabbitmq:3.12.10` server.