### PR TITLE
Refine access_admin option doc for mod_muc

### DIFF
--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -53,6 +53,8 @@ Access Rule to determine who is allowed to create rooms.
 
 Access Rule to determine who is the administrator in all rooms.
 
+Note: Setting this option to `"all"` results in every user being considered a MUC admin. This means that they cannot be added to a room, since it would mean changing their affiliation to `member` which can't be done for a global admin. However, any user is then free to send and receive messages from any room.
+
 ### `modules.mod_muc.access_persistent`
  * **Syntax:** non-empty string
  * **Default:** `"all"`


### PR DESCRIPTION
This PR adds additional note to the `muc.access_admin` option to avoid confusion. Original issue: https://github.com/esl/MongooseIM/issues/4359
