### PR TITLE
MIM-2681 Collect errors from all reachable MIM nodes

### DIFF
--- a/big_tests/src/cth_error_report.erl
+++ b/big_tests/src/cth_error_report.erl
@@ -1,24 +1,28 @@
-%%% @doc CT hook that collects error logs from MongooseIM nodes during test
-%%% execution and writes a report file per test suite.
-%%%
-%%% Reports are written to a `logged_errors/' subfolder in the CT log
-%%% directory (ct_report/ct_run.*). Each suite gets its own file named
-%%% `SuiteName.log'. Errors are broken down by group and testcase.
-%%%
-%%% Uses cth_error_report_sink (a runner-side gen_server) to collect log
-%%% entries pushed from MIM nodes by the log_error_collector handler.
-%%%
-%%% Tests can declare expected error patterns using expect/1.
-%%% In the .log report, unexpected errors are prefixed with
-%%% *** UNEXPECTED ***. In the .html report, unexpected errors
-%%% are red and expected errors are green.
-%%%
-%%% Usage in *.spec:
-%%%   {ct_hooks, [cth_error_report]}.
-%%%
-%%% Usage in tests:
-%%%   cth_error_report:expect({what, some_expected_error}).
 -module(cth_error_report).
+-moduledoc """
+CT hook that collects error logs from MongooseIM nodes during test
+execution and writes a report file per test suite.
+
+Reports are written to a `logged_errors/` subfolder in the CT log
+directory (`ct_report/ct_run.*`). Each suite gets its own file named
+`SuiteName.log`. Errors are broken down by group and testcase.
+
+Uses `cth_error_report_sink` (a runner-side gen_server) to collect
+log entries pushed from MIM nodes by the `log_error_collector` handler.
+
+Tests can declare expected error patterns using `expect/1`. In the
+`.log` report, unexpected errors are prefixed with `*** UNEXPECTED ***`.
+In the `.html` report, unexpected errors are red and expected errors
+are green.
+
+Usage in `*.spec`:
+
+    {ct_hooks, [cth_error_report]}.
+
+Usage in tests:
+
+    cth_error_report:expect({what, some_expected_error}).
+""".
 
 %% CT hook callbacks
 -export([id/1, init/2]).
@@ -87,24 +91,30 @@
 
 %% API
 
-%% @doc Declare an expected error pattern with unlimited matches.
-%% All matching errors will be classified as expected.
+-doc """
+Declares an expected error pattern with unlimited matches. All
+matching errors are classified as expected.
+""".
 -spec expect(pattern()) -> true.
 expect(Pattern) ->
     ets:insert(?PATTERNS_TABLE, {expect, Pattern}).
 
-%% @doc Declare an expected error pattern with a specific count.
-%% Multiple calls with the same pattern accumulate:
-%% expect(P, 3) + expect(P, 5) expects 8 matches total.
-%% An unlimited expect/1 for the same pattern overrides counts.
+-doc """
+Declares an expected error pattern with a specific count. Multiple
+calls with the same pattern accumulate: `expect(P, 3) + expect(P, 5)`
+expects 8 matches total. An unlimited `expect/1` for the same pattern
+overrides counts.
+""".
 -spec expect(pattern(), pos_integer()) -> true.
 expect(Pattern, N) when is_integer(N), N > 0 ->
     ets:insert(?PATTERNS_TABLE, {expect_count, Pattern, N}).
 
-%% @doc Set the maximum allowed unexpected errors for the current suite.
-%% If the count exceeds this limit, end_per_suite will return
-%% {error, too_many_unexpected_errors}.
-%% Call from init_per_suite or init_per_group.
+-doc """
+Sets the maximum allowed unexpected errors for the current suite. If
+the count exceeds this limit, `end_per_suite` returns
+`{error, too_many_unexpected_errors}`. Should be called from
+`init_per_suite` or `init_per_group`.
+""".
 -spec max_unexpected_errors_logged(non_neg_integer()) -> true.
 max_unexpected_errors_logged(N) when is_integer(N), N >= 0 ->
     ets:insert(?PATTERNS_TABLE, {max_unexpected_errors_logged, N}).

--- a/big_tests/src/cth_error_report.erl
+++ b/big_tests/src/cth_error_report.erl
@@ -50,7 +50,7 @@
     %% Stack of {GroupName, IsParallel} tuples, innermost first
     groups = [] :: [{atom(), boolean()}],
     parallel_depth = 0 :: non_neg_integer(),
-    entries = [] :: [entry()],
+    entries = [] :: [report_entry()],
     %% Count of unexpected errors in current suite
     unexpected_total = 0 :: non_neg_integer(),
     %% Count of all errors (unexpected + expected) in current suite
@@ -63,15 +63,11 @@
 
 -type suite_result() :: {atom(), non_neg_integer(), non_neg_integer()}.
 
--type msg() :: {report, map()} | {string, binary() | string()}
-             | {list(), list()} | term().
--type meta() :: #{atom() => term()}.
-%% Sink-side entry shape. Note: no per-entry timestamp field
-%% (formatting falls back to meta.time, which logger always provides).
--type log_entry() :: {Node :: node(), Level :: atom(),
-                      Msg :: msg(), Meta :: meta()}.
--type entry() :: {section(), Unexpected :: [log_entry()],
-                  Expected :: [log_entry()]}.
+-type msg() :: log_error_collector:msg().
+-type meta() :: log_error_collector:meta().
+-type log_entry() :: cth_error_report_sink:log_entry().
+-type report_entry() :: {section(), Unexpected :: [log_entry()],
+                         Expected :: [log_entry()]}.
 -type group_info() :: {atom(), boolean()}.
 -type pattern() :: {what, atom()}
                  | {module, atom()}

--- a/big_tests/src/cth_error_report.erl
+++ b/big_tests/src/cth_error_report.erl
@@ -256,8 +256,7 @@ check_unexpected_limit(Suite, Unexp, Max, ReportDir) ->
 
 %% Node spec resolution
 
--spec node_specs() ->
-    [{atom(), distributed_helper:rpc_spec()}].
+-spec node_specs() -> [{atom(), distributed_helper:rpc_spec()}].
 node_specs() ->
     lists:filtermap(
         fun(Key) ->

--- a/big_tests/src/cth_error_report.erl
+++ b/big_tests/src/cth_error_report.erl
@@ -5,7 +5,8 @@
 %%% directory (ct_report/ct_run.*). Each suite gets its own file named
 %%% `SuiteName.log'. Errors are broken down by group and testcase.
 %%%
-%%% Uses a named instance of log_error_collector (`cth_error_report').
+%%% Uses cth_error_report_sink (a runner-side gen_server) to collect log
+%%% entries pushed from MIM nodes by the log_error_collector handler.
 %%%
 %%% Tests can declare expected error patterns using expect/1.
 %%% In the .log report, unexpected errors are prefixed with
@@ -36,20 +37,19 @@
 %% API for tests
 -export([expect/1, expect/2, max_unexpected_errors_logged/1]).
 
--import(distributed_helper, [rpc/4, mim/0]).
-
--define(COLLECTOR, log_error_collector).
--define(INSTANCE, cth_error_report).
 -define(PATTERNS_TABLE, cth_error_report_patterns).
+-define(NODE_KEYS, [mim, mim2, mim3, fed, reg]).
 
 -record(state, {
     report_dir :: undefined | string(),
     %% Persists across suites for the summary file
     summary_dir :: undefined | string(),
+    %% Sink sequence captured at the most recent section boundary.
+    %% `undefined' means collection failed to start for this suite.
+    mark :: undefined | non_neg_integer(),
     %% Stack of {GroupName, IsParallel} tuples, innermost first
     groups = [] :: [{atom(), boolean()}],
     parallel_depth = 0 :: non_neg_integer(),
-    mark :: undefined | integer(),
     entries = [] :: [entry()],
     %% Count of unexpected errors in current suite
     unexpected_total = 0 :: non_neg_integer(),
@@ -58,15 +58,18 @@
     %% Number of errors already matched per counted pattern
     consumed = #{} :: #{pattern() => non_neg_integer()},
     %% Accumulated across suites for the final summary
-    %% {Suite, AllErrors, UnexpectedErrors}
     suite_results = [] :: [suite_result()]
 }).
 
 -type suite_result() :: {atom(), non_neg_integer(), non_neg_integer()}.
 
--type msg() :: log_error_collector:msg().
--type meta() :: log_error_collector:meta().
--type log_entry() :: log_error_collector:log_entry().
+-type msg() :: {report, map()} | {string, binary() | string()}
+             | {list(), list()} | term().
+-type meta() :: #{atom() => term()}.
+%% Sink-side entry shape. Note: no per-entry timestamp field
+%% (formatting falls back to meta.time, which logger always provides).
+-type log_entry() :: {Node :: node(), Level :: atom(),
+                      Msg :: msg(), Meta :: meta()}.
 -type entry() :: {section(), Unexpected :: [log_entry()],
                   Expected :: [log_entry()]}.
 -type group_info() :: {atom(), boolean()}.
@@ -116,13 +119,15 @@ id(_Opts) ->
     "cth_error_report".
 
 init(_Id, _Opts) ->
+    {ok, _Pid} = cth_error_report_sink:start_link(),
     {ok, #state{}}.
 
 pre_init_per_suite(_Suite, Config, State) ->
     try
-        mongoose_helper:inject_module(?COLLECTOR),
-        rpc(mim(), ?COLLECTOR, start, [?INSTANCE, [error]]),
-        Mark = rpc(mim(), ?COLLECTOR, timestamp, []),
+        Specs = node_specs(),
+        ok = cth_error_report_sink:clear(),
+        ok = cth_error_report_sink:watch_nodes(Specs, [error]),
+        Mark = cth_error_report_sink:mark(),
         ReportDir = init_report_dir(Config),
         SummaryDir = case State#state.summary_dir of
             undefined -> ReportDir;
@@ -138,7 +143,7 @@ pre_init_per_suite(_Suite, Config, State) ->
     catch Class:Reason:Stacktrace ->
         ct:pal("cth_error_report: failed to start: ~p:~p~n~p",
                [Class, Reason, Stacktrace]),
-        {Config, State#state{report_dir = undefined}}
+        {Config, State#state{report_dir = undefined, mark = undefined}}
     end.
 
 post_init_per_suite(_Suite, _Config, Return, #state{mark = undefined} = State) ->
@@ -199,7 +204,7 @@ post_end_per_suite(Suite, _Config, Return, State) ->
     SuiteResult = try
         MaxUnexp = get_max_unexpected_errors_logged(),
         State1 = collect_errors({end_per_suite}, State),
-        rpc(mim(), ?COLLECTOR, stop, [?INSTANCE]),
+        ok = cth_error_report_sink:unwatch(),
         delete_patterns_table(),
         write_report(Suite, State1),
         Unexp = State1#state.unexpected_total,
@@ -209,6 +214,7 @@ post_end_per_suite(Suite, _Config, Return, State) ->
     catch Class:Reason:Stacktrace ->
         ct:pal("cth_error_report: failed for ~p: ~p:~p~n~p",
                [Suite, Class, Reason, Stacktrace]),
+        _ = catch cth_error_report_sink:unwatch(),
         delete_patterns_table(),
         {Suite, State#state.all_total,
          State#state.unexpected_total}
@@ -220,12 +226,14 @@ post_end_per_suite(Suite, _Config, Return, State) ->
                          consumed = #{},
                          suite_results = Results}}.
 
-terminate(#state{summary_dir = undefined}) ->
-    ok;
-terminate(#state{suite_results = []}) ->
-    ok;
 terminate(#state{summary_dir = Dir, suite_results = RevResults}) ->
-    write_summary(Dir, lists:sort(RevResults)).
+    case {Dir, RevResults} of
+        {undefined, _} -> ok;
+        {_, []} -> ok;
+        {_, _} -> write_summary(Dir, lists:sort(RevResults))
+    end,
+    _ = catch cth_error_report_sink:stop(),
+    ok.
 
 %% Unexpected errors limit check
 
@@ -239,6 +247,19 @@ check_unexpected_limit(Suite, Unexp, Max, ReportDir) ->
                         [Suite, Unexp, plural(Unexp, "error"), Max]),
     MarkerFile = filename:join(ReportDir, "limit_exceeded"),
     file:write_file(MarkerFile, Msg, [append]).
+
+%% Node spec resolution
+
+-spec node_specs() ->
+    [{atom(), distributed_helper:rpc_spec()}].
+node_specs() ->
+    lists:filtermap(
+        fun(Key) ->
+            try {true, {Key, distributed_helper:rpc_spec(Key)}}
+            catch _:_ -> false
+            end
+        end,
+        ?NODE_KEYS).
 
 %% Parallel group detection
 
@@ -302,9 +323,7 @@ get_max_unexpected_errors_logged() ->
 -spec collect_errors(section(), #state{}) -> #state{}.
 collect_errors(Section, #state{mark = Mark} = State) ->
     try
-        Errors = rpc(mim(), ?COLLECTOR, get_errors_after, [?INSTANCE, Mark]),
-        NewMark = rpc(mim(), ?COLLECTOR, timestamp, []),
-        %% Compute effective allowances: ETS totals minus consumed
+        {Errors, NewMark} = cth_error_report_sink:get_after(Mark),
         Allowances = effective_allowances(get_pattern_allowances(), State#state.consumed),
         {Unexpected, Expected, NewConsumed} = classify_errors(Errors, Allowances, State#state.consumed),
         Entry = {Section, Unexpected, Expected},
@@ -338,7 +357,7 @@ classify_errors(Errors, Allowances, Consumed)
 classify_errors(Errors, Allowances, Consumed) ->
     {Unexpected, Expected, _, NewConsumed} = lists:foldl(
         fun(Entry, {UnexpAcc, ExpAcc, AllowAcc, ConsAcc}) ->
-            {_Ts, _Level, Msg, Meta} = Entry,
+            {_Node, _Level, Msg, Meta} = Entry,
             case find_matching_pattern(Msg, Meta, AllowAcc) of
                 {ok, P} ->
                     NewAllow = decrement_allowance(P, AllowAcc),
@@ -580,7 +599,7 @@ format_entry_unexpected_log(Entry) ->
 format_entry_expected_log(Entry) ->
     format_entry_log(Entry).
 
-format_entry_log({_Timestamp, Level, Msg, Meta}) ->
+format_entry_log({_Node, Level, Msg, Meta}) ->
     Time = format_time(Meta),
     Node = format_node(Meta),
     MsgFormatted = format_msg(Msg),
@@ -638,7 +657,7 @@ format_section_errors_html(Unexpected, Expected) ->
     ELines = [format_entry_html(E, "expected") || E <- Expected],
     [ULines, ELines].
 
-format_entry_html({_Timestamp, Level, Msg, Meta}, Class) ->
+format_entry_html({_Node, Level, Msg, Meta}, Class) ->
     Time = format_time(Meta),
     Node = format_node(Meta),
     MsgFmt = html_escape(format_msg(Msg)),

--- a/big_tests/src/cth_error_report_sink.erl
+++ b/big_tests/src/cth_error_report_sink.erl
@@ -106,22 +106,17 @@ handle_call(clear, _From, #state{table = T} = State) ->
 handle_call({watch_nodes, Specs, Levels}, _From, State) ->
     Watched = lists:foldl(
         fun({_Key, #{node := Node} = Spec}, Acc) ->
+                do_inject(Spec, Levels),
                 Acc#{Node => Spec}
         end,
         #{}, Specs),
-    [spawn(fun() -> inject_async(Spec, Levels) end)
-     || {_Key, Spec} <- Specs],
     {reply, ok, State#state{watched = Watched, levels = Levels}};
 handle_call({inject, #{node := Node} = Spec}, _From,
             #state{watched = Watched, levels = Levels} = State) ->
-    spawn(fun() -> inject_async(Spec, Levels) end),
+    do_inject(Spec, Levels),
     {reply, ok, State#state{watched = Watched#{Node => Spec}}};
 handle_call(unwatch, _From, #state{watched = Watched} = State) ->
-    maps:foreach(
-        fun(_Node, Spec) ->
-                spawn(fun() -> remove_async(Spec) end)
-        end,
-        Watched),
+    maps:foreach(fun(_Node, Spec) -> do_remove(Spec) end, Watched),
     {reply, ok, State#state{watched = #{}}};
 handle_call(_, _From, State) ->
     {reply, {error, unknown_call}, State}.
@@ -141,11 +136,14 @@ handle_info(_, State) ->
 terminate(_Reason, _State) ->
     ok.
 
-%% Internal: injection / removal performed in a transient process
-%% so the gen_server stays responsive.
+%% Internal: injection / removal happen synchronously inside the
+%% gen_server call so the caller is guaranteed the handler is
+%% attached (or failure logged) before inject/1 or watch_nodes/2
+%% returns. Test setup is sequential -- there is no concurrency to
+%% serve here, and correctness beats parallelism.
 
--spec inject_async(spec(), [level()]) -> ok.
-inject_async(#{node := Node} = Spec, Levels) ->
+-spec do_inject(spec(), [level()]) -> ok.
+do_inject(#{node := Node} = Spec, Levels) ->
     try
         mongoose_helper:inject_module(Spec, log_error_collector, no_reload),
         SinkRef = {?NAME, node()},
@@ -157,8 +155,8 @@ inject_async(#{node := Node} = Spec, Levels) ->
         ok
     end.
 
--spec remove_async(spec()) -> ok.
-remove_async(Spec) ->
+-spec do_remove(spec()) -> ok.
+do_remove(Spec) ->
     try distributed_helper:rpc(Spec, log_error_collector, stop, [])
     catch _:_ -> ok
     end,

--- a/big_tests/src/cth_error_report_sink.erl
+++ b/big_tests/src/cth_error_report_sink.erl
@@ -1,12 +1,14 @@
-%%% @doc Test-runner-side sink for error log entries pushed from MIM nodes.
-%%%
-%%% Owns one ETS table keyed by a global monotonic sequence.
-%%% Receives `{log_entry, Node, Level, Msg, Meta}' messages from
-%%% `log_error_collector' handlers running on MIM nodes.
-%%%
-%%% Survives across all suites in a CT run; cleared at each
-%%% `pre_init_per_suite' via `clear/0'.
 -module(cth_error_report_sink).
+-moduledoc """
+Test-runner-side sink for error log entries pushed from MIM nodes.
+
+Owns one ETS table keyed by a global monotonic sequence. Receives
+`{log_entry, Node, Level, Msg, Meta}` messages from `log_error_collector`
+handlers running on MIM nodes.
+
+Survives across all suites in a CT run; cleared at each
+`pre_init_per_suite` via `clear/0`.
+""".
 -behaviour(gen_server).
 
 -export([start_link/0, stop/0,
@@ -50,40 +52,50 @@ start_link() ->
 stop() ->
     gen_server:stop(?NAME).
 
-%% Returns the current sequence number; entries inserted after this
-%% call will have a strictly greater sequence.
+-doc """
+Returns the current sequence number. Entries inserted after this call
+have a strictly greater sequence.
+""".
 -spec mark() -> non_neg_integer().
 mark() ->
     gen_server:call(?NAME, mark).
 
-%% Returns {EntriesNewerThanMark, NewMark}. Entries are returned in
-%% sequence order (oldest first).
+-doc """
+Returns `{Entries, NewMark}` for entries with sequence strictly greater
+than `Mark`. Entries are returned in sequence order (oldest first).
+""".
 -spec get_after(non_neg_integer()) -> {[log_entry()], non_neg_integer()}.
 get_after(Mark) ->
     gen_server:call(?NAME, {get_after, Mark}).
 
-%% Drops all stored entries and resets sequence to 0.
+-doc "Drops all stored entries and resets the sequence to 0.".
 -spec clear() -> ok.
 clear() ->
     gen_server:call(?NAME, clear).
 
-%% Declare which nodes the sink should watch and inject the
-%% log_error_collector handler on each of them. Re-injection after
-%% a node restart is the responsibility of the restart caller --
-%% see inject/1 below; distributed_helper:start_node/2 calls it.
+-doc """
+Declares which nodes the sink should watch and injects the
+`log_error_collector` handler on each of them. Re-injection after
+a node restart is the responsibility of the restart caller — see
+`inject/1`; `distributed_helper:start_node/2` calls it.
+""".
 -spec watch_nodes([{atom(), spec()}], [level()]) -> ok.
 watch_nodes(Specs, Levels) ->
     gen_server:call(?NAME, {watch_nodes, Specs, Levels}).
 
-%% (Re-)inject the log_error_collector handler on the given node.
-%% Called by node-restart helpers (e.g. distributed_helper:start_node/2)
-%% after a node has come back up so error collection resumes.
+-doc """
+(Re-)injects the `log_error_collector` handler on the given node.
+Called by node-restart helpers (e.g. `distributed_helper:start_node/2`)
+after a node has come back up so error collection resumes.
+""".
 -spec inject(spec()) -> ok.
 inject(Spec) ->
     gen_server:call(?NAME, {inject, Spec}).
 
-%% Stop watching all nodes; best-effort handler removal on nodes
-%% that are still up.
+-doc """
+Stops watching all nodes; performs best-effort handler removal on
+nodes that are still up.
+""".
 -spec unwatch() -> ok.
 unwatch() ->
     gen_server:call(?NAME, unwatch).

--- a/big_tests/src/cth_error_report_sink.erl
+++ b/big_tests/src/cth_error_report_sink.erl
@@ -20,9 +20,16 @@
 -define(NAME, ?MODULE).
 
 -type spec() :: distributed_helper:rpc_spec().
--type level() :: atom().
--type entry() :: {Node :: node(), Level :: level(),
-                  Msg :: term(), Meta :: map()}.
+-type level() :: log_error_collector:level().
+%% Storage shape: a single log event captured from a MIM node.
+%% Same arity as the wire format `{log_entry, Node, Level, Msg, Meta}'
+%% but without the leading tag.
+-type log_entry() :: {Node :: node(),
+                      Level :: log_error_collector:level(),
+                      Msg :: log_error_collector:msg(),
+                      Meta :: log_error_collector:meta()}.
+
+-export_type([log_entry/0]).
 
 -record(state, {
     seq = 0 :: non_neg_integer(),
@@ -51,7 +58,7 @@ mark() ->
 
 %% Returns {EntriesNewerThanMark, NewMark}. Entries are returned in
 %% sequence order (oldest first).
--spec get_after(non_neg_integer()) -> {[entry()], non_neg_integer()}.
+-spec get_after(non_neg_integer()) -> {[log_entry()], non_neg_integer()}.
 get_after(Mark) ->
     gen_server:call(?NAME, {get_after, Mark}).
 

--- a/big_tests/src/cth_error_report_sink.erl
+++ b/big_tests/src/cth_error_report_sink.erl
@@ -11,7 +11,7 @@
 
 -export([start_link/0, stop/0,
          mark/0, get_after/1, clear/0,
-         watch_nodes/2, unwatch/0]).
+         watch_nodes/2, inject/1, unwatch/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2,
@@ -27,8 +27,8 @@
 -record(state, {
     seq = 0 :: non_neg_integer(),
     table :: ets:tid() | atom(),
-    %% Nodes we want a handler on. Keyed by node() atom for fast
-    %% lookup on nodeup events.
+    %% Nodes where a handler has been (re-)injected. Used by
+    %% unwatch/0 for best-effort handler removal at suite end.
     watched = #{} :: #{node() => spec()},
     levels = [error] :: [level()]
 }).
@@ -60,12 +60,20 @@ get_after(Mark) ->
 clear() ->
     gen_server:call(?NAME, clear).
 
-%% Declare which nodes the sink should watch. The sink will inject
-%% the log_error_collector handler on each one that's currently up,
-%% and re-inject on nodeup for nodes that come back later.
+%% Declare which nodes the sink should watch and inject the
+%% log_error_collector handler on each of them. Re-injection after
+%% a node restart is the responsibility of the restart caller --
+%% see inject/1 below; distributed_helper:start_node/2 calls it.
 -spec watch_nodes([{atom(), spec()}], [level()]) -> ok.
 watch_nodes(Specs, Levels) ->
     gen_server:call(?NAME, {watch_nodes, Specs, Levels}).
+
+%% (Re-)inject the log_error_collector handler on the given node.
+%% Called by node-restart helpers (e.g. distributed_helper:start_node/2)
+%% after a node has come back up so error collection resumes.
+-spec inject(spec()) -> ok.
+inject(Spec) ->
+    gen_server:call(?NAME, {inject, Spec}).
 
 %% Stop watching all nodes; best-effort handler removal on nodes
 %% that are still up.
@@ -77,7 +85,6 @@ unwatch() ->
 
 init([]) ->
     Tab = ets:new(?MODULE, [ordered_set, private]),
-    ok = net_kernel:monitor_nodes(true),
     {ok, #state{table = Tab}}.
 
 handle_call(mark, _From, #state{seq = Seq} = State) ->
@@ -105,6 +112,10 @@ handle_call({watch_nodes, Specs, Levels}, _From, State) ->
     [spawn(fun() -> inject_async(Spec, Levels) end)
      || {_Key, Spec} <- Specs],
     {reply, ok, State#state{watched = Watched, levels = Levels}};
+handle_call({inject, #{node := Node} = Spec}, _From,
+            #state{watched = Watched, levels = Levels} = State) ->
+    spawn(fun() -> inject_async(Spec, Levels) end),
+    {reply, ok, State#state{watched = Watched#{Node => Spec}}};
 handle_call(unwatch, _From, #state{watched = Watched} = State) ->
     maps:foreach(
         fun(_Node, Spec) ->
@@ -124,17 +135,6 @@ handle_info({log_entry, Node, Level, Msg, Meta},
     Entry = {Node, Level, Msg, Meta},
     ets:insert(T, {NewSeq, Entry}),
     {noreply, State#state{seq = NewSeq}};
-handle_info({nodeup, Node}, #state{watched = Watched,
-                                   levels = Levels} = State) ->
-    case maps:find(Node, Watched) of
-        {ok, Spec} ->
-            spawn(fun() -> inject_async(Spec, Levels) end);
-        error ->
-            ok
-    end,
-    {noreply, State};
-handle_info({nodedown, _Node}, State) ->
-    {noreply, State};
 handle_info(_, State) ->
     {noreply, State}.
 
@@ -147,17 +147,10 @@ terminate(_Reason, _State) ->
 -spec inject_async(spec(), [level()]) -> ok.
 inject_async(#{node := Node} = Spec, Levels) ->
     try
-        Cookie = ct:get_config(ejabberd_cookie),
-        erlang:set_cookie(Node, Cookie),
-        case net_kernel:connect_node(Node) of
-            true ->
-                mongoose_helper:inject_module(Spec, log_error_collector, no_reload),
-                SinkRef = {?NAME, node()},
-                _ = distributed_helper:rpc(Spec, log_error_collector, start, [Levels, SinkRef]),
-                ok;
-            _ ->
-                ok
-        end
+        mongoose_helper:inject_module(Spec, log_error_collector, no_reload),
+        SinkRef = {?NAME, node()},
+        _ = distributed_helper:rpc(Spec, log_error_collector, start, [Levels, SinkRef]),
+        ok
     catch Class:Reason:Stack ->
         ct:pal("cth_error_report_sink: failed to inject handler on ~p: ~p:~p~n~p",
                [Node, Class, Reason, Stack]),

--- a/big_tests/src/cth_error_report_sink.erl
+++ b/big_tests/src/cth_error_report_sink.erl
@@ -123,12 +123,8 @@ handle_call(clear, _From, #state{table = T} = State) ->
     ets:delete_all_objects(T),
     {reply, ok, State#state{seq = 0}};
 handle_call({watch_nodes, Specs, Levels}, _From, State) ->
-    Watched = lists:foldl(
-        fun({_Key, #{node := Node} = Spec}, Acc) ->
-                do_inject(Spec, Levels),
-                Acc#{Node => Spec}
-        end,
-        #{}, Specs),
+    lists:foreach(fun({_Key, Spec}) -> do_inject(Spec, Levels) end, Specs),
+    Watched = #{Node => Spec || {_Key, #{node := Node} = Spec} <- Specs},
     {reply, ok, State#state{watched = Watched, levels = Levels}};
 handle_call({inject, #{node := Node} = Spec}, _From,
             #state{watched = Watched, levels = Levels} = State) ->

--- a/big_tests/src/cth_error_report_sink.erl
+++ b/big_tests/src/cth_error_report_sink.erl
@@ -1,0 +1,172 @@
+%%% @doc Test-runner-side sink for error log entries pushed from MIM nodes.
+%%%
+%%% Owns one ETS table keyed by a global monotonic sequence.
+%%% Receives `{log_entry, Node, Level, Msg, Meta}' messages from
+%%% `log_error_collector' handlers running on MIM nodes.
+%%%
+%%% Survives across all suites in a CT run; cleared at each
+%%% `pre_init_per_suite' via `clear/0'.
+-module(cth_error_report_sink).
+-behaviour(gen_server).
+
+-export([start_link/0, stop/0,
+         mark/0, get_after/1, clear/0,
+         watch_nodes/2, unwatch/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2,
+         handle_info/2, terminate/2]).
+
+-define(NAME, ?MODULE).
+
+-type spec() :: distributed_helper:rpc_spec().
+-type level() :: atom().
+-type entry() :: {Node :: node(), Level :: level(),
+                  Msg :: term(), Meta :: map()}.
+
+-record(state, {
+    seq = 0 :: non_neg_integer(),
+    table :: ets:tid() | atom(),
+    %% Nodes we want a handler on. Keyed by node() atom for fast
+    %% lookup on nodeup events.
+    watched = #{} :: #{node() => spec()},
+    levels = [error] :: [level()]
+}).
+
+%% API
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?NAME}, ?MODULE, [], []).
+
+-spec stop() -> ok.
+stop() ->
+    gen_server:stop(?NAME).
+
+%% Returns the current sequence number; entries inserted after this
+%% call will have a strictly greater sequence.
+-spec mark() -> non_neg_integer().
+mark() ->
+    gen_server:call(?NAME, mark).
+
+%% Returns {EntriesNewerThanMark, NewMark}. Entries are returned in
+%% sequence order (oldest first).
+-spec get_after(non_neg_integer()) -> {[entry()], non_neg_integer()}.
+get_after(Mark) ->
+    gen_server:call(?NAME, {get_after, Mark}).
+
+%% Drops all stored entries and resets sequence to 0.
+-spec clear() -> ok.
+clear() ->
+    gen_server:call(?NAME, clear).
+
+%% Declare which nodes the sink should watch. The sink will inject
+%% the log_error_collector handler on each one that's currently up,
+%% and re-inject on nodeup for nodes that come back later.
+-spec watch_nodes([{atom(), spec()}], [level()]) -> ok.
+watch_nodes(Specs, Levels) ->
+    gen_server:call(?NAME, {watch_nodes, Specs, Levels}).
+
+%% Stop watching all nodes; best-effort handler removal on nodes
+%% that are still up.
+-spec unwatch() -> ok.
+unwatch() ->
+    gen_server:call(?NAME, unwatch).
+
+%% gen_server
+
+init([]) ->
+    Tab = ets:new(?MODULE, [ordered_set, private]),
+    ok = net_kernel:monitor_nodes(true),
+    {ok, #state{table = Tab}}.
+
+handle_call(mark, _From, #state{seq = Seq} = State) ->
+    {reply, Seq, State};
+handle_call({get_after, Mark}, _From, #state{table = T, seq = Seq} = State) ->
+    Entries = ets:select(T, [{ {'$1', '$2'}, [{'>', '$1', {const, Mark}}], ['$2'] }]),
+    {reply, {Entries, Seq}, State};
+handle_call(clear, _From, #state{table = T} = State) ->
+    %% NOTE: in-flight {log_entry, ...} messages already in the
+    %% mailbox at this point are still drained after the clear and
+    %% will land under sequence numbers >0. Per-suite boundaries are
+    %% quiet (no triggered work between the previous post_end_per_suite
+    %% and this call), so the practical risk of an entry being
+    %% mis-attributed to the next suite is negligible. If that ever
+    %% becomes a problem, switch to a generation counter checked in
+    %% the {log_entry, ...} handler.
+    ets:delete_all_objects(T),
+    {reply, ok, State#state{seq = 0}};
+handle_call({watch_nodes, Specs, Levels}, _From, State) ->
+    Watched = lists:foldl(
+        fun({_Key, #{node := Node} = Spec}, Acc) ->
+                Acc#{Node => Spec}
+        end,
+        #{}, Specs),
+    [spawn(fun() -> inject_async(Spec, Levels) end)
+     || {_Key, Spec} <- Specs],
+    {reply, ok, State#state{watched = Watched, levels = Levels}};
+handle_call(unwatch, _From, #state{watched = Watched} = State) ->
+    maps:foreach(
+        fun(_Node, Spec) ->
+                spawn(fun() -> remove_async(Spec) end)
+        end,
+        Watched),
+    {reply, ok, State#state{watched = #{}}};
+handle_call(_, _From, State) ->
+    {reply, {error, unknown_call}, State}.
+
+handle_cast(_, State) ->
+    {noreply, State}.
+
+handle_info({log_entry, Node, Level, Msg, Meta},
+            #state{table = T, seq = Seq} = State) ->
+    NewSeq = Seq + 1,
+    Entry = {Node, Level, Msg, Meta},
+    ets:insert(T, {NewSeq, Entry}),
+    {noreply, State#state{seq = NewSeq}};
+handle_info({nodeup, Node}, #state{watched = Watched,
+                                   levels = Levels} = State) ->
+    case maps:find(Node, Watched) of
+        {ok, Spec} ->
+            spawn(fun() -> inject_async(Spec, Levels) end);
+        error ->
+            ok
+    end,
+    {noreply, State};
+handle_info({nodedown, _Node}, State) ->
+    {noreply, State};
+handle_info(_, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+%% Internal: injection / removal performed in a transient process
+%% so the gen_server stays responsive.
+
+-spec inject_async(spec(), [level()]) -> ok.
+inject_async(#{node := Node} = Spec, Levels) ->
+    try
+        Cookie = ct:get_config(ejabberd_cookie),
+        erlang:set_cookie(Node, Cookie),
+        case net_kernel:connect_node(Node) of
+            true ->
+                mongoose_helper:inject_module(Spec, log_error_collector, no_reload),
+                SinkRef = {?NAME, node()},
+                _ = distributed_helper:rpc(Spec, log_error_collector, start, [Levels, SinkRef]),
+                ok;
+            _ ->
+                ok
+        end
+    catch Class:Reason:Stack ->
+        ct:pal("cth_error_report_sink: failed to inject handler on ~p: ~p:~p~n~p",
+               [Node, Class, Reason, Stack]),
+        ok
+    end.
+
+-spec remove_async(spec()) -> ok.
+remove_async(Spec) ->
+    try distributed_helper:rpc(Spec, log_error_collector, stop, [])
+    catch _:_ -> ok
+    end,
+    ok.

--- a/big_tests/tests/cth_error_report_SUITE.erl
+++ b/big_tests/tests/cth_error_report_SUITE.erl
@@ -269,10 +269,10 @@ errors_survive_handler_restart_on_mim2(_Config) ->
     %% expected to be lost. Trigger and forget.
     trigger_error_on(mim2(), during_restart, "drop"),
 
-    %% Re-inject. We cheat slightly: instead of waiting for the
-    %% sink's nodeup-driven re-injection, call start/2 directly
-    %% with the same SinkRef the sink would have used.
-    rpc(mim2(), log_error_collector, start, [[error], {cth_error_report_sink, node()}]),
+    %% Re-inject via the sink's public API -- this is the contract
+    %% that distributed_helper:start_node/2 uses after restarting
+    %% a real node.
+    cth_error_report_sink:inject(mim2()),
 
     %% Trigger another error after restart. Both `before_restart'
     %% and `after_restart' should appear in the report; the

--- a/big_tests/tests/cth_error_report_SUITE.erl
+++ b/big_tests/tests/cth_error_report_SUITE.erl
@@ -12,7 +12,8 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--import(distributed_helper, [rpc/4, mim/0, require_rpc_nodes/1]).
+-import(distributed_helper, [rpc/4, mim/0, mim2/0,
+                             require_rpc_nodes/1]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration
@@ -25,7 +26,8 @@ all() ->
     [{group, unlimited_patterns},
      {group, counted_patterns},
      {group, mixed_patterns},
-     {group, report_verification}].
+     {group, report_verification},
+     {group, multi_node}].
 
 groups() ->
     [{unlimited_patterns, [],
@@ -51,7 +53,12 @@ groups() ->
        no_patterns_all_unexpected]},
      {report_verification, [],
       [verify_report_files_created,
-       verify_unexpected_prefix_in_log]}].
+       verify_unexpected_prefix_in_log]},
+     {multi_node, [],
+      [errors_from_mim2_collected,
+       errors_from_multiple_nodes,
+       expect_pattern_covers_all_nodes,
+       errors_survive_handler_restart_on_mim2]}].
 
 %%--------------------------------------------------------------------
 %% Init & teardown
@@ -64,6 +71,19 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
+init_per_group(multi_node, Config) ->
+    try
+        #{node := Node2} = mim2(),
+        case net_kernel:connect_node(Node2) of
+            true ->
+                mongoose_helper:inject_module(mim2(), log_error_test_helper, no_reload),
+                Config;
+            _ ->
+                {skip, mim2_not_available}
+        end
+    catch _:_ ->
+        {skip, mim2_not_available}
+    end;
 init_per_group(_Group, Config) ->
     Config.
 
@@ -215,12 +235,60 @@ verify_unexpected_prefix_in_log(_Config) ->
     trigger_error(prefix_test_err, "check prefix in log").
 
 %%--------------------------------------------------------------------
+%% Multi-node tests
+%%--------------------------------------------------------------------
+
+errors_from_mim2_collected(_Config) ->
+    %% Trigger an error on mim2 -- it should appear in the report
+    %% as unexpected since we don't declare it expected
+    trigger_error_on(mim2(), err_on_mim2, "from mim2").
+
+errors_from_multiple_nodes(_Config) ->
+    %% Errors from both nodes should be collected
+    trigger_error(err_multi_mim1, "from mim1"),
+    trigger_error_on(mim2(), err_multi_mim2, "from mim2").
+
+expect_pattern_covers_all_nodes(_Config) ->
+    %% An expect declaration should match errors from any node
+    cth_error_report:expect({what, err_expected_any_node}),
+    trigger_error(err_expected_any_node, "from mim1"),
+    trigger_error_on(mim2(), err_expected_any_node, "from mim2").
+
+errors_survive_handler_restart_on_mim2(_Config) ->
+    %% Trigger an error on mim2 BEFORE simulated restart.
+    cth_error_report:expect({what, before_restart}),
+    cth_error_report:expect({what, after_restart}),
+    trigger_error_on(mim2(), before_restart, "pre"),
+
+    %% Simulate a node restart by removing and re-adding the
+    %% logger handler. Entries already in the runner-side sink
+    %% must remain after this round-trip.
+    rpc(mim2(), log_error_collector, stop, []),
+
+    %% While the handler is down, errors logged on mim2 are
+    %% expected to be lost. Trigger and forget.
+    trigger_error_on(mim2(), during_restart, "drop"),
+
+    %% Re-inject. We cheat slightly: instead of waiting for the
+    %% sink's nodeup-driven re-injection, call start/2 directly
+    %% with the same SinkRef the sink would have used.
+    rpc(mim2(), log_error_collector, start, [[error], {cth_error_report_sink, node()}]),
+
+    %% Trigger another error after restart. Both `before_restart'
+    %% and `after_restart' should appear in the report; the
+    %% `during_restart' one is expected to be missing.
+    trigger_error_on(mim2(), after_restart, "post").
+
+%%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
 
 trigger_error(What, Reason) ->
     rpc(mim(), log_error_test_helper, log_error,
         [What, Reason]).
+
+trigger_error_on(Node, What, Reason) ->
+    rpc(Node, log_error_test_helper, log_error, [What, Reason]).
 
 trigger_error_extra(What, Reason, Extra) ->
     rpc(mim(), log_error_test_helper, log_error,

--- a/big_tests/tests/cth_error_report_SUITE.erl
+++ b/big_tests/tests/cth_error_report_SUITE.erl
@@ -12,8 +12,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--import(distributed_helper, [rpc/4, mim/0, mim2/0,
-                             require_rpc_nodes/1]).
+-import(distributed_helper, [rpc/4, mim/0, mim2/0, require_rpc_nodes/1]).
 
 %%--------------------------------------------------------------------
 %% Suite configuration

--- a/big_tests/tests/log_error_collector.erl
+++ b/big_tests/tests/log_error_collector.erl
@@ -1,165 +1,45 @@
-%% @doc Logger handler injected into MIM nodes to collect error logs into ETS.
-%% This module is injected into MIM nodes by cth_error_report.
+%% @doc Logger handler injected into MIM nodes that pushes error log
+%% events to the test-runner-side `cth_error_report_sink'.
 %%
-%% Supports multiple named instances running simultaneously.
-%% The default instance uses the atom `log_error_collector' as the name.
-%% Each instance has its own ETS table, owner process, and logger handler.
-%%
-%% Stores structured log data for precise pattern matching:
-%% - {Timestamp, Level, Msg, Meta}
-%% - Msg is the original logger msg tuple: {report, Map} | {string, S} | {Format, Args}
-%% - Meta contains extracted metadata: #{mfa => {M, F, A}, ...}
+%% Stateless on the MIM node: no ETS, no owner process. Each error
+%% event becomes a message
+%%   {log_entry, node(), Level, Msg, Meta}
+%% sent to the sink with [noconnect, nosuspend], so a slow or
+%% disconnected runner cannot back-pressure logging.
 -module(log_error_collector).
 
--export([start/1, start/2, stop/0, stop/1,
-         get_errors/0, get_errors/1,
-         get_errors_after/1, get_errors_after/2,
-         clear/0, clear/1, timestamp/0]).
--export([adding_handler/1, removing_handler/1, log/2]).  %% Logger callbacks
--export([table_owner_loop/0]).  %% Internal - for spawned process
+-export([start/2, stop/0]).
+%% Logger callbacks
+-export([adding_handler/1, removing_handler/1, log/2]).
 
--define(DEFAULT_NAME, ?MODULE).
+-define(HANDLER_ID, cth_error_report_handler).
 
-%% Stored entry: {Timestamp, Level, Msg, Meta}
-%% - Msg: {report, #{what => atom(), ...}} | {string, binary()} | {Format, Args}
-%% - Meta: #{mfa => {Module, Function, Arity}} | #{}
--type log_entry() :: {integer(), atom(), msg(), meta()}.
--type msg() :: {report, map()} | {string, binary() | string()} | {list(), list()} | term().
--type meta() :: #{mfa => mfa(), atom() => term()}.
--type instance_name() :: atom().
+-type sink_ref() :: {RegName :: atom(), Node :: node()}.
+-type level() :: atom().
+-type msg() :: {report, map()} | {string, binary() | string()}
+             | {list(), list()} | term().
+-type meta() :: #{atom() => term()}.
 
--export_type([log_entry/0, msg/0, meta/0, instance_name/0]).
+-export_type([sink_ref/0, level/0, msg/0, meta/0]).
 
-%% API - default instance
+%% API
 
-%% @doc Start collecting errors with the default instance name.
--spec start([atom()]) -> ok | {error, term()}.
-start(Levels) ->
-    start(?DEFAULT_NAME, Levels).
+%% @doc Add the logger handler that forwards `Levels'-level events
+%% to `SinkRef' (a `{RegisteredName, Node}' tuple). Idempotent.
+-spec start([level()], sink_ref()) -> ok | {error, term()}.
+start(Levels, SinkRef) ->
+    case logger:get_handler_config(?HANDLER_ID) of
+        {ok, _} -> ok;
+        {error, _} ->
+            logger:add_handler(?HANDLER_ID, ?MODULE,
+                               #{config => #{levels => Levels, sink => SinkRef}})
+    end.
 
-%% @doc Stop the default instance.
--spec stop() -> ok | {error, term()}.
+%% @doc Remove the logger handler. Idempotent.
+-spec stop() -> ok.
 stop() ->
-    stop(?DEFAULT_NAME).
-
-%% @doc Get errors from the default instance.
--spec get_errors() -> [log_entry()].
-get_errors() ->
-    get_errors(?DEFAULT_NAME).
-
-%% @doc Clear the default instance.
--spec clear() -> true | ok.
-clear() ->
-    clear(?DEFAULT_NAME).
-
-%% API - named instances
-
-%% @doc Start collecting errors with a given instance name. Idempotent.
--spec start(instance_name(), [atom()]) -> ok | {error, term()}.
-start(Name, Levels) ->
-    OwnerName = owner_name(Name),
-    case whereis(OwnerName) of
-        undefined ->
-            do_start(Name, Levels);
-        _Pid ->
-            ok
-    end.
-
-%% @doc Stop the named instance. Idempotent.
--spec stop(instance_name()) -> ok | {error, term()}.
-stop(Name) ->
-    OwnerName = owner_name(Name),
-    HandlerId = handler_id(Name),
-    case whereis(OwnerName) of
-        undefined ->
-            ok;
-        Pid ->
-            _ = logger:remove_handler(HandlerId),
-            Pid ! stop,
-            ok
-    end.
-
-%% @doc Get errors from the named instance.
--spec get_errors(instance_name()) -> [log_entry()].
-get_errors(Name) ->
-    TableName = table_name(Name),
-    case ets:whereis(TableName) of
-        undefined -> [];
-        _Tid -> ets:tab2list(TableName)
-    end.
-
-%% @doc Clear the named instance.
--spec clear(instance_name()) -> true | ok.
-clear(Name) ->
-    TableName = table_name(Name),
-    case ets:whereis(TableName) of
-        undefined -> ok;
-        _Tid -> ets:delete_all_objects(TableName)
-    end.
-
-%% @doc Get errors with timestamp strictly greater than After (default instance).
--spec get_errors_after(integer()) -> [log_entry()].
-get_errors_after(After) ->
-    get_errors_after(?DEFAULT_NAME, After).
-
-%% @doc Get errors with timestamp strictly greater than After (named instance).
--spec get_errors_after(instance_name(), integer()) -> [log_entry()].
-get_errors_after(Name, After) ->
-    TableName = table_name(Name),
-    case ets:whereis(TableName) of
-        undefined ->
-            [];
-        _Tid ->
-            MatchSpec = [{{'$1', '$2', '$3', '$4'},
-                          [{'>', '$1', {const, After}}],
-                          ['$_']}],
-            ets:select(TableName, MatchSpec)
-    end.
-
--spec timestamp() -> integer().
-timestamp() ->
-    erlang:monotonic_time().
-
-%% Internal - starting
-
-do_start(Name, Levels) ->
-    OwnerName = owner_name(Name),
-    TableName = table_name(Name),
-    HandlerId = handler_id(Name),
-    Owner = spawn(?MODULE, table_owner_loop, []),
-    try register(OwnerName, Owner) of
-        true ->
-            Owner ! {create_table, TableName, self()},
-            receive
-                table_created -> ok
-            after 5000 ->
-                error(table_creation_timeout)
-            end,
-            HandlerConfig = #{config => #{levels => Levels, table => TableName}},
-            logger:add_handler(HandlerId, ?MODULE, HandlerConfig)
-    catch
-        error:badarg ->
-            Owner ! stop,
-            ok
-    end.
-
-%% Table owner process - keeps the ETS table alive
-table_owner_loop() ->
-    receive
-        {create_table, TableName, Caller} ->
-            ets:new(TableName, [named_table, public, ordered_set]),
-            Caller ! table_created,
-            table_owner_loop(TableName);
-        stop ->
-            ok
-    end.
-
-table_owner_loop(TableName) ->
-    receive
-        stop ->
-            ets:delete(TableName),
-            ok
-    end.
+    _ = logger:remove_handler(?HANDLER_ID),
+    ok.
 
 %% Logger callbacks
 
@@ -170,42 +50,17 @@ removing_handler(_Config) ->
     ok.
 
 log(#{level := Level, msg := Msg, meta := LogMeta},
-    #{config := #{levels := Levels, table := Table}}) ->
+    #{config := #{levels := Levels, sink := SinkRef}}) ->
     case lists:member(Level, Levels) of
         true ->
             Meta = extract_meta(LogMeta),
-            ets:insert(Table, {erlang:monotonic_time(), Level, Msg, Meta});
-        false ->
-            ok
-    end;
-log(#{level := Level, msg := Msg},
-    #{config := #{levels := Levels, table := Table}}) ->
-    case lists:member(Level, Levels) of
-        true ->
-            ets:insert(Table, {erlang:monotonic_time(), Level, Msg, #{}});
+            erlang:send(SinkRef, {log_entry, node(), Level, Msg, Meta}, [noconnect, nosuspend]),
+            ok;
         false ->
             ok
     end.
 
-%% Name derivation
-
--spec table_name(instance_name()) -> atom().
-table_name(Name) ->
-    to_atom(Name, "_table").
-
--spec owner_name(instance_name()) -> atom().
-owner_name(Name) ->
-    to_atom(Name, "_owner").
-
--spec handler_id(instance_name()) -> atom().
-handler_id(Name) ->
-    to_atom(Name, "_handler").
-
--spec to_atom(atom(), string()) -> atom().
-to_atom(Name, Suffix) ->
-    list_to_atom(atom_to_list(Name) ++ Suffix).
-
-%% Internal functions
+%% Internal
 
 -spec extract_meta(map()) -> meta().
 extract_meta(LogMeta) ->

--- a/big_tests/tests/log_error_collector.erl
+++ b/big_tests/tests/log_error_collector.erl
@@ -1,12 +1,13 @@
-%% @doc Logger handler injected into MIM nodes that pushes error log
-%% events to the test-runner-side `cth_error_report_sink'.
-%%
-%% Stateless on the MIM node: no ETS, no owner process. Each error
-%% event becomes a message
-%%   {log_entry, node(), Level, Msg, Meta}
-%% sent to the sink with [noconnect, nosuspend], so a slow or
-%% disconnected runner cannot back-pressure logging.
 -module(log_error_collector).
+-moduledoc """
+Logger handler injected into MIM nodes that pushes error log events
+to the test-runner-side `cth_error_report_sink`.
+
+Stateless on the MIM node: no ETS, no owner process. Each error event
+becomes a message `{log_entry, node(), Level, Msg, Meta}` sent to the
+sink with `[noconnect, nosuspend]`, so a slow or disconnected runner
+cannot back-pressure logging.
+""".
 
 -export([start/2, stop/0]).
 %% Logger callbacks
@@ -24,8 +25,11 @@
 
 %% API
 
-%% @doc Add the logger handler that forwards `Levels'-level events
-%% to `SinkRef' (a `{RegisteredName, Node}' tuple). Idempotent.
+-doc """
+Adds the logger handler that forwards events of the given levels to
+the sink. The sink reference is a `{RegisteredName, Node}` tuple.
+Idempotent.
+""".
 -spec start([level()], sink_ref()) -> ok | {error, term()}.
 start(Levels, SinkRef) ->
     case logger:get_handler_config(?HANDLER_ID) of
@@ -35,7 +39,7 @@ start(Levels, SinkRef) ->
                                #{config => #{levels => Levels, sink => SinkRef}})
     end.
 
-%% @doc Remove the logger handler. Idempotent.
+-doc "Removes the logger handler. Idempotent.".
 -spec stop() -> ok.
 stop() ->
     _ = logger:remove_handler(?HANDLER_ID),

--- a/doc/developers-guide/Error-log-tracking.md
+++ b/doc/developers-guide/Error-log-tracking.md
@@ -185,21 +185,23 @@ The hook collects errors from all reachable MongooseIM nodes
   `{log_entry, Node, Level, Msg, Meta}` Erlang message to the sink
   using `[noconnect, nosuspend]` (a slow or disconnected runner
   cannot back-pressure logging).
-- The sink calls `net_kernel:monitor_nodes(true)` and re-injects the
-  handler automatically when a watched node comes back up
-  (`nodeup`). Accumulated entries on the sink are unaffected by node
-  restarts -- only the brief window between a node's death and the
-  re-injection of the handler loses error entries.
+- After a MIM node restart, the restart caller is responsible for
+  re-injecting the handler. `distributed_helper:start_node/2` does
+  this automatically by calling `cth_error_report_sink:inject/1`.
+  Accumulated entries on the runner-side sink are unaffected by
+  node restarts -- only entries logged in the brief window between
+  the node coming up and `inject/1` returning are missed.
 
 Each error entry includes the originating node (in the `meta` map),
 so reports show which node logged each error. Expected error
 patterns apply to all nodes -- a single `expect` declaration matches
 errors regardless of which node produced them.
 
-**Limitation:** errors logged during the brief boot window between a
-MIM node's restart and re-injection of the logger handler may be
-lost. This window is on the order of seconds, not the rest of the
-suite.
+**Limitation:** if a MIM node is restarted by a path that does not go
+through `distributed_helper:start_node/2` (e.g. an external script,
+or a future custom helper), error collection on that node will not
+resume until something calls `cth_error_report_sink:inject/1`
+explicitly. Plan-fully restarted nodes are fine.
 
 ## Parallel groups
 

--- a/doc/developers-guide/Error-log-tracking.md
+++ b/doc/developers-guide/Error-log-tracking.md
@@ -172,6 +172,35 @@ my_SUITE: 8 unexpected errors logged, max allowed: 5
 
 Suites without `max_unexpected_errors_logged` are not checked.
 
+## Multi-node collection
+
+The hook collects errors from all reachable MongooseIM nodes
+(`mim`, `mim2`, `mim3`, `fed`, `reg`) using a push-mode design:
+
+- A single **sink** (`cth_error_report_sink`, a gen_server) runs on
+  the test runner. It owns one ETS table that holds every error
+  entry from every node, keyed by a global monotonic sequence.
+- A **logger handler** (`log_error_collector`) is injected on each
+  reachable MIM node. For every error-level event it sends a
+  `{log_entry, Node, Level, Msg, Meta}` Erlang message to the sink
+  using `[noconnect, nosuspend]` (a slow or disconnected runner
+  cannot back-pressure logging).
+- The sink calls `net_kernel:monitor_nodes(true)` and re-injects the
+  handler automatically when a watched node comes back up
+  (`nodeup`). Accumulated entries on the sink are unaffected by node
+  restarts -- only the brief window between a node's death and the
+  re-injection of the handler loses error entries.
+
+Each error entry includes the originating node (in the `meta` map),
+so reports show which node logged each error. Expected error
+patterns apply to all nodes -- a single `expect` declaration matches
+errors regardless of which node produced them.
+
+**Limitation:** errors logged during the brief boot window between a
+MIM node's restart and re-injection of the logger handler may be
+lost. This window is on the order of seconds, not the rest of the
+suite.
+
 ## Parallel groups
 
 For parallel test groups, per-testcase error tracking is not possible because

--- a/test/common/distributed_helper.erl
+++ b/test/common/distributed_helper.erl
@@ -194,7 +194,15 @@ get_or_fail(Key) ->
 
 start_node(Node, Config) ->
     {_, 0} = mongooseimctl_helper:mongooseimctl(Node, "start", [], Config),
-    timer:sleep(3000).
+    timer:sleep(3000),
+    %% Re-attach the error log collector if the sink is running
+    %% (big_tests context). In other contexts the sink is absent and
+    %% this is a no-op.
+    case erlang:whereis(cth_error_report_sink) of
+        undefined -> ok;
+        _ -> cth_error_report_sink:inject(Node)
+    end,
+    ok.
 
 stop_node(Node, Config) ->
     {_, 0} = mongooseim_script(Node, "stop", [], Config).


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                        
                                                            
  Replaces the per-MIM-node ETS-based error log collection with a runner-side sink that receives error events pushed from MIM nodes via Erlang messaging. Fixes the central correctness issue with the previous design: when a MIM node restarted, the ETS table holding its        
  collected errors went with it.
                                                                                                                                                                                                                                                                                    
  ## Why                                                    

  The previous attempt at MIM-2681 (now absorbed by this branch) injected `log_error_collector` on each reachable MIM node and *pulled* errors via RPC at every CT section boundary. The collector kept a per-node ETS table; if the node restarted mid-suite, all collected errors 
  for that suite were lost. This branch moves the source of truth to the test runner.
                                                                                                                                                                                                                                                                                    
  ## Architecture                                           

  Three modules, push-mode:                                                                                                                                                                                                                                                         
   
  - **`cth_error_report_sink`** *(new, on the test runner)* — a gen_server owning one ETS table keyed by a global monotonic sequence. Receives `{log_entry, Node, Level, Msg, Meta}` messages from injected handlers on all MIM nodes.                                              
  - **`log_error_collector`** *(rewritten)* — a stateless OTP `logger` handler injected on each MIM node. On each error event, calls `erlang:send/3` with `[noconnect, nosuspend]` to the runner-side sink — never blocks the logger, never auto-connects.
  - **`cth_error_report`** *(rewired)* — the CT hook now starts/stops the sink in `init/2`/`terminate/1` and reads from the sink at each section boundary instead of doing per-node RPC fan-out.                                                                                    
                                                                                                                                                                                                                                                                                    
  **Restart contract:** re-injection is the responsibility of the utility that brought the node back. `distributed_helper:start_node/2` now calls `cth_error_report_sink:inject/1` after the node is up. The sink does not subscribe to `nodeup` itself — log collection should not 
  be in the business of distribution-layer concerns.                                                                                                                                                                                                                                
                                                            
  ## Public API                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                    
  - `cth_error_report:expect/1,2` and `max_unexpected_errors_logged/1` — **unchanged**.
  - New: `cth_error_report_sink` exports `start_link/0`, `stop/0`, `mark/0`, `get_after/1`, `clear/0`, `watch_nodes/2`, `inject/1`, `unwatch/0`.                                                                                                                                    
                                                                                                                                                                                                                                                                                    
  ## Empirical validation
                                                                                                                                                                                                                                                                                    
  A full test run collected **217 errors from non-mim1 nodes** across 7 suites — primarily `mod_global_distrib_SUITE` (126 from `reg1@localhost` / `mongooseim2@localhost`) and `service_domain_db_SUITE` (81). The new `errors_survive_handler_restart_on_mim2` test 
  case demonstrates the correctness claim end-to-end.                                                                                                                                                                                                                               
                                                            
  ## Limitations                                                                                                                                                                                                                                                                    
                                                            
  Errors logged on a MIM node during the brief boot window between restart and re-injection of the handler are lost. If a node is restarted by a path that does not go through `distributed_helper:start_node/2` (e.g. an external script), error collection on that node will not 
  resume until something calls `cth_error_report_sink:inject/1` explicitly. Documented in `doc/developers-guide/Error-log-tracking.md`.                                                                                                                                             
   
  ## Files                                                                                                                                                                                                                                                                          
                                                            
  | File | Change |
  |---|---|
  | `big_tests/src/cth_error_report.erl` | Hook rewired to drive the sink |
  | `big_tests/src/cth_error_report_sink.erl` | **New** — runner-side sink gen_server |                                                                                                                                                                                             
  | `big_tests/tests/log_error_collector.erl` | Rewritten as a stateless push-mode handler |
  | `big_tests/tests/cth_error_report_SUITE.erl` | New `multi_node` group + restart-resilience test |                                                                                                                                                                               
  | `test/common/distributed_helper.erl` | `start_node/2` re-injects the handler post-start |                                                                                                                                                                                       
  | `doc/developers-guide/Error-log-tracking.md` | Multi-node section reflects the new design |                                                                                                                                                                                     
