### PR TITLE
Reduce log noise in `mongoose_s2s_in`

### DIFF
--- a/src/s2s/mongoose_s2s_in.erl
+++ b/src/s2s/mongoose_s2s_in.erl
@@ -113,7 +113,7 @@ handle_event(internal, #xmlel{} = El, stream_established, Data) ->
 handle_event(info, {Tag, _, _} = SocketData, _, Data) when Tag =:= tcp; Tag =:= ssl ->
     handle_socket_data(Data, SocketData);
 handle_event(info, {Tag, _}, State, _) when Tag =:= tcp_closed; Tag =:= ssl_closed ->
-    ?LOG_WARNING(#{what => s2s_connection_closed, tag => Tag, state => State}),
+    ?LOG_DEBUG(#{what => s2s_connection_closed, tag => Tag, state => State}),
     {stop, {shutdown, Tag}};
 handle_event(info, {Tag, _, Reason}, State, _) when Tag =:= tcp_error; Tag =:= ssl_error ->
     ?LOG_WARNING(#{what => s2s_connection_error, tag => Tag, reason => Reason, state => State}),


### PR DESCRIPTION
This PR lowers logging from warning to debug in `mongoose_s2s_in` when a TCP/SSL socket is closed. Such socket closures are normal (e.g., during health checks). For reference, `mongoose_c2s` does not log a warning in this situation.

Logs after the change:

```
$ grep '<0.2887.0>' mongooseim.log.1
when=2026-03-27T12:58:12.877572+00:00 level=debug what=s2s_in_started pid=<0.2887.0> at=mongoose_s2s_in:handle_event/4:88 text="New incoming S2S connection" socket={ranch_tcp,#Port<0.34>,s2s,{5269,{0,0,0,0},tcp},{{127,0,0,1},54417}}
when=2026-03-27T12:58:13.877073+00:00 level=debug what=s2s_connection_closed pid=<0.2887.0> at=mongoose_s2s_in:handle_event/4:116 state={wait_for_stream,stream_start} tag=tcp_closed
```
