### PR TITLE
MIM-2670 Muc remove user

### DIFF
--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -5,6 +5,7 @@
 -import(distributed_helper, [mim/0, rpc/4, subhost_pattern/1]).
 -import(domain_helper, [host_type/0, domain_to_host_type/2, domain/0]).
 -import(config_parser_helper, [mod_config/2]).
+-import(muc_helper, [get_member_list/2]).
 
 -include("mam_helper.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -272,7 +273,11 @@ muc_removal(Config0) ->
         run_remove_domain(),
         ?assertMatch([], get_muc_rooms(MucHost)),
         ?assertMatch([], get_muc_room_aff(Domain)),
-        ?assertMatch({error, not_registered}, get_muc_registered(MucHost, AliceJid))
+        ?assertMatch({error, not_registered}, get_muc_registered(MucHost, AliceJid)),
+        % make sure the room is not running (it used to)
+        ListResponse = get_member_list(Alice, ?config(room, Config)),
+        escalus:assert(is_error, [<<"cancel">>, <<"item-not-found">>], ListResponse),
+        ok
     end).
 
 muc_light_removal(Config0) ->

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -1479,8 +1479,6 @@ admin_member_list(ConfigIn) ->
   end).
 
 %% removing user from the system removes them from a room
-%% TODO: what if the room is offline?
-%% TODO: remove_domain
 admin_remove_user(ConfigIn) ->
     UserSpecs = [{alice, 1}, {bob, 1}],
     story_with_room(ConfigIn, admin_room_opts(), UserSpecs, fun(Config, Alice, Bob) ->

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -175,6 +175,7 @@ groups() ->
                               admin_membership_with_reason,
                               admin_member_list,
                               admin_remove_user,
+                              admin_remove_user_from_offline_room,
                               admin_member_list_allowed,
                               admin_moderator,
                               admin_moderator_with_reason,
@@ -1251,6 +1252,7 @@ admin_get_form(ConfigIn) ->
         escalus:send(Alice, F),
         Form = escalus:wait_for_stanza(Alice),
         escalus:assert(is_iq_result, Form),
+        RoomJID = rpc(mim(), jid, make, [?config(room, Config), muc_host(), <<>>]),
         ok
     end),
     ok.
@@ -1480,40 +1482,81 @@ admin_member_list(ConfigIn) ->
 admin_remove_user(ConfigIn) ->
     UserSpecs = [{alice, 1}, {bob, 1}],
     story_with_room(ConfigIn, admin_room_opts(), UserSpecs, fun(Config, Alice, Bob) ->
+        Room = ?config(room, Config),
         %% Bob joins room
-        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
-        escalus:wait_for_stanzas(Bob, 2),
-
-        %% Make Bob a member
-        Items = [{escalus_utils:get_short_jid(Bob), <<"member">>}],
-        escalus:send(Alice, stanza_set_affiliations(?config(room, Config), Items)),
-        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
-
+        add_user_to_room(Bob, Room, Alice),
         %% Request member list
-        escalus:send(Alice, stanza_affiliation_list_request(
-            ?config(room, Config), <<"member">>)),
-        List = escalus:wait_for_stanza(Alice),
-        escalus:assert(is_iq_result, List),
+        List = get_member_list(Alice, Room),
         %% Bob should be on the list
         true = is_iq_with_affiliation(List, <<"member">>),
         true = is_iq_with_short_jid(List, Bob),
-
         %% Remove Bob's account
-        BJ = escalus_client:full_jid(Bob),
-        B = jid:from_binary(BJ),
-        true = rpc(mim(), ejabberd_auth, does_user_exist, [B]),
-        ok = rpc(mim(), ejabberd_auth, remove_user, [B]),
-        false = rpc(mim(), ejabberd_auth, does_user_exist, [B]),
-
+        remove_user(Bob),
         %% Request again
-        escalus:send(Alice, stanza_affiliation_list_request(
-            ?config(room, Config), <<"member">>)),
-        List2 = escalus:wait_for_stanza(Alice),
+        List2 = get_member_list(Alice, Room),
         escalus:assert(is_iq_result, List2),
         %% List should be empty
         true = is_item_list_empty(List2),
         ok
     end).
+
+admin_remove_user_from_offline_room(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, admin_room_opts(), UserSpecs, fun(Config, Alice, Bob) ->
+        Room = ?config(room, Config),
+        %% Bob joins room
+        add_user_to_room(Bob, Room, Alice),
+        %% Request member list
+        List = get_member_list(Alice, Room),
+        %% Bob should be on the list
+        true = is_iq_with_affiliation(List, <<"member">>),
+        true = is_iq_with_short_jid(List, Bob),
+        %% make Bob offline so that we can hibernate the room
+        escalus_client:stop(Config, Bob),
+        %% stop room process
+        stop_room(Room),
+        %% Remove Bob's account
+        remove_user(Bob),
+        %% Request again
+        List2 = get_member_list(Alice, Room),
+        escalus:assert(is_iq_result, List2),
+        %% List should be empty
+        true = is_item_list_empty(List2),
+        RoomJID = rpc(mim(), jid, make, [Room, muc_host(), <<>>]),
+        assert_room_event(mod_muc_deep_hibernations, RoomJID),
+        assert_room_event(mod_muc_process_recreations, RoomJID),
+        ok
+    end).
+
+stop_room(Room) ->
+    {ok, Pid} = rpc(mim(), mod_muc_online_backend, find_room_pid,
+            [domain_helper:host_type(), muc_host(), Room]),
+    Pid ! stop_persistent_room_process,
+    wait_helper:wait_until(fun() ->
+                               rpc(mim(), mod_muc_online_backend, find_room_pid,
+                                   [domain_helper:host_type(), muc_host(), Room])
+                           end, {error, not_found}),
+    ok.
+
+get_member_list(Alice, Room) ->
+    escalus:send(Alice, stanza_affiliation_list_request(Room, <<"member">>)),
+    List = escalus:wait_for_stanza(Alice),
+    escalus:assert(is_iq_result, List),
+    List.
+
+remove_user(Bob) ->
+    BJ = escalus_client:full_jid(Bob),
+    B = jid:from_binary(BJ),
+    true = rpc(mim(), ejabberd_auth, does_user_exist, [B]),
+    ok = rpc(mim(), ejabberd_auth, remove_user, [B]),
+    false = rpc(mim(), ejabberd_auth, does_user_exist, [B]).
+
+add_user_to_room(Bob, Room, Alice) ->
+    escalus:send(Bob, stanza_muc_enter_room(Room, <<"bob">>)),
+    escalus:wait_for_stanzas(Bob, 2),
+    Items = [{escalus_utils:get_short_jid(Bob), <<"member">>}],
+    escalus:send(Alice, stanza_set_affiliations(Room, Items)),
+    escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)).
 
 check_memberlist(LoginData, yes, Config) ->
     escalus:send(LoginData, stanza_affiliation_list_request(

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -22,6 +22,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("exml/include/exml.hrl").
 -include("assert_received_match.hrl").
+-include_lib("jid/include/jid.hrl").
 
 -import(distributed_helper, [mim/0,
                              subhost_pattern/1,
@@ -173,6 +174,7 @@ groups() ->
                               admin_membership,
                               admin_membership_with_reason,
                               admin_member_list,
+                              admin_remove_user,
                               admin_member_list_allowed,
                               admin_moderator,
                               admin_moderator_with_reason,
@@ -1471,6 +1473,47 @@ admin_member_list(ConfigIn) ->
         Error = escalus:wait_for_stanza(Kate),
         escalus:assert(is_error, [<<"auth">>, <<"forbidden">>], Error)
   end).
+
+%% removing user from the system removes them from a room
+%% TODO: what if the room is offline?
+%% TODO: remove_domain
+admin_remove_user(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, admin_room_opts(), UserSpecs, fun(Config, Alice, Bob) ->
+        %% Bob joins room
+        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
+        escalus:wait_for_stanzas(Bob, 2),
+
+        %% Make Bob a member
+        Items = [{escalus_utils:get_short_jid(Bob), <<"member">>}],
+        escalus:send(Alice, stanza_set_affiliations(?config(room, Config), Items)),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+
+        %% Request member list
+        escalus:send(Alice, stanza_affiliation_list_request(
+            ?config(room, Config), <<"member">>)),
+        List = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, List),
+        %% Bob should be on the list
+        true = is_iq_with_affiliation(List, <<"member">>),
+        true = is_iq_with_short_jid(List, Bob),
+
+        %% Remove Bob's account
+        BJ = escalus_client:full_jid(Bob),
+        B = jid:from_binary(BJ),
+        true = rpc(mim(), ejabberd_auth, does_user_exist, [B]),
+        ok = rpc(mim(), ejabberd_auth, remove_user, [B]),
+        false = rpc(mim(), ejabberd_auth, does_user_exist, [B]),
+
+        %% Request again
+        escalus:send(Alice, stanza_affiliation_list_request(
+            ?config(room, Config), <<"member">>)),
+        List2 = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, List2),
+        %% List should be empty
+        true = is_item_list_empty(List2),
+        ok
+    end).
 
 check_memberlist(LoginData, yes, Config) ->
     escalus:send(LoginData, stanza_affiliation_list_request(

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -34,7 +34,9 @@
          generate_rpc_jid/1,
          destroy_room/1,
          destroy_room/2,
+         get_member_list/2,
          stanza_muc_enter_room/2,
+         stanza_affiliation_list_request/2,
          stanza_to_room/2,
          stanza_to_room/3,
          room_address/1,
@@ -1537,12 +1539,6 @@ stop_room(Room) ->
                                    [domain_helper:host_type(), muc_host(), Room])
                            end, {error, not_found}),
     ok.
-
-get_member_list(Alice, Room) ->
-    escalus:send(Alice, stanza_affiliation_list_request(Room, <<"member">>)),
-    List = escalus:wait_for_stanza(Alice),
-    escalus:assert(is_iq_result, List),
-    List.
 
 remove_user(Bob) ->
     BJ = escalus_client:full_jid(Bob),
@@ -5140,11 +5136,6 @@ stanza_role_list_request(Room, Role) ->
 stanza_form_request(Room) ->
     Payload = [],
     stanza_to_room(escalus_stanza:iq_get(?NS_MUC_OWNER, Payload), Room).
-
-stanza_affiliation_list_request(Room, Affiliation) ->
-    Payload = [ #xmlel{name = <<"item">>,
-                       attrs = #{<<"affiliation">> => Affiliation}} ],
-    stanza_to_room(escalus_stanza:iq_get(?NS_MUC_ADMIN, Payload), Room).
 
 stanza_ban_list_request(Room) ->
     stanza_affiliation_list_request(Room, <<"outcast">>).

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -164,6 +164,10 @@ create_instant_room(Room, From, Nick, Opts) ->
     ok = rpc(mim(), mod_muc, create_instant_room,
         [ServerHost, muc_host(), Room1, From, Nick, Opts]).
 
+get_member_list(Caller, Room) ->
+    escalus:send(Caller, stanza_affiliation_list_request(Room, <<"member">>)),
+    escalus:wait_for_stanza(Caller).
+
 assert_valid_server(ServerHost) ->
     HostType = domain_helper:host_type(),
     case rpc(mim(), mongoose_domain_api, get_domain_host_type, [ServerHost]) of
@@ -214,6 +218,11 @@ stanza_default_muc_room(Room, Nick) ->
     Query = escalus_stanza:query_el(?NS_MUC_OWNER, [Form]),
     IQSet = escalus_stanza:iq(<<"set">>, [Query]),
     stanza_to_room(IQSet, Room, Nick).
+
+stanza_affiliation_list_request(Room, Affiliation) ->
+    Payload = [ #xmlel{name = <<"item">>,
+                       attrs = #{<<"affiliation">> => Affiliation}} ],
+    stanza_to_room(escalus_stanza:iq_get(?NS_MUC_ADMIN, Payload), Room).
 
 stanza_to_room(Stanza, Room) ->
     escalus_stanza:to(Stanza, room_address(Room)).

--- a/src/muc/mod_muc.erl
+++ b/src/muc/mod_muc.erl
@@ -1229,7 +1229,6 @@ remove_user(Acc, #{jid := #jid{luser = UserU, lserver = UserS}},
     Res = mod_muc_backend:get_user_rooms(HostType, MUCHost, UserU, UserS),
     {ok, Rooms} = Res,
     Failures = lists:filtermap(fun(R) -> remove_user_from_online(R, UserU, UserS) end, Rooms),
-    logger:warning("asdf Failures: ~p~n", [Failures]),
     lists:foreach(fun(R) -> remove_user_from_offline(HostType, R, UserU, UserS) end, Failures),
     {ok, Acc}.
 

--- a/src/muc/mod_muc.erl
+++ b/src/muc/mod_muc.erl
@@ -72,6 +72,7 @@
 -export([is_muc_room_owner/3,
          can_access_room/3,
          remove_domain/3,
+         remove_user/3,
          acc_room_affiliations/3,
          can_access_identity/3,
          disco_local_items/3,
@@ -1210,6 +1211,25 @@ can_access_room(_, #{room := Room, user := User}, _) ->
     mod_muc_backend:remove_domain(HostType, MUCHost, Domain),
     {ok, Acc}.
 
+-spec remove_user(Acc, Params, Extra) -> {ok, Acc} when
+    Acc :: mongoose_acc:t(),
+    Params :: #{jid := jid:jid()},
+    Extra :: gen_hook:extra().
+remove_user(Acc, #{jid := #jid{luser = UserU, lserver = UserS}},
+            #{host_type := HostType}) ->
+    MUCHost = server_host_to_muc_host(HostType, UserS),
+    Res = mod_muc_backend:get_user_rooms(HostType, MUCHost, UserU, UserS),
+    {ok, Rooms} = Res,
+    Failures = lists:filtermap(fun(R) -> remove_user_from_online(R, UserU, UserS) end, Rooms),
+    logger:warning("asdf Failures: ~p~n", [Failures]),
+    {ok, Acc}.
+
+remove_user_from_online(#muc_room{name_host = {Name, Host}} = Room, UserU, UserS) ->
+    case mod_muc_room:remove_user(#jid{luser = Name, lserver = Host}, UserU, UserS) of
+        ok -> false;
+        E -> {true, Room}
+    end.
+
 -spec acc_room_affiliations(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_acc:t(),
     Params :: #{room := jid:jid()},
@@ -1298,6 +1318,7 @@ hooks(HostType) ->
     [{is_muc_room_owner, HostType, fun ?MODULE:is_muc_room_owner/3, #{}, 50},
      {can_access_room, HostType, fun ?MODULE:can_access_room/3, #{}, 50},
      {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
+     {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
      {acc_room_affiliations, HostType, fun ?MODULE:acc_room_affiliations/3, #{}, 50},
      {can_access_identity, HostType, fun ?MODULE:can_access_identity/3, #{}, 50},
      {disco_local_items, HostType, fun ?MODULE:disco_local_items/3, #{}, 250},

--- a/src/muc/mod_muc.erl
+++ b/src/muc/mod_muc.erl
@@ -1208,7 +1208,15 @@ can_access_room(_, #{room := Room, user := User}, _) ->
     Extra :: gen_hook:extra().
  remove_domain(Acc, #{domain := Domain}, #{host_type := HostType}) ->
     MUCHost = server_host_to_muc_host(HostType, Domain),
+    {ok, Rooms} = mod_muc_backend:get_rooms(HostType, MUCHost),
     mod_muc_backend:remove_domain(HostType, MUCHost, Domain),
+    Pids = lists:filtermap(fun(#muc_room{name_host = {N, _}}) ->
+                               case find_room_pid(HostType, MUCHost, N) of
+                                   {ok, Pid} -> {true, Pid};
+                                   _ -> false
+                               end
+                           end, Rooms),
+    lists:foreach(fun mod_muc_room:stop/1, Pids),
     {ok, Acc}.
 
 -spec remove_user(Acc, Params, Extra) -> {ok, Acc} when

--- a/src/muc/mod_muc.erl
+++ b/src/muc/mod_muc.erl
@@ -1222,13 +1222,17 @@ remove_user(Acc, #{jid := #jid{luser = UserU, lserver = UserS}},
     {ok, Rooms} = Res,
     Failures = lists:filtermap(fun(R) -> remove_user_from_online(R, UserU, UserS) end, Rooms),
     logger:warning("asdf Failures: ~p~n", [Failures]),
+    lists:foreach(fun(R) -> remove_user_from_offline(HostType, R, UserU, UserS) end, Failures),
     {ok, Acc}.
 
 remove_user_from_online(#muc_room{name_host = {Name, Host}} = Room, UserU, UserS) ->
     case mod_muc_room:remove_user(#jid{luser = Name, lserver = Host}, UserU, UserS) of
         ok -> false;
-        E -> {true, Room}
+        _ -> {true, Room}
     end.
+
+remove_user_from_offline(HostType, #muc_room{name_host = {Name, Host}}, UserU, UserS) ->
+    mod_muc_backend:remove_user(HostType, Name, Host, UserU, UserS).
 
 -spec acc_room_affiliations(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_acc:t(),

--- a/src/muc/mod_muc_backend.erl
+++ b/src/muc/mod_muc_backend.erl
@@ -9,6 +9,7 @@
          get_nick/3,
          set_nick/4,
          unset_nick/3,
+         remove_user/5,
          remove_domain/3
     ]).
 
@@ -63,6 +64,8 @@
     ok | {error, term()}.
 
 -callback remove_domain(mongooseim:host_type(), muc_host(), jid:lserver()) -> ok.
+
+-callback remove_user(mongooseim:host_type(), mod_muc:room(), muc_host(), jid:luser(), jid:lserver()) -> ok.
 
 -optional_callbacks([remove_domain/3]).
 
@@ -142,3 +145,8 @@ remove_domain(HostType, MUCHost, Domain) ->
         false ->
             ok
     end.
+
+-spec remove_user(mongooseim:host_type(), mod_muc:room(), muc_host(), jid:luser(), jid:lserver()) -> ok.
+remove_user(HostType, RoomName, MUCHost, UserU, UserS) ->
+    Args = [HostType, RoomName, MUCHost, UserU, UserS],
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).

--- a/src/muc/mod_muc_backend.erl
+++ b/src/muc/mod_muc_backend.erl
@@ -4,6 +4,7 @@
          restore_room/3,
          forget_room/3,
          get_rooms/2,
+         get_user_rooms/4,
          can_use_nick/4,
          get_nick/3,
          set_nick/4,
@@ -42,6 +43,9 @@
 -callback get_rooms(mongooseim:host_type(), muc_host()) ->
     {ok, [#muc_room{}]} | {error, term()}.
 
+-callback get_user_rooms(mongooseim:host_type(), muc_host(), jid:luser(), jid:lserver()) ->
+    {ok, [#muc_room{}]} | {error, term()}.
+
 -callback can_use_nick(mongooseim:host_type(), muc_host(),
                        client_jid(), mod_muc:nick()) -> boolean().
 
@@ -65,7 +69,7 @@
 %% Called when MUC service starts or restarts for each domain
 -spec init(mongooseim:host_type(), Opts :: gen_mod:module_opts()) -> ok.
 init(HostType, Opts) ->
-    TrackedFuns = [store_room, restore_room, forget_room, get_rooms,
+    TrackedFuns = [store_room, restore_room, forget_room, get_rooms, get_user_rooms,
                      can_use_nick, get_nick, set_nick, unset_nick],
     mongoose_backend:init(HostType, ?MAIN_MODULE, TrackedFuns, Opts),
     Args = [HostType, Opts],
@@ -93,6 +97,12 @@ forget_room(HostType, MucHost, Room) ->
     {ok, [#muc_room{}]} | {error, term()}.
 get_rooms(HostType, MucHost) ->
     Args = [HostType, MucHost],
+    mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec get_user_rooms(mongooseim:host_type(), muc_host(), jid:luser(), jid:lserver()) ->
+    {ok, [#muc_room{}]} | {error, term()}.
+get_user_rooms(HostType, MucHost, LUser, LServer) ->
+    Args = [HostType, MucHost, LUser, LServer],
     mongoose_backend:call_tracked(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
 -spec can_use_nick(mongooseim:host_type(), muc_host(), client_jid(), mod_muc:nick()) ->

--- a/src/muc/mod_muc_mnesia.erl
+++ b/src/muc/mod_muc_mnesia.erl
@@ -32,6 +32,7 @@
          restore_room/3,
          forget_room/3,
          get_rooms/2,
+         get_user_rooms/4,
          can_use_nick/4,
          get_nick/3,
          set_nick/4,
@@ -40,6 +41,8 @@
 -include("mongoose.hrl").
 -include("jlib.hrl").
 -include("mod_muc.hrl").
+
+-type muc_host() :: jid:server().
 
 -record(muc_registered, {
             us_host    :: {US :: jid:simple_bare_jid(), MucHost :: jid:lserver()} | '$1',
@@ -118,6 +121,16 @@ get_rooms(HostType, MucHost) ->
                      class => Class, reason => Reason, stacktrace => Stacktrace}),
         {error, {Class, Reason}}
     end.
+
+-spec get_user_rooms(mongooseim:host_type(), muc_host(), jid:luser(), jid:lserver()) -> {ok, [#muc_room{}]}.
+get_user_rooms(HostType, MucHost, UserU, UserS) ->
+    {ok, Rooms} = get_rooms(HostType, MucHost),
+    {ok, lists:filter(fun(Room) -> has_user(UserU, UserS, Room) end, Rooms)}.
+
+has_user(UserU, UserS, #muc_room{opts = Opts}) ->
+    Affs = proplists:get_value(affiliations, Opts, []),
+    Matcher = fun({{U, S, _}, _}) -> {U, S} == {UserU, UserS} end,
+    lists:any(Matcher, Affs).
 
 -spec can_use_nick(mongooseim:host_type(), jid:server(),
                    jid:jid(), mod_muc:nick()) -> boolean().

--- a/src/muc/mod_muc_mnesia.erl
+++ b/src/muc/mod_muc_mnesia.erl
@@ -31,6 +31,7 @@
          store_room/4,
          restore_room/3,
          forget_room/3,
+         remove_user/5,
          get_rooms/2,
          get_user_rooms/4,
          can_use_nick/4,
@@ -107,6 +108,19 @@ forget_room(HostType, MucHost, RoomName) ->
                          sub_host => MucHost, host_type => HostType,
                          room => RoomName, reason => Result}),
             {error, Result}
+    end.
+
+-spec remove_user(mongooseim:host_type(), mod_muc:room(), muc_host(), jid:luser(), jid:lserver()) -> ok.
+remove_user(HostType, RoomName, MucHost, UserU, UserS) ->
+    case restore_room(HostType, MucHost, RoomName) of
+        {ok, Opts} ->
+            Affs = proplists:get_value(affiliations, Opts, []),
+            Matcher = fun({{U, S, _}, _}) -> {U, S} /= {UserU, UserS} end,
+            Affs1 = lists:filter(Matcher, Affs),
+            Opts1 = [{affiliations, Affs1} | proplists:delete(affiliations, Opts)],
+            store_room(HostType, MucHost, RoomName, Opts1);
+        {error, room_not_found} ->
+            ok
     end.
 
 get_rooms(HostType, MucHost) ->

--- a/src/muc/mod_muc_rdbms.erl
+++ b/src/muc/mod_muc_rdbms.erl
@@ -7,6 +7,7 @@
          restore_room/3,
          forget_room/3,
          get_rooms/2,
+         get_user_rooms/4,
          can_use_nick/4,
          get_nick/3,
          set_nick/4,
@@ -57,6 +58,11 @@ prepare_queries(HostType) ->
             <<"DELETE FROM muc_rooms WHERE muc_host = ?">>),
     prepare(muc_select_rooms, muc_rooms, [muc_host],
             <<"SELECT id, room_name, options FROM muc_rooms WHERE muc_host = ?">>),
+    prepare(muc_select_user_rooms, muc_rooms,
+            [muc_host, luser, lserver],
+            <<"SELECT room_name "
+              "FROM muc_rooms WHERE muc_host = ? AND id IN "
+              "(SELECT room_id FROM muc_room_aff WHERE luser = ? and lserver = ?)" >>),
     %% Queries to muc_room_aff table
     prepare(muc_insert_aff, muc_room_aff,
             [room_id, luser, lserver, resource, aff],
@@ -159,6 +165,12 @@ forget_room(HostType, MucHost, RoomName) ->
 get_rooms(HostType, MucHost) ->
     {selected, RoomRows} = execute_select_rooms(HostType, MucHost),
     RoomRecs = [handle_room_row(HostType, MucHost, Row) || Row <- RoomRows],
+    {ok, RoomRecs}.
+
+-spec get_user_rooms(mongooseim:host_type(), muc_host(), jid:luser(), jid:lserver()) -> {ok, [#muc_room{}]}.
+get_user_rooms(HostType, MucHost, UserU, UserS) ->
+    {selected, RoomRows} = execute_select_user_rooms(HostType, MucHost, UserU, UserS),
+    RoomRecs = [#muc_room{name_host = {RoomName, MucHost}} || {RoomName} <- RoomRows],
     {ok, RoomRecs}.
 
 handle_room_row(HostType, MucHost, {ExtRoomID, RoomName, ExtOpts}) ->
@@ -284,6 +296,10 @@ execute_delete_room(HostType, MucHost, RoomName) ->
 -spec execute_select_rooms(mongooseim:host_type(), muc_host()) -> term().
 execute_select_rooms(HostType, MucHost) ->
     execute_successfully(HostType, muc_select_rooms, [MucHost]).
+
+-spec execute_select_user_rooms(mongooseim:host_type(), muc_host(), jid:luser(), jid:lserver()) -> term().
+execute_select_user_rooms(HostType, MucHost, UserU, UserS) ->
+    execute_successfully(HostType, muc_select_user_rooms, [MucHost, UserU, UserS]).
 
 -spec execute_select_nick_user(mongooseim:host_type(), muc_host(), jid:luser(), mod_muc:nick()) -> term().
 execute_select_nick_user(HostType, MucHost, UserS, Nick) ->

--- a/src/muc/mod_muc_rdbms.erl
+++ b/src/muc/mod_muc_rdbms.erl
@@ -12,11 +12,13 @@
          get_nick/3,
          set_nick/4,
          unset_nick/3,
-         remove_domain/3
+         remove_domain/3,
+         remove_user/5
         ]).
 
 -ignore_xref([can_use_nick/4, forget_room/3, get_nick/3, get_rooms/2, remove_domain/3, init/2,
-              restore_room/3, set_nick/4, store_room/4, unset_nick/3]).
+              restore_room/3, set_nick/4, store_room/4, unset_nick/3, get_user_rooms/4,
+              remove_user/5]).
 
 -import(mongoose_rdbms, [prepare/4, execute_successfully/3]).
 
@@ -82,6 +84,9 @@ prepare_queries(HostType) ->
     prepare(muc_room_aff_remove_user_domain, muc_room_aff,
             [lserver],
             <<"DELETE FROM muc_room_aff WHERE lserver = ?">>),
+    prepare(muc_delete_user_aff, muc_room_aff,
+            [room_id, luser, lserver],
+            <<"DELETE FROM muc_room_aff WHERE room_id = ? AND luser = ? AND lserver = ?">>),
     %% Queries to muc_registered table
     prepare(muc_select_nick_user, muc_registered,
             [muc_host, lserver, nick],
@@ -123,6 +128,22 @@ remove_domain(HostType, MucHost, Domain) ->
         mongoose_rdbms:execute_successfully(
             HostType, muc_rooms_remove_domain, [MucHost]),
         ok
+        end,
+    {atomic, ok} = mongoose_rdbms:sql_transaction(HostType, F),
+    ok.
+
+-spec remove_user(mongooseim:host_type(), mod_muc:room(), muc_host(), jid:luser(), jid:lserver()) -> ok.
+remove_user(HostType, RoomName, MucHost, UserU, UserS) ->
+    F = fun() ->
+            mongoose_rdbms:execute_successfully(HostType, muc_delete_nick, [MucHost, UserS, UserU]),
+            case execute_select_room(HostType, MucHost, RoomName) of
+                {selected, [{ExtRoomID, _}]} ->
+                    mongoose_rdbms:execute_successfully(HostType, muc_delete_user_aff, [ExtRoomID, UserU, UserS]),
+                    ok;
+                {selected, []} ->
+                    ok % we don't care
+            end,
+            ok
         end,
     {atomic, ok} = mongoose_rdbms:sql_transaction(HostType, F),
     ok.

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -41,6 +41,7 @@
          get_room_config/1,
          change_room_config/2,
          delete_room/2,
+         remove_user/3,
          is_room_owner/2,
          can_access_room/2,
          can_access_identity/2]).
@@ -260,6 +261,15 @@ delete_room(RoomJID, ReasonIn) ->
     case mod_muc:room_jid_to_pid(RoomJID) of
         {ok, Pid} ->
             gen_fsm_compat:send_all_state_event(Pid, {destroy, ReasonIn});
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec remove_user(jid:jid(), jid:luser(), jid:lserver()) -> ok | {error, not_found}.
+remove_user(RoomJID, UserU, UserS) ->
+    case mod_muc:room_jid_to_pid(RoomJID) of
+        {ok, Pid} ->
+            gen_fsm_compat:send_all_state_event(Pid, {remove_user, UserU, UserS});
         {error, Reason} ->
             {error, Reason}
     end.
@@ -625,6 +635,11 @@ handle_event({destroy, Reason}, _StateName, StateData) ->
     {stop, shutdown, StateData};
 handle_event(destroy, StateName, StateData) ->
     handle_event({destroy, none}, StateName, StateData);
+
+handle_event({remove_user, UserU, UserS}, StateName, StateData) ->
+    S1 = remove_user_from_room(#jid{luser = UserU, lserver = UserS},
+                               <<"user remove">>, StateData),
+    {next_state, StateName, S1};
 
 handle_event({set_affiliations, Affiliations},
              #state{hibernate_timeout = Timeout} = StateName, StateData) ->
@@ -2793,16 +2808,7 @@ process_admin_item_set_unsafe({JID, role, none, Reason}, _UJID, SD) ->
     safe_send_kickban_presence(JID, Reason, <<"307">>, SD),
     set_role(JID, none, SD);
 process_admin_item_set_unsafe({JID, affiliation, none, Reason}, _UJID, SD) ->
-    case  (SD#state.config)#config.members_only of
-        true ->
-            safe_send_kickban_presence(JID, Reason, <<"321">>, none, SD),
-            SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
-            set_role(JID, none, SD1);
-        _ ->
-            SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
-            send_update_presence(JID, Reason, SD1),
-            SD1
-    end;
+    remove_user_from_room(JID, Reason, SD);
 process_admin_item_set_unsafe({JID, affiliation, outcast, Reason}, _UJID, SD) ->
     safe_send_kickban_presence(JID, Reason, <<"301">>, outcast, SD),
     set_affiliation_and_reason(JID, outcast, Reason, set_role(JID, none, SD));
@@ -2829,6 +2835,18 @@ process_admin_item_set_unsafe({JID, affiliation, A, Reason}, _UJID, SD) ->
     SD1 = set_affiliation(JID, A, SD),
     send_update_presence(JID, Reason, SD1),
     SD1.
+
+remove_user_from_room(JID, Reason, SD) ->
+    case (SD#state.config)#config.members_only of
+        true ->
+            safe_send_kickban_presence(JID, Reason, <<"321">>, none, SD),
+            SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
+            set_role(JID, none, SD1);
+        _ ->
+            SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
+            send_update_presence(JID, Reason, SD1),
+            SD1
+    end.
 
 -type res_row() :: {jid:simple_jid() | jid:jid(),
                     'affiliation' | 'role', any(), any()}.


### PR DESCRIPTION
This addresses a silly bug - when you removed a user from the system MUC did not remove the membership information, so the room appeared to still have that user. This is fixed now - if the room is online (meaning there is a running process representing the room) then the room is "told" to remove that user, otherwise it is just a database operation.