### PR TITLE
Upgrade OTP versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 references:
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3
-  - &LATEST_OTP erlangsolutions/erlang:cimg-28.0.2
+  - &LATEST_OTP erlangsolutions/erlang:cimg-28.4.2
 
 # this allows you to use CircleCI's dynamic configuration feature
 setup: true

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -7,7 +7,7 @@ references:
   # https://github.com/esl/cimg-erlang#trigger-build-using-trigger-pipeline-on-circleci
   - &LATEST_OTP_VERSION 28.4.2
   - &LATEST_OTP erlangsolutions/erlang:cimg-28.4.2
-  - &LEGACY_OTP erlangsolutions/erlang:cimg-27.3.4.2
+  - &LEGACY_OTP erlangsolutions/erlang:cimg-27.3.4.10
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days
   - &CERT_KEY certs-cache-{{ checksum "certs_cache_key" }}-v3

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -5,8 +5,8 @@ references:
   # Available cimg-erlang images: https://hub.docker.com/r/erlangsolutions/erlang/tags?name=cimg
   # You could need to trigger a pipeline to create a Docker image:
   # https://github.com/esl/cimg-erlang#trigger-build-using-trigger-pipeline-on-circleci
-  - &LATEST_OTP_VERSION 28.0.2
-  - &LATEST_OTP erlangsolutions/erlang:cimg-28.0.2
+  - &LATEST_OTP_VERSION 28.4.2
+  - &LATEST_OTP erlangsolutions/erlang:cimg-28.4.2
   - &LEGACY_OTP erlangsolutions/erlang:cimg-27.3.4.2
   - &ENTRYPOINT ["/bin/sh", "-c", "eval ${INSTALL_DEPS_CMD:-echo} && echo __INJECT_FILES__ | eval ${BASE32DEC:-base32 --decode} | bash"]
   # Caches created via the save_cache step are stored for up to 15 days

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         ## the full list of supported (prebuilt) OTP versions for ubuntu-22.04 runners
         ## can be found here:
         ##     https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
-        otp: [ '27.3.4.2', '28.0.2' ]
+        otp: [ '27.3.4.10', '28.4.2' ]
     runs-on: ubuntu-22.04
     env:
       PRESET: 'small_tests'
@@ -67,17 +67,17 @@ jobs:
       matrix:
         preset: [internal_mnesia, pgsql_mnesia, mysql_redis,
                  ldap_mnesia, elasticsearch_and_cassandra_mnesia]
-        otp: [ '28.0.2' ]
+        otp: [ '28.4.2' ]
         include:
           - test-spec: "default.spec"
           - preset: elasticsearch_and_cassandra_mnesia
             test-spec: "mam.spec"
           - preset: ldap_mnesia
             test-spec: "default.spec"
-            otp: '27.3.4.2'
+            otp: '27.3.4.10'
           - preset: pgsql_mnesia
             test-spec: "default.spec"
-            otp: '27.3.4.2'
+            otp: '27.3.4.10'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -103,11 +103,11 @@ jobs:
       fail-fast: false
       matrix:
         preset: [pgsql_mnesia, mysql_redis]
-        otp: [ '28.0.2' ]
+        otp: [ '28.4.2' ]
         test-spec: ["dynamic_domains.spec"]
         include:
           - preset: pgsql_mnesia
-            otp: '27.3.4.2'
+            otp: '27.3.4.10'
             test-spec: "dynamic_domains.spec"
     runs-on: ubuntu-22.04
     steps:
@@ -143,7 +143,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '27.3.4.2' ]
+        otp: [ '27.3.4.10' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '27.3.4.2' ]
+        otp: [ '27.3.4.10' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -178,7 +178,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp: [ '27.3.4.2' ]
+        otp: [ '27.3.4.10' ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -198,7 +198,7 @@ jobs:
         pkg: [ubuntu-jammy]
     runs-on: ubuntu-22.04
     env:
-      pkg_OTP_VERSION: "28.0.2"
+      pkg_OTP_VERSION: "28.4.2"
       pkg_PLATFORM: ${{matrix.pkg}}
       GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
This PR bumps both the current and legacy OTP versions to the latest versions:

- current: 28.4.2
- legacy: 27.3.4.10

MIM-2640
