### PR TITLE
MIM-2697 Deprecate `mod_muc_log`

### DIFF
--- a/doc/configuration/Modules.md
+++ b/doc/configuration/Modules.md
@@ -138,6 +138,7 @@ It is tightly coupled with user presence in chat rooms.
 
 ### [mod_muc_log](../modules/mod_muc_log.md)
 Implements a logging subsystem for [mod_muc](../modules/mod_muc.md).
+Deprecated: this module will be removed in the next release.
 
 ### [mod_muc_light](../modules/mod_muc_light.md)
 Implements [XEP Multi-User Chat Light](https://xmpp.org/extensions/inbox/muc-light.html).

--- a/doc/migrations/6.6.0_6.x.x.md
+++ b/doc/migrations/6.6.0_6.x.x.md
@@ -1,3 +1,12 @@
+## Removal and deprecation
+
+The following features are removed or deprecated.
+
+### Deprecation of `mod_muc_log`
+
+`mod_muc_log` module is deprecated and will be removed in the next release.
+If you rely on room history and retrieval, consider migrating to `mod_mam`.
+
 ## Configuration options
 
 We have changed or removed some configuration options.

--- a/doc/modules/mod_muc.md
+++ b/doc/modules/mod_muc.md
@@ -6,6 +6,9 @@ This extension consists of two Erlang modules: `mod_muc` and `mod_muc_room`, the
 Note that only `mod_muc` needs to be enabled in the configuration file.
 Also `mod_muc_log` is a logging submodule.
 
+!!! Warning
+    `mod_muc_log` is deprecated and will be removed in the next release.
+
 ## Options
 
 ### `modules.mod_muc.host`
@@ -360,6 +363,9 @@ Available room configuration options to be overridden in the initial state:
 
     Enables logging of room events (messages, presences) to a file on the disk.
     Uses `mod_muc_log`.
+
+    !!! Warning
+        `mod_muc_log` is deprecated and will be removed in the next release.
 
 * `modules.mod_muc.default_room.maygetmemberlist` 
     * **Syntax:** array of non-empty strings

--- a/doc/modules/mod_muc_log.md
+++ b/doc/modules/mod_muc_log.md
@@ -1,3 +1,7 @@
+## Deprecation Notice
+
+This module is deprecated and will be removed in the next release.
+
 ## Module Description
 A logging submodule for [mod_muc](mod_muc.md). 
 Is must be explicitly configured to work. 

--- a/src/muc/mod_muc_log.erl
+++ b/src/muc/mod_muc_log.erl
@@ -208,6 +208,11 @@ set_room_occupants(HostType, RoomPID, RoomJID, Occupants) ->
 %%--------------------------------------------------------------------
 -spec init({HostType :: mongooseim:host_type(), map()}) -> {ok, logstate()}.
 init({HostType, Opts}) ->
+    Text = <<"mod_muc_log is deprecated and will be removed in the next release.">>,
+    mongoose_deprecations:log(
+        {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY},
+        #{what => mod_muc_log_deprecated, text => Text, host_type => HostType},
+        [{log_level, warning}]),
     #{
         access_log := AccessLog,
         css_file := CSSFile,


### PR DESCRIPTION
This pull request deprecates the `mod_muc_log` module, which provides logging for multi-user chat rooms, and prepares for its removal in the next release.

⚓ MIM-1189 & MIM-2697