### PR TITLE
Use the mongooseim-docker version w/o odbc

### DIFF
--- a/tools/circleci-prepare-mongooseim-docker.sh
+++ b/tools/circleci-prepare-mongooseim-docker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 set -e
-# master from 2025-06-05
-MIM_DOCKER_VERSION=b2cf9273764632bcb1b1d1c8ab5b5047fa4ee27c
+# master from 2025-12-19
+MIM_DOCKER_VERSION=ab618585cf3a38d8648f5f5aa276bffa609c2a14
 
 # We use output of generate_vsn, because it does not contain illegal characters, returns
 # git tag when building from tag itself, and is unique in any other case


### PR DESCRIPTION
We have already updated [mongooseim-docker](https://github.com/esl/mongooseim-docker/pull/60), and this PR uses the latest version.