### PR TITLE
Align Helm repo links with new distribution page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It is brought to you by [Erlang Solutions](https://www.erlang-solutions.com/).
 For a quick start just download:
 
 * The [Docker image](https://hub.docker.com/r/erlangsolutions/mongooseim/) ([source code repository](https://github.com/esl/mongooseim-docker))
-* The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
+* The [Helm chart](https://trymongoose.im/downloads#helm)
 * The [pre-built packages](https://github.com/esl/MongooseIM/releases/latest) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
 
 ## Public testing

--- a/doc/getting-started/Installation.md
+++ b/doc/getting-started/Installation.md
@@ -55,14 +55,10 @@ The `mongooseimctl` command is available in `/usr/lib/mongooseim/bin/mongooseimc
 
 ## Helm
 
-You can easily install MongooseIM to a Kubernetes cluster with the help of our [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim), defined in the [source code repository](https://github.com/esl/MongooseHelm).
-After you have a Kubernetes cluster set up, simply run:
+You can easily install MongooseIM to a Kubernetes cluster with the help of our [Helm chart](https://trymongoose.im/downloads#helm).
 
-```bash
-helm repo add mongoose https://esl.github.io/MongooseHelm/
-```
+Once you’ve set up your Kubernetes cluster and added the MongooseIM repository (as described in the link above), simply run:
 
-to add our chart repository, and then:
 
 ```bash
 helm install my-mongooseim mongoose/mongooseim

--- a/doc/index.md
+++ b/doc/index.md
@@ -59,7 +59,7 @@ For a quick start just download:
 
 * The [pre-built packages](https://github.com/esl/MongooseIM/releases/latest) that suit your platform (Ubuntu, Debian, CentOS compatible: AlmaLinux and Rocky Linux)
 * The [Docker image](https://hub.docker.com/r/erlangsolutions/mongooseim/) ([source code repository](https://github.com/esl/mongooseim-docker))
-* The [Helm chart](https://artifacthub.io/packages/helm/mongoose/mongooseim) ([source code repository](https://github.com/esl/MongooseHelm))
+* The [Helm chart](https://trymongoose.im/downloads#helm)
 
 See the [installation guide](getting-started/Installation.md) for more details.
 

--- a/doc/tutorials/CETS-configure.md
+++ b/doc/tutorials/CETS-configure.md
@@ -36,7 +36,7 @@ If you want to use CETS instead of Mnesia, ensure that these options are set:
 Ensure that `outgoing_pools` are configured with RDBMS, so CETS could get a list of MongooseIM nodes, which use the same
 relational database and cluster them together.
 
-A preferred way to install MongooseIM is [Helm Charts](https://github.com/esl/MongooseHelm/) on Kubernetes, so it allows
+A preferred way to install MongooseIM is [Helm Charts](https://trymongoose.im/downloads#helm) on Kubernetes, so it allows
 to set `volatileDatabase` to `cets` and the values would be applied using Helm's templates
 
 


### PR DESCRIPTION
This PR updates the Helm repo links across the documentation to point to the new download page.

MIM-2674

