### PR TITLE
Fix component IsValidFromJid returning non boolean

### DIFF
--- a/src/component/mongoose_component_connection.erl
+++ b/src/component/mongoose_component_connection.erl
@@ -250,7 +250,7 @@ handle_stream_established(StateData, #xmlel{name = Name} = El) ->
             %% If the admin does not want to check the from field when accept packets from any
             %% address. In this case, the component can send packet of behalf of the server users.
             _ ->
-                ok
+                true
         end,
     ToJid = jid:from_binary(exml_query:attr(El, <<"to">>, <<>>)),
     IsStanza = (<<"iq">> =:= Name)


### PR DESCRIPTION
When check_from is set to `false` the function IsValidFromJid returned `ok` which can not be matched in downstream processing and resulted in `{badarg, ok}` to the function `andalso`

