### PR TITLE
Change externalId GQL type to ID in mod_external_filter

### DIFF
--- a/doc/modules/mod_external_filter.md
+++ b/doc/modules/mod_external_filter.md
@@ -10,8 +10,8 @@ described in the next section.
 type RootMutation {
     verifyMessage(
         body: String!
-        rawMessage: String
-        externalId: String!
+        rawData: String
+        externalId: ID!
         recipient: String!
         sender: String!
     ): VerificationResult

--- a/src/mod_external_filter.erl
+++ b/src/mod_external_filter.erl
@@ -26,7 +26,7 @@
         <<"mutation verifyMessage(
                $body: String!,
                $rawData: String!,
-               $externalId: String!,
+               $externalId: ID!,
                $recipient: String!,
                $sender: String!) {
            verifyMessage(


### PR DESCRIPTION
This PR addresses changes GQL schema for `mod_external_filter`, i.e. change `externalId` field type to `ID`.
