### PR TITLE
Send pings with correct interval in `mod_ping`

### DIFF
--- a/big_tests/tests/mod_ping_SUITE.erl
+++ b/big_tests/tests/mod_ping_SUITE.erl
@@ -258,7 +258,7 @@ check_connection(_, Client) ->
     true = escalus_connection:is_connected(Client).
 
 wait_for_ping_req(Alice) ->
-    PingReq = escalus_client:wait_for_stanza(Alice, timer:seconds(10)),
+    PingReq = escalus_client:wait_for_stanza(Alice, ping_interval() + timer:seconds(1)),
     escalus:assert(is_iq_get, PingReq),
     <<"urn:xmpp:ping">> = exml_query:path(PingReq, [{element, <<"ping">>},
                                                     {attr, <<"xmlns">>}]),

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -173,15 +173,10 @@ determine_action(<<"error">>) ->
     mongoose_c2s_hooks:result().
 user_send_packet(Acc, _Params, #{host_type := HostType}) ->
     Interval = gen_mod:get_module_opt(HostType, ?MODULE, ping_interval),
-    Action = {{timeout, ping}, Interval, fun ping_c2s_handler/2},
+    Action = {{timeout, send_ping}, Interval, fun ping_c2s_handler/2},
     {ok, mongoose_c2s_acc:to_acc(Acc, actions, Action)}.
 
 -spec ping_c2s_handler(atom(), mongoose_c2s:data()) -> mongoose_c2s_acc:t().
-ping_c2s_handler(ping, StateData) ->
-    HostType = mongoose_c2s:get_host_type(StateData),
-    Interval = gen_mod:get_module_opt(HostType, ?MODULE, ping_req_timeout),
-    Actions = [{{timeout, send_ping}, Interval, fun ping_c2s_handler/2}],
-    mongoose_c2s_acc:new(#{actions => Actions});
 ping_c2s_handler(send_ping, StateData) ->
     PingId = mongoose_bin:gen_from_crypto(),
     IQ = ping_get(PingId),


### PR DESCRIPTION
The current implementation does not match the documentation. Following configuration options are available: `ping_interval` and `ping_req_timout`. The expectation would be that a server to client ping is send after `ping_interval` seconds after the last user activity and then the user has `ping_req_timeout` seconds to answer the ping before ping action is executed. But the ping is only sent after `ping_interval` + `ping_req_timeout` This change removes the additional timer for `ping_req_timeout`.