### PR TITLE
MIM-2699 Fix undefined host type in acc

### DIFF
--- a/big_tests/tests/local_iq_SUITE.erl
+++ b/big_tests/tests/local_iq_SUITE.erl
@@ -84,6 +84,7 @@ process_iq_timeout(Config) ->
 route_iq(Alice, Timeout) ->
     Jid = escalus_client:full_jid(Alice),
     Server = escalus_client:server(Alice),
+    {ok, HostType} = rpc(mim(), mongoose_domain_api, get_host_type, [Server]),
     To = jid:from_binary(Jid),
     From = jid:from_binary(Server),
     Query = #xmlel{name = <<"query">>,
@@ -93,7 +94,7 @@ route_iq(Alice, Timeout) ->
                            <<"from">> => Server, <<"to">> => Jid},
                  children = [Query]},
     Acc = rpc(mim(), mongoose_acc, new,
-              [#{location => #{}, lserver => Server, element => Xml}]),
+              [#{location => #{}, lserver => Server, host_type => HostType, element => Xml}]),
     IQ = rpc(mim(), jlib, iq_query_info, [Xml]),
     Self = self(),
     Callback = fun(CbFrom, CbTo, CbAcc, CbIQ) ->

--- a/big_tests/tests/vcard_SUITE.erl
+++ b/big_tests/tests/vcard_SUITE.erl
@@ -1119,7 +1119,8 @@ get_jid_record(JID) ->
     jid:make_bare(User, Server).
 
 vcard_rpc(JID, Stanza) ->
-    Acc = rpc(mim(), mongoose_acc, new, [JID, JID, Stanza, ?LOCATION]),
+    {ok, HostType} = rpc(mim(), mongoose_domain_api, get_host_type, [jid:lserver(JID)]),
+    Acc = rpc(mim(), mongoose_acc, new, [HostType, JID, JID, Stanza, ?LOCATION]),
     Res = rpc(mim(), mongoose_router, route, [Acc]),
     case Res of
         #{stanza := #{type := <<"set">>}} ->

--- a/src/component/mongoose_component_connection.erl
+++ b/src/component/mongoose_component_connection.erl
@@ -434,6 +434,58 @@ host_type_from_subdomain_parent(#component_data{lserver = Prefix, is_subdomain =
 host_type_from_subdomain_parent(_, _) ->
     {error, not_found}.
 
+%% Resolve the host_type for a stanza originated by an external component.
+%% Component's #component_data.lserver does not directly map to a host type:
+%%  * for is_subdomain = true, lserver is just the configured prefix (e.g. <<"muc">>),
+%%    not a fully qualified subdomain;
+%%  * for is_subdomain = false, lserver is the component's own hostname which is
+%%    typically not a registered XMPP domain.
+%% Try, in order: (1) parent of FromJID for prefix subdomains,
+%% (2) FromJID's domain when check_from is disabled, (3) ToJID's domain,
+%% (4) fall back to a configured static domain or any configured host type.
+-spec component_host_type(data(), jid:jid(), jid:jid()) -> mongooseim:host_type().
+component_host_type(StateData, FromJid, ToJid) ->
+    Steps = [fun() -> host_type_from_subdomain_parent(StateData, FromJid) end,
+             fun() -> host_type_from_jid_when_unchecked(StateData, FromJid) end,
+             fun() -> mongoose_domain_api:get_host_type(ToJid#jid.lserver) end],
+    case first_ok(Steps) of
+        {ok, HostType} ->
+            HostType;
+        error ->
+            %% Last-resort host type for stanzas from components routed over S2S (or any
+            %% other case where neither From nor To resolves to a known host type).
+            hd(?ALL_HOST_TYPES)
+    end.
+
+-spec first_ok([fun(() -> {ok, term()} | {error, term()})]) -> {ok, term()} | error.
+first_ok([]) -> error;
+first_ok([F | Rest]) ->
+    case F() of
+        {ok, _} = Ok -> Ok;
+        _ -> first_ok(Rest)
+    end.
+
+-spec host_type_from_subdomain_parent(data(), jid:jid()) ->
+    {ok, mongooseim:host_type()} | {error, not_found}.
+host_type_from_subdomain_parent(#component_data{lserver = Prefix, is_subdomain = true},
+                                #jid{lserver = FromLServer}) ->
+    FullPrefix = <<Prefix/binary, ".">>,
+    case string:prefix(FromLServer, FullPrefix) of
+        nomatch -> {error, not_found};
+        <<>> -> {error, not_found};
+        Parent -> mongoose_domain_api:get_host_type(Parent)
+    end;
+host_type_from_subdomain_parent(_, _) ->
+    {error, not_found}.
+
+-spec host_type_from_jid_when_unchecked(data(), jid:jid()) ->
+    {ok, mongooseim:host_type()} | {error, not_found}.
+host_type_from_jid_when_unchecked(#component_data{listener_opts = #{check_from := false}},
+                                  #jid{lserver = FromLServer}) ->
+    mongoose_domain_api:get_host_type(FromLServer);
+host_type_from_jid_when_unchecked(_, _) ->
+    {error, not_found}.
+
 -spec stream_start_error(data(), exml:element()) -> fsm_res().
 stream_start_error(StateData, Error) ->
     ?LOG_DEBUG(#{what => stream_start_error, xml_error => Error, component_state => StateData}),

--- a/src/component/mongoose_component_connection.erl
+++ b/src/component/mongoose_component_connection.erl
@@ -434,58 +434,6 @@ host_type_from_subdomain_parent(#component_data{lserver = Prefix, is_subdomain =
 host_type_from_subdomain_parent(_, _) ->
     {error, not_found}.
 
-%% Resolve the host_type for a stanza originated by an external component.
-%% Component's #component_data.lserver does not directly map to a host type:
-%%  * for is_subdomain = true, lserver is just the configured prefix (e.g. <<"muc">>),
-%%    not a fully qualified subdomain;
-%%  * for is_subdomain = false, lserver is the component's own hostname which is
-%%    typically not a registered XMPP domain.
-%% Try, in order: (1) parent of FromJID for prefix subdomains,
-%% (2) FromJID's domain when check_from is disabled, (3) ToJID's domain,
-%% (4) fall back to a configured static domain or any configured host type.
--spec component_host_type(data(), jid:jid(), jid:jid()) -> mongooseim:host_type().
-component_host_type(StateData, FromJid, ToJid) ->
-    Steps = [fun() -> host_type_from_subdomain_parent(StateData, FromJid) end,
-             fun() -> host_type_from_jid_when_unchecked(StateData, FromJid) end,
-             fun() -> mongoose_domain_api:get_host_type(ToJid#jid.lserver) end],
-    case first_ok(Steps) of
-        {ok, HostType} ->
-            HostType;
-        error ->
-            %% Last-resort host type for stanzas from components routed over S2S (or any
-            %% other case where neither From nor To resolves to a known host type).
-            hd(?ALL_HOST_TYPES)
-    end.
-
--spec first_ok([fun(() -> {ok, term()} | {error, term()})]) -> {ok, term()} | error.
-first_ok([]) -> error;
-first_ok([F | Rest]) ->
-    case F() of
-        {ok, _} = Ok -> Ok;
-        _ -> first_ok(Rest)
-    end.
-
--spec host_type_from_subdomain_parent(data(), jid:jid()) ->
-    {ok, mongooseim:host_type()} | {error, not_found}.
-host_type_from_subdomain_parent(#component_data{lserver = Prefix, is_subdomain = true},
-                                #jid{lserver = FromLServer}) ->
-    FullPrefix = <<Prefix/binary, ".">>,
-    case string:prefix(FromLServer, FullPrefix) of
-        nomatch -> {error, not_found};
-        <<>> -> {error, not_found};
-        Parent -> mongoose_domain_api:get_host_type(Parent)
-    end;
-host_type_from_subdomain_parent(_, _) ->
-    {error, not_found}.
-
--spec host_type_from_jid_when_unchecked(data(), jid:jid()) ->
-    {ok, mongooseim:host_type()} | {error, not_found}.
-host_type_from_jid_when_unchecked(#component_data{listener_opts = #{check_from := false}},
-                                  #jid{lserver = FromLServer}) ->
-    mongoose_domain_api:get_host_type(FromLServer);
-host_type_from_jid_when_unchecked(_, _) ->
-    {error, not_found}.
-
 -spec stream_start_error(data(), exml:element()) -> fsm_res().
 stream_start_error(StateData, Error) ->
     ?LOG_DEBUG(#{what => stream_start_error, xml_error => Error, component_state => StateData}),

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -836,7 +836,7 @@ can_access_room(HostType, Acc, Room, User) ->
       NewAcc :: mongoose_acc:t().
 acc_room_affiliations(Acc, Room) ->
     Params = #{room => Room},
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     run_hook_for_host_type(acc_room_affiliations, HostType, Acc, Params).
 
 -spec room_exists(HostType, Room) -> Result when
@@ -855,7 +855,7 @@ room_exists(HostType, Room) ->
       NewAcc :: mongoose_acc:t().
 room_new_affiliations(Acc, Room, NewAffs, Version) ->
     Params = #{room => Room, new_affs => NewAffs, version => Version},
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     run_hook_for_host_type(room_new_affiliations, HostType, Acc, Params).
 
 %% MAM related hooks

--- a/src/mam/mod_mam_pm.erl
+++ b/src/mam/mod_mam_pm.erl
@@ -287,15 +287,6 @@ lserver_to_host_type(LServer) ->
             error({get_domain_host_type_failed, LServer})
     end.
 
--spec acc_to_host_type(mongoose_acc:t()) -> host_type().
-acc_to_host_type(Acc) ->
-    case mongoose_acc:host_type(Acc) of
-        undefined ->
-            lserver_to_host_type(mongoose_acc:lserver(Acc));
-        HostType ->
-            HostType
-    end.
-
 -spec is_action_allowed(HostType :: host_type(),
                         Action :: mam_iq:action(), From :: jid:jid(),
                         To :: jid:jid()) -> boolean().
@@ -334,7 +325,7 @@ handle_set_prefs(ArcJID=#jid{}, IQ=#iq{sub_el = PrefsEl}, Acc) ->
     {DefaultMode, AlwaysJIDs, NeverJIDs} = mod_mam_utils:parse_prefs(PrefsEl),
     ?LOG_DEBUG(#{what => mam_set_prefs, default_mode => DefaultMode,
                  always_jids => AlwaysJIDs, never_jids => NeverJIDs, iq => IQ}),
-    HostType = acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     ArcID = archive_id_int(HostType, ArcJID),
     Res = set_prefs(HostType, ArcID, ArcJID, DefaultMode, AlwaysJIDs, NeverJIDs),
     handle_set_prefs_result(Res, DefaultMode, AlwaysJIDs, NeverJIDs, IQ).
@@ -350,7 +341,7 @@ handle_set_prefs_result({error, Reason},
 -spec handle_get_prefs(jid:jid(), IQ :: jlib:iq(), Acc :: mongoose_acc:t()) ->
                               jlib:iq() | {error, term(), jlib:iq()}.
 handle_get_prefs(ArcJID=#jid{}, IQ=#iq{}, Acc) ->
-    HostType = acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     ArcID = archive_id_int(HostType, ArcJID),
     Res = get_prefs(HostType, ArcID, ArcJID, always),
     handle_get_prefs_result(Res, IQ).
@@ -368,7 +359,7 @@ handle_get_prefs_result({error, Reason}, IQ) ->
                               IQ :: jlib:iq(), Acc :: mongoose_acc:t()) ->
     jlib:iq() | ignore | {error, term(), jlib:iq()}.
 handle_set_message_form(#jid{} = From, #jid{} = ArcJID, #iq{} = IQ, Acc) ->
-    HostType = acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     ArcID = archive_id_int(HostType, ArcJID),
     try iq_to_lookup_params(HostType, IQ) of
         Params0 ->
@@ -439,13 +430,13 @@ send_message(SendModule, Row, ArcJID, From, Packet) ->
 -spec handle_get_message_form(jid:jid(), jid:jid(), jlib:iq(), mongoose_acc:t()) ->
                                      jlib:iq().
 handle_get_message_form(_From=#jid{}, _ArcJID=#jid{}, IQ=#iq{}, Acc) ->
-    HostType = acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     return_message_form_iq(HostType, IQ).
 
 -spec handle_get_metadata(jid:jid(), jlib:iq(), mongoose_acc:t()) ->
                                  jlib:iq() | {error, term(), jlib:iq()}.
 handle_get_metadata(ArcJID=#jid{}, IQ=#iq{}, Acc) ->
-    HostType = acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     ArcID = archive_id_int(HostType, ArcJID),
     case mod_mam_utils:lookup_first_and_last_messages(HostType, ArcID, ArcJID,
                                                       fun lookup_messages/2) of
@@ -472,7 +463,7 @@ amp_deliver_strategy([direct, none]) -> [direct, stored, none].
     {MaybeMessID :: binary() | undefined, Acc :: mongoose_acc:t()}.
 handle_package(Dir, ReturnMessID,
                LocJID = #jid{}, RemJID = #jid{}, SrcJID = #jid{}, Packet, Acc) ->
-    HostType = acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     MsgType = exml_query:attr(Packet, <<"type">>),
     case is_archivable_message(HostType, Dir, Packet)
          andalso should_archive_if_groupchat(HostType, MsgType)

--- a/src/mod_amp.erl
+++ b/src/mod_amp.erl
@@ -201,18 +201,19 @@ return_result(pass, _Event, Rules) ->
 
 -spec take_action_for_matched_rule(exml:element(), jid:jid(), amp_rule(), mongoose_acc:t()) ->
           pass | drop.
-take_action_for_matched_rule(Packet, From, #amp_rule{action = notify} = Rule, _Acc) ->
-    reply_to_sender(Rule, server_jid(From), From, Packet),
+take_action_for_matched_rule(Packet, From, #amp_rule{action = notify} = Rule, Acc) ->
+    reply_to_sender(Rule, server_jid(From), From, Packet, Acc),
     pass;
 take_action_for_matched_rule(Packet, From, #amp_rule{action = error} = Rule, Acc) ->
     send_error_and_drop(Packet, From, 'undefined-condition', Rule, Acc);
 take_action_for_matched_rule(_Packet, _From, #amp_rule{action = drop}, Acc) ->
     update_metric_and_drop(Acc).
 
--spec reply_to_sender(amp_rule(), jid:jid(), jid:jid(), exml:element()) -> mongoose_acc:t().
-reply_to_sender(MatchedRule, ServerJid, OriginalSender, OriginalPacket) ->
+-spec reply_to_sender(amp_rule(), jid:jid(), jid:jid(), exml:element(), mongoose_acc:t()) -> mongoose_acc:t().
+reply_to_sender(MatchedRule, ServerJid, OriginalSender, OriginalPacket, Acc) ->
+    HostType = mongoose_acc:host_type(Acc),
     Response = amp:make_response(MatchedRule, OriginalSender, OriginalPacket),
-    mongoose_router:route(mongoose_acc:new(ServerJid, OriginalSender, Response, ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(HostType, ServerJid, OriginalSender, Response, ?LOCATION)).
 
 -spec send_error_and_drop(exml:element(), jid:jid(), amp_error(), amp_rule(), mongoose_acc:t()) -> drop.
 send_error_and_drop(Packet, From, AmpError, MatchedRule, Acc) ->
@@ -225,9 +226,10 @@ send_errors_and_drop(Packet, From, [], Acc) ->
                  exml_packet => Packet, from => From}),
     update_metric_and_drop(Acc);
 send_errors_and_drop(Packet, From, ErrorRules, Acc) ->
+    HostType = mongoose_acc:host_type(Acc),
     {Errors, Rules} = lists:unzip(ErrorRules),
     ErrorResponse = amp:make_error_response(Errors, Rules, From, Packet),
-    mongoose_router:route(mongoose_acc:new(server_jid(From), From, ErrorResponse, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(HostType, server_jid(From), From, ErrorResponse, ?LOCATION)),
     update_metric_and_drop(Acc).
 
 -spec update_metric_and_drop(mongoose_acc:t()) -> drop.

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -268,7 +268,8 @@ attempt_cancelation(HostType, #jid{} = ClientJID, #jid{lserver = ServerDomain}, 
             %% with failure.
             ResIQ = IQ#iq{type = result, sub_el = []},
             mongoose_router:route(
-                mongoose_acc:new(jid:make_noprep(<<>>, <<>>, <<>>),
+                mongoose_acc:new(HostType,
+                                 jid:make_noprep(<<>>, <<>>, <<>>),
                                  ClientJID,
                                  jlib:iq_to_xml(ResIQ),
                                  ?LOCATION)),
@@ -401,6 +402,7 @@ send_welcome_message(HostType, #jid{lserver = Server} = JID) ->
                                             children = [#xmlcdata{content = Body}]}]},
             mongoose_router:route(
                 mongoose_acc:new(
+                    HostType,
                     jid:make_noprep(<<>>, Server, <<>>),
                     JID,
                     Msg,
@@ -417,12 +419,12 @@ send_registration_notifications(HostType, #jid{lserver = Domain} = UJID, Source)
                        "on node ~w using ~p.",
                        [get_time_string(), jid:to_binary(UJID),
                         ip_to_string(Source), node(), ?MODULE])),
-            lists:foreach(fun(S) -> send_registration_notification(S, Domain, Body) end, JIDs);
+            lists:foreach(fun(S) -> send_registration_notification(S, HostType, Domain, Body) end, JIDs);
         _ ->
             ok
     end.
 
-send_registration_notification(JIDBin, Domain, Body) ->
+send_registration_notification(JIDBin, HostType, Domain, Body) ->
     case jid:from_binary(JIDBin) of
         error -> ok;
         JID ->
@@ -430,7 +432,9 @@ send_registration_notification(JIDBin, Domain, Body) ->
                              attrs = #{<<"type">> => <<"chat">>},
                              children = [#xmlel{name = <<"body">>,
                                                 children = [#xmlcdata{content = Body}]}]},
-            mongoose_router:route(mongoose_acc:new(jid:make_noprep(<<>>, Domain, <<>>), JID, Message, ?LOCATION))
+            mongoose_router:route(mongoose_acc:new(HostType,
+                                                   jid:make_noprep(<<>>, Domain, <<>>),
+                                                   JID, Message, ?LOCATION))
     end.
 
 check_timeout(Source) ->

--- a/src/mongoose_acc.erl
+++ b/src/mongoose_acc.erl
@@ -17,7 +17,7 @@
 
 %% API
 % Constructor
--export([new/1, new/4]).
+-export([new/1, new/5]).
 % Access to built-in fields
 -export([
          ref/1,
@@ -86,7 +86,7 @@
         origin_location := location(),
         stanza := stanza_metadata() | undefined,
         lserver := jid:lserver(),
-        host_type := binary() | undefined,
+        host_type := mongooseim:host_type(),
         non_strippable := [ns_key()],
         statem_acc := mongoose_c2s_acc:t(),
         origin := origin() | undefined,
@@ -105,7 +105,7 @@
         location := location(),
         lserver => jid:lserver(),
         element => exml:element() | undefined,
-        host_type => binary() | undefined, % optional
+        host_type := mongooseim:host_type(),
         from_jid => jid:jid() | undefined, % optional
         to_jid => jid:jid() | mod_muc:nick() | undefined, % optional
         statem_acc => mongoose_c2s_acc:t(), % optional
@@ -115,7 +115,7 @@
 -type strip_params() :: #{
         lserver := jid:lserver(),
         element := exml:element(),
-        host_type => binary() | undefined, % optional
+        host_type := mongooseim:host_type(),
         from_jid => jid:jid() | undefined, % optional
         to_jid => jid:jid() | undefined % optional
        }.
@@ -135,12 +135,11 @@
 %% --------------------------------------------------------
 
 -spec new(Params :: new_acc_params()) -> t().
-new(#{ location := Location, lserver := LServer } = Params) ->
+new(#{ location := Location, lserver := LServer, host_type := HostType } = Params) ->
     Stanza = case maps:get(element, Params, undefined) of
                  undefined -> undefined;
                  _Element -> stanza_from_params(Params)
              end,
-    HostType = get_host_type(Params),
     Origin = get_origin(Params),
     #{
       mongoose_acc => true,
@@ -159,10 +158,16 @@ new(#{ location := Location, lserver := LServer } = Params) ->
       non_strippable => []
      }.
 
--spec new(jid:jid(), jid:jid() | mod_muc:nick(), exml:element(), location()) -> t().
-new(From, To, Packet, Location) ->
+-spec new(mongooseim:host_type(),
+          jid:jid(),
+          jid:jid() | mod_muc:nick(),
+          exml:element(),
+          location()) ->
+    t().
+new(HostType, From, To, Packet, Location) ->
     new(#{ location => Location,
            lserver => From#jid.lserver,
+           host_type => HostType,
            element => Packet,
            from_jid => From,
            to_jid => To }).
@@ -179,7 +184,7 @@ timestamp(#{ mongoose_acc := true, timestamp := TS }) ->
 lserver(#{ mongoose_acc := true, lserver := LServer }) ->
     LServer.
 
--spec host_type(Acc :: t()) -> binary() | undefined.
+-spec host_type(Acc :: t()) -> mongooseim:host_type().
 host_type(#{ mongoose_acc := true, host_type := HostType }) ->
     HostType.
 
@@ -233,7 +238,7 @@ update_stanza(NewStanzaParams, #{ mongoose_acc := true } = Acc) ->
 
 -spec update(element | from_jid | to_jid,
              exml:element() | jid:jid(),
-             Acc :: t()) -> t() | {error, malformed_acc}.
+             Acc :: t()) -> t() | {error, badarg}.
 update(element, El, #{ mongoose_acc := true, stanza := Stanza } = Acc) ->
     Acc#{stanza := Stanza#{element := El,
                            name => El#xmlel.name,
@@ -350,19 +355,14 @@ strip(#{ mongoose_acc := true, non_strippable := NonStrippable } = Acc) ->
     Stripped#{statem_acc := mongoose_c2s_acc:new()}.
 
 -spec strip(ParamsToOverwrite :: strip_params(), Acc :: t()) -> t().
-strip(#{ lserver := NewLServer } = Params, Acc) ->
+strip(#{ lserver := NewLServer, host_type := NewHostType } = Params, Acc) ->
     StrippedAcc = strip(Acc),
-    StrippedAcc#{ lserver := NewLServer, host_type := get_host_type(Params),
+    StrippedAcc#{ lserver := NewLServer, host_type := NewHostType,
                   stanza := stanza_from_params(Params) }.
 
 %% --------------------------------------------------------
 %% Internal functions
 %% --------------------------------------------------------
--spec get_host_type(new_acc_params() | strip_params()) -> binary() | undefined.
-get_host_type(#{host_type := HostType}) ->
-    HostType;
-get_host_type(_) ->
-    undefined.
 
 -spec get_origin(new_acc_params()) -> origin() | undefined.
 get_origin(#{origin := Origin}) ->

--- a/src/mongoose_local_delivery.erl
+++ b/src/mongoose_local_delivery.erl
@@ -26,6 +26,7 @@ do_route(OrigFrom, OrigTo, OrigAcc, OrigPacket, Handler) ->
             %% This can happen e.g. for external components
             %% No handlers can be registered for filter_local_packet in this case
             Acc = mongoose_acc:strip(#{lserver => LDstDomain,
+                                       host_type => mongoose_acc:host_type(OrigAcc),
                                        from_jid => OrigFrom,
                                        to_jid => OrigTo,
                                        element => OrigPacket}, OrigAcc),

--- a/src/muc/mod_muc.erl
+++ b/src/muc/mod_muc.erl
@@ -418,15 +418,15 @@ forget_room(HostType, MucHost, Name) ->
     Result.
 
 %% For rooms
--spec process_iq_disco_items(MucHost :: jid:server(), From :: jid:jid(),
-        To :: jid:jid(), jlib:iq()) -> mongoose_acc:t().
-process_iq_disco_items(MucHost, From, To, #iq{lang = Lang} = IQ) ->
+-spec process_iq_disco_items(HostType :: host_type(), MucHost :: jid:server(), From :: jid:jid(),
+                             To :: jid:jid(), jlib:iq()) -> mongoose_acc:t().
+process_iq_disco_items(HostType, MucHost, From, To, #iq{lang = Lang} = IQ) ->
     Rsm = jlib:rsm_decode(IQ),
     Res = IQ#iq{type = result,
                 sub_el = [#xmlel{name = <<"query">>,
                                  attrs = #{<<"xmlns">> => ?NS_DISCO_ITEMS},
                                  children = iq_disco_items(MucHost, From, Lang, Rsm)}]},
-    mongoose_router:route(mongoose_acc:new(To, From, jlib:iq_to_xml(Res), ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(HostType, To, From, jlib:iq_to_xml(Res), ?LOCATION)).
 
 -spec can_use_nick(host_type(), jid:server(), jid:jid(), nick()) -> boolean().
 can_use_nick(_HostType, _Host, _JID, <<>>) ->
@@ -776,16 +776,16 @@ route_by_type(<<"iq">>, {From, To, Acc, Packet}, #muc_state{} = State) ->
                         sub_el = [#xmlel{name = <<"query">>,
                                          attrs = #{<<"xmlns">> => XMLNS},
                                          children = IdentityXML ++ FeatureXML ++ InfoXML}]},
-            mongoose_router:route(mongoose_acc:new(To, From, jlib:iq_to_xml(Res), ?LOCATION));
+            mongoose_router:route(mongoose_acc:new(HostType, To, From, jlib:iq_to_xml(Res), ?LOCATION));
         #iq{type = get, xmlns = ?NS_DISCO_ITEMS} = IQ ->
-            proc_lib:spawn(fun() -> process_iq_disco_items(MucHost, From, To, IQ) end);
+            proc_lib:spawn(fun() -> process_iq_disco_items(HostType, MucHost, From, To, IQ) end);
         #iq{type = get, xmlns = ?NS_REGISTER = XMLNS, lang = Lang} = IQ ->
             Result = iq_get_register_info(HostType, MucHost, From, Lang),
             Res = IQ#iq{type = result,
                         sub_el = [#xmlel{name = <<"query">>,
                                          attrs = #{<<"xmlns">> => XMLNS},
                                          children = Result}]},
-            mongoose_router:route(mongoose_acc:new(To, From, jlib:iq_to_xml(Res), ?LOCATION));
+            mongoose_router:route(mongoose_acc:new(HostType, To, From, jlib:iq_to_xml(Res), ?LOCATION));
         #iq{type = set,
             xmlns = ?NS_REGISTER = XMLNS,
             lang = Lang,
@@ -796,7 +796,7 @@ route_by_type(<<"iq">>, {From, To, Acc, Packet}, #muc_state{} = State) ->
                                 sub_el = [#xmlel{name = <<"query">>,
                                                  attrs = #{<<"xmlns">> => XMLNS},
                                                  children = IQRes}]},
-                    mongoose_router:route(mongoose_acc:new(To, From, jlib:iq_to_xml(Res), ?LOCATION));
+                    mongoose_router:route(mongoose_acc:new(HostType, To, From, jlib:iq_to_xml(Res), ?LOCATION));
                 {error, Error} ->
                     {Acc1, Err} = jlib:make_error_reply(Acc, Packet, Error),
                     mongoose_router:route(mongoose_acc:update(To, From, Err, Acc1))
@@ -806,13 +806,13 @@ route_by_type(<<"iq">>, {From, To, Acc, Packet}, #muc_state{} = State) ->
                         sub_el = [#xmlel{name = <<"vCard">>,
                                          attrs = #{<<"xmlns">> => XMLNS},
                                          children = iq_get_vcard(Lang)}]},
-            mongoose_router:route(mongoose_acc:new(To, From, jlib:iq_to_xml(Res), ?LOCATION));
+            mongoose_router:route(mongoose_acc:new(HostType, To, From, jlib:iq_to_xml(Res), ?LOCATION));
         #iq{type = get, xmlns = ?NS_MUC_UNIQUE} = IQ ->
            Res = IQ#iq{type = result,
                        sub_el = [#xmlel{name = <<"unique">>,
                                         attrs = #{<<"xmlns">> => ?NS_MUC_UNIQUE},
                                         children = [iq_get_unique(From)]}]},
-           mongoose_router:route(mongoose_acc:new(To, From, jlib:iq_to_xml(Res), ?LOCATION));
+           mongoose_router:route(mongoose_acc:new(HostType, To, From, jlib:iq_to_xml(Res), ?LOCATION));
         #iq{} ->
             ?LOG_INFO(#{what => muc_ignore_unknown_iq, acc => Acc}),
             {Acc1, Err} = jlib:make_error_reply(Acc, Packet,

--- a/src/muc/mod_muc_api.erl
+++ b/src/muc/mod_muc_api.erl
@@ -126,16 +126,22 @@ verify_user(JID) ->
 %% Send presence to create a room.
 -spec create_room(jid:jid(), jid:jid()) -> ok | {could_not_create_room, iolist()}.
 create_room(OwnerJID, UserRoomJID) ->
+    HostType = room_host_type(UserRoomJID, OwnerJID),
     CreationStanza = presence(OwnerJID, UserRoomJID, undefined),
-    ResponseAcc = mongoose_router:route(mongoose_acc:new(OwnerJID, UserRoomJID, CreationStanza, ?LOCATION)),
+    ResponseAcc = mongoose_router:route(mongoose_acc:new(HostType, OwnerJID,
+                                                         UserRoomJID, CreationStanza,
+                                                         ?LOCATION)),
     ResponseEl = mongoose_acc:element(ResponseAcc),
     verify_routing_result(ResponseEl).
 
 %% Send IQ set to unlock the room.
 -spec unlock_room(jid:jid(), jid:jid()) -> ok | {could_not_create_room, iolist()}.
 unlock_room(OwnerJID, BareRoomJID) ->
+    HostType = room_host_type(BareRoomJID, OwnerJID),
     UnlockStanza = declination(OwnerJID, BareRoomJID),
-    ResponseAcc = mongoose_router:route(mongoose_acc:new(OwnerJID, BareRoomJID, UnlockStanza, ?LOCATION)),
+    ResponseAcc = mongoose_router:route(mongoose_acc:new(HostType, OwnerJID,
+                                                         BareRoomJID, UnlockStanza,
+                                                         ?LOCATION)),
     ResponseEl = #xmlel{} = mongoose_acc:element(ResponseAcc),
     verify_routing_result(ResponseEl).
 
@@ -178,6 +184,7 @@ modify_room_config(RoomJID, Fun) ->
 invite_to_room(RoomJID, SenderJID, RecipientJID, Reason) ->
     case verify_room(RoomJID, SenderJID) of
         ok ->
+            HostType = room_host_type(RoomJID, SenderJID),
             Attrs = case get_room_config(RoomJID) of
                         {ok, #config{password_protected = true, password = Pass}} ->
                             #{<<"password">> => Pass};
@@ -191,7 +198,9 @@ invite_to_room(RoomJID, SenderJID, RecipientJID, Reason) ->
                                       <<"reason">> => Reason}
             },
             Invite = message(SenderJID, RecipientJID, <<>>, [X]),
-            mongoose_router:route(mongoose_acc:new(SenderJID, RecipientJID, Invite, ?LOCATION)),
+            mongoose_router:route(mongoose_acc:new(HostType, SenderJID,
+                                                   RecipientJID, Invite,
+                                                   ?LOCATION)),
             {ok, "Invitation sent successfully"};
         Error ->
             Error
@@ -199,20 +208,24 @@ invite_to_room(RoomJID, SenderJID, RecipientJID, Reason) ->
 
 -spec send_message_to_room(jid:jid(), jid:jid(), binary()) -> {ok, iolist()}.
 send_message_to_room(RoomJID, SenderJID, Message) ->
+    HostType = room_host_type(RoomJID, SenderJID),
     Body = #xmlel{name = <<"body">>,
                   children = [#xmlcdata{content = Message}]},
     Stanza = message(SenderJID, RoomJID, <<"groupchat">>, [Body]),
-    mongoose_router:route(mongoose_acc:new(SenderJID, RoomJID, Stanza, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(HostType, SenderJID, RoomJID,
+                                           Stanza, ?LOCATION)),
     {ok, "Message sent successfully"}.
 
 -spec send_private_message(jid:jid(), jid:jid(), binary(), binary()) -> {ok, iolist()}.
 send_private_message(RoomJID, SenderJID, ToNick, Message) ->
+    HostType = room_host_type(RoomJID, SenderJID),
     RoomJIDRes = jid:replace_resource(RoomJID, ToNick),
     Body = #xmlel{name = <<"body">>,
                   children = [#xmlcdata{content = Message}]},
     X = #xmlel{name = <<"x">>, attrs = #{<<"xmlns">> => ?NS_MUC}},
     Stanza = message(SenderJID, RoomJID, <<"chat">>, [Body, X]),
-    mongoose_router:route(mongoose_acc:new(SenderJID, RoomJIDRes, Stanza, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(HostType, SenderJID, RoomJIDRes,
+                                           Stanza, ?LOCATION)),
     {ok, "Message sent successfully"}.
 
 -spec kick_user_from_room(jid:jid(), binary(), binary()) ->
@@ -400,20 +413,25 @@ set_role(RoomJID, UserJID, Nick, Role) ->
 
 -spec enter_room(jid:jid(), jid:jid(), binary() | undefined) -> {ok, iolist()}.
 enter_room(RoomJID, UserJID, Password) ->
+    HostType = room_host_type(RoomJID, UserJID),
     Presence = presence(UserJID, RoomJID, Password),
-    mongoose_router:route(mongoose_acc:new(UserJID, RoomJID, Presence, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(HostType, UserJID, RoomJID,
+                                           Presence, ?LOCATION)),
     {ok, "Entering room message sent successfully"}.
 
 -spec exit_room(jid:jid(), jid:jid()) -> {ok, iolist()}.
 exit_room(RoomJID, UserJID) ->
+    HostType = room_host_type(RoomJID, UserJID),
     Presence = exit_room_presence(UserJID, RoomJID),
-    mongoose_router:route(mongoose_acc:new(UserJID, RoomJID, Presence, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(HostType, UserJID, RoomJID,
+                                           Presence, ?LOCATION)),
     {ok, "Exiting room message sent successfully"}.
 
 %% Internal
 
 -spec kick_user_from_room_raw(jid:jid(), jid:jid(), binary(), binary()) -> {ok, iolist()}.
 kick_user_from_room_raw(RoomJID, ModJID, Nick, ReasonIn) ->
+    HostType = room_host_type(RoomJID, ModJID),
     Reason = #xmlel{name = <<"reason">>,
                     children = [#xmlcdata{content = ReasonIn}]
                    },
@@ -423,7 +441,8 @@ kick_user_from_room_raw(RoomJID, ModJID, Nick, ReasonIn) ->
                   children = [ Reason ]
                  },
     IQ = iq(<<"set">>, ModJID, RoomJID, [ query(?NS_MUC_ADMIN, [ Item ]) ]),
-    mongoose_router:route(mongoose_acc:new(ModJID, RoomJID, IQ, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(HostType, ModJID, RoomJID,
+                                           IQ, ?LOCATION)),
     {ok, "Kick message sent successfully"}.
 
 -spec try_add_role_resource(jid:jid(), jid:jid(), mod_muc:role()) ->
@@ -606,3 +625,13 @@ format_affs(AffsMap) ->
                   ({K, {V, <<>>}}) -> {K, V};
                   ({K, V}) -> {K, V}
               end, maps:to_list(AffsMap)).
+
+-spec room_host_type(jid:jid(), jid:jid()) -> mongooseim:host_type().
+room_host_type(#jid{lserver = MUCServer}, #jid{lserver = UserServer}) ->
+    case mongoose_domain_api:get_subdomain_host_type(MUCServer) of
+        {ok, HostType} ->
+            HostType;
+        {error, not_found} ->
+            {ok, HostType} = mongoose_domain_api:get_domain_host_type(UserServer),
+            HostType
+    end.

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -749,7 +749,8 @@ stop_if_only_owner_is_online(RoomName, 1, #state{users = Users, jid = RoomJID} =
             ItemAttrs = #{<<"affiliation">> => <<"owner">>, <<"role">> => <<"none">>},
             Packet = unavailable_presence(ItemAttrs, <<"Room hibernation">>),
             FromRoom = jid:replace_resource(RoomJID, Nick),
-            mongoose_router:route(mongoose_acc:new(FromRoom, LastUser, Packet, ?LOCATION)),
+            mongoose_router:route(mongoose_acc:new(State#state.host_type, FromRoom,
+                                                   LastUser, Packet, ?LOCATION)),
             tab_remove_online_user(LJID, State),
             do_stop_persistent_room(RoomName, State);
         _ ->
@@ -783,6 +784,7 @@ terminate(Reason, _StateName, StateData) ->
                   shutdown ->
                       mongoose_router:route(
                           mongoose_acc:new(
+                              StateData#state.host_type,
                               jid:replace_resource(StateData#state.jid, Nick),
                               Info#user.jid,
                               Packet,
@@ -897,7 +899,8 @@ process_message_from_allowed_user(From, #routed_message{packet = Packet} = RMess
         false ->
             ErrText = <<"Visitors are not allowed to send messages to all occupants">>,
             Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:forbidden(Lang, ErrText)),
-            mongoose_router:route(mongoose_acc:new(StateData#state.jid, From, Err, ?LOCATION)),
+            mongoose_router:route(mongoose_acc:new(StateData#state.host_type,
+                                                   StateData#state.jid, From, Err, ?LOCATION)),
             next_normal_state(StateData)
     end.
 
@@ -928,7 +931,7 @@ broadcast_room_packet(From, FromNick, Role, RMess, StateData) ->
     run_update_inbox_for_muc_hook(StateData#state.host_type, HookInfo),
     maps_foreach(fun(_LJID, Info) ->
                      mongoose_router:route(
-                         mongoose_acc:new(RouteFrom,
+                         mongoose_acc:new(StateData#state.host_type, RouteFrom,
                                              Info#user.jid,
                                              FilteredPacket,
                                              ?LOCATION))
@@ -953,7 +956,8 @@ change_subject_error(From, FromNick, Packet, Lang, StateData) ->
                                            " to change the subject in this room">>)
           end,
     mongoose_router:route(
-        mongoose_acc:new(jid:replace_resource(StateData#state.jid, FromNick),
+        mongoose_acc:new(StateData#state.host_type,
+                         jid:replace_resource(StateData#state.jid, FromNick),
                          From,
                          jlib:make_error_reply(Packet, Err),
                          ?LOCATION)).
@@ -1180,7 +1184,8 @@ handle_new_user(From, Nick = <<>>, _Packet, StateData, Packet) ->
                 #xmlel{name = <<"presence">>},
                 mongoose_xmpp_errors:jid_malformed(Lang, ErrText)),
     mongoose_router:route(
-        mongoose_acc:new(jid:replace_resource(StateData#state.jid, Nick),
+        mongoose_acc:new(StateData#state.host_type,
+                         jid:replace_resource(StateData#state.jid, Nick),
                          From,
                          Error,
                          ?LOCATION)),
@@ -1190,7 +1195,8 @@ handle_new_user(From, Nick, Packet, StateData, Packet) ->
         undefined ->
             Response = kick_stanza_for_old_protocol(Packet),
             mongoose_router:route(
-                mongoose_acc:new(jid:replace_resource(StateData#state.jid, Nick),
+                mongoose_acc:new(StateData#state.host_type,
+                                 jid:replace_resource(StateData#state.jid, Nick),
                                  From,
                                  Response,
                                  ?LOCATION)),
@@ -2325,7 +2331,8 @@ send_new_presence_to_single(NJID, #user{jid = RealJID, nick = Nick, last_presenc
                        children = [#xmlel{name = <<"item">>, attrs = ItemAttrs,
                                           children = ItemEls} | Status2]}]),
     mongoose_router:route(
-        mongoose_acc:new(jid:replace_resource(StateData#state.jid, Nick),
+        mongoose_acc:new(StateData#state.host_type,
+                         jid:replace_resource(StateData#state.jid, Nick),
                          ReceiverInfo#user.jid,
                          Packet,
                          ?LOCATION)).
@@ -2370,7 +2377,8 @@ send_existing_presence({_LJID, #user{jid = FromJID, nick = FromNick,
                        children = [#xmlel{name = <<"item">>,
                                           attrs = ItemAttrs}]}]),
     mongoose_router:route(
-        mongoose_acc:new(jid:replace_resource(StateData#state.jid, FromNick),
+        mongoose_acc:new(StateData#state.host_type,
+                         jid:replace_resource(StateData#state.jid, FromNick),
                          RealToJID,
                          Packet,
                          ?LOCATION)).
@@ -2396,7 +2404,8 @@ send_invitation(From, To, Reason, StateData=#state{host=Host,
         true -> Config#config.password
     end,
     Packet = jlib:make_invitation(jid:to_bare(From), Password, Reason),
-    mongoose_router:route(mongoose_acc:new(RoomJID, To, Packet, ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(StateData#state.host_type,
+                                           RoomJID, To, Packet, ?LOCATION)).
 
 
 -spec change_nick(jid:jid(), binary(), state()) -> state().
@@ -2449,14 +2458,16 @@ send_nick_change(Presence, OldNick, JID, RealJID, Affiliation, Role,
     Unavailable = nick_unavailable_presence(MaybePublicJID, Nick, Affiliation,
                                             Role, MaybeSelfPresenceCode),
     mongoose_router:route(
-        mongoose_acc:new(jid:replace_resource(S#state.jid, OldNick),
+        mongoose_acc:new(S#state.host_type,
+                         jid:replace_resource(S#state.jid, OldNick),
                          Info#user.jid,
                          Unavailable,
                          ?LOCATION)),
     Available = nick_available_presence(Presence, MaybePublicJID, Affiliation,
                                         Role, MaybeSelfPresenceCode),
     mongoose_router:route(
-        mongoose_acc:new(jid:replace_resource(S#state.jid, Nick),
+        mongoose_acc:new(S#state.host_type,
+                         jid:replace_resource(S#state.jid, Nick),
                          Info#user.jid,
                          Available,
                          ?LOCATION)).
@@ -2597,6 +2608,7 @@ send_history(JID, Shift, StateData) ->
       fun({Nick, Packet, HaveSubject, _TimeStamp, _Size}, B) ->
           mongoose_router:route(
               mongoose_acc:new(
+                  StateData#state.host_type,
                   jid:replace_resource(StateData#state.jid, Nick),
                   JID,
                   Packet, ?LOCATION)),
@@ -2610,7 +2622,8 @@ send_subject(JID, _Lang, StateData = #state{subject = <<>>, subject_author = <<>
                     attrs = #{<<"type">> => <<"groupchat">>},
                     children = [#xmlel{name = <<"subject">>},
                                 #xmlel{name = <<"body">>}]},
-    mongoose_router:route(mongoose_acc:new(StateData#state.jid, JID, Packet, ?LOCATION));
+    mongoose_router:route(mongoose_acc:new(StateData#state.host_type,
+                                           StateData#state.jid, JID, Packet, ?LOCATION));
 send_subject(JID, _Lang, StateData) ->
     Subject = StateData#state.subject,
     TimeStamp = StateData#state.subject_timestamp,
@@ -2623,7 +2636,8 @@ send_subject(JID, _Lang, StateData) ->
                                        attrs = #{<<"xmlns">> => ?NS_DELAY,
                                                  <<"from">> => jid:to_binary(RoomJID),
                                                  <<"stamp">> => TimeStamp}}]},
-    mongoose_router:route(mongoose_acc:new(RoomJID, JID, Packet, ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(StateData#state.host_type,
+                                           RoomJID, JID, Packet, ?LOCATION)).
 
 
 -spec check_subject(exml:element()) -> undefined | binary().
@@ -3132,6 +3146,7 @@ send_kickban_presence1(UJID, Reason, Code, Affiliation, StateData) ->
                                                                 attrs = #{<<"code">> => Code}}]}]},
         mongoose_router:route(
             mongoose_acc:new(
+                StateData#state.host_type,
                 jid:replace_resource(StateData#state.jid, Nick),
                 Info#user.jid,
                 Packet,
@@ -3680,7 +3695,8 @@ remove_each_occupant_from_room(DestroyEl, StateData) ->
 send_to_occupants(Packet, StateData=#state{jid=RoomJID}) ->
     F = fun(User=#user{jid=UserJID}) ->
         mongoose_router:route(
-            mongoose_acc:new(occupant_jid(User, RoomJID), UserJID, Packet, ?LOCATION))
+            mongoose_acc:new(StateData#state.host_type,
+                             occupant_jid(User, RoomJID), UserJID, Packet, ?LOCATION))
         end,
     foreach_user(F, StateData).
 
@@ -3688,7 +3704,8 @@ send_to_occupants(Packet, StateData=#state{jid=RoomJID}) ->
 send_to_all_users(Packet, StateData=#state{jid=RoomJID}) ->
     F = fun(#user{jid = UserJID}) ->
           mongoose_router:route(
-              mongoose_acc:new(RoomJID, UserJID, Packet, ?LOCATION))
+                            mongoose_acc:new(StateData#state.host_type,
+                                             RoomJID, UserJID, Packet, ?LOCATION))
       end,
     foreach_user(F, StateData).
 
@@ -3909,7 +3926,8 @@ unsafe_check_invitation(FromJID, Els, Lang,
                       mongoose_hooks:invitation_sent(Host, ServerHost, RoomJID,
                                                      FromJID, JID, Reason),
                       mongoose_router:route(
-                          mongoose_acc:new(StateData#state.jid, JID, Msg, ?LOCATION))
+                                                    mongoose_acc:new(StateData#state.host_type,
+                                                                     StateData#state.jid, JID, Msg, ?LOCATION))
               end, InviteEls),
             {ok, JIDs}
     end.
@@ -4069,6 +4087,7 @@ check_decline_invitation(Packet) ->
 -spec send_decline_invitation({exml:element(), exml:element(), exml:element(), jid:jid()},
         jid:jid(), jid:simple_jid() | jid:jid()) -> mongoose_acc:t().
 send_decline_invitation({Packet, XEl, DEl, ToJID}, RoomJID, FromJID) ->
+    {ok, HostType} = mongoose_domain_api:get_subdomain_host_type(RoomJID#jid.lserver),
     FromString = jid:to_binary(FromJID),
     #xmlel{name = <<"decline">>, attrs = DAttrs, children = DEls} = DEl,
     DAttrs2 = maps:remove(<<"to">>, DAttrs),
@@ -4076,17 +4095,18 @@ send_decline_invitation({Packet, XEl, DEl, ToJID}, RoomJID, FromJID) ->
     DEl2 = #xmlel{name = <<"decline">>, attrs = DAttrs3, children = DEls},
     XEl2 = jlib:replace_subelement(XEl, DEl2),
     Packet2 = jlib:replace_subelement(Packet, XEl2),
-    mongoose_router:route(mongoose_acc:new(RoomJID, ToJID, Packet2, ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(HostType, RoomJID, ToJID, Packet2, ?LOCATION)).
 
 -spec send_error_only_occupants(binary(), exml:element(),
                                 binary() | nonempty_string(),
                                 jid:jid(), jid:jid()) -> mongoose_acc:t().
 send_error_only_occupants(What, Packet, Lang, RoomJID, From)
   when is_binary(What) ->
+    {ok, HostType} = mongoose_domain_api:get_subdomain_host_type(RoomJID#jid.lserver),
     ErrText = <<"Only occupants are allowed to send ",
                 What/bytes, " to the conference">>,
     Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:not_acceptable(Lang, ErrText)),
-    mongoose_router:route(mongoose_acc:new(RoomJID, From, Err, ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(HostType, RoomJID, From, Err, ?LOCATION)).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Users number checking
@@ -4147,7 +4167,8 @@ route_message(#routed_message{allowed = true, type = <<"groupchat">>,
         {true, _, _} ->
             ErrText = <<"Traffic rate limit is exceeded">>,
             Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:resource_constraint(Lang, ErrText)),
-            mongoose_router:route(mongoose_acc:new(StateData#state.jid, From, Err, ?LOCATION)),
+            mongoose_router:route(mongoose_acc:new(StateData#state.host_type,
+                                                   StateData#state.jid, From, Err, ?LOCATION)),
             StateData;
         {false, true, 0} ->
             {RoomShaper, RoomShaperInterval} = mongoose_shaper:update(StateData#state.room_shaper, Size),
@@ -4197,7 +4218,8 @@ route_message(#routed_message{allowed = true, type = <<"chat">>, from = From, pa
     ErrText = <<"It is not allowed to send private messages to the conference">>,
     Err = jlib:make_error_reply(
         Packet, mongoose_xmpp_errors:not_acceptable(Lang, ErrText)),
-    mongoose_router:route(mongoose_acc:new(StateData#state.jid, From, Err, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(StateData#state.host_type,
+                                           StateData#state.jid, From, Err, ?LOCATION)),
     StateData;
 route_message(#routed_message{allowed = true, type = Type, from = From,
                               packet = #xmlel{name = <<"message">>,
@@ -4217,7 +4239,7 @@ route_message(#routed_message{allowed = true, from = From, packet = Packet,
     ErrText = <<"Improper message type">>,
     Err = jlib:make_error_reply(Packet, mongoose_xmpp_errors:not_acceptable(Lang, ErrText)),
     mongoose_router:route(
-        mongoose_acc:new(StateData#state.jid, From, Err, ?LOCATION)),
+        mongoose_acc:new(StateData#state.host_type, StateData#state.jid, From, Err, ?LOCATION)),
     StateData;
 route_message(#routed_message{type = <<"error">>}, StateData) ->
     StateData;
@@ -4241,8 +4263,9 @@ schedule_queue_processing_when_empty(_RoomQueueEmpty, _RoomShaper,
 route_error(Nick, From, Error, StateData) ->
     %% TODO: s/Nick/<<>>/
     mongoose_router:route(
-        mongoose_acc:new(jid:replace_resource(StateData#state.jid, Nick),
-                          From, Error, ?LOCATION)),
+        mongoose_acc:new(StateData#state.host_type,
+                         jid:replace_resource(StateData#state.jid, Nick),
+                         From, Error, ?LOCATION)),
     StateData.
 
 
@@ -4251,18 +4274,19 @@ route_error(Nick, From, Error, StateData) ->
         ejabberd:lang(), state()) -> state().
 route_voice_approval({error, ErrType}, From, Packet, _Lang, StateData) ->
     mongoose_router:route(
-        mongoose_acc:new(StateData#state.jid, From,
-                          jlib:make_error_reply(Packet, ErrType), ?LOCATION)),
+        mongoose_acc:new(StateData#state.host_type, StateData#state.jid, From,
+                         jlib:make_error_reply(Packet, ErrType), ?LOCATION)),
     StateData;
 route_voice_approval({form, RoleName}, From, _Packet, _Lang, StateData) ->
     {Nick, _} = get_participant_data(From, StateData),
     ApprovalForm = make_voice_approval_form(From, Nick, RoleName),
     F = fun({_, Info}) ->
                 mongoose_router:route(
-                    mongoose_acc:new(StateData#state.jid,
-                                        Info#user.jid,
-                                        ApprovalForm,
-                                        ?LOCATION))
+                    mongoose_acc:new(StateData#state.host_type,
+                                     StateData#state.jid,
+                                     Info#user.jid,
+                                     ApprovalForm,
+                                     ?LOCATION))
         end,
     lists:foreach(F, search_role(moderator, StateData)),
     StateData;
@@ -4274,18 +4298,20 @@ route_voice_approval({role, BRole, Nick}, From, Packet, Lang, StateData) ->
         {result, _Res, SD1} -> SD1;
         {error, Error} ->
             mongoose_router:route(
-                mongoose_acc:new(StateData#state.jid,
-                                    From,
-                                    jlib:make_error_reply(Packet, Error),
-                                    ?LOCATION)),
+                mongoose_acc:new(StateData#state.host_type,
+                                 StateData#state.jid,
+                                 From,
+                                 jlib:make_error_reply(Packet, Error),
+                                 ?LOCATION)),
             StateData
     end;
 route_voice_approval(_Type, From, Packet, _Lang, StateData) ->
     mongoose_router:route(
-        mongoose_acc:new(StateData#state.jid,
-                            From,
-                            jlib:make_error_reply(Packet, mongoose_xmpp_errors:bad_request()),
-                            ?LOCATION)),
+        mongoose_acc:new(StateData#state.host_type,
+                         StateData#state.jid,
+                         From,
+                         jlib:make_error_reply(Packet, mongoose_xmpp_errors:bad_request()),
+                         ?LOCATION)),
     StateData.
 
 
@@ -4298,7 +4324,8 @@ route_voice_approval(_Type, From, Packet, _Lang, StateData) ->
       Lang :: ejabberd:lang().
 route_invitation({error, Error}, From, Packet, _Lang, StateData) ->
     Err = jlib:make_error_reply(Packet, Error),
-    mongoose_router:route(mongoose_acc:new(StateData#state.jid, From, Err, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(StateData#state.host_type,
+                                           StateData#state.jid, From, Err, ?LOCATION)),
     StateData;
 route_invitation({ok, IJIDs}, _From, _Packet, _Lang,
                  #state{ config = #config{ members_only = true } } = StateData0) ->
@@ -4426,6 +4453,7 @@ route_nick_message(#routed_nick_message{decide = continue_delivery, allow_pm = t
         StateData#state.users),
     mongoose_router:route(
         mongoose_acc:new(
+            StateData#state.host_type,
             jid:replace_resource(StateData#state.jid, FromNick),
             ToJID,
             Packet1,
@@ -4466,6 +4494,7 @@ route_nick_iq(#routed_nick_iq{allow_query = true, online = {true, NewId, FromFul
     {ToJID2, Packet2} = handle_iq_vcard(FromFull, ToJID, StanzaId, NewId, Packet),
     mongoose_router:route(
         mongoose_acc:new(
+            StateData#state.host_type,
             jid:replace_resource(StateData#state.jid, FromNick),
             ToJID2, Packet2, ?LOCATION));
 route_nick_iq(#routed_nick_iq{online = {false, _, _}, iq = reply}, _StateData) ->

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -304,7 +304,7 @@ hooks(HostType) ->
 -spec process_packet(Acc :: mongoose_acc:t(), From ::jid:jid(), To ::jid:jid(),
                      El :: exml:element(), Extra :: gen_hook:extra()) -> mongoose_acc:t().
 process_packet(Acc, From, To, El, _Extra) ->
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     DecodedPacket = mod_muc_light_codec_backend:decode(From, To, El, Acc),
     process_decoded_packet(HostType, From, To, Acc, El, DecodedPacket).
 

--- a/src/muc_light/mod_muc_light_api.erl
+++ b/src/muc_light/mod_muc_light_api.erl
@@ -201,13 +201,16 @@ create_room_raw(#{room := InRoomJID, user := CreatorJID, options := Options}) ->
             ?VALIDATION_ERROR_RESULT(Key, Reason)
     end.
 
-do_invite_to_room(#{user := SenderJID, room := RoomJID, recipient := RecipientJID}) ->
+do_invite_to_room(#{user := SenderJID, room := RoomJID,
+                    recipient := RecipientJID, muc_host_type := HostType}) ->
     S = jid:to_bare(SenderJID),
     R = jid:to_bare(RoomJID),
     RecipientBin = jid:to_binary(jid:to_bare(RecipientJID)),
     Changes = query(?NS_MUC_LIGHT_AFFILIATIONS, [affiliate(RecipientBin, <<"member">>)]),
     mongoose_router:route(
-      mongoose_acc:new(S, R, iq(jid:to_binary(S), jid:to_binary(R), <<"set">>, [Changes]), ?LOCATION)),
+        mongoose_acc:new(HostType, S, R,
+                         iq(jid:to_binary(S), jid:to_binary(R), <<"set">>, [Changes]),
+                         ?LOCATION)),
     {ok, "User invited successfully"}.
 
 do_change_room_config(#{user := UserJID, room := RoomJID, config := Config,
@@ -254,23 +257,26 @@ get_user_aff(M = #{muc_host_type := HostType, user := UserJID, room := RoomJID})
             ?ROOM_NOT_FOUND_RESULT
     end.
 
-do_change_affiliation(#{user := SenderJID, room := RoomJID, recipient := RecipientJID, op := Op}) ->
+do_change_affiliation(#{user := SenderJID, room := RoomJID,
+                        recipient := RecipientJID, op := Op, muc_host_type := HostType}) ->
     RecipientBare = jid:to_bare(RecipientJID),
     S = jid:to_bare(SenderJID),
     Changes = query(?NS_MUC_LIGHT_AFFILIATIONS,
                     [affiliate(jid:to_binary(RecipientBare), op_to_aff(Op))]),
     mongoose_router:route(
-      mongoose_acc:new(S, RoomJID, iq(jid:to_binary(S), jid:to_binary(RoomJID),
-                                         <<"set">>, [Changes]), ?LOCATION)),
+      mongoose_acc:new(HostType, S, RoomJID,
+                       iq(jid:to_binary(S), jid:to_binary(RoomJID), <<"set">>, [Changes]),
+                       ?LOCATION)),
     {ok, "Affiliation change request sent successfully"}.
 
-do_send_message(#{user := SenderJID, room := RoomJID, children := Children, attrs := ExtraAttrs}) ->
+do_send_message(#{user := SenderJID, room := RoomJID,
+                  children := Children, attrs := ExtraAttrs, muc_host_type := HostType}) ->
     SenderBare = jid:to_bare(SenderJID),
     RoomBare = jid:to_bare(RoomJID),
     Stanza = #xmlel{name = <<"message">>,
                     attrs = ExtraAttrs#{<<"type">> => <<"groupchat">>},
                     children = Children},
-    mongoose_router:route(mongoose_acc:new(SenderBare, RoomBare, Stanza, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(HostType, SenderBare, RoomBare, Stanza, ?LOCATION)),
     {ok, "Message sent successfully"}.
 
 do_delete_room(#{room := RoomJID}) ->
@@ -353,7 +359,8 @@ do_set_blocking_list(#{user := UserJID, user_host_type := HostType, items := Ite
     MUCServer = mod_muc_light_utils:server_host_to_muc_host(HostType, UserJID#jid.lserver),
     Q = query(?NS_MUC_LIGHT_BLOCKING, [blocking_item(I) || I <- Items]),
     Iq = iq(jid:to_binary(UserJID), MUCServer, <<"set">>, [Q]),
-    mongoose_router:route(mongoose_acc:new(UserJID, jid:from_binary(MUCServer), Iq, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(HostType, UserJID,
+                                           jid:from_binary(MUCServer), Iq, ?LOCATION)),
     {ok, "User blocking list updated successfully"}.
 
 %% Internal: helpers

--- a/src/muc_light/mod_muc_light_cache.erl
+++ b/src/muc_light/mod_muc_light_cache.erl
@@ -120,7 +120,7 @@ remove_domain(Acc, #{domain := Domain}, #{host_type := HostType}) ->
     Params :: map(),
     Extra :: gen_hook:extra().
 room_new_affiliations(Acc, #{room := RoomJid, new_affs := NewAffs, version := NewVersion}, _Extra) ->
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     % make sure other nodes forget about stale values
     mongoose_user_cache:delete_user(HostType, ?MODULE, RoomJid),
     mongoose_user_cache:merge_entry(HostType, ?MODULE, RoomJid, #{affs => {ok, NewAffs, NewVersion}}),

--- a/src/muc_light/mod_muc_light_codec_legacy.erl
+++ b/src/muc_light/mod_muc_light_codec_legacy.erl
@@ -64,7 +64,7 @@ encode({#msg{} = Msg, AffUsers}, Sender, RoomBareJid, HandleFun, Acc) ->
                   stable_stanza_id => mongoose_acc:get(stable_stanza_id, value, undefined, Acc),
                   role => mod_muc_light_utils:light_aff_to_muc_role(Aff),
                   timestamp => TS},
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     Packet1 = #xmlel{ children = Children }
         = mongoose_hooks:filter_room_packet(HostType, MsgForArch, EventData),
     lists:foreach(
@@ -244,7 +244,7 @@ parse_blocking_list([Item | RItemsEls], ItemsAcc) ->
     {iq_reply, XMLNS :: binary(), Els :: [exml:child()], ID :: binary()} |
     noreply.
 encode_meta({get, #disco_info{ id = ID }}, RoomJID, SenderJID, _HandleFun, Acc) ->
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     IdentityXML = mongoose_disco:identities_to_xml([identity()]),
     FeatureXML = mongoose_disco:get_muc_features(HostType, SenderJID, RoomJID, <<>>, <<>>,
                                                  [?NS_MUC]),
@@ -273,7 +273,7 @@ encode_meta({set, #affiliations{} = Affs, OldAffUsers, NewAffUsers},
                        Affs#affiliations.aff_users, HandleFun),
     {iq_reply, Affs#affiliations.id};
 encode_meta({get, #blocking{} = Blocking}, RoomJID, _SenderJID, _HandleFun, Acc) ->
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     ServerHost = mod_muc_light_utils:room_jid_to_server_host(RoomJID),
     MUCHost = mongoose_subdomain_utils:get_fqdn(mod_muc_light:subdomain_pattern(HostType), ServerHost),
     BlockingEls = [ blocking_to_el(BlockingItem, MUCHost)

--- a/src/muc_light/mod_muc_light_codec_modern.erl
+++ b/src/muc_light/mod_muc_light_codec_modern.erl
@@ -68,7 +68,7 @@ encode({#msg{} = Msg, AffUsers}, Sender, RoomBareJid, HandleFun, Acc) ->
                   stable_stanza_id => mongoose_acc:get(stable_stanza_id, value, undefined, Acc),
                   role => mod_muc_light_utils:light_aff_to_muc_role(Aff),
                   timestamp => TS},
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     Packet1 = #xmlel{ children = Children }
                      = mongoose_hooks:filter_room_packet(HostType, MsgForArch, EventData),
     lists:foreach(
@@ -257,7 +257,7 @@ parse_blocking_list(_, _) ->
 %%====================================================================
 
 encode_iq({get, #disco_info{ id = ID }}, Sender, RoomJID, _RoomBin, _HandleFun, Acc) ->
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     IdentityXML = mongoose_disco:identities_to_xml([identity()]),
     FeatureXML = mongoose_disco:get_muc_features(HostType, Sender, RoomJID, <<>>, <<>>,
                                                  [?NS_MUC_LIGHT]),
@@ -313,7 +313,7 @@ encode_iq({set, #affiliations{} = Affs, OldAffUsers, NewAffUsers},
                          children = msg_envelope(?NS_MUC_LIGHT_AFFILIATIONS,
                                                  NotifForCurrentNoPrevVersion) },
     EventData = room_event(Acc, RoomJID),
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     #xmlel{children = FinalChildrenForCurrentNoPrevVersion}
         = mongoose_hooks:filter_room_packet(HostType, MsgForArch, EventData),
     FinalChildrenForCurrent = inject_prev_version(FinalChildrenForCurrentNoPrevVersion,
@@ -342,7 +342,7 @@ encode_iq({set, #create{} = Create, UniqueRequested},
     MsgForArch = #xmlel{ name = <<"message">>, attrs = Attrs,
                          children = msg_envelope(?NS_MUC_LIGHT_AFFILIATIONS, AllAffsEls) },
     EventData = room_event(Acc, RoomJID),
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     mongoose_hooks:filter_room_packet(HostType, MsgForArch, EventData),
 
     %% IQ reply "from"
@@ -374,7 +374,7 @@ encode_iq({set, #config{} = Config, AffUsers},
           _Sender, RoomJID, RoomBin, HandleFun, Acc) ->
     MsgForArch = encode_set_config(Config, RoomBin),
     EventData = room_event(Acc, RoomJID),
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     #xmlel{ children = FinalConfigNotif }
         = mongoose_hooks:filter_room_packet(HostType, MsgForArch, EventData),
 

--- a/src/muc_light/mod_muc_light_room.erl
+++ b/src/muc_light/mod_muc_light_room.erl
@@ -51,7 +51,7 @@ handle_request(From, RoomJID, OrigPacket, Request, Acc1) ->
                    NewAffUsers :: aff_users(),
                    Version :: binary() ) -> any().
 maybe_forget(Acc, {RoomU, RoomS} = RoomUS, [], _Version) ->
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     mongoose_hooks:forget_room(HostType, RoomS, RoomU),
     mod_muc_light_db_backend:destroy_room(HostType, RoomUS);
 maybe_forget(Acc, {RoomU, RoomS}, NewAffs, Version) ->
@@ -126,13 +126,13 @@ process_request({get, #info{} = InfoReq},
                         raw_config = RawConfig }};
 process_request({set, #config{} = ConfigReq},
                 _From, RoomUS, {_, UserAff}, AffUsers, Acc) ->
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     AllCanConfigure = all_can_configure(HostType),
     process_config_set(HostType, ConfigReq, RoomUS, UserAff, AffUsers, AllCanConfigure);
 process_request({set, #affiliations{} = AffReq},
                 From, RoomUS, {_, UserAff}, AffUsers, Acc) ->
     UserUS = jid:to_lus(From),
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     OwnerUS = case lists:keyfind(owner, 2, AffUsers) of
                   false -> undefined;
                   {OwnerUS0, _} -> OwnerUS0
@@ -260,9 +260,11 @@ send_response(From, RoomJID, _OriginalPacket, Response, Acc) ->
 %% Internal functions
 %%====================================================================
 make_handler_fun(Acc) ->
+    HostType = mongoose_acc:host_type(Acc),
     fun(From, To, Packet) ->
         NewAcc0 = mongoose_acc:new(#{location => ?LOCATION,
                                      lserver => From#jid.lserver,
+                                     host_type => HostType,
                                      element => Packet,
                                      from_jid => From,
                                      to_jid => To}),

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -29,7 +29,6 @@
 -export([light_aff_to_muc_role/1]).
 -export([room_limit_reached/2]).
 -export([filter_out_prevented/4]).
--export([acc_to_host_type/1]).
 -export([room_jid_to_host_type/1]).
 -export([room_jid_to_server_host/1]).
 -export([muc_host_to_host_type/1]).
@@ -279,16 +278,6 @@ apply_aff_users_change([{User, _} | RAU], NAU, [{User, NewAff} | RAUC], CD) ->
 apply_aff_users_change([OldUser | RAU], NAU, AUC, CD) ->
     %% keep user affiliation unchanged
     apply_aff_users_change(RAU, [OldUser | NAU], AUC, CD).
-
--spec acc_to_host_type(mongoose_acc:t()) -> mongooseim:host_type().
-acc_to_host_type(Acc) ->
-    case mongoose_acc:host_type(Acc) of
-        undefined ->
-            MucHost = mongoose_acc:lserver(Acc),
-            muc_host_to_host_type(MucHost);
-        HostType ->
-            HostType
-    end.
 
 -spec room_jid_to_host_type(jid:jid()) -> mongooseim:host_type().
 room_jid_to_host_type(#jid{lserver = MucHost}) ->

--- a/src/privacy/mod_blocking.erl
+++ b/src/privacy/mod_blocking.erl
@@ -100,15 +100,17 @@ blocking_push_to_resources(Action, JIDs, StateData) ->
                 unblock -> blocking_stanza(JIDs, <<"unblock">>)
             end,
     PrivPushIQ = blocking_iq(SubEl),
+    HostType = mongoose_c2s:get_host_type(StateData),
     T = mongoose_c2s:get_jid(StateData),
     F = jid:to_bare(T),
     PrivPushEl = jlib:replace_from_to(F, T, jlib:iq_to_xml(PrivPushIQ)),
-    mongoose_router:route(mongoose_acc:new(F, T, PrivPushEl, ?LOCATION)),
+    mongoose_router:route(mongoose_acc:new(HostType, F, T, PrivPushEl, ?LOCATION)),
     ok.
 
 -spec blocking_presence_to_contacts(blocking_type(), [binary()], mongoose_c2s:data()) -> ok.
 blocking_presence_to_contacts(_Action, [], _StateData) -> ok;
 blocking_presence_to_contacts(Action, [Jid | JIDs], StateData) ->
+    HostType = mongoose_c2s:get_host_type(StateData),
     Presences = mod_presence:maybe_get_handler(StateData),
     Pres = case Action of
                block ->
@@ -120,7 +122,7 @@ blocking_presence_to_contacts(Action, [Jid | JIDs], StateData) ->
     case mod_presence:is_subscribed_to_my_presence(T, jid:to_bare(T), Presences) of
         true ->
             F = jid:to_bare(mongoose_c2s:get_jid(StateData)),
-            mongoose_router:route(mongoose_acc:new(F, T, Pres, ?LOCATION));
+            mongoose_router:route(mongoose_acc:new(HostType, F, T, Pres, ?LOCATION));
         false ->
             ok
     end,

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -1640,6 +1640,7 @@ get_node_subscriptions_transaction(Owner, #pubsub_node{id = Nidx, type = Type}) 
 
 send_authorization_request(#pubsub_node{nodeid = {Host, Node}, owners = Owners},
                            Subscriber) ->
+    HostType = host_to_host_type(Host),
     Lang = <<"en">>,
     Title = service_translations:do(Lang, <<"PubSub subscriber request">>),
     Instructions = service_translations:do(Lang, <<"Choose whether to approve this entity's "
@@ -1663,7 +1664,9 @@ send_authorization_request(#pubsub_node{nodeid = {Host, Node}, owners = Owners},
                     attrs = #{<<"id">> => mongoose_bin:gen_from_crypto()},
                     children = [Form]},
     lists:foreach(fun(Owner) ->
-                          mongoose_router:route(mongoose_acc:new(service_jid(Host), jid:make(Owner), Stanza, ?LOCATION))
+                    mongoose_router:route(mongoose_acc:new(HostType, service_jid(Host),
+                                        jid:make(Owner), Stanza,
+                                        ?LOCATION))
                   end, Owners).
 
 find_authorization_response(El) ->
@@ -1681,11 +1684,12 @@ find_authorization_response(El) ->
 
 %% @doc Send a message to JID with the supplied Subscription
 send_authorization_approval(Host, JID, SNode, Subscription) ->
+    HostType = host_to_host_type(Host),
     Attrs1 = node_attr(SNode),
     Attrs2 = Attrs1#{<<"subscription">> => subscription_to_string(Subscription)},
     Stanza = event_stanza(<<"subscription">>,
                           Attrs2#{<<"jid">> => jid:to_binary(JID)}),
-    mongoose_router:route(mongoose_acc:new(service_jid(Host), JID, Stanza, ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(HostType, service_jid(Host), JID, Stanza, ?LOCATION)).
 
 handle_authorization_response(Acc, Host, From, To, Packet, XFields) ->
     case XFields of
@@ -2580,9 +2584,11 @@ dispatch_items({_, FromS, _} = From, To, Options, Stanza) ->
     Acc = mongoose_acc:new(AccParams),
     mongoose_router:route(Acc);
 dispatch_items(From, To, Options, Stanza) ->
+    HostType = host_to_host_type(From),
     NotificationType = get_option(Options, notification_type, headline),
     Message = add_message_type(Stanza, NotificationType),
-    mongoose_router:route(mongoose_acc:new(service_jid(From), jid:make(To), Message, ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(HostType, service_jid(From), jid:make(To),
+                                           Message, ?LOCATION)).
 
 %% @doc <p>Return the list of affiliations as an XMPP response.</p>
 -spec get_affiliations(
@@ -3069,6 +3075,7 @@ set_subscription_transaction(Host, Node, Nidx, Type, {JID, Sub, SubId}, Acc) ->
     end.
 
 notify_subscription_change(Host, Node, JID, Sub) ->
+    HostType = host_to_host_type(Host),
     Attrs = node_attr(Node),
     SubscriptionEl = #xmlel{name = <<"subscription">>,
                             attrs = Attrs#{<<"jid">> => jid:to_binary(JID),
@@ -3077,7 +3084,8 @@ notify_subscription_change(Host, Node, JID, Sub) ->
                       attrs = #{<<"xmlns">> => ?NS_PUBSUB},
                       children = [SubscriptionEl]},
     Stanza = #xmlel{name = <<"message">>, children = [PubSubEl]},
-    mongoose_router:route(mongoose_acc:new(service_jid(Host), jid:make(JID), Stanza, ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(HostType, service_jid(Host), jid:make(JID),
+                                           Stanza, ?LOCATION)).
 
 -spec get_presence_and_roster_permissions(Host :: mod_pubsub:host(),
                                           From :: jid:jid() | jid:ljid(),
@@ -3463,6 +3471,7 @@ broadcast_step(Host, F) ->
 
 broadcast_stanza(Host, Node, _Nidx, _Type, NodeOptions,
                  SubsByDepth, NotifyType, BaseStanza, SHIM) ->
+    HostType = host_to_host_type(Host),
     NotificationType = get_option(NodeOptions, notification_type, headline),
     %% Option below is not standard, but useful
     BroadcastAll = get_option(NodeOptions, broadcast_all_resources),
@@ -3483,7 +3492,8 @@ broadcast_stanza(Host, Node, _Nidx, _Type, NodeOptions,
 
                           lists:foreach(fun(To) ->
                                                 mongoose_router:route(
-                                                  mongoose_acc:new(From, jid:make(To), StanzaToSend, ?LOCATION))
+                                                    mongoose_acc:new(HostType, From, jid:make(To),
+                                                                     StanzaToSend, ?LOCATION))
                                         end, LJIDs)
                   end, SubIDsByJID).
 

--- a/src/roster/mod_roster.erl
+++ b/src/roster/mod_roster.erl
@@ -409,7 +409,7 @@ set_roster_item(HostType, ContactJID, From, To, MakeItem) ->
             push_item(HostType, From, To, NewItem),
             case NewItem#roster.subscription of
                 remove ->
-                    send_unsubscribing_presence(From, OldItem),
+                    send_unsubscribing_presence(HostType, From, OldItem),
                     ok;
                 _ -> ok
             end;
@@ -494,7 +494,7 @@ push_item(HostType, JID, From, Item) ->
     broadcast_item(JID, Item#roster.jid, Item#roster.subscription),
     case roster_versioning_enabled(HostType) of
         true ->
-            push_item_version(JID, From, Item, roster_version(HostType, JID));
+            push_item_version(HostType, JID, From, Item, roster_version(HostType, JID));
         false ->
             lists:foreach(fun(Resource) ->
                                   push_item_without_version(HostType, JID, Resource, From, Item)
@@ -513,15 +513,16 @@ push_item_without_version(HostType, JID, Resource, From, Item) ->
     mongoose_instrument:execute(mod_roster_push, #{host_type => HostType},
                                 #{count => 1, jid => TargetJID}),
     mongoose_hooks:roster_push(HostType, From, Item),
-    push_item_final(TargetJID, From, Item, not_found).
+    push_item_final(HostType, TargetJID, From, Item, not_found).
 
-push_item_version(JID, From, Item, RosterVersion) ->
+push_item_version(HostType, JID, From, Item, RosterVersion) ->
     lists:foreach(fun(Resource) ->
-                          push_item_final(jid:replace_resource(JID, Resource),
+                          push_item_final(HostType,
+                                          jid:replace_resource(JID, Resource),
                                           From, Item, RosterVersion)
                   end, ejabberd_sm:get_user_resources(JID)).
 
-push_item_final(JID, From, Item, RosterVersion) ->
+push_item_final(HostType, JID, From, Item, RosterVersion) ->
     ExtraAttrs = case RosterVersion of
                      not_found -> #{};
                      _ -> #{<<"ver">> => RosterVersion}
@@ -534,7 +535,7 @@ push_item_final(JID, From, Item, RosterVersion) ->
                 [#xmlel{name = <<"query">>,
                         attrs = ExtraAttrs#{<<"xmlns">> => ?NS_ROSTER},
                         children = [item_to_xml(Item)]}]},
-    mongoose_router:route(mongoose_acc:new(From, JID, jlib:iq_to_xml(ResIQ), ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(HostType, From, JID, jlib:iq_to_xml(ResIQ), ?LOCATION)).
 
 -spec get_subscription_lists(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_acc:t(),
@@ -625,7 +626,8 @@ process_subscription(HostType, Direction, JID, ContactJID, Type, Reason) ->
                     PresenceStanza = #xmlel{name = <<"presence">>,
                                             attrs = #{<<"type">> => autoreply_to_type(AutoReply)},
                                             children = []},
-                    mongoose_router:route(mongoose_acc:new(JID, ContactJID, PresenceStanza, ?LOCATION))
+                    mongoose_router:route(mongoose_acc:new(HostType, JID, ContactJID,
+                                                          PresenceStanza, ?LOCATION))
             end,
             case Push of
                 {push, #roster{subscription = none, ask = in}} ->
@@ -829,32 +831,33 @@ try_send_unsubscription_to_rosteritems(Acc, JID) ->
 %% Both or To, send a "unsubscribe" presence stanza.
 -spec send_unsubscription_to_rosteritems(mongoose_acc:t(), jid:jid()) -> mongoose_acc:t().
 send_unsubscription_to_rosteritems(Acc, JID) ->
-    RosterItems = do_get_user_roster(mongoose_acc:host_type(Acc), JID),
+    HostType = mongoose_acc:host_type(Acc),
+    RosterItems = do_get_user_roster(HostType, JID),
     lists:foreach(fun(RosterItem) ->
-                          send_unsubscribing_presence(JID, RosterItem)
+                          send_unsubscribing_presence(HostType, JID, RosterItem)
                   end, RosterItems),
     Acc.
 
--spec send_unsubscribing_presence(From :: jid:jid(), Item :: roster()) -> ok | mongoose_acc:t().
-send_unsubscribing_presence(From, #roster{ subscription = Subscription } = Item) ->
+-spec send_unsubscribing_presence(mongooseim:host_type(), jid:jid(), roster()) -> ok | mongoose_acc:t().
+send_unsubscribing_presence(HostType, From, #roster{ subscription = Subscription } = Item) ->
     BareFrom = jid:to_bare(From),
     ContactJID = jid:make_noprep(Item#roster.jid),
     IsTo = Subscription == both orelse Subscription == to,
     IsFrom = Subscription == both orelse Subscription == from,
     case IsTo of
-        true -> send_presence_type(BareFrom, ContactJID, <<"unsubscribe">>);
+        true -> send_presence_type(HostType, BareFrom, ContactJID, <<"unsubscribe">>);
         _ -> ok
     end,
     case IsFrom of
-        true -> send_presence_type(BareFrom, ContactJID, <<"unsubscribed">>);
+        true -> send_presence_type(HostType, BareFrom, ContactJID, <<"unsubscribed">>);
         _ -> ok
     end.
 
-send_presence_type(From, To, Type) ->
+send_presence_type(HostType, From, To, Type) ->
     Pres = #xmlel{name = <<"presence">>,
                   attrs = #{<<"type">> => Type},
                   children = []},
-    mongoose_router:route( mongoose_acc:new(From, To, Pres, ?LOCATION)).
+    mongoose_router:route(mongoose_acc:new(HostType, From, To, Pres, ?LOCATION)).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/s2s/mongoose_s2s_in.erl
+++ b/src/s2s/mongoose_s2s_in.erl
@@ -322,6 +322,7 @@ route_incoming_stanza(Data, El, RemoteJid, LocalJid) ->
     FromTo = {LLocalServer, LRemoteServer},
     Acc = mongoose_acc:new(#{location => ?LOCATION,
                              lserver => LLocalServer,
+                             host_type => Data#s2s_data.host_type,
                              element => El,
                              from_jid => RemoteJid,
                              to_jid => LocalJid,

--- a/src/smart_markers/mod_smart_markers.erl
+++ b/src/smart_markers/mod_smart_markers.erl
@@ -263,7 +263,7 @@ forget_room(Acc, #{muc_host := RoomS, room := RoomU}, #{host_type := HostType}) 
       Params :: #{room := jid:jid()},
       Extra :: gen_hook:extra().
 room_new_affiliations(Acc, #{room := RoomJID}, _) ->
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
+    HostType = mongoose_acc:host_type(Acc),
     Packet = mongoose_acc:element(Acc),
     maybe_remove_to_for_users(Packet, RoomJID, HostType),
     {ok, Acc}.


### PR DESCRIPTION
This PR fixes cases where `mongoose_acc` could be created or reused without a defined `host_type`. This made routing and hook execution fragile.

By making `host_type` required at ACC construction time, the code becomes more explicit and avoids hidden fallback logic. And above else - it eliminates a condition under which bugs like MIM-2699 may occur in the first place.

### Changes
* make `host_type` mandatory in `mongoose_acc`
* resolve host type properly (or like in case of components - with best effort) when creating a new ACC

### Notes
* the main API change is that `mongoose_acc:new/4` becomes `mongoose_acc:new/5`
* helper functions such as `mod_muc_light_utils:acc_to_host_type/1` and the local fallback in `mod_mam_pm` are removed where they are no longer needed