### PR TITLE
MIM-2548 Better script portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ EBIN = ebin
 DEVNODES = mim1 mim2 mim3 fed1 reg1
 REBAR=./rebar3
 
+ifndef MAKE_VERSION
+$(error GNU Make is required. Use gmake on BSD systems.)
+endif
+
 # Top-level targets aka user interface
 
 all: rel
@@ -56,7 +60,7 @@ $(DEVNODES): certs configure.out rel/vars-toml.config
 maybe_clean_certs:
 	if [ "$$SKIP_CERT_BUILD" != 1 ]; then \
 		if ! openssl x509 -checkend 36000 -noout -in tools/ssl/ca/cacert.pem ; then \
-			cd tools/ssl && make clean_certs; \
+			$(MAKE) -C tools/ssl clean_certs; \
 		fi \
 	fi
 
@@ -64,7 +68,7 @@ certs: maybe_clean_certs
 	if [ "$$SKIP_CERT_BUILD" = 1 ]; then \
 		echo "Skip cert build"; \
 	else \
-		cd tools/ssl && make; \
+		$(MAKE) -C tools/ssl; \
 	fi
 
 xeplist:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 .PHONY: rel docs
 
+# GNU Make is required. Use gmake on BSD systems.
+
 RUN=./tools/silent_exec.sh "$@.log"
 XEP_TOOL = tools/xep_tool
 EBIN = ebin
 DEVNODES = mim1 mim2 mim3 fed1 reg1
 REBAR=./rebar3
-
-ifndef MAKE_VERSION
-$(error GNU Make is required. Use gmake on BSD systems.)
-endif
 
 # Top-level targets aka user interface
 

--- a/big_tests/Makefile
+++ b/big_tests/Makefile
@@ -1,10 +1,6 @@
 .PHONY: all test console compile
 all: test
 
-ifndef MAKE_VERSION
-$(error This target requires GNU Make. On BSD, run it with gmake.)
-endif
-
 # user overridable
 TESTSPEC ?= default.spec
 PRESET   ?= all

--- a/big_tests/Makefile
+++ b/big_tests/Makefile
@@ -1,6 +1,10 @@
 .PHONY: all test console compile
 all: test
 
+ifndef MAKE_VERSION
+$(error This target requires GNU Make. On BSD, run it with gmake.)
+endif
+
 # user overridable
 TESTSPEC ?= default.spec
 PRESET   ?= all

--- a/big_tests/tests/graphql_SUITE_data/sign_cert.sh
+++ b/big_tests/tests/graphql_SUITE_data/sign_cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function invalid_usage()
 {

--- a/big_tests/tests/mongooseimctl_SUITE_data/test_file_upload.sh
+++ b/big_tests/tests/mongooseimctl_SUITE_data/test_file_upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 content_type="$1"
 

--- a/big_tests/tests/sasl_external_SUITE_data/sign_cert.sh
+++ b/big_tests/tests/sasl_external_SUITE_data/sign_cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function invalid_usage()
 {

--- a/doc/developers-guide/Testing-MongooseIM.md
+++ b/doc/developers-guide/Testing-MongooseIM.md
@@ -335,7 +335,7 @@ big_tests/ct_report/ct_run.[gobbledygook][datetime]/
 Each run is saved into a new directory. This snippet:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 
 lst=$(ls -rt ct_report | grep ct_run | tail -n 1)
 rm ct_report/lastrun

--- a/rel/files/mongooseim
+++ b/rel/files/mongooseim
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- tab-width:4;indent-tabs-mode:nil -*-
 # ex: ts=4 sw=4 et
 

--- a/rel/files/mongooseimctl
+++ b/rel/files/mongooseimctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RUNNER_SCRIPT_DIR={{{mongooseim_script_dir}}}
 RUNNER_BASE_DIR="${RUNNER_SCRIPT_DIR%/*}"
@@ -20,7 +20,7 @@ function preserved_variables
 # Make sure this script is running as the appropriate user
 if [ ! -z "$RUNNER_USER" ] && [ `whoami` != "$RUNNER_USER" ]; then
     # Preserve some env variables
-    exec runuser -s /bin/bash -l "$RUNNER_USER" -c "$(preserved_variables) $0 $*"
+    exec runuser -s "$(command -v bash)" -l "$RUNNER_USER" -c "$(preserved_variables) $0 $*"
 fi
 
 MIM_DIR="${RUNNER_SCRIPT_DIR%/*}"

--- a/tools/build-docker-from-remote.sh
+++ b/tools/build-docker-from-remote.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/build-tests.sh
+++ b/tools/build-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Env variables:
 # BUILD_TESTS - disable the script

--- a/tools/circle-build-and-push-docker.sh
+++ b/tools/circle-build-and-push-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 SRC_ROOT="$(dirname "${BASH_SOURCE}")"

--- a/tools/circle-upload-codecov.sh
+++ b/tools/circle-upload-codecov.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eo pipefail
 

--- a/tools/circleci-prepare-mongooseim-docker.sh
+++ b/tools/circleci-prepare-mongooseim-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 # master from 2026-01-13

--- a/tools/circleci-upload-to-s3.sh
+++ b/tools/circleci-upload-to-s3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source tools/helpers.sh
 

--- a/tools/common-vars.sh
+++ b/tools/common-vars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TOOLS=`dirname $0`
 

--- a/tools/db_configs/cassandra/docker_entry.sh
+++ b/tools/db_configs/cassandra/docker_entry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 password=fake_server

--- a/tools/docker-setup-cockroachdb.sh
+++ b/tools/docker-setup-cockroachdb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 certs_dir="certs"
 lifetime="--lifetime=10h"

--- a/tools/docker-setup-mysql.sh
+++ b/tools/docker-setup-mysql.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MYSQLDIR=/var/lib/mysql
 

--- a/tools/docker-setup-postgres.sh
+++ b/tools/docker-setup-postgres.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Preparing SSL certificates
 cp ${SQL_TEMP_DIR}/fake_cert.pem ${PGDATA}/.

--- a/tools/extract_translations/prepare-translation.sh
+++ b/tools/extract_translations/prepare-translation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Frontend for ejabberd's extract_translations.erl
 # by Badlop

--- a/tools/gh-actions-configure-preset.sh
+++ b/tools/gh-actions-configure-preset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##########################################################################################################
 ## for testing purposes run:
 ##    GITHUB_ENV=/dev/tty tools/gh-actions-configure-preset.sh internal_mnesia TESTSPEC=default.spec

--- a/tools/gh-upload-to-s3.sh
+++ b/tools/gh-upload-to-s3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 dir="$1"
 

--- a/tools/prepare-log-dir.sh
+++ b/tools/prepare-log-dir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source tools/helpers.sh
 

--- a/tools/redis
+++ b/tools/redis
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# != 1 ] || ([ $1 != "start" ] && [ $1 != "stop" ])
 then

--- a/tools/secure-erase.sh
+++ b/tools/secure-erase.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Securely erases file contents under a path given by argument.
 
 set -eu

--- a/tools/setup_minio.sh
+++ b/tools/setup_minio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # cd to repo
 cd "$(dirname "$0")/../"

--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -1,3 +1,7 @@
+ifndef MAKE_VERSION
+$(error This target requires GNU Make. On BSD, run it with gmake.)
+endif
+
 all: mongooseim/cert.pem mongooseim/key.pem \
   mongooseim/server.pem mongooseim/dh_server.pem \
   mongooseim/pubkey.pem mongooseim/privkey.pem \

--- a/tools/ssl/Makefile
+++ b/tools/ssl/Makefile
@@ -1,7 +1,3 @@
-ifndef MAKE_VERSION
-$(error This target requires GNU Make. On BSD, run it with gmake.)
-endif
-
 all: mongooseim/cert.pem mongooseim/key.pem \
   mongooseim/server.pem mongooseim/dh_server.pem \
   mongooseim/pubkey.pem mongooseim/privkey.pem \


### PR DESCRIPTION
This PR:

- Replaces `#!/bin/bash` with `#!/usr/bin/env bash` where relevant in scripts. This improves portability in case the OS does not keep BASH executable in `/bin`.
- Improves main `Makefile` so it is possible to build MongooseIM on OS that uses non-GNU make by default, e.g. FreeBSD.

This PR **does not** ensure compatibility with BSD family. There is no new image in CI matrix used, no docs update for BSD, big tests won't build by default. It is possible to build and start MIM on FreeBSD 15 - I've verified it manually.