### PR TITLE
Add support for static and dynamic domain types in GraphQL schema and queries

### DIFF
--- a/big_tests/tests/graphql_domain_SUITE.erl
+++ b/big_tests/tests/graphql_domain_SUITE.erl
@@ -48,6 +48,7 @@ domain_tests() ->
      get_domains_by_host_type,
      get_all_domains,
      get_domain_details,
+     get_static_domain_details,
      delete_domain,
      request_delete_domain,
      get_domains_after_deletion,
@@ -213,8 +214,8 @@ get_all_domains_with_disabled(Config) ->
     Result = execute_command(<<"domain">>, <<"allDomains">>, #{}, Config),
     ParsedResult = get_ok_value([data, domain, allDomains], Result),
     Expected = [
-        #{<<"domain">> => ?EXAMPLE_DOMAIN, <<"hostType">> => ?HOST_TYPE, <<"status">> => <<"DISABLED">>},
-        #{<<"domain">> => ?SECOND_EXAMPLE_DOMAIN, <<"hostType">> => ?HOST_TYPE, <<"status">> => <<"ENABLED">>}
+        #{<<"domain">> => ?EXAMPLE_DOMAIN, <<"hostType">> => ?HOST_TYPE, <<"status">> => <<"DISABLED">>, <<"type">> => <<"DYNAMIC">>},
+        #{<<"domain">> => ?SECOND_EXAMPLE_DOMAIN, <<"hostType">> => ?HOST_TYPE, <<"status">> => <<"ENABLED">>, <<"type">> => <<"DYNAMIC">>}
     ],
     lists:foreach(fun(E) -> ?assert(lists:member(E, ParsedResult)) end, Expected).
 
@@ -233,8 +234,9 @@ get_all_domains(Config) ->
     Result = execute_command(<<"domain">>, <<"allDomains">>, #{}, Config),
     ParsedResult = get_ok_value([data, domain, allDomains], Result),
     Expected = [
-        #{<<"domain">> => ?EXAMPLE_DOMAIN, <<"hostType">> => ?HOST_TYPE, <<"status">> => <<"ENABLED">>},
-        #{<<"domain">> => ?SECOND_EXAMPLE_DOMAIN, <<"hostType">> => ?HOST_TYPE, <<"status">> => <<"ENABLED">>}
+        #{<<"domain">> => ?EXAMPLE_DOMAIN, <<"hostType">> => ?HOST_TYPE, <<"status">> => <<"ENABLED">>, <<"type">> => <<"DYNAMIC">>},
+        #{<<"domain">> => ?SECOND_EXAMPLE_DOMAIN, <<"hostType">> => ?HOST_TYPE, <<"status">> => <<"ENABLED">>, <<"type">> => <<"DYNAMIC">>},
+        #{<<"domain">> => <<"localhost">>, <<"hostType">> => <<"localhost">>, <<"status">> => <<"ENABLED">>, <<"type">> => <<"STATIC">>}
     ],
     lists:foreach(fun(E) -> ?assert(lists:member(E, ParsedResult)) end, Expected).
 
@@ -243,7 +245,16 @@ get_domain_details(Config) ->
     ParsedResult = get_ok_value([data, domain, domainDetails], Result),
     ?assertEqual(#{<<"domain">> => ?EXAMPLE_DOMAIN,
                    <<"hostType">> => ?HOST_TYPE,
-                   <<"status">> => <<"ENABLED">>}, ParsedResult).
+                   <<"status">> => <<"ENABLED">>,
+                   <<"type">> => <<"DYNAMIC">>}, ParsedResult).
+
+get_static_domain_details(Config) ->
+    Result = get_domain_details(<<"localhost">>, Config),
+    ParsedResult = get_ok_value([data, domain, domainDetails], Result),
+    ?assertEqual(#{<<"domain">> => <<"localhost">>,
+                   <<"hostType">> => <<"localhost">>,
+                   <<"status">> => <<"ENABLED">>,
+                   <<"type">> => <<"STATIC">>}, ParsedResult).
 
 delete_domain(Config) ->
     Result1 = remove_domain(?EXAMPLE_DOMAIN, ?HOST_TYPE, Config),
@@ -302,7 +313,8 @@ domain_admin_get_domain_details(Config) ->
     ParsedResult = get_ok_value([data, domain, domainDetails], Result),
     ?assertEqual(#{<<"domain">> => ?DOMAIN_ADMIN_EXAMPLE_DOMAIN,
                    <<"hostType">> => ?HOST_TYPE,
-                   <<"status">> => <<"ENABLED">>}, ParsedResult).
+                   <<"status">> => <<"ENABLED">>,
+                   <<"type">> => <<"DYNAMIC">>}, ParsedResult).
 
 domain_admin_set_domain_password(Config) ->
     Result = set_domain_password(?DOMAIN_ADMIN_EXAMPLE_DOMAIN, <<"secret">>, Config),

--- a/priv/graphql/schemas/admin/domain.gql
+++ b/priv/graphql/schemas/admin/domain.gql
@@ -2,11 +2,11 @@ type DomainAdminQuery @use(services: ["service_domain_db"]) @protected{
   "Get all enabled domains by hostType. Only for global admin"
   domainsByHostType(hostType: String!): [DomainName!]
     @protected(type: GLOBAL) @use
-  "Get all domains with details. Returns a list of Domain objects. Only for global admin"
-  allDomains: [Domain!]
+  "Get all domains with details. Returns a list of DomainWithType objects. Only for global admin"
+  allDomains: [DomainWithType!]
     @protected(type: GLOBAL) @use
   "Get information about the domain"
-  domainDetails(domain: DomainName!): Domain
+  domainDetails(domain: DomainName!): DomainWithType
     @protected(type: DOMAIN, args: ["domain"]) @use
 }
 

--- a/priv/graphql/schemas/global/domain.gql
+++ b/priv/graphql/schemas/global/domain.gql
@@ -11,6 +11,21 @@ type Domain{
   status: DomainStatus
 }
 
+"""
+A domain representation with type.
+Some operation could return incomplete object i.e. some fields can be null.
+"""
+type DomainWithType{
+  "Domain name"
+  domain: DomainName
+  "Domain hostType"
+  hostType: String
+  "Is domain enabled?"
+  status: DomainStatus
+  "Domain source type"
+  type: DomainType
+}
+
 enum DomainStatus {
   "Domain is enabled and ready to route traffic"
   ENABLED
@@ -20,4 +35,11 @@ enum DomainStatus {
   DELETING
   "Domain is deleted and does not exist anymore"
   DELETED
+}
+
+enum DomainType {
+  "Domain is defined in the configuration file"
+  STATIC
+  "Domain is stored in the database"
+  DYNAMIC
 }

--- a/src/graphql/mongoose_graphql.erl
+++ b/src/graphql/mongoose_graphql.erl
@@ -204,6 +204,7 @@ admin_mapping_rules() ->
         'HttpUploadAdminMutation' => mongoose_graphql_http_upload_admin_mutation,
         'RosterAdminMutation' => mongoose_graphql_roster_admin_mutation,
         'Domain' => mongoose_graphql_domain,
+        'DomainWithType' => mongoose_graphql_domain,
         'MetricAdminQuery' => mongoose_graphql_metric_admin_query,
         default => mongoose_graphql_default},
       interfaces => #{default => mongoose_graphql_default},

--- a/src/graphql/mongoose_graphql_domain.erl
+++ b/src/graphql/mongoose_graphql_domain.erl
@@ -10,5 +10,7 @@ execute(_Ctx, #{status := Status}, <<"status">>, _Args) ->
     {ok, Status};
 execute(_Ctx, #{domain := Name}, <<"domain">>, _Args) ->
     {ok, Name};
+execute(_Ctx, #{type := Type}, <<"type">>, _Args) ->
+    {ok, Type};
 execute(_Ctx, #{}, _, _Args) ->
     {ok, null}.

--- a/src/graphql/mongoose_graphql_enum.erl
+++ b/src/graphql/mongoose_graphql_enum.erl
@@ -38,6 +38,8 @@ input(<<"MetricType">>, Name) -> {ok, Name}.
 
 output(<<"DomainStatus">>, Type) ->
     {ok, string:uppercase(atom_to_binary(Type))};
+output(<<"DomainType">>, Type) ->
+    {ok, string:uppercase(atom_to_binary(Type))};
 output(<<"PresenceShow">>, Show) ->
     {ok, string:uppercase(Show)};
 output(<<"PresenceType">>, Type) ->


### PR DESCRIPTION
This PR addresses the enhancement of domain type handling in the GraphQL API.

* Introduced support for both static and dynamic domain types in the GraphQL schema and queries.

