### PR TITLE
MIM-2682 Pass presence subscription state to disco SM hooks

### DIFF
--- a/big_tests/tests/disco_and_caps_SUITE.erl
+++ b/big_tests/tests/disco_and_caps_SUITE.erl
@@ -173,8 +173,8 @@ user_cannot_query_stranger_resources(Config) ->
         Request = escalus_stanza:disco_items(BobJid),
         escalus:send(Alice, Request),
         Stanza = escalus:wait_for_stanza(Alice),
-        escalus:assert(is_iq_error, [Request], Stanza),
-        escalus:assert(is_error, [<<"cancel">>, <<"service-unavailable">>], Stanza),
+        Query = exml_query:subelement(Stanza, <<"query">>),
+        ?assertEqual([], exml_query:subelements(Query, <<"item">>)),
         escalus:assert(is_stanza_from, [BobJid], Stanza),
         assert_roster_get_event(Alice)
     end).
@@ -236,7 +236,7 @@ user_cannot_query_friend_resources_with_unknown_node(Config) ->
         escalus:send(Alice, Request),
         Stanza = escalus:wait_for_stanza(Alice),
         escalus:assert(is_iq_error, [Request], Stanza),
-        escalus:assert(is_error, [<<"cancel">>, <<"not-allowed">>], Stanza),
+        escalus:assert(is_error, [<<"cancel">>, <<"item-not-found">>], Stanza),
         escalus:assert(is_stanza_from, [BobJid], Stanza)
     end).
 

--- a/big_tests/tests/disco_and_caps_SUITE.erl
+++ b/big_tests/tests/disco_and_caps_SUITE.erl
@@ -38,7 +38,11 @@ basic_test_cases() ->
      user_can_query_friend_resources,
      user_can_query_friend_features,
      user_cannot_query_own_resources_with_unknown_node,
+     user_cannot_query_own_features_with_unknown_node,
      user_cannot_query_friend_resources_with_unknown_node,
+     user_cannot_query_friend_features_with_unknown_node,
+     user_cannot_query_stranger_resources_with_unknown_node,
+     user_cannot_query_stranger_features_with_unknown_node,
      user_can_query_server_features].
 
 server_caps_test_cases() ->
@@ -228,6 +232,17 @@ user_cannot_query_own_resources_with_unknown_node(Config) ->
         escalus:assert(is_stanza_from, [AliceJid], Stanza)
     end).
 
+user_cannot_query_own_features_with_unknown_node(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        AliceJid = escalus_client:short_jid(Alice),
+        Request = escalus_stanza:disco_info(AliceJid, <<"unknown-node">>),
+        escalus:send(Alice, Request),
+        Stanza = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_iq_error, [Request], Stanza),
+        escalus:assert(is_error, [<<"cancel">>, <<"item-not-found">>], Stanza),
+        escalus:assert(is_stanza_from, [AliceJid], Stanza)
+    end).
+
 user_cannot_query_friend_resources_with_unknown_node(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         escalus_story:make_all_clients_friends([Alice, Bob]),
@@ -238,6 +253,42 @@ user_cannot_query_friend_resources_with_unknown_node(Config) ->
         escalus:assert(is_iq_error, [Request], Stanza),
         escalus:assert(is_error, [<<"cancel">>, <<"item-not-found">>], Stanza),
         escalus:assert(is_stanza_from, [BobJid], Stanza)
+    end).
+
+user_cannot_query_friend_features_with_unknown_node(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        escalus_story:make_all_clients_friends([Alice, Bob]),
+        BobJid = escalus_client:short_jid(Bob),
+        Request = escalus_stanza:disco_info(BobJid, <<"unknown-node">>),
+        escalus:send(Alice, Request),
+        Stanza = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_iq_error, [Request], Stanza),
+        escalus:assert(is_error, [<<"cancel">>, <<"item-not-found">>], Stanza),
+        escalus:assert(is_stanza_from, [BobJid], Stanza)
+    end).
+
+user_cannot_query_stranger_resources_with_unknown_node(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        BobJid = escalus_client:short_jid(Bob),
+        Request = escalus_stanza:disco_items(BobJid, <<"unknown-node">>),
+        escalus:send(Alice, Request),
+        Stanza = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_iq_error, [Request], Stanza),
+        escalus:assert(is_error, [<<"cancel">>, <<"service-unavailable">>], Stanza),
+        escalus:assert(is_stanza_from, [BobJid], Stanza),
+        assert_roster_get_event(Alice)
+    end).
+
+user_cannot_query_stranger_features_with_unknown_node(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        BobJid = escalus_client:short_jid(Bob),
+        Request = escalus_stanza:disco_info(BobJid, <<"unknown-node">>),
+        escalus:send(Alice, Request),
+        Stanza = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_iq_error, [Request], Stanza),
+        escalus:assert(is_error, [<<"cancel">>, <<"service-unavailable">>], Stanza),
+        escalus:assert(is_stanza_from, [BobJid], Stanza),
+        assert_roster_get_event(Alice)
     end).
 
 user_can_query_extra_domains(Config) ->

--- a/big_tests/tests/offline_SUITE.erl
+++ b/big_tests/tests/offline_SUITE.erl
@@ -44,11 +44,9 @@ chat_markers_tests() ->
      room_chatmarker_is_overriden_and_only_unique_markers_are_delivered].
 
 groups() ->
-    G = [{mod_offline_tests, [parallel], all_tests()},
-         {with_groupchat, [], [groupchat_message_is_stored]},
-         {chatmarkers, [], chat_markers_tests()}
-        ],
-    ct_helper:repeat_all_until_all_ok(G).
+    [{mod_offline_tests, [parallel], all_tests()},
+     {with_groupchat, [], [groupchat_message_is_stored]},
+     {chatmarkers, [], chat_markers_tests()}].
 
 suite() ->
     escalus:suite().
@@ -119,13 +117,23 @@ end_per_testcase(Name, C) -> escalus:end_per_testcase(Name, C).
 %%%===================================================================
 
 disco_info_sm(Config) ->
-    escalus:fresh_story(Config, [{alice, 1}],
-        fun(Alice) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}],
+        fun(Alice, Bob) ->
+                %% Alice should be able to get her own features
                 AliceJid = escalus_client:short_jid(Alice),
                 escalus:send(Alice, escalus_stanza:disco_info(AliceJid)),
                 Stanza = escalus:wait_for_stanza(Alice),
                 escalus:assert(has_feature, [?NS_FEATURE_MSGOFFLINE], Stanza),
-                escalus:assert(is_stanza_from, [AliceJid], Stanza)
+                escalus:assert(is_stanza_from, [AliceJid], Stanza),
+
+                %% Alice shouldn't be able to get Bob's features
+                BobJid = escalus_client:short_jid(Bob),
+                Request = escalus_stanza:disco_info(BobJid),
+                escalus:send(Alice, Request),
+                Error = escalus:wait_for_stanza(Alice),
+                escalus:assert(is_iq_error, [Request], Error),
+                escalus:assert(is_error, [~"cancel", ~"service-unavailable"], Error),
+                escalus:assert(is_stanza_from, [BobJid], Error)
         end).
 
 offline_message_is_stored_and_delivered_at_login(Config) ->

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -114,11 +114,11 @@
          s2s_send_packet/4]).
 
 -export([disco_local_identity/1,
-         disco_sm_identity/1,
+         disco_sm_identity/2,
          disco_local_items/1,
-         disco_sm_items/1,
+         disco_sm_items/2,
          disco_local_features/1,
-         disco_sm_features/1,
+         disco_sm_features/2,
          disco_muc_features/1,
          disco_info/1]).
 
@@ -1177,9 +1177,10 @@ disco_local_identity(Acc = #{host_type := HostType}) ->
 
 %%% @doc `disco_sm_identity' hook is called to get the identity of the
 %%% client when a discovery IQ gets to session management.
--spec disco_sm_identity(mongoose_disco:identity_acc()) -> mongoose_disco:identity_acc().
-disco_sm_identity(Acc = #{host_type := HostType}) ->
-    run_hook_for_host_type(disco_sm_identity, HostType, Acc, #{}).
+-spec disco_sm_identity(mongoose_disco:identity_acc(), mongoose_disco:sm_params()) ->
+    mongoose_disco:identity_acc().
+disco_sm_identity(Acc = #{host_type := HostType}, Params) ->
+    run_hook_for_host_type(disco_sm_identity, HostType, Acc, Params).
 
 %%% @doc `disco_local_items' hook is called to extract items associated with the server.
 -spec disco_local_items(mongoose_disco:item_acc()) -> mongoose_disco:item_acc().
@@ -1188,9 +1189,10 @@ disco_local_items(Acc = #{host_type := HostType}) ->
 
 %%% @doc `disco_sm_items' hook is called to get the items associated
 %%% with the client when a discovery IQ gets to session management.
--spec disco_sm_items(mongoose_disco:item_acc()) -> mongoose_disco:item_acc().
-disco_sm_items(Acc = #{host_type := HostType}) ->
-    run_hook_for_host_type(disco_sm_items, HostType, Acc, #{}).
+-spec disco_sm_items(mongoose_disco:item_acc(), mongoose_disco:sm_params()) ->
+    mongoose_disco:item_acc().
+disco_sm_items(Acc = #{host_type := HostType}, Params) ->
+    run_hook_for_host_type(disco_sm_items, HostType, Acc, Params).
 
 %%% @doc `disco_local_features' hook is called to extract features
 %%% offered by the server.
@@ -1200,9 +1202,10 @@ disco_local_features(Acc = #{host_type := HostType}) ->
 
 %%% @doc `disco_sm_features' hook is called to get the features of the client
 %%% when a discovery IQ gets to session management.
--spec disco_sm_features(mongoose_disco:feature_acc()) -> mongoose_disco:feature_acc().
-disco_sm_features(Acc = #{host_type := HostType}) ->
-    run_hook_for_host_type(disco_sm_features, HostType, Acc, #{}).
+-spec disco_sm_features(mongoose_disco:feature_acc(), mongoose_disco:sm_params()) ->
+    mongoose_disco:feature_acc().
+disco_sm_features(Acc = #{host_type := HostType}, Params) ->
+    run_hook_for_host_type(disco_sm_features, HostType, Acc, Params).
 
 %%% @doc `disco_muc_features' hook is called to get the features
 %%% supported by the MUC (Light) service.

--- a/src/mam/mod_mam_pm.erl
+++ b/src/mam/mod_mam_pm.erl
@@ -160,8 +160,9 @@ disco_local_features(Acc, _, _) ->
     {ok, Acc}.
 
 -spec disco_sm_features(mongoose_disco:feature_acc(),
-                        map(), map()) -> {ok, mongoose_disco:feature_acc()}.
-disco_sm_features(Acc = #{host_type := HostType, node := <<>>}, _, _) ->
+                        mongoose_disco:sm_params(), map()) -> {ok, mongoose_disco:feature_acc()}.
+disco_sm_features(Acc = #{host_type := HostType, node := <<>>},
+                  #{presence_subscribed := true}, _) ->
     {ok, mongoose_disco:add_features(mod_mam_utils:features(?MODULE, HostType), Acc)};
 disco_sm_features(Acc, _, _) ->
     {ok, Acc}.

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -164,9 +164,10 @@ disco_local_items(Acc, _, _) ->
 
 -spec disco_sm_items(Acc, Params, Extra) -> {ok, Acc} when
       Acc :: mongoose_disco:item_acc(),
-      Params :: map(),
+      Params :: mongoose_disco:sm_params(),
       Extra :: #{host_type := mongooseim:host_type()}.
-disco_sm_items(Acc = #{to_jid := To, node := <<>>, lang := Lang}, _, #{host_type := HostType}) ->
+disco_sm_items(Acc = #{to_jid := To, node := <<>>, lang := Lang},
+               #{presence_subscribed := true}, #{host_type := HostType}) ->
     Items = case are_commands_visible(HostType) of
                 false ->
                     [];
@@ -202,9 +203,10 @@ disco_local_identity(Acc, _, _) ->
 %% @doc On disco info request to the ad-hoc node, return automation/command-list.
 -spec disco_sm_identity(Acc, Params, Extra) -> {ok, Acc} when
       Acc :: mongoose_disco:identity_acc(),
-      Params :: map(),
+      Params :: mongoose_disco:sm_params(),
       Extra :: gen_hook:extra().
-disco_sm_identity(Acc = #{node := ?NS_COMMANDS, lang := Lang}, _, _) ->
+disco_sm_identity(Acc = #{node := ?NS_COMMANDS, lang := Lang},
+                  #{presence_subscribed := true}, _) ->
     {ok, mongoose_disco:add_identities([command_list_identity(Lang)], Acc)};
 disco_sm_identity(Acc, _, _) ->
     {ok, Acc}.
@@ -240,11 +242,11 @@ disco_local_features(Acc, _, _) ->
 
 -spec disco_sm_features(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_disco:feature_acc(),
-    Params :: map(),
+    Params :: mongoose_disco:sm_params(),
     Extra :: gen_hook:extra().
-disco_sm_features(Acc = #{node := <<>>}, _, _) ->
+disco_sm_features(Acc = #{node := <<>>}, #{presence_subscribed := true}, _) ->
     {ok, mongoose_disco:add_features([?NS_COMMANDS], Acc)};
-disco_sm_features(Acc = #{node := ?NS_COMMANDS}, _, _) ->
+disco_sm_features(Acc = #{node := ?NS_COMMANDS}, #{presence_subscribed := true}, _) ->
     %% override all lesser features...
     {ok, Acc#{result := []}};
 disco_sm_features(Acc, _, _) ->

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -160,19 +160,17 @@ process_local_iq_info(Acc, From, To, #iq{type = get, lang = Lang, sub_el = SubEl
 process_sm_iq_items(Acc, _From, _To, #iq{type = set, sub_el = SubEl} = IQ, _Extra) ->
     {Acc, IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:not_allowed()]}};
 process_sm_iq_items(Acc, From, To, #iq{type = get, lang = Lang, sub_el = SubEl} = IQ, _Extra) ->
-    case is_presence_subscribed(From, To) of
-        true ->
-            HostType = mongoose_acc:host_type(Acc),
-            Node = exml_query:attr(SubEl, <<"node">>, <<>>),
-            case mongoose_disco:get_sm_items(HostType, From, To, Node, Lang) of
-                empty ->
-                    Error = sm_error(From, To),
-                    {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}};
-                {result, ItemsXML} ->
-                    {Acc, make_iq_result(IQ, ?NS_DISCO_ITEMS, Node, ItemsXML)}
-            end;
-        false ->
-            {Acc, IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:service_unavailable()]}}
+    IsPresenceSubscribed = is_presence_subscribed(From, To),
+    HostType = mongoose_acc:host_type(Acc),
+    Node = exml_query:attr(SubEl, ~"node", ~""),
+    case mongoose_disco:get_sm_items(HostType, From, To, Node, Lang, IsPresenceSubscribed) of
+        empty when Node =:= ~"" ->
+            {Acc, make_iq_result(IQ, ?NS_DISCO_ITEMS, Node, [])};
+        empty ->
+            Error = sm_error(IsPresenceSubscribed),
+            {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}};
+        {result, ItemsXML} ->
+            {Acc, make_iq_result(IQ, ?NS_DISCO_ITEMS, Node, ItemsXML)}
     end.
 
 -spec process_sm_iq_info(mongoose_acc:t(), jid:jid(), jid:jid(), jlib:iq(), map()) ->
@@ -180,20 +178,19 @@ process_sm_iq_items(Acc, From, To, #iq{type = get, lang = Lang, sub_el = SubEl} 
 process_sm_iq_info(Acc, _From, _To, #iq{type = set, sub_el = SubEl} = IQ, _Extra) ->
     {Acc, IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:not_allowed()]}};
 process_sm_iq_info(Acc, From, To, #iq{type = get, lang = Lang, sub_el = SubEl} = IQ, _Extra) ->
-    case is_presence_subscribed(From, To) of
-        true ->
-            HostType = mongoose_acc:host_type(Acc),
-            Node = exml_query:attr(SubEl, <<"node">>, <<>>),
-            case mongoose_disco:get_sm_features(HostType, From, To, Node, Lang) of
-                empty ->
-                    Error = sm_error(From, To),
-                    {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}};
-                {result, FeaturesXML} ->
-                    IdentityXML = mongoose_disco:get_sm_identity(HostType, From, To, Node, Lang),
-                    {Acc, make_iq_result(IQ, ?NS_DISCO_INFO, Node, IdentityXML ++ FeaturesXML)}
-            end;
-        false ->
-            {Acc, IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:service_unavailable()]}}
+    IsPresenceSubscribed = is_presence_subscribed(From, To),
+    HostType = mongoose_acc:host_type(Acc),
+    Node = exml_query:attr(SubEl, ~"node", ~""),
+    case mongoose_disco:get_sm_features(HostType, From, To, Node, Lang, IsPresenceSubscribed) of
+        empty when Node =:= ~"" ->
+            {Acc, IQ#iq{type = error, sub_el = [SubEl, mongoose_xmpp_errors:service_unavailable()]}};
+        empty ->
+            Error = sm_error(IsPresenceSubscribed),
+            {Acc, IQ#iq{type = error, sub_el = [SubEl, Error]}};
+        {result, FeaturesXML} ->
+            IdentityXML = mongoose_disco:get_sm_identity(HostType, From, To, Node, Lang,
+                                                         IsPresenceSubscribed),
+            {Acc, make_iq_result(IQ, ?NS_DISCO_INFO, Node, IdentityXML ++ FeaturesXML)}
     end.
 
 %% Hook handlers
@@ -211,10 +208,10 @@ disco_local_identity(Acc, _, _) ->
 
 -spec disco_sm_identity(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_disco:identity_acc(),
-    Params :: map(),
+    Params :: mongoose_disco:sm_params(),
     Extra :: map().
-disco_sm_identity(Acc = #{to_jid := JID}, _, _) ->
-    NewAcc = case ejabberd_auth:does_user_exist(JID) of
+disco_sm_identity(Acc = #{to_jid := JID}, #{presence_subscribed := PresenceSubscribed}, _) ->
+    NewAcc = case PresenceSubscribed andalso ejabberd_auth:does_user_exist(JID) of
         true -> mongoose_disco:add_identities([#{category => <<"account">>,
                                                  type => <<"registered">>}], Acc);
         false -> Acc
@@ -237,11 +234,10 @@ disco_local_items(Acc, _, _) ->
 
 -spec disco_sm_items(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_disco:item_acc(),
-    Params :: map(),
+    Params :: mongoose_disco:sm_params(),
     Extra :: map().
-disco_sm_items(Acc = #{to_jid := To, node := <<>>}, _, _) ->
-    Items = get_user_resources(To),
-    {ok, mongoose_disco:add_items(Items, Acc)};
+disco_sm_items(Acc = #{to_jid := To, node := <<>>}, #{presence_subscribed := true}, _) ->
+    {ok, mongoose_disco:add_items(get_user_resources(To), Acc)};
 disco_sm_items(Acc, _, _) ->
     {ok, Acc}.
 
@@ -295,7 +291,10 @@ get_external_components(ReturnHidden) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 -spec is_presence_subscribed(jid:jid(), jid:jid()) -> boolean().
-is_presence_subscribed(#jid{luser = LFromUser, lserver = LFromServer} = FromJID,
+is_presence_subscribed(#jid{luser = LUser, lserver = LServer},
+                       #jid{luser = LUser, lserver = LServer}) ->
+    true;
+is_presence_subscribed(#jid{lserver = LFromServer} = FromJID,
                        #jid{luser = LToUser, lserver = LToServer} = _To) ->
     {ok, HostType} = mongoose_domain_api:get_domain_host_type(LFromServer),
     A = mongoose_acc:new(#{ location => ?LOCATION,
@@ -309,14 +308,10 @@ is_presence_subscribed(#jid{luser = LFromUser, lserver = LFromServer} = FromJID,
                       {TUser, TServer} = jid:to_lus(JID),
                       LToUser == TUser andalso LToServer == TServer andalso S /= none
               end,
-              Roster)
-    orelse LFromUser == LToUser andalso LFromServer == LToServer.
+              Roster).
 
-sm_error(#jid{luser = LUser, lserver = LServer},
-         #jid{luser = LUser, lserver = LServer}) ->
-    mongoose_xmpp_errors:item_not_found();
-sm_error(_From, _To) ->
-    mongoose_xmpp_errors:not_allowed().
+sm_error(true) -> mongoose_xmpp_errors:item_not_found();
+sm_error(false) -> mongoose_xmpp_errors:service_unavailable().
 
 -spec get_user_resources(jid:jid()) -> [mongoose_disco:item()].
 get_user_resources(JID = #jid{luser = LUser}) ->

--- a/src/mongoose_disco.erl
+++ b/src/mongoose_disco.erl
@@ -6,11 +6,11 @@
 
 %% Hooks wrappers
 -export([get_local_identity/5,
-         get_sm_identity/5,
+         get_sm_identity/6,
          get_local_items/5,
-         get_sm_items/5,
+         get_sm_items/6,
          get_local_features/5,
-         get_sm_features/5,
+         get_sm_features/6,
          get_muc_features/6,
          get_info/4]).
 
@@ -34,7 +34,7 @@
 -type feature() :: binary().
 
 -type item_acc() :: acc(item()).
--type item() :: #{jid := jid:lserver(), name => binary(), node => binary()}.
+-type item() :: #{jid := jid:literal_jid(), name => binary(), node => binary()}.
 
 -type identity_acc() :: acc(identity()).
 -type identity() :: #{category := binary(), type := binary(), name => binary()}.
@@ -46,6 +46,7 @@
                       result := empty | [info()]}.
 -type info() :: #{xmlns := binary(), fields := [info_field()]}.
 -type info_field() :: #{var := binary(), values := [binary()], label => binary()}.
+-type sm_params() :: #{presence_subscribed := boolean()}.
 
 -type acc(Elem) :: #{host_type := mongooseim:host_type(),
                      from_jid := jid:jid(),
@@ -54,7 +55,7 @@
                      lang := ejabberd:lang(),
                      result := empty | [Elem]}.
 
--export_type([item_acc/0, feature_acc/0, identity_acc/0,
+-export_type([item_acc/0, feature_acc/0, identity_acc/0, sm_params/0,
               item/0, feature/0, identity/0,
               info_field/0, info/0, info_acc/0]).
 
@@ -68,11 +69,11 @@ get_local_identity(HostType, From, To, Node, Lang) ->
     Identities = extract_result(FinalAcc),
     identities_to_xml(Identities).
 
--spec get_sm_identity(mongooseim:host_type(), jid:jid(), jid:jid(), binary(), ejabberd:lang()) ->
-          [exml:element()].
-get_sm_identity(HostType, From, To, Node, Lang) ->
+-spec get_sm_identity(mongooseim:host_type(), jid:jid(), jid:jid(), binary(), ejabberd:lang(),
+                      boolean()) -> [exml:element()].
+get_sm_identity(HostType, From, To, Node, Lang, PresenceSubscribed) ->
     InitialAcc = new_acc(HostType, From, To, Node, Lang),
-    IdentityAcc = mongoose_hooks:disco_sm_identity(InitialAcc),
+    IdentityAcc = mongoose_hooks:disco_sm_identity(InitialAcc, sm_params(PresenceSubscribed)),
     Identities = extract_result(IdentityAcc),
     identities_to_xml(Identities).
 
@@ -85,11 +86,11 @@ get_local_items(HostType, From, To, Node, Lang) ->
         #{result := Items} -> {result, items_to_xml(Items)}
     end.
 
--spec get_sm_items(mongooseim:host_type(), jid:jid(), jid:jid(), binary(), ejabberd:lang()) ->
-          {result, [exml:element()]} | empty.
-get_sm_items(HostType, From, To, Node, Lang) ->
+-spec get_sm_items(mongooseim:host_type(), jid:jid(), jid:jid(), binary(), ejabberd:lang(),
+                   boolean()) -> {result, [exml:element()]} | empty.
+get_sm_items(HostType, From, To, Node, Lang, PresenceSubscribed) ->
     Acc = new_acc(HostType, From, To, Node, Lang),
-    case mongoose_hooks:disco_sm_items(Acc) of
+    case mongoose_hooks:disco_sm_items(Acc, sm_params(PresenceSubscribed)) of
         #{result := empty} -> empty;
         #{result := Items} -> {result, items_to_xml(Items)}
     end.
@@ -103,11 +104,11 @@ get_local_features(HostType, From, To, Node, Lang) ->
         #{result := Features} -> {result, features_to_xml(Features)}
     end.
 
--spec get_sm_features(mongooseim:host_type(), jid:jid(), jid:jid(), binary(), ejabberd:lang()) ->
-          {result, [exml:element()]} | empty.
-get_sm_features(HostType, From, To, Node, Lang) ->
+-spec get_sm_features(mongooseim:host_type(), jid:jid(), jid:jid(), binary(), ejabberd:lang(),
+                      boolean()) -> {result, [exml:element()]} | empty.
+get_sm_features(HostType, From, To, Node, Lang, PresenceSubscribed) ->
     Acc = new_acc(HostType, From, To, Node, Lang),
-    case mongoose_hooks:disco_sm_features(Acc) of
+    case mongoose_hooks:disco_sm_features(Acc, sm_params(PresenceSubscribed)) of
         #{result := empty} -> empty;
         #{result := Features} -> {result, features_to_xml(Features)}
     end.
@@ -199,6 +200,10 @@ add(Elements, Acc = #{result := InitialElements}) ->
                     (info_acc()) -> [info()].
 extract_result(#{result := empty}) -> [];
 extract_result(#{result := Elements}) -> Elements.
+
+-spec sm_params(boolean()) -> sm_params().
+sm_params(PresenceSubscribed) ->
+    #{presence_subscribed => PresenceSubscribed}.
 
 %% Conversion to XML
 

--- a/src/offline/mod_offline.erl
+++ b/src/offline/mod_offline.erl
@@ -41,7 +41,8 @@
          pop_offline_messages/3,
          remove_user/3,
          remove_domain/3,
-         disco_features/3,
+         disco_local_features/3,
+         disco_sm_features/3,
          determine_amp_strategy/3,
          amp_failed_event/3,
          get_personal_data/3]).
@@ -139,8 +140,8 @@ hooks(HostType) ->
         {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
         {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
         {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50},
-        {disco_sm_features, HostType, fun ?MODULE:disco_features/3, #{}, 50},
-        {disco_local_features, HostType, fun ?MODULE:disco_features/3, #{}, 50},
+        {disco_sm_features, HostType, fun ?MODULE:disco_sm_features/3, #{}, 50},
+        {disco_local_features, HostType, fun ?MODULE:disco_local_features/3, #{}, 50},
         {amp_determine_strategy, HostType, fun ?MODULE:determine_amp_strategy/3, #{}, 30},
         {failed_to_store_message, HostType, fun ?MODULE:amp_failed_event/3, #{}, 30},
         {get_personal_data, HostType, fun ?MODULE:get_personal_data/3, #{}, 50}
@@ -472,16 +473,30 @@ remove_domain(Acc, #{domain := Domain}, #{host_type := HostType}) ->
     mod_offline_backend:remove_domain(HostType, Domain),
     {ok, Acc}.
 
--spec disco_features(Acc, Params, Extra) -> {ok, Acc} when
+-spec disco_local_features(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_disco:feature_acc(),
     Params :: map(),
     Extra :: gen_hook:extra().
-disco_features(Acc = #{node := <<>>}, _Params, _Extra) ->
+disco_local_features(Acc, _Params, _Extra) ->
+    add_offline_disco_features(Acc).
+
+-spec disco_sm_features(Acc, Params, Extra) -> {ok, Acc} when
+    Acc :: mongoose_disco:feature_acc(),
+    Params :: mongoose_disco:sm_params(),
+    Extra :: gen_hook:extra().
+disco_sm_features(Acc, #{presence_subscribed := true}, _Extra) ->
+    add_offline_disco_features(Acc);
+disco_sm_features(Acc, _Params, _Extra) ->
+    {ok, Acc}.
+
+-spec add_offline_disco_features(Acc) -> {ok, Acc} when
+    Acc :: mongoose_disco:feature_acc().
+add_offline_disco_features(Acc = #{node := <<>>}) ->
     {ok, mongoose_disco:add_features([?NS_FEATURE_MSGOFFLINE], Acc)};
-disco_features(Acc = #{node := ?NS_FEATURE_MSGOFFLINE}, _Params, _Extra) ->
+add_offline_disco_features(Acc = #{node := ?NS_FEATURE_MSGOFFLINE}) ->
     %% override all lesser features...
     {ok, Acc#{result := []}};
-disco_features(Acc, _Params, _Extra) ->
+add_offline_disco_features(Acc) ->
     {ok, Acc}.
 
 -spec determine_amp_strategy(Acc, Params, Extra) -> {ok, Acc} when

--- a/src/pubsub_old/mod_pubsub_old.erl
+++ b/src/pubsub_old/mod_pubsub_old.erl
@@ -663,11 +663,13 @@ disco_local_features(Acc, _, _) ->
 
 -spec disco_sm_identity(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_disco:identity_acc(),
-    Params :: map(),
+    Params :: mongoose_disco:sm_params(),
     Extra :: gen_hook:extra().
-disco_sm_identity(Acc = #{from_jid := From, to_jid := To}, _, _) ->
+disco_sm_identity(Acc = #{from_jid := From, to_jid := To}, #{presence_subscribed := true}, _) ->
     Identities = disco_identity(jid:to_lower(jid:to_bare(To)), From),
-    {ok, mongoose_disco:add_identities(Identities, Acc)}.
+    {ok, mongoose_disco:add_identities(Identities, Acc)};
+disco_sm_identity(Acc, _, _) ->
+    {ok, Acc}.
 
 disco_identity(error, _From) ->
     [];
@@ -679,11 +681,13 @@ pep_identity() ->
 
 -spec disco_sm_features(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_disco:feature_acc(),
-    Params :: map(),
+    Params :: mongoose_disco:sm_params(),
     Extra :: gen_hook:extra().
-disco_sm_features(Acc = #{from_jid := From, to_jid := To}, _, _) ->
+disco_sm_features(Acc = #{from_jid := From, to_jid := To}, #{presence_subscribed := true}, _) ->
     Features = disco_features(jid:to_lower(jid:to_bare(To)), From),
-    {ok, mongoose_disco:add_features(Features, Acc)}.
+    {ok, mongoose_disco:add_features(Features, Acc)};
+disco_sm_features(Acc, _, _) ->
+    {ok, Acc}.
 
 -spec disco_features(error | jid:simple_jid(), jid:jid()) -> [mongoose_disco:feature()].
 disco_features(error, _From) ->
@@ -693,11 +697,13 @@ disco_features(_Host, _From) ->
 
 -spec disco_sm_items(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: mongoose_disco:item_acc(),
-    Params :: map(),
+    Params :: mongoose_disco:sm_params(),
     Extra :: gen_hook:extra().
-disco_sm_items(Acc = #{from_jid := From, to_jid := To}, _, _) ->
+disco_sm_items(Acc = #{from_jid := From, to_jid := To}, #{presence_subscribed := true}, _) ->
     Items = disco_items(jid:to_lower(jid:to_bare(To)), From),
-    {ok, mongoose_disco:add_items(Items, Acc)}.
+    {ok, mongoose_disco:add_items(Items, Acc)};
+disco_sm_items(Acc, _, _) ->
+    {ok, Acc}.
 
 -spec disco_items(mod_pubsub_old:host(), jid:jid()) -> [mongoose_disco:item()].
 disco_items(Host, From) ->


### PR DESCRIPTION
## Summary

Pass the SM disco presence-subscription state to `disco_sm_*` hook handlers as explicit hook params.

The new `mod_pubsub` implementation will use this to apply PEP-specific discovery rules while `mod_disco` remains responsible for generic SM disco routing.

## Motivation

SM disco visibility should not be decided only by a hard gate in `mod_disco`. Modules need the request context plus the presence-subscription state to decide whether they can expose identities, features, or items - in particular, the new PEP-focused `mod_pubsub` will require this.

## Changed SM disco rules

| Case | New behavior | XEP basis |
|---|---|---|
| `disco#items` to bare JID, no node, no presence subscription | Empty successful result | [XEP-0030 §8 Security Considerations](https://xmpp.org/extensions/xep-0030.html#security): bare-JID `disco#items` with no node MUST return an empty result set when only available resources would be exposed and requester is not presence-authorized. |
| `disco#info` to bare JID, no node, no presence subscription | `service-unavailable` if no module contributes visible features | [XEP-0030 §8 Security Considerations](https://xmpp.org/extensions/xep-0030.html#security): bare-JID `disco#info` MUST return `service-unavailable` when requester is not presence-authorized. |
| Unknown node with presence subscription | `item-not-found` | [XEP-0030 §7 Error Conditions](https://xmpp.org/extensions/xep-0030.html#errors): `item-not-found` means the JID or JID+NodeID target does not exist and this fact can be disclosed. |
| Unknown node without presence subscription | `service-unavailable` | [XEP-0030 §7 Error Conditions](https://xmpp.org/extensions/xep-0030.html#errors) and [§8 Security Considerations](https://xmpp.org/extensions/xep-0030.html#security): `service-unavailable` is used when existence cannot be disclosed due to privacy/security policy, and bare-JID disco must avoid leaking information to non-presence-authorized requesters. |

## Other changes

- Add exported `mongoose_disco:sm_params()` with `presence_subscribed`, and pass them through `mongoose_hooks:disco_sm_*`.
- Update SM disco handlers in `mod_disco`, `mod_adhoc`, `mod_mam_pm`, `mod_offline`, and `mod_pubsub_old`.
- Update affected disco/caps tests.
- Add tests to cover most important changed lines. Less important lines in `mod_pubsub_old` are not covered as this module will be phased out.