### PR TITLE
MIM-2662 Report only unexpected errors in logged_errors report

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -103,6 +103,7 @@
 {suites, "tests", cets_disco_SUITE}.
 {suites, "tests", start_node_id_SUITE}.
 {suites, "tests", tr_util_SUITE}.
+{suites, "tests", cth_error_report_SUITE}.
 
 %% the below suites restart MIM nodes, so they were moved to the end
 %% to minimise impact on other tests

--- a/big_tests/run_common_test.erl
+++ b/big_tests/run_common_test.erl
@@ -62,12 +62,13 @@ main(RawArgs) ->
         timer:sleep(50),
         CTRunDirsAfterRun = ct_run_dirs(),
         inject_error_report_link(CTRunDirsBeforeRun, CTRunDirsAfterRun),
+        ErrorLimitExceeded = check_error_limit_exceeded(CTRunDirsBeforeRun, CTRunDirsAfterRun),
         ExitStatusByGroups = exit_status_by_groups(CTRunDirsBeforeRun, CTRunDirsAfterRun, Results),
         ExitStatusByTestCases = process_results(Results),
-        case ExitStatusByGroups of
+        ExitStatus = case ExitStatusByGroups of
             undefined ->
                 io:format("Exiting by test cases summary: ~p~n", [ExitStatusByTestCases]),
-                init:stop(ExitStatusByTestCases);
+                ExitStatusByTestCases;
             _ when is_integer(ExitStatusByGroups) ->
                 %% FIXME: This is incorrect assumption, it ignores results of all individual
                 %% tests cases and groups w/o 'repeat_until_all_ok' flag. So we can return
@@ -76,8 +77,17 @@ main(RawArgs) ->
                 %% may result in squashing ct output, since execution of run_common_test.erl
                 %% is wrapped using silent_exec.sh tool.
                 io:format("Exiting by groups summary: ~p~n",  [ExitStatusByGroups]),
-                init:stop(ExitStatusByGroups)
-        end
+                ExitStatusByGroups
+        end,
+        FinalStatus = case {ExitStatus, ErrorLimitExceeded} of
+            {0, {true, Details}} ->
+                io:format("~n**** Failing due to unexpected error"
+                          " log limit exceeded:~n~s", [Details]),
+                1;
+            _ ->
+                ExitStatus
+        end,
+        init:stop(FinalStatus)
     catch Type:Reason:StackTrace ->
         io:format("TEST CRASHED~n Error type: ~p~n Reason: ~p~n Stacktrace:~n~p~n",
                                [Type, Reason, StackTrace]),
@@ -660,6 +670,21 @@ handle_file_error(_FileName, Other) ->
 
 ct_run_dirs() ->
     filelib:wildcard("ct_report/ct_run*").
+
+check_error_limit_exceeded(Before, After) ->
+    case After -- Before of
+        [RunDir] ->
+            Marker = filename:join([RunDir, "logged_errors",
+                                    "limit_exceeded"]),
+            case file:read_file(Marker) of
+                {ok, Content} ->
+                    {true, Content};
+                _ ->
+                    false
+            end;
+        _ ->
+            false
+    end.
 
 inject_error_report_link(Before, After) ->
     case After -- Before of

--- a/big_tests/run_common_test.erl
+++ b/big_tests/run_common_test.erl
@@ -674,8 +674,7 @@ ct_run_dirs() ->
 check_error_limit_exceeded(Before, After) ->
     case After -- Before of
         [RunDir] ->
-            Marker = filename:join([RunDir, "logged_errors",
-                                    "limit_exceeded"]),
+            Marker = filename:join([RunDir, "logged_errors", "limit_exceeded"]),
             case file:read_file(Marker) of
                 {ok, Content} ->
                     {true, Content};

--- a/big_tests/src/cth_error_report.erl
+++ b/big_tests/src/cth_error_report.erl
@@ -35,7 +35,7 @@
 -export([terminate/1]).
 
 %% API for tests
--export([expect/1]).
+-export([expect/1, max_unexpected_errors_logged/1]).
 
 -import(distributed_helper, [rpc/4, mim/0]).
 
@@ -81,7 +81,15 @@
 %% Uses the same pattern types as log_error_helper:expect/1.
 -spec expect(pattern()) -> true.
 expect(Pattern) ->
-    ets:insert(?PATTERNS_TABLE, {Pattern}).
+    ets:insert(?PATTERNS_TABLE, {expect, Pattern}).
+
+%% @doc Set the maximum allowed unexpected errors for the current suite.
+%% If the count exceeds this limit, end_per_suite will return
+%% {error, too_many_unexpected_errors}.
+%% Call from init_per_suite or init_per_group.
+-spec max_unexpected_errors_logged(non_neg_integer()) -> true.
+max_unexpected_errors_logged(N) when is_integer(N), N >= 0 ->
+    ets:insert(?PATTERNS_TABLE, {max_unexpected_errors_logged, N}).
 
 %% CT hook callbacks
 
@@ -169,16 +177,21 @@ post_end_per_suite(Suite, _Config, Return, #state{report_dir = undefined} = Stat
     {Return, State};
 post_end_per_suite(Suite, _Config, Return, State) ->
     SuiteResult = try
+        MaxUnexp = get_max_unexpected_errors_logged(),
         State1 = collect_errors({end_per_suite}, State),
         rpc(mim(), ?COLLECTOR, stop, [?INSTANCE]),
         delete_patterns_table(),
         write_report(Suite, State1),
-        {Suite, State1#state.all_total, State1#state.unexpected_total}
+        Unexp = State1#state.unexpected_total,
+        check_unexpected_limit(Suite, Unexp, MaxUnexp,
+                               State1#state.report_dir),
+        {Suite, State1#state.all_total, Unexp}
     catch Class:Reason:Stacktrace ->
-        ct:pal("cth_error_report: failed to write report for ~p: ~p:~p~n~p",
+        ct:pal("cth_error_report: failed for ~p: ~p:~p~n~p",
                [Suite, Class, Reason, Stacktrace]),
         delete_patterns_table(),
-        {Suite, State#state.all_total, State#state.unexpected_total}
+        {Suite, State#state.all_total,
+         State#state.unexpected_total}
     end,
     Results = [SuiteResult | State#state.suite_results],
     {Return, State#state{report_dir = undefined, mark = undefined,
@@ -193,6 +206,19 @@ terminate(#state{suite_results = []}) ->
 terminate(#state{summary_dir = Dir, suite_results = RevResults}) ->
     write_summary(Dir, lists:sort(RevResults)).
 
+%% Unexpected errors limit check
+
+check_unexpected_limit(_Suite, _Unexp, undefined, _Dir) ->
+    ok;
+check_unexpected_limit(_Suite, Unexp, Max, _Dir) when Unexp =< Max ->
+    ok;
+check_unexpected_limit(Suite, Unexp, Max, ReportDir) ->
+    Msg = io_lib:format("~p: ~p unexpected ~s logged,"
+                        " max allowed: ~p~n",
+                        [Suite, Unexp, plural(Unexp, "error"), Max]),
+    MarkerFile = filename:join(ReportDir, "limit_exceeded"),
+    file:write_file(MarkerFile, Msg, [append]).
+
 %% Parallel group detection
 
 -spec is_parallel_group(list()) -> boolean().
@@ -205,8 +231,7 @@ is_parallel_group(Config) ->
 init_patterns_table() ->
     case ets:whereis(?PATTERNS_TABLE) of
         undefined ->
-            ets:new(?PATTERNS_TABLE,
-                    [named_table, public, bag]);
+            ets_helper:new(?PATTERNS_TABLE, [bag]);
         _Tid ->
             ets:delete_all_objects(?PATTERNS_TABLE)
     end.
@@ -214,13 +239,24 @@ init_patterns_table() ->
 delete_patterns_table() ->
     case ets:whereis(?PATTERNS_TABLE) of
         undefined -> ok;
-        _Tid -> ets:delete(?PATTERNS_TABLE)
+        _Tid -> ets_helper:delete(?PATTERNS_TABLE)
     end.
 
 get_patterns() ->
     case ets:whereis(?PATTERNS_TABLE) of
         undefined -> [];
-        _Tid -> [P || {P} <- ets:tab2list(?PATTERNS_TABLE)]
+        _Tid -> [P || {expect, P} <- ets:tab2list(?PATTERNS_TABLE)]
+    end.
+
+get_max_unexpected_errors_logged() ->
+    case ets:whereis(?PATTERNS_TABLE) of
+        undefined ->
+            undefined;
+        _Tid ->
+            case ets:match(?PATTERNS_TABLE, {max_unexpected_errors_logged, '$1'}) of
+                [[N] | _] -> N;
+                [] -> undefined
+            end
     end.
 
 %% Error collection
@@ -433,13 +469,15 @@ format_section_header({testcase, _Groups, TC}) ->
 format_section_errors_log([], []) ->
     "(no errors)\n";
 format_section_errors_log([], Expected) ->
-    io_lib:format("(~p expected error(s))~n", [length(Expected)]);
+    N = length(Expected),
+    io_lib:format("(~p expected ~s)~n", [N, plural(N, "error")]);
 format_section_errors_log(Unexpected, Expected) ->
     ULines = lists:map(fun format_entry_unexpected_log/1, Unexpected),
     ELines = lists:map(fun format_entry_expected_log/1, Expected),
+    Total = length(Unexpected) + length(Expected),
     Summary = io_lib:format(
-        "~p error(s): ~p unexpected, ~p expected~n",
-        [length(Unexpected) + length(Expected),
+        "~p ~s: ~p unexpected, ~p expected~n",
+        [Total, plural(Total, "error"),
          length(Unexpected), length(Expected)]),
     [Summary, ULines, ELines].
 
@@ -587,6 +625,9 @@ pretty_print_map(Map) ->
     Pairs = maps:to_list(Map),
     Lines = [io_lib:format("  ~0p => ~0p", [K, V]) || {K, V} <- Pairs],
     ["#{\n", lists:join(",\n", Lines), "\n}"].
+
+plural(1, Word) -> Word;
+plural(_, Word) -> Word ++ "s".
 
 html_escape(Bin) when is_binary(Bin) ->
     html_escape(binary_to_list(Bin));

--- a/big_tests/src/cth_error_report.erl
+++ b/big_tests/src/cth_error_report.erl
@@ -35,7 +35,7 @@
 -export([terminate/1]).
 
 %% API for tests
--export([expect/1, max_unexpected_errors_logged/1]).
+-export([expect/1, expect/2, max_unexpected_errors_logged/1]).
 
 -import(distributed_helper, [rpc/4, mim/0]).
 
@@ -56,6 +56,8 @@
     unexpected_total = 0 :: non_neg_integer(),
     %% Count of all errors (unexpected + expected) in current suite
     all_total = 0 :: non_neg_integer(),
+    %% Number of errors already matched per counted pattern
+    consumed = #{} :: #{pattern() => non_neg_integer()},
     %% Accumulated across suites for the final summary
     %% {Suite, AllErrors, UnexpectedErrors}
     suite_results = [] :: [suite_result()]
@@ -76,12 +78,20 @@
 
 %% API
 
-%% @doc Declare an expected error pattern for the current suite.
-%% Matching errors will be filtered from the report.
+%% @doc Declare an expected error pattern with unlimited matches.
+%% All matching errors will be classified as expected.
 %% Uses the same pattern types as log_error_helper:expect/1.
 -spec expect(pattern()) -> true.
 expect(Pattern) ->
     ets:insert(?PATTERNS_TABLE, {expect, Pattern}).
+
+%% @doc Declare an expected error pattern with a specific count.
+%% Multiple calls with the same pattern accumulate:
+%% expect(P, 3) + expect(P, 5) expects 8 matches total.
+%% An unlimited expect/1 for the same pattern overrides counts.
+-spec expect(pattern(), pos_integer()) -> true.
+expect(Pattern, N) when is_integer(N), N > 0 ->
+    ets:insert(?PATTERNS_TABLE, {expect_count, Pattern, N}).
 
 %% @doc Set the maximum allowed unexpected errors for the current suite.
 %% If the count exceeds this limit, end_per_suite will return
@@ -114,7 +124,8 @@ pre_init_per_suite(_Suite, Config, State) ->
                              summary_dir = SummaryDir,
                              groups = [], parallel_depth = 0,
                              entries = [],
-                             unexpected_total = 0, all_total = 0}}
+                             unexpected_total = 0, all_total = 0,
+                             consumed = #{}}}
     catch Class:Reason:Stacktrace ->
         ct:pal("cth_error_report: failed to start: ~p:~p~n~p",
                [Class, Reason, Stacktrace]),
@@ -197,6 +208,7 @@ post_end_per_suite(Suite, _Config, Return, State) ->
     {Return, State#state{report_dir = undefined, mark = undefined,
                          entries = [],
                          unexpected_total = 0, all_total = 0,
+                         consumed = #{},
                          suite_results = Results}}.
 
 terminate(#state{summary_dir = undefined}) ->
@@ -242,11 +254,28 @@ delete_patterns_table() ->
         _Tid -> ets_helper:delete(?PATTERNS_TABLE)
     end.
 
-get_patterns() ->
+%% Build a map of Pattern => unlimited | Count from the ETS table.
+%% {expect, P} entries mean unlimited.
+%% {expect_count, P, N} entries accumulate counts.
+%% An unlimited entry overrides any counts for the same pattern.
+get_pattern_allowances() ->
     case ets:whereis(?PATTERNS_TABLE) of
-        undefined -> [];
-        _Tid -> [P || {expect, P} <- ets:tab2list(?PATTERNS_TABLE)]
+        undefined ->
+            #{};
+        _Tid ->
+            lists:foldl(fun build_allowance/2, #{},
+                        ets:tab2list(?PATTERNS_TABLE))
     end.
+
+build_allowance({expect, P}, Acc) ->
+    Acc#{P => unlimited};
+build_allowance({expect_count, P, N}, Acc) ->
+    case maps:get(P, Acc, 0) of
+        unlimited -> Acc;
+        Existing -> Acc#{P => Existing + N}
+    end;
+build_allowance(_, Acc) ->
+    Acc.
 
 get_max_unexpected_errors_logged() ->
     case ets:whereis(?PATTERNS_TABLE) of
@@ -266,32 +295,90 @@ collect_errors(Section, #state{mark = Mark} = State) ->
     try
         Errors = rpc(mim(), ?COLLECTOR, get_errors_after, [?INSTANCE, Mark]),
         NewMark = rpc(mim(), ?COLLECTOR, timestamp, []),
-        {Unexpected, Expected} = classify_errors(Errors, get_patterns()),
+        %% Compute effective allowances: ETS totals minus consumed
+        Allowances = effective_allowances(get_pattern_allowances(),
+                                          State#state.consumed),
+        {Unexpected, Expected, NewConsumed} =
+            classify_errors(Errors, Allowances,
+                            State#state.consumed),
         Entry = {Section, Unexpected, Expected},
         State#state{mark = NewMark,
                     entries = [Entry | State#state.entries],
                     unexpected_total = State#state.unexpected_total
                         + length(Unexpected),
                     all_total = State#state.all_total
-                        + length(Unexpected) + length(Expected)}
+                        + length(Unexpected) + length(Expected),
+                    consumed = NewConsumed}
     catch Class:Reason:Stacktrace ->
         ct:pal("cth_error_report: collect_errors failed: ~p:~p~n~p",
                [Class, Reason, Stacktrace]),
         State
     end.
 
--spec classify_errors([log_entry()], [pattern()]) ->
-    {Unexpected :: [log_entry()], Expected :: [log_entry()]}.
-classify_errors(Errors, []) ->
-    {Errors, []};
-classify_errors(Errors, Patterns) ->
-    lists:partition(
-        fun({_Ts, _Level, Msg, Meta}) ->
-            not lists:any(
-                fun(P) -> log_error_helper:matches_pattern(Msg, Meta, P) end,
-                Patterns)
+%% Compute effective allowances: declared totals minus consumed.
+effective_allowances(Declared, Consumed) ->
+    maps:map(
+        fun(_P, unlimited) ->
+                unlimited;
+           (P, Total) ->
+                Used = maps:get(P, Consumed, 0),
+                max(0, Total - Used)
         end,
-        Errors).
+        Declared).
+
+-spec classify_errors([log_entry()], map(), map()) ->
+    {Unexpected :: [log_entry()], Expected :: [log_entry()], map()}.
+classify_errors(Errors, Allowances, Consumed)
+  when map_size(Allowances) =:= 0 ->
+    {Errors, [], Consumed};
+classify_errors(Errors, Allowances, Consumed) ->
+    {Unexpected, Expected, _, NewConsumed} = lists:foldl(
+        fun(Entry, {UnexpAcc, ExpAcc, AllowAcc, ConsAcc}) ->
+            {_Ts, _Level, Msg, Meta} = Entry,
+            case find_matching_pattern(Msg, Meta, AllowAcc) of
+                {ok, P} ->
+                    NewAllow = decrement_allowance(P, AllowAcc),
+                    NewCons = increment_consumed(P, ConsAcc),
+                    {UnexpAcc, [Entry | ExpAcc], NewAllow, NewCons};
+                none ->
+                    {[Entry | UnexpAcc], ExpAcc, AllowAcc, ConsAcc}
+            end
+        end,
+        {[], [], Allowances, Consumed},
+        Errors),
+    {lists:reverse(Unexpected), lists:reverse(Expected),
+     NewConsumed}.
+
+find_matching_pattern(Msg, Meta, Allowances) ->
+    find_matching_pattern_impl(Msg, Meta,
+                               maps:keys(Allowances),
+                               Allowances).
+
+find_matching_pattern_impl(_Msg, _Meta, [], _Allowances) ->
+    none;
+find_matching_pattern_impl(Msg, Meta, [P | Rest], Allowances) ->
+    case log_error_helper:matches_pattern(Msg, Meta, P) of
+        true ->
+            case maps:get(P, Allowances) of
+                unlimited -> {ok, P};
+                N when N > 0 -> {ok, P};
+                0 ->
+                    find_matching_pattern_impl(
+                        Msg, Meta, Rest, Allowances)
+            end;
+        false ->
+            find_matching_pattern_impl(
+                Msg, Meta, Rest, Allowances)
+    end.
+
+decrement_allowance(P, Allowances) ->
+    case maps:get(P, Allowances) of
+        unlimited -> Allowances;
+        N when N > 0 -> Allowances#{P := N - 1}
+    end.
+
+increment_consumed(P, Consumed) ->
+    maps:update_with(P, fun(N) -> N + 1 end, 1, Consumed).
 
 %% Report directory
 

--- a/big_tests/src/cth_error_report.erl
+++ b/big_tests/src/cth_error_report.erl
@@ -296,18 +296,13 @@ collect_errors(Section, #state{mark = Mark} = State) ->
         Errors = rpc(mim(), ?COLLECTOR, get_errors_after, [?INSTANCE, Mark]),
         NewMark = rpc(mim(), ?COLLECTOR, timestamp, []),
         %% Compute effective allowances: ETS totals minus consumed
-        Allowances = effective_allowances(get_pattern_allowances(),
-                                          State#state.consumed),
-        {Unexpected, Expected, NewConsumed} =
-            classify_errors(Errors, Allowances,
-                            State#state.consumed),
+        Allowances = effective_allowances(get_pattern_allowances(), State#state.consumed),
+        {Unexpected, Expected, NewConsumed} = classify_errors(Errors, Allowances, State#state.consumed),
         Entry = {Section, Unexpected, Expected},
         State#state{mark = NewMark,
                     entries = [Entry | State#state.entries],
-                    unexpected_total = State#state.unexpected_total
-                        + length(Unexpected),
-                    all_total = State#state.all_total
-                        + length(Unexpected) + length(Expected),
+                    unexpected_total = State#state.unexpected_total + length(Unexpected),
+                    all_total = State#state.all_total + length(Unexpected) + length(Expected),
                     consumed = NewConsumed}
     catch Class:Reason:Stacktrace ->
         ct:pal("cth_error_report: collect_errors failed: ~p:~p~n~p",
@@ -360,21 +355,23 @@ find_matching_pattern_impl(Msg, Meta, [P | Rest], Allowances) ->
     case log_error_helper:matches_pattern(Msg, Meta, P) of
         true ->
             case maps:get(P, Allowances) of
-                unlimited -> {ok, P};
-                N when N > 0 -> {ok, P};
+                unlimited ->
+                    {ok, P};
+                N when N > 0 ->
+                    {ok, P};
                 0 ->
-                    find_matching_pattern_impl(
-                        Msg, Meta, Rest, Allowances)
+                    find_matching_pattern_impl(Msg, Meta, Rest, Allowances)
             end;
         false ->
-            find_matching_pattern_impl(
-                Msg, Meta, Rest, Allowances)
+            find_matching_pattern_impl(Msg, Meta, Rest, Allowances)
     end.
 
 decrement_allowance(P, Allowances) ->
     case maps:get(P, Allowances) of
-        unlimited -> Allowances;
-        N when N > 0 -> Allowances#{P := N - 1}
+        unlimited ->
+            Allowances;
+        N when N > 0 ->
+            Allowances#{P := N - 1}
     end.
 
 increment_consumed(P, Consumed) ->
@@ -415,7 +412,7 @@ write_summary(ReportDir, Results) ->
 
 write_summary_log(ReportDir, Sorted) ->
     File = filename:join(ReportDir, "summary.log"),
-    Header = "Errors Logged During Tests Summary\n\n",
+    Header = "Errors Logged During Tests\n\n",
     Lines = lists:map(fun format_summary_line/1, Sorted),
     ok = file:write_file(File, [Header | Lines]).
 
@@ -425,7 +422,7 @@ write_summary_html(ReportDir, Sorted) ->
     Html = [
         "<!DOCTYPE html>\n<html>\n<head>\n"
         "<meta charset=\"utf-8\">\n"
-        "<title>Errors Logged During Tests Summary</title>\n"
+        "<title>Errors Logged During Tests</title>\n"
         "<style>\n"
         "body { font-family: monospace; margin: 2em; }\n"
         "table { border-collapse: collapse; }\n"
@@ -438,7 +435,7 @@ write_summary_html(ReportDir, Sorted) ->
         "a { color: inherit; }\n"
         "</style>\n"
         "</head>\n<body>\n",
-        "<h1>Errors Logged During Tests Summary</h1>\n",
+        "<h1>Errors Logged During Tests</h1>\n",
         "<table>\n<tr><th>Suite</th>"
         "<th>All errors</th>"
         "<th>Unexpected errors</th></tr>\n",

--- a/big_tests/src/cth_error_report.erl
+++ b/big_tests/src/cth_error_report.erl
@@ -1,15 +1,23 @@
 %%% @doc CT hook that collects error logs from MongooseIM nodes during test
 %%% execution and writes a report file per test suite.
 %%%
-%%% Reports are written to an `error_reports/' subfolder in the CT log
+%%% Reports are written to a `logged_errors/' subfolder in the CT log
 %%% directory (ct_report/ct_run.*). Each suite gets its own file named
 %%% `SuiteName.log'. Errors are broken down by group and testcase.
 %%%
 %%% Uses a named instance of log_error_collector (`cth_error_report')
 %%% to avoid conflicts with log_error_helper's default instance.
 %%%
+%%% Tests can declare expected error patterns using expect/1.
+%%% In the .log report, unexpected errors are prefixed with
+%%% *** UNEXPECTED ***. In the .html report, unexpected errors
+%%% are red and expected errors are green.
+%%%
 %%% Usage in *.spec:
 %%%   {ct_hooks, [cth_error_report]}.
+%%%
+%%% Usage in tests:
+%%%   cth_error_report:expect({what, some_expected_error}).
 -module(cth_error_report).
 
 %% CT hook callbacks
@@ -26,10 +34,14 @@
 -export([post_end_per_suite/4]).
 -export([terminate/1]).
 
+%% API for tests
+-export([expect/1]).
+
 -import(distributed_helper, [rpc/4, mim/0]).
 
 -define(COLLECTOR, log_error_collector).
 -define(INSTANCE, cth_error_report).
+-define(PATTERNS_TABLE, cth_error_report_patterns).
 
 -record(state, {
     report_dir :: undefined | string(),
@@ -40,18 +52,36 @@
     parallel_depth = 0 :: non_neg_integer(),
     mark :: undefined | integer(),
     entries = [] :: [entry()],
-    total = 0 :: non_neg_integer(),
+    %% Count of unexpected errors in current suite
+    unexpected_total = 0 :: non_neg_integer(),
+    %% Count of all errors (unexpected + expected) in current suite
+    all_total = 0 :: non_neg_integer(),
     %% Accumulated across suites for the final summary
-    suite_results = [] :: [{atom(), non_neg_integer()}]
+    %% {Suite, AllErrors, UnexpectedErrors}
+    suite_results = [] :: [suite_result()]
 }).
 
--type entry() :: {section(), [log_error_collector:log_entry()]}.
+-type suite_result() :: {atom(), non_neg_integer(), non_neg_integer()}.
+
+-type log_entry() :: log_error_collector:log_entry().
+-type entry() :: {section(), Unexpected :: [log_entry()],
+                  Expected :: [log_entry()]}.
 -type group_info() :: {atom(), boolean()}.
+-type pattern() :: log_error_helper:pattern().
 -type section() :: {init_per_suite}
                  | {end_per_suite}
                  | {init_per_group, [group_info()]}
                  | {end_per_group, [group_info()]}
                  | {testcase, [group_info()], atom()}.
+
+%% API
+
+%% @doc Declare an expected error pattern for the current suite.
+%% Matching errors will be filtered from the report.
+%% Uses the same pattern types as log_error_helper:expect/1.
+-spec expect(pattern()) -> true.
+expect(Pattern) ->
+    ets:insert(?PATTERNS_TABLE, {Pattern}).
 
 %% CT hook callbacks
 
@@ -71,10 +101,12 @@ pre_init_per_suite(_Suite, Config, State) ->
             undefined -> ReportDir;
             Existing -> Existing
         end,
+        init_patterns_table(),
         {Config, State#state{report_dir = ReportDir, mark = Mark,
                              summary_dir = SummaryDir,
                              groups = [], parallel_depth = 0,
-                             entries = [], total = 0}}
+                             entries = [],
+                             unexpected_total = 0, all_total = 0}}
     catch Class:Reason:Stacktrace ->
         ct:pal("cth_error_report: failed to start: ~p:~p~n~p",
                [Class, Reason, Stacktrace]),
@@ -136,19 +168,22 @@ post_end_per_suite(Suite, _Config, Return, #state{report_dir = undefined} = Stat
     ct:pal("cth_error_report: no report_dir for ~p, skipping", [Suite]),
     {Return, State};
 post_end_per_suite(Suite, _Config, Return, State) ->
-    SuiteTotal = try
+    SuiteResult = try
         State1 = collect_errors({end_per_suite}, State),
         rpc(mim(), ?COLLECTOR, stop, [?INSTANCE]),
+        delete_patterns_table(),
         write_report(Suite, State1),
-        State1#state.total
+        {Suite, State1#state.all_total, State1#state.unexpected_total}
     catch Class:Reason:Stacktrace ->
         ct:pal("cth_error_report: failed to write report for ~p: ~p:~p~n~p",
                [Suite, Class, Reason, Stacktrace]),
-        State#state.total
+        delete_patterns_table(),
+        {Suite, State#state.all_total, State#state.unexpected_total}
     end,
-    Results = [{Suite, SuiteTotal} | State#state.suite_results],
+    Results = [SuiteResult | State#state.suite_results],
     {Return, State#state{report_dir = undefined, mark = undefined,
-                         entries = [], total = 0,
+                         entries = [],
+                         unexpected_total = 0, all_total = 0,
                          suite_results = Results}}.
 
 terminate(#state{summary_dir = undefined}) ->
@@ -165,6 +200,29 @@ is_parallel_group(Config) ->
     Props = proplists:get_value(tc_group_properties, Config, []),
     lists:member(parallel, Props).
 
+%% Expected patterns table
+
+init_patterns_table() ->
+    case ets:whereis(?PATTERNS_TABLE) of
+        undefined ->
+            ets:new(?PATTERNS_TABLE,
+                    [named_table, public, bag]);
+        _Tid ->
+            ets:delete_all_objects(?PATTERNS_TABLE)
+    end.
+
+delete_patterns_table() ->
+    case ets:whereis(?PATTERNS_TABLE) of
+        undefined -> ok;
+        _Tid -> ets:delete(?PATTERNS_TABLE)
+    end.
+
+get_patterns() ->
+    case ets:whereis(?PATTERNS_TABLE) of
+        undefined -> [];
+        _Tid -> [P || {P} <- ets:tab2list(?PATTERNS_TABLE)]
+    end.
+
 %% Error collection
 
 -spec collect_errors(section(), #state{}) -> #state{}.
@@ -172,16 +230,32 @@ collect_errors(Section, #state{mark = Mark} = State) ->
     try
         Errors = rpc(mim(), ?COLLECTOR, get_errors_after, [?INSTANCE, Mark]),
         NewMark = rpc(mim(), ?COLLECTOR, timestamp, []),
-        Count = length(Errors),
-        Entry = {Section, Errors},
+        {Unexpected, Expected} = classify_errors(Errors, get_patterns()),
+        Entry = {Section, Unexpected, Expected},
         State#state{mark = NewMark,
                     entries = [Entry | State#state.entries],
-                    total = State#state.total + Count}
+                    unexpected_total = State#state.unexpected_total
+                        + length(Unexpected),
+                    all_total = State#state.all_total
+                        + length(Unexpected) + length(Expected)}
     catch Class:Reason:Stacktrace ->
         ct:pal("cth_error_report: collect_errors failed: ~p:~p~n~p",
                [Class, Reason, Stacktrace]),
         State
     end.
+
+-spec classify_errors([log_entry()], [pattern()]) ->
+    {Unexpected :: [log_entry()], Expected :: [log_entry()]}.
+classify_errors(Errors, []) ->
+    {Errors, []};
+classify_errors(Errors, Patterns) ->
+    lists:partition(
+        fun({_Ts, _Level, Msg, Meta}) ->
+            not lists:any(
+                fun(P) -> log_error_helper:matches_pattern(Msg, Meta, P) end,
+                Patterns)
+        end,
+        Errors).
 
 %% Report directory
 
@@ -195,85 +269,128 @@ init_report_dir(Config) ->
 %% Report writing
 
 -spec write_report(atom(), #state{}) -> ok.
-write_report(Suite, #state{report_dir = ReportDir, entries = RevEntries, total = Total}) ->
-    File = filename:join(ReportDir, atom_to_list(Suite) ++ ".log"),
+write_report(Suite, #state{report_dir = ReportDir, entries = RevEntries,
+                           all_total = AllTotal,
+                           unexpected_total = UnexpTotal}) ->
+    SuiteStr = atom_to_list(Suite),
     Entries = lists:reverse(RevEntries),
-    Content = format_report(Suite, Total, Entries),
-    ok = file:write_file(File, Content).
+    LogFile = filename:join(ReportDir, SuiteStr ++ ".log"),
+    LogContent = format_report_log(Suite, AllTotal, UnexpTotal, Entries),
+    ok = file:write_file(LogFile, LogContent),
+    HtmlFile = filename:join(ReportDir, SuiteStr ++ ".html"),
+    HtmlContent = format_report_html(Suite, AllTotal, UnexpTotal, Entries),
+    ok = file:write_file(HtmlFile, HtmlContent).
 
--spec write_summary(string(), [{atom(), non_neg_integer()}]) -> ok.
+-spec write_summary(string(), [suite_result()]) -> ok.
 write_summary(ReportDir, Results) ->
-    GrandTotal = lists:foldl(fun({_, N}, Acc) -> Acc + N end, 0, Results),
-    Sorted = lists:sort(fun({_, A}, {_, B}) -> A >= B end, Results),
-    write_summary_log(ReportDir, GrandTotal, Sorted),
-    write_summary_html(ReportDir, GrandTotal, Sorted).
+    %% Sort by unexpected count descending (primary),
+    %% alphabetical by suite name (secondary, from input)
+    Sorted = lists:sort(
+        fun({_, _, U1}, {_, _, U2}) -> U1 >= U2 end, Results),
+    write_summary_log(ReportDir, Sorted),
+    write_summary_html(ReportDir, Sorted).
 
-write_summary_log(ReportDir, GrandTotal, Sorted) ->
+write_summary_log(ReportDir, Sorted) ->
     File = filename:join(ReportDir, "summary.log"),
-    Header = io_lib:format("Error log summary~nTotal errors: ~p~n~n",
-                           [GrandTotal]),
+    Header = "Errors Logged During Tests Summary\n\n",
     Lines = lists:map(fun format_summary_line/1, Sorted),
     ok = file:write_file(File, [Header | Lines]).
 
-write_summary_html(ReportDir, GrandTotal, Sorted) ->
+write_summary_html(ReportDir, Sorted) ->
     File = filename:join(ReportDir, "summary.html"),
     Rows = lists:map(fun format_summary_html_row/1, Sorted),
     Html = [
         "<!DOCTYPE html>\n<html>\n<head>\n"
         "<meta charset=\"utf-8\">\n"
-        "<title>Error Log Summary</title>\n"
+        "<title>Errors Logged During Tests Summary</title>\n"
         "<style>\n"
         "body { font-family: monospace; margin: 2em; }\n"
-        "table { border-collapse: collapse; min-width: 500px; }\n"
+        "table { border-collapse: collapse; }\n"
         "th, td { border: 1px solid #ccc; padding: 6px 12px;"
         " text-align: left; }\n"
         "th { background: #f0f0f0; }\n"
+        "td.num { text-align: right; }\n"
         ".zero { color: green; }\n"
         ".errors { color: red; font-weight: bold; }\n"
         "a { color: inherit; }\n"
         "</style>\n"
         "</head>\n<body>\n",
-        io_lib:format("<h1>Error Log Summary</h1>\n"
-                      "<p>Total errors: ~p</p>\n", [GrandTotal]),
-        "<table>\n<tr><th>Suite</th><th>Errors</th></tr>\n",
+        "<h1>Errors Logged During Tests Summary</h1>\n",
+        "<table>\n<tr><th>Suite</th>"
+        "<th>All errors</th>"
+        "<th>Unexpected errors</th></tr>\n",
         Rows,
         "</table>\n</body>\n</html>\n"
     ],
     ok = file:write_file(File, Html).
 
--spec format_summary_line({atom(), non_neg_integer()}) -> iolist().
-format_summary_line({Suite, 0}) ->
-    io_lib:format("  ~s: 0~n", [Suite]);
-format_summary_line({Suite, Count}) ->
-    io_lib:format("  ~s: ~p  <---~n", [Suite, Count]).
+-spec format_summary_line(suite_result()) -> iolist().
+format_summary_line({Suite, All, 0}) ->
+    io_lib:format("  ~s: ~p errors, 0 unexpected~n", [Suite, All]);
+format_summary_line({Suite, All, Unexp}) ->
+    io_lib:format("  ~s: ~p errors, ~p unexpected  <---~n",
+                  [Suite, All, Unexp]).
 
--spec format_summary_html_row({atom(), non_neg_integer()}) -> iolist().
-format_summary_html_row({Suite, 0}) ->
+-spec format_summary_html_row(suite_result()) -> iolist().
+format_summary_html_row({Suite, All, Unexp}) ->
     SuiteStr = atom_to_list(Suite),
-    io_lib:format("<tr><td><a href=\"~s.log\">~s</a></td>"
-                  "<td class=\"zero\">0</td></tr>\n",
-                  [SuiteStr, SuiteStr]);
-format_summary_html_row({Suite, Count}) ->
-    SuiteStr = atom_to_list(Suite),
-    io_lib:format("<tr><td><a href=\"~s.log\">~s</a></td>"
-                  "<td class=\"errors\">~p</td></tr>\n",
-                  [SuiteStr, SuiteStr, Count]).
+    UnexpClass = case Unexp of
+        0 -> "num zero";
+        _ -> "num errors"
+    end,
+    io_lib:format("<tr>"
+                  "<td><a href=\"~s.html\">~s</a></td>"
+                  "<td class=\"num\">~p</td>"
+                  "<td class=\"~s\">~p</td>"
+                  "</tr>\n",
+                  [SuiteStr, SuiteStr, All, UnexpClass, Unexp]).
 
--spec format_report(atom(), non_neg_integer(), [entry()]) -> iolist().
-format_report(Suite, Total, Entries) ->
-    Header = io_lib:format("Suite: ~p~nTotal errors: ~p~n", [Suite, Total]),
-    Body = format_entries(Entries, []),
+%% Plain text report
+
+format_report_log(Suite, AllTotal, UnexpTotal, Entries) ->
+    Header = io_lib:format(
+        "Suite: ~p~nTotal errors: ~p, unexpected: ~p~n",
+        [Suite, AllTotal, UnexpTotal]),
+    Body = format_entries_log(Entries, []),
     [Header | Body].
 
--spec format_entries([entry()], [group_info()]) -> iolist().
-format_entries([], _PrevGroups) ->
+format_entries_log([], _PrevGroups) ->
     [];
-format_entries([{Section, Errors} | Rest], PrevGroups) ->
+format_entries_log([{Section, Unexpected, Expected} | Rest], PrevGroups) ->
     Groups = section_groups(Section),
     GroupHeaders = format_group_transitions(PrevGroups, Groups),
     SectionHeader = format_section_header(Section),
-    ErrorBody = format_section_errors(Errors),
-    [GroupHeaders, SectionHeader, ErrorBody | format_entries(Rest, Groups)].
+    ErrorBody = format_section_errors_log(Unexpected, Expected),
+    [GroupHeaders, SectionHeader, ErrorBody
+     | format_entries_log(Rest, Groups)].
+
+%% HTML report
+
+format_report_html(Suite, AllTotal, UnexpTotal, Entries) ->
+    SuiteStr = atom_to_list(Suite),
+    Body = format_entries_html(Entries, []),
+    ["<!DOCTYPE html>\n<html>\n<head>\n"
+     "<meta charset=\"utf-8\">\n",
+     io_lib:format("<title>~s errors</title>\n", [SuiteStr]),
+     "<style>\n"
+     "body { font-family: monospace; margin: 2em; }\n"
+     ".unexpected { color: red; }\n"
+     ".expected { color: green; }\n"
+     ".section { margin: 1em 0; }\n"
+     ".group-header { font-weight: bold; font-size: 1.1em;"
+     " margin-top: 1.5em; }\n"
+     ".section-header { font-weight: bold; margin-top: 1em; }\n"
+     ".entry { margin: 0.3em 0 0.3em 2em;"
+     " white-space: pre-wrap; }\n"
+     ".meta { font-size: 0.9em; }\n"
+     ".note { color: gray; font-style: italic; }\n"
+     "</style>\n"
+     "</head>\n<body>\n",
+     io_lib:format("<h1>~s</h1>\n", [SuiteStr]),
+     io_lib:format("<p>Total errors: ~p, unexpected: ~p</p>\n",
+                   [AllTotal, UnexpTotal]),
+     Body,
+     "</body>\n</html>\n"].
 
 -spec section_groups(section()) -> [group_info()].
 section_groups({init_per_suite}) -> [];
@@ -295,9 +412,9 @@ format_group_transitions_impl(_Prev, NewGroups) ->
     [format_group_header(GI) || GI <- NewGroups].
 
 format_group_header({Group, true}) ->
-    io_lib:format("~n=== Group: ~p [parallel] ===~n", [Group]);
+    io_lib:format("~n~n=== Group: ~p [parallel] ===~n", [Group]);
 format_group_header({Group, false}) ->
-    io_lib:format("~n=== Group: ~p ===~n", [Group]).
+    io_lib:format("~n~n=== Group: ~p ===~n", [Group]).
 
 -spec format_section_header(section()) -> iolist().
 format_section_header({init_per_suite}) ->
@@ -311,40 +428,171 @@ format_section_header({end_per_group, _Groups}) ->
 format_section_header({testcase, _Groups, TC}) ->
     io_lib:format("~n--- ~p ---~n", [TC]).
 
--spec format_section_errors([log_error_collector:log_entry()]) -> iolist().
-format_section_errors([]) ->
+%% Log section errors
+
+format_section_errors_log([], []) ->
     "(no errors)\n";
-format_section_errors(Errors) ->
-    Count = io_lib:format("~p error(s)~n", [length(Errors)]),
-    Body = lists:map(fun format_entry/1, Errors),
-    [Count | Body].
+format_section_errors_log([], Expected) ->
+    io_lib:format("(~p expected error(s))~n", [length(Expected)]);
+format_section_errors_log(Unexpected, Expected) ->
+    ULines = lists:map(fun format_entry_unexpected_log/1, Unexpected),
+    ELines = lists:map(fun format_entry_expected_log/1, Expected),
+    Summary = io_lib:format(
+        "~p error(s): ~p unexpected, ~p expected~n",
+        [length(Unexpected) + length(Expected),
+         length(Unexpected), length(Expected)]),
+    [Summary, ULines, ELines].
 
--spec format_entry(log_error_collector:log_entry()) -> iolist().
-format_entry({_Timestamp, Level, Msg, Meta}) ->
-    Location = format_location(Meta),
+format_entry_unexpected_log(Entry) ->
+    ["*** UNEXPECTED *** ", format_entry_log(Entry)].
+
+format_entry_expected_log(Entry) ->
+    format_entry_log(Entry).
+
+format_entry_log({_Timestamp, Level, Msg, Meta}) ->
+    Time = format_time(Meta),
+    Node = format_node(Meta),
     MsgFormatted = format_msg(Msg),
-    What = extract_what(Msg),
-    WhatStr = case What of
-        undefined -> "";
-        Atom -> io_lib:format(" what=~p", [Atom])
-    end,
-    io_lib:format("  [~p]~s~s~n    ~s~n", [Level, Location, WhatStr, MsgFormatted]).
+    MetaLine = format_meta_line(Meta),
+    io_lib:format("[~p] ~s~s~n    ~s~n    ~s~n",
+                  [Level, Time, Node, MsgFormatted, MetaLine]).
 
-format_location(#{mfa := {M, F, A}}) ->
-    io_lib:format(" ~p:~p/~p", [M, F, A]);
-format_location(_) ->
+%% HTML entries
+
+format_entries_html([], _PrevGroups) ->
+    [];
+format_entries_html([{Section, Unexpected, Expected} | Rest],
+                    PrevGroups) ->
+    Groups = section_groups(Section),
+    GroupHeaders = format_group_transitions_html(PrevGroups, Groups),
+    SectionHeader = format_section_header_html(Section),
+    ErrorBody = format_section_errors_html(Unexpected, Expected),
+    [GroupHeaders, SectionHeader, ErrorBody
+     | format_entries_html(Rest, Groups)].
+
+format_group_transitions_html(Prev, Curr) ->
+    PrevR = lists:reverse(Prev),
+    CurrR = lists:reverse(Curr),
+    format_group_transitions_html_impl(PrevR, CurrR).
+
+format_group_transitions_html_impl([Same | PrevRest],
+                                   [Same | CurrRest]) ->
+    format_group_transitions_html_impl(PrevRest, CurrRest);
+format_group_transitions_html_impl(_Prev, NewGroups) ->
+    [format_group_header_html(GI) || GI <- NewGroups].
+
+format_group_header_html({Group, true}) ->
+    io_lib:format("<br/>\n<div class=\"group-header\">"
+                  "Group: ~p [parallel]</div>\n", [Group]);
+format_group_header_html({Group, false}) ->
+    io_lib:format("<br/>\n<div class=\"group-header\">"
+                  "Group: ~p</div>\n", [Group]).
+
+format_section_header_html({init_per_suite}) ->
+    "<div class=\"section-header\">init_per_suite</div>\n";
+format_section_header_html({end_per_suite}) ->
+    "<div class=\"section-header\">end_per_suite</div>\n";
+format_section_header_html({init_per_group, _}) ->
+    "<div class=\"section-header\">init_per_group</div>\n";
+format_section_header_html({end_per_group, _}) ->
+    "<div class=\"section-header\">end_per_group</div>\n";
+format_section_header_html({testcase, _, TC}) ->
+    io_lib:format("<div class=\"section-header\">~p</div>\n",
+                  [TC]).
+
+format_section_errors_html([], []) ->
+    "<div class=\"note\">(no errors)</div>\n";
+format_section_errors_html(Unexpected, Expected) ->
+    ULines = [format_entry_html(E, "unexpected") || E <- Unexpected],
+    ELines = [format_entry_html(E, "expected") || E <- Expected],
+    [ULines, ELines].
+
+format_entry_html({_Timestamp, Level, Msg, Meta}, Class) ->
+    Time = format_time(Meta),
+    Node = format_node(Meta),
+    MsgFmt = html_escape(format_msg(Msg)),
+    MetaLine = html_escape(
+        iolist_to_binary(format_meta_line(Meta))),
+    io_lib:format("<div class=\"entry ~s\">"
+                  "[~p] ~s~s<br/>~s<br/>"
+                  "<span class=\"meta\">~s</span>"
+                  "</div>\n",
+                  [Class, Level, Time, Node,
+                   MsgFmt, MetaLine]).
+
+format_time(#{time := Time}) ->
+    USec = Time rem 1000000,
+    Sec = Time div 1000000,
+    BaseDate = calendar:datetime_to_gregorian_seconds(
+        {{1970, 1, 1}, {0, 0, 0}}),
+    UtcGSec = BaseDate + Sec,
+    UtcDateTime = calendar:gregorian_seconds_to_datetime(UtcGSec),
+    LocalDateTime = calendar:universal_time_to_local_time(
+        UtcDateTime),
+    LocalGSec = calendar:datetime_to_gregorian_seconds(LocalDateTime),
+    OffsetMin = (LocalGSec - UtcGSec) div 60,
+    OffsetH = abs(OffsetMin) div 60,
+    OffsetM = abs(OffsetMin) rem 60,
+    Sign = case OffsetMin >= 0 of true -> $+; false -> $- end,
+    {{Y, Mo, D}, {H, Mi, S}} = LocalDateTime,
+    io_lib:format(
+        "~4..0B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0B.~6..0B"
+        "~c~2..0B:~2..0B ",
+        [Y, Mo, D, H, Mi, S, USec, Sign, OffsetH, OffsetM]);
+format_time(_) ->
     "".
+
+format_node(#{node := Node}) ->
+    io_lib:format("~s ", [Node]);
+format_node(_) ->
+    "".
+
+format_meta_line(Meta) ->
+    Parts = lists:filtermap(fun(F) -> F(Meta) end,
+        [fun format_meta_pid/1, fun format_meta_mfa/1,
+         fun format_meta_file/1, fun format_meta_lineno/1]),
+    case Parts of
+        [] -> "";
+        _ -> ["meta: " | lists:join(", ", Parts)]
+    end.
+
+format_meta_pid(#{pid := Pid}) ->
+    {true, io_lib:format("pid=~p", [Pid])};
+format_meta_pid(_) -> false.
+
+format_meta_mfa(#{mfa := {M, F, A}}) ->
+    {true, io_lib:format("mfa=~p:~p/~p", [M, F, A])};
+format_meta_mfa(_) -> false.
+
+format_meta_file(#{file := File}) ->
+    {true, io_lib:format("file=~s", [File])};
+format_meta_file(_) -> false.
+
+format_meta_lineno(#{line := Line}) ->
+    {true, io_lib:format("line=~p", [Line])};
+format_meta_lineno(_) -> false.
 
 format_msg({string, String}) when is_list(String) ->
     unicode:characters_to_binary(String);
 format_msg({string, Binary}) when is_binary(Binary) ->
     Binary;
 format_msg({report, Report}) when is_map(Report) ->
-    unicode:characters_to_binary(io_lib:format("~0p", [Report]));
+    unicode:characters_to_binary(pretty_print_map(Report));
 format_msg({Format, Args}) when is_list(Format), is_list(Args) ->
     unicode:characters_to_binary(io_lib:format(Format, Args));
 format_msg(Other) ->
     unicode:characters_to_binary(io_lib:format("~0p", [Other])).
 
-extract_what({report, #{what := What}}) -> What;
-extract_what(_) -> undefined.
+pretty_print_map(Map) ->
+    Pairs = maps:to_list(Map),
+    Lines = [io_lib:format("  ~0p => ~0p", [K, V]) || {K, V} <- Pairs],
+    ["#{\n", lists:join(",\n", Lines), "\n}"].
+
+html_escape(Bin) when is_binary(Bin) ->
+    html_escape(binary_to_list(Bin));
+html_escape([]) -> [];
+html_escape([$< | T]) -> "&lt;" ++ html_escape(T);
+html_escape([$> | T]) -> "&gt;" ++ html_escape(T);
+html_escape([$& | T]) -> "&amp;" ++ html_escape(T);
+html_escape([$" | T]) -> "&quot;" ++ html_escape(T);
+html_escape([H | T]) -> [H | html_escape(T)].

--- a/big_tests/tests/cth_error_report_SUITE.erl
+++ b/big_tests/tests/cth_error_report_SUITE.erl
@@ -1,0 +1,227 @@
+%% @doc Test suite for cth_error_report CT hook.
+%% Verifies expected error declarations, pattern matching,
+%% counted allowances, and report generation.
+%%
+%% After the run, inspect the reports:
+%%   ct_report/ct_run.*/logged_errors/cth_error_report_SUITE.html
+%%   ct_report/ct_run.*/logged_errors/cth_error_report_SUITE.log
+%%   ct_report/ct_run.*/logged_errors/summary.html
+-module(cth_error_report_SUITE).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-import(distributed_helper, [rpc/4, mim/0, require_rpc_nodes/1]).
+
+%%--------------------------------------------------------------------
+%% Suite configuration
+%%--------------------------------------------------------------------
+
+suite() ->
+    require_rpc_nodes([mim]).
+
+all() ->
+    [{group, unlimited_patterns},
+     {group, counted_patterns},
+     {group, mixed_patterns},
+     {group, report_verification}].
+
+groups() ->
+    [{unlimited_patterns, [],
+      [expect_by_what,
+       expect_by_module,
+       expect_by_function,
+       expect_by_mfa_wildcard,
+       expect_by_reason,
+       expect_by_generic_key,
+       expect_by_substring,
+       expect_by_regex,
+       expect_by_custom_function,
+       multiple_unlimited_patterns,
+       unlimited_allows_any_count]},
+     {counted_patterns, [],
+      [expect_counted_exact,
+       expect_counted_accumulate,
+       expect_counted_overflow_is_unexpected,
+       expect_counted_across_testcases]},
+     {mixed_patterns, [],
+      [unlimited_overrides_counted,
+       some_expected_some_not,
+       no_patterns_all_unexpected]},
+     {report_verification, [],
+      [verify_report_files_created,
+       verify_unexpected_prefix_in_log]}].
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+init_per_suite(Config) ->
+    mongoose_helper:inject_module(log_error_test_helper),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Unlimited pattern tests
+%%--------------------------------------------------------------------
+
+expect_by_what(_Config) ->
+    cth_error_report:expect({what, err_by_what}),
+    trigger_error(err_by_what, "by what").
+
+expect_by_module(_Config) ->
+    cth_error_report:expect({module, log_error_test_helper}),
+    trigger_error(err_by_module, "by module").
+
+expect_by_function(_Config) ->
+    cth_error_report:expect({function, log_error}),
+    trigger_error(err_by_function, "by function").
+
+expect_by_mfa_wildcard(_Config) ->
+    cth_error_report:expect(
+        {mfa, {log_error_test_helper, '_', '_'}}),
+    trigger_error(err_by_mfa, "by mfa wildcard").
+
+expect_by_reason(_Config) ->
+    cth_error_report:expect({reason, "by reason value"}),
+    trigger_error(err_by_reason, "by reason value").
+
+expect_by_generic_key(_Config) ->
+    cth_error_report:expect({custom_key, custom_value}),
+    trigger_error_extra(err_by_key, "by key",
+                        #{custom_key => custom_value}).
+
+expect_by_substring(_Config) ->
+    cth_error_report:expect(<<"substr_marker_123">>),
+    trigger_error(substr_marker_123, "by substring").
+
+expect_by_regex(_Config) ->
+    cth_error_report:expect({regex, <<"regex_test_[0-9]+">>}),
+    trigger_error(regex_test_42, "by regex").
+
+expect_by_custom_function(_Config) ->
+    Filter = fun({report, #{what := err_custom_fn}}, _Meta) ->
+                     true;
+                (_, _) ->
+                     false
+             end,
+    cth_error_report:expect(Filter),
+    trigger_error(err_custom_fn, "by custom function").
+
+multiple_unlimited_patterns(_Config) ->
+    cth_error_report:expect({what, multi_err_1}),
+    cth_error_report:expect({what, multi_err_2}),
+    cth_error_report:expect({what, multi_err_3}),
+    trigger_error(multi_err_1, "first"),
+    trigger_error(multi_err_2, "second"),
+    trigger_error(multi_err_3, "third").
+
+unlimited_allows_any_count(_Config) ->
+    cth_error_report:expect({what, unlimited_repeat}),
+    trigger_error(unlimited_repeat, "one"),
+    trigger_error(unlimited_repeat, "two"),
+    trigger_error(unlimited_repeat, "three"),
+    trigger_error(unlimited_repeat, "four"),
+    trigger_error(unlimited_repeat, "five").
+
+%%--------------------------------------------------------------------
+%% Counted pattern tests
+%%--------------------------------------------------------------------
+
+expect_counted_exact(_Config) ->
+    %% Expect exactly 3 -- trigger exactly 3
+    cth_error_report:expect({what, counted_exact}, 3),
+    trigger_error(counted_exact, "one"),
+    trigger_error(counted_exact, "two"),
+    trigger_error(counted_exact, "three").
+
+expect_counted_accumulate(_Config) ->
+    %% Two declarations for the same pattern should add up
+    cth_error_report:expect({what, counted_accum}, 2),
+    cth_error_report:expect({what, counted_accum}, 3),
+    %% Total allowed: 5
+    trigger_error(counted_accum, "one"),
+    trigger_error(counted_accum, "two"),
+    trigger_error(counted_accum, "three"),
+    trigger_error(counted_accum, "four"),
+    trigger_error(counted_accum, "five").
+
+expect_counted_overflow_is_unexpected(_Config) ->
+    %% Expect 2, trigger 4 -- 2 should be expected, 2 unexpected
+    cth_error_report:expect({what, counted_overflow}, 2),
+    trigger_error(counted_overflow, "expected one"),
+    trigger_error(counted_overflow, "expected two"),
+    trigger_error(counted_overflow, "unexpected three"),
+    trigger_error(counted_overflow, "unexpected four").
+
+expect_counted_across_testcases(_Config) ->
+    %% This test runs after expect_counted_exact and
+    %% expect_counted_accumulate in the same group.
+    %% Verify that their allowances don't leak here:
+    %% trigger an error with a fresh pattern, no expect.
+    trigger_error(counted_no_expect, "should be unexpected").
+
+%%--------------------------------------------------------------------
+%% Mixed pattern tests
+%%--------------------------------------------------------------------
+
+unlimited_overrides_counted(_Config) ->
+    %% Declare counted first, then unlimited -- unlimited wins
+    cth_error_report:expect({what, override_test}, 2),
+    cth_error_report:expect({what, override_test}),
+    %% All should be expected regardless of count
+    trigger_error(override_test, "one"),
+    trigger_error(override_test, "two"),
+    trigger_error(override_test, "three"),
+    trigger_error(override_test, "four").
+
+some_expected_some_not(_Config) ->
+    %% Only one pattern is declared
+    cth_error_report:expect({what, partially_expected}),
+    trigger_error(partially_expected, "this is expected"),
+    trigger_error(totally_unexpected, "this is not expected").
+
+no_patterns_all_unexpected(_Config) ->
+    %% No expect calls -- everything is unexpected
+    trigger_error(no_pattern_err, "all unexpected").
+
+%%--------------------------------------------------------------------
+%% Report verification tests
+%%--------------------------------------------------------------------
+
+verify_report_files_created(_Config) ->
+    %% Just trigger an error so the report has content
+    cth_error_report:expect({what, report_verify_err}),
+    trigger_error(report_verify_err, "for report verification").
+
+verify_unexpected_prefix_in_log(_Config) ->
+    %% Trigger an unexpected error -- it should appear
+    %% with *** UNEXPECTED *** prefix in the .log file
+    trigger_error(prefix_test_err, "check prefix in log").
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+trigger_error(What, Reason) ->
+    rpc(mim(), log_error_test_helper, log_error,
+        [What, Reason]).
+
+trigger_error_extra(What, Reason, Extra) ->
+    rpc(mim(), log_error_test_helper, log_error,
+        [What, Reason, Extra]).

--- a/big_tests/tests/log_error_collector.erl
+++ b/big_tests/tests/log_error_collector.erl
@@ -209,4 +209,5 @@ to_atom(Name, Suffix) ->
 
 -spec extract_meta(map()) -> meta().
 extract_meta(LogMeta) ->
-    maps:with([mfa, file, line, pid], LogMeta).
+    Meta = maps:with([mfa, file, line, pid, time], LogMeta),
+    Meta#{node => node()}.

--- a/big_tests/tests/log_error_helper.erl
+++ b/big_tests/tests/log_error_helper.erl
@@ -39,8 +39,9 @@
 %% API for expecting errors
 -export([expect/1, expect/2]).
 
-%% Exported for testing
+%% Exported for testing and reuse by cth_error_report
 -export([matches_pattern/3, format_msg/1]).
+-export_type([pattern/0]).
 
 -import(distributed_helper, [rpc/4, mim/0]).
 

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -129,6 +129,17 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
+    cth_error_report:max_unexpected_errors_logged(0),
+    %% known flaky error - a race between supervisor and worker shutting down,
+    %% if the worker dies first it passes ETS ownership to heir process,
+    %% which is the supervisor process not expecting this message
+    %%
+    %% [error] 2026-03-31T18:54:49.467092+02:00 mongooseim@localhost 
+    %% Supervisor received unexpected message: {'ETS-TRANSFER',mongoose_wpool_http,
+    %%                                     <10782.4892.0>,testing}
+    %%
+    cth_error_report:expect({regex, <<"'ETS-TRANSFER',mongoose_wpool_">>}),
+    cth_error_report:expect({what, push_send_failed}, 6),
     catch mongoose_push_mock:stop(),
     mongoose_push_mock:start(Config),
     Port = mongoose_push_mock:port(),

--- a/doc/developers-guide/Error-log-tracking.md
+++ b/doc/developers-guide/Error-log-tracking.md
@@ -32,14 +32,15 @@ A link to `summary.html` appears as a "LOGGED ERRORS" button on the CT
 
 ## Declaring expected errors
 
-Tests can declare that certain errors are expected using `cth_error_report:expect/1`.
-Expected errors appear in green in the HTML report and are not prefixed with
-`*** UNEXPECTED ***` in the log report. They do not count toward the
-unexpected error total in the summary.
+Tests can declare that certain errors are expected using
+`cth_error_report:expect/1,2`. Expected errors appear in green in the HTML
+report and are not prefixed with `*** UNEXPECTED ***` in the log report.
+They do not count toward the unexpected error total in the summary.
 
 ### Pattern types
 
-The `expect/1` function accepts the same pattern types as `log_error_helper:expect/1`:
+The `expect/1,2` functions accept the same pattern types as
+`log_error_helper:expect/1`:
 
 | Pattern | Matches |
 |---------|---------|
@@ -53,17 +54,64 @@ The `expect/1` function accepts the same pattern types as `log_error_helper:expe
 | `{regex, <<"pattern">>}` | Regex match on the formatted message |
 | `fun((Msg, Meta) -> boolean())` | Custom filter function |
 
-### Where to call expect/1
+### Unlimited vs counted expectations
 
-Call `cth_error_report:expect/1` from `init_per_suite`, `init_per_group`,
+`expect/1` declares a pattern with unlimited matches -- all matching errors
+are classified as expected, regardless of how many occur:
+
+```erlang
+cth_error_report:expect({what, push_send_failed}).
+```
+
+`expect/2` declares a pattern with a specific expected count. Only that many
+matches are classified as expected; additional matches become unexpected:
+
+```erlang
+%% Expect exactly 3 occurrences of this error
+cth_error_report:expect({what, push_send_failed}, 3).
+```
+
+### Accumulating counts
+
+Multiple `expect/2` calls for the same pattern accumulate their counts.
+This is useful when different groups or testcases each contribute a known
+number of expected errors:
+
+```erlang
+init_per_group(group_a, Config) ->
+    %% This group triggers 3 push errors
+    cth_error_report:expect({what, push_send_failed}, 3),
+    Config;
+init_per_group(group_b, Config) ->
+    %% This group triggers 2 more
+    cth_error_report:expect({what, push_send_failed}, 2),
+    Config.
+%% Total: 5 errors expected for this pattern across the suite
+```
+
+An unlimited `expect/1` call for the same pattern overrides any counted
+declarations -- all matches become expected:
+
+```erlang
+%% These 3 are expected
+cth_error_report:expect({what, some_error}, 3),
+%% Now all matches are expected, the count of 3 is ignored
+cth_error_report:expect({what, some_error}).
+```
+
+### Where to call expect/1,2
+
+Call `cth_error_report:expect/1,2` from `init_per_suite`, `init_per_group`,
 or `init_per_testcase`. Patterns accumulate for the duration of the suite --
-once declared, they apply to all subsequent error classification in that suite.
+once declared, they apply to all subsequent error classification in that
+suite. Counted allowances are consumed as errors are matched, tracking
+across all testcases within the suite.
 
 ### Examples
 
 ```erlang
 init_per_suite(Config) ->
-    %% This module always logs an error on startup, it's expected
+    %% This module always logs errors on startup, expect all of them
     cth_error_report:expect({what, push_send_failed}),
 
     %% Expect any error from a specific module
@@ -75,8 +123,9 @@ init_per_suite(Config) ->
     %% Expect errors matching a regex
     cth_error_report:expect({regex, <<"timeout after [0-9]+ ms">>}),
 
-    %% Expect errors from a specific function (any arity)
-    cth_error_report:expect({mfa, {mod_mam_rdbms_arch, retract_message, '_'}}),
+    %% Expect exactly 2 errors from a specific function
+    cth_error_report:expect(
+        {mfa, {mod_mam_rdbms_arch, retract_message, '_'}}, 2),
 
     Config.
 ```
@@ -85,13 +134,13 @@ Patterns can also be declared per-group or per-testcase:
 
 ```erlang
 init_per_group(reconnect_tests, Config) ->
-    cth_error_report:expect({what, session_replaced}),
+    cth_error_report:expect({what, session_replaced}, 5),
     Config;
 init_per_group(_, Config) ->
     Config.
 
 init_per_testcase(test_connection_timeout, Config) ->
-    cth_error_report:expect(<<"connection closed">>),
+    cth_error_report:expect(<<"connection closed">>, 1),
     Config;
 init_per_testcase(_, Config) ->
     Config.

--- a/doc/developers-guide/Error-log-tracking.md
+++ b/doc/developers-guide/Error-log-tracking.md
@@ -1,0 +1,133 @@
+# Error Log Tracking in Big Tests
+
+The `cth_error_report` CT hook captures error-level logs from MongooseIM nodes
+during big test execution. It produces per-suite reports showing which errors
+were logged, broken down by group and testcase.
+
+## How it works
+
+The hook is enabled via test spec files (e.g., `default.spec`):
+
+```erlang
+{ct_hooks, [..., cth_error_report]}.
+```
+
+During test execution it:
+
+1. Injects a logger handler into the MIM node to capture error-level log events
+2. Collects errors at each testcase/group boundary
+3. Writes reports to `ct_report/ct_run.*/logged_errors/`
+
+## Reports
+
+After a test run, the `logged_errors/` directory contains:
+
+- `summary.html` -- overview table of all suites, with error counts
+- `summary.log` -- plain text version of the summary
+- `SuiteName.html` -- per-suite report with color-coded errors
+- `SuiteName.log` -- plain text version
+
+A link to `summary.html` appears as a "LOGGED ERRORS" button on the CT
+`index.html` page.
+
+## Declaring expected errors
+
+Tests can declare that certain errors are expected using `cth_error_report:expect/1`.
+Expected errors appear in green in the HTML report and are not prefixed with
+`*** UNEXPECTED ***` in the log report. They do not count toward the
+unexpected error total in the summary.
+
+### Pattern types
+
+The `expect/1` function accepts the same pattern types as `log_error_helper:expect/1`:
+
+| Pattern | Matches |
+|---------|---------|
+| `{what, Atom}` | Report map with `#{what := Atom}` -- most common |
+| `{module, Atom}` | Error logged from the given module (from MFA metadata) |
+| `{function, Atom}` | Error logged from the given function |
+| `{mfa, {M, F, A}}` | Exact MFA match, use `'_'` as wildcard for any element |
+| `{reason, Term}` | Report map with `#{reason := Term}` |
+| `{Key, Value}` | Any key-value pair in the report map |
+| `<<"substring">>` | Binary substring match in the formatted message |
+| `{regex, <<"pattern">>}` | Regex match on the formatted message |
+| `fun((Msg, Meta) -> boolean())` | Custom filter function |
+
+### Where to call expect/1
+
+Call `cth_error_report:expect/1` from `init_per_suite`, `init_per_group`,
+or `init_per_testcase`. Patterns accumulate for the duration of the suite --
+once declared, they apply to all subsequent error classification in that suite.
+
+### Examples
+
+```erlang
+init_per_suite(Config) ->
+    %% This module always logs an error on startup, it's expected
+    cth_error_report:expect({what, push_send_failed}),
+
+    %% Expect any error from a specific module
+    cth_error_report:expect({module, mod_push_service_mongoosepush}),
+
+    %% Expect errors matching a substring
+    cth_error_report:expect(<<"connection refused">>),
+
+    %% Expect errors matching a regex
+    cth_error_report:expect({regex, <<"timeout after [0-9]+ ms">>}),
+
+    %% Expect errors from a specific function (any arity)
+    cth_error_report:expect({mfa, {mod_mam_rdbms_arch, retract_message, '_'}}),
+
+    Config.
+```
+
+Patterns can also be declared per-group or per-testcase:
+
+```erlang
+init_per_group(reconnect_tests, Config) ->
+    cth_error_report:expect({what, session_replaced}),
+    Config;
+init_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(test_connection_timeout, Config) ->
+    cth_error_report:expect(<<"connection closed">>),
+    Config;
+init_per_testcase(_, Config) ->
+    Config.
+```
+
+## Asserting a maximum number of unexpected errors
+
+Use `cth_error_report:max_unexpected_errors_logged/1` to set a limit on
+unexpected errors for a suite. If the limit is exceeded, the test run
+fails with a non-zero exit code.
+
+```erlang
+init_per_suite(Config) ->
+    %% Allow at most 5 unexpected errors in this suite
+    cth_error_report:max_unexpected_errors_logged(5),
+
+    %% Declare known expected errors
+    cth_error_report:expect({what, known_flaky_error}),
+
+    Config.
+```
+
+The check runs after all testcases complete. If the unexpected error count
+exceeds the limit, the test run exits with code 1 and prints:
+
+```
+**** Failing due to unexpected error log limit exceeded:
+my_SUITE: 8 unexpected errors logged, max allowed: 5
+```
+
+Suites without `max_unexpected_errors_logged` are not checked.
+
+## Parallel groups
+
+For parallel test groups, per-testcase error tracking is not possible because
+CT forks the hook state for each parallel testcase. Errors from parallel
+testcases are collected at the group level instead and attributed to the
+group's `end_per_group` section. Parallel groups are marked with `[parallel]`
+in the reports.


### PR DESCRIPTION
MIM-2662

This PR improves `cth_error_report` Common Test hook, which runs for each test suite.
It allows to assert maximum number of unexpected errors logged during execution of the test suite using cth_error_report:max_unexpected_errors_logged(N) function.

Expected errors can be decared using cth_error_report:expect/1,2 functions, the declarations accumulate for the test suite, can be declared anywhere in the suite.

If a max_unexpected_errors_logged value is declared in a suite, the value is checked against errors logged and the test suite invalidated in case the number of errors is exceeded.

Summary in `<test_dir>/logged_errors/`  now shows both 'All errors' and 'Unexpected errors' columns.

Developer documentation is in `doc/developers-guide/Error-log-tracking.md`

This mechanism is applied to test suite `push_integration_SUITE`.
