### PR TITLE
MIM-1853 Deprecate MSSQL backend

### DIFF
--- a/doc/configuration/database-backends-configuration.md
+++ b/doc/configuration/database-backends-configuration.md
@@ -156,6 +156,9 @@ for more information.
 
 ### Microsoft SQL Server
 
+!!! Warning
+    MSSQL backend is deprecated and will be removed in the next release.
+
 Microsoft SQL Server, sometimes called MSSQL, or Azure SQL Database.
 
 !!! Warning

--- a/doc/configuration/general.md
+++ b/doc/configuration/general.md
@@ -74,6 +74,9 @@ Default language for messages sent by the server to users. You can get a full li
 
 ## Database settings
 
+!!! Warning
+    MSSQL backend is deprecated and will be removed in the next release.
+
 RDBMS connection pools are set using [outgoing connections configuration](./outgoing-connections.md).
 There are some additional options that influence all database connections in the server:
 

--- a/doc/migrations/6.4.0_6.5.0.md
+++ b/doc/migrations/6.4.0_6.5.0.md
@@ -20,3 +20,7 @@ However, previous versions of MongooseIM also allowed putting the certificate co
 into one file referenced with the `certfile` option.
 This is **no longer accepted** due to an update in Erlang/OTP 28.1,
 and you need to make sure to use separate `certfile` and `keyfile` before upgrading MongooseIM.
+
+### Deprecation
+
+MSSQL backend is deprecated and will be removed in the next release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -218,7 +218,7 @@ nav:
       - '6.3.0 to 6.3.1': 'migrations/6.3.0_6.3.1.md'
       - '6.3.1 to 6.3.2': 'migrations/6.3.1_6.3.2.md'
       - '6.3.3 to 6.4.0': 'migrations/6.3.3_6.4.0.md'
-      - '6.4.0 to 6.4.1': 'migrations/6.4.0_6.4.1.md'
+      - '6.4.0 to 6.5.0': 'migrations/6.4.0_6.5.0.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - 'Contributions to the Ecosystem': 'Contributions.md'
   - 'MongooseIM History': 'History.md'

--- a/priv/mssql2012.sql
+++ b/priv/mssql2012.sql
@@ -1,4 +1,6 @@
-﻿GO
+﻿/* Warning: MSSQL backend is deprecated and will be removed in the next release */
+
+GO
 CREATE TABLE [dbo].[test_types](
     [unicode] [nvarchar](max),
     [unicode250] [nvarchar](250),


### PR DESCRIPTION
This PR deprecates MSSQL as a rdbms backend for MIM.

Support for MSSQL will be removed in the next release.
