### PR TITLE
MIM-2719 Lightweight PEP implementation

### DIFF
--- a/big_tests/default.spec
+++ b/big_tests/default.spec
@@ -75,6 +75,7 @@
 {suites, "tests", oauth_SUITE}.
 {suites, "tests", offline_SUITE}.
 {suites, "tests", offline_stub_SUITE}.
+{suites, "tests", pep_SUITE}.
 {suites, "tests", pep_old_SUITE}.
 {suites, "tests", presence_SUITE}.
 {suites, "tests", privacy_SUITE}.

--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -90,6 +90,7 @@
 {suites, "tests", oauth_SUITE}.
 {suites, "tests", offline_SUITE}.
 {suites, "tests", offline_stub_SUITE}.
+{suites, "tests", pep_SUITE}.
 {suites, "tests", presence_SUITE}.
 {suites, "tests", privacy_SUITE}.
 {suites, "tests", private_SUITE}.

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -1,0 +1,1024 @@
+-module(pep_SUITE).
+-moduledoc "PEP (XEP-0163) tests for mod_pubsub".
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("escalus/include/escalus_xmlns.hrl").
+-include_lib("exml/include/exml.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-import(config_parser_helper, [default_mod_config/1]).
+-import(distributed_helper, [require_rpc_nodes/1]).
+-import(domain_helper, [host_type/0]).
+-import(pubsub_tools, [check_item_notification/4,
+                       create_node/3, delete_node/3,
+                       get_all_items/3, get_configuration/3, get_item/4, get_items/4,
+                       item_content/0, item_el/2,
+                       publish/4, publish_raw/4, publish_with_options/5, published_item_id/2,
+                       receive_item_notification/4, receive_node_deletion_notification/3,
+                       send_generic_request/6,
+                       set_configuration/4,
+                       subscribe/3, unsubscribe/3]).
+
+%%--------------------------------------------------------------------
+%% Init & teardown
+%%--------------------------------------------------------------------
+
+suite() ->
+    require_rpc_nodes([mim]) ++ escalus:suite().
+
+init_per_suite(Config) ->
+    maybe
+        ok ?= caps_helper:check_backend(),
+        escalus:init_per_suite(dynamic_modules:save_modules(host_type(), Config))
+    end.
+
+end_per_suite(Config) ->
+    dynamic_modules:restore_modules(Config),
+    escalus:end_per_suite(Config).
+
+init_per_group(GroupName, Config) ->
+    Config1 = dynamic_modules:save_modules(host_type(), Config),
+    dynamic_modules:ensure_modules(host_type(), required_modules(GroupName)),
+    Config1.
+
+end_per_group(_GroupName, Config) ->
+    escalus_fresh:clean(),
+    dynamic_modules:restore_modules(Config).
+
+init_per_testcase(TestName, Config) ->
+    escalus:init_per_testcase(TestName, Config).
+
+end_per_testcase(TestName, Config) ->
+    escalus:end_per_testcase(TestName, Config).
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+all() ->
+    [{group, pep},
+     {group, pep_no_caps}].
+
+groups() ->
+    [{pep, [parallel], pep_tests()},
+     {pep_no_caps, [parallel], pep_no_caps_tests()}].
+
+pep_tests() ->
+    disco_tests() ++ protocol_tests() ++ protocol_tests_with_sm().
+
+pep_no_caps_tests() ->
+    [disco_info_no_caps,
+     create_presence_and_publish_implicit_sub_no_caps].
+
+-doc "Tests for XEP-0030 Service Discovery with rules from XEP-0163 / XEP-0060".
+disco_tests() ->
+    [disco_info,
+     disco_info_node,
+     disco_items,
+     disco_items_node,
+     disco_items_open].
+
+-doc "PEP tests for the XEP-0163 / XEP-0060 protocol".
+protocol_tests() ->
+    basic_tests() ++ negative_tests().
+
+basic_tests() ->
+    [create_and_delete,
+     create_with_empty_config,
+     create_and_configure,
+     create_open_and_publish_both_subs,
+     create_open_and_publish_explicit_sub,
+     create_open_and_publish_implicit_sub,
+     create_open_and_publish_no_sub,
+     create_presence_and_publish_explicit_sub,
+     create_presence_and_publish_implicit_sub,
+     create_presence_and_publish_no_sub,
+     publish_and_get_items,
+     publish_implicit_sub,
+     publish_open_explicit_sub,
+     publish_self_notify,
+     send_last_item_on_caps,
+     send_last_item_on_implicit_sub].
+
+negative_tests() ->
+    [bad_request_fails,
+     configure_with_invalid_form_fails,
+     create_at_foreign_jid_fails,
+     create_duplicate_node_fails,
+     create_with_invalid_config_fails,
+     delete_nonexistent_node_fails,
+     get_item_without_id_fails,
+     manage_nonexistent_node_fails,
+     manage_foreign_node_fails,
+     publish_to_foreign_node_fails,
+     publish_with_invalid_items_fails,
+     publish_options_invalid_config_fails,
+     request_without_nodeid_fails,
+     subscribe_presence_required_fails,
+     subscribe_to_nonexistent_node_fails,
+     subscribe_with_invalid_jid_fails,
+     unsubscribe_implicit_fails,
+     unsubscribe_foreign_jid_fails].
+
+-doc "Tests ensuring that PEP works with XEP-0198 Stream Management enabled".
+protocol_tests_with_sm() ->
+    [send_last_item_on_implicit_sub_with_sm]. % check for regressions in a typical scenario
+
+%% Disco
+
+disco_info(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun disco_info_story/1).
+
+disco_info_node(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun disco_info_node_story/3).
+
+disco_items(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun disco_items_story/3).
+
+disco_items_node(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun disco_items_node_story/3).
+
+disco_items_open(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun disco_items_open_story/3).
+
+%% Basic cases
+
+create_and_delete(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun create_and_delete_story/2).
+
+create_open_and_publish_both_subs(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{alice, 1}, {bob, 1}],
+                                    fun create_open_and_publish_both_subs_story/3).
+
+create_open_and_publish_explicit_sub(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}],
+                        fun create_open_and_publish_explicit_sub_story/2).
+
+create_open_and_publish_implicit_sub(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{alice, 1}, {bob, 1}],
+                                    fun create_open_and_publish_implicit_sub_story/3).
+
+create_open_and_publish_no_sub(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{alice, 1}, {bob, 1}, {mike, 1}],
+                                    fun create_open_and_publish_no_sub_story/4).
+
+create_presence_and_publish_explicit_sub(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}],
+                        fun create_presence_and_publish_explicit_sub_story/2).
+
+create_presence_and_publish_implicit_sub(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{alice, 1}, {bob, 1}],
+                                    fun create_presence_and_publish_implicit_sub_story/3).
+
+create_presence_and_publish_no_sub(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{alice, 1}, {bob, 1}, {mike, 1}],
+                                    fun create_presence_and_publish_no_sub_story/4).
+
+create_with_empty_config(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun create_with_empty_config_story/1).
+
+create_and_configure(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun create_and_configure_story/1).
+
+publish_and_get_items(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun publish_and_get_items_story/1).
+
+publish_implicit_sub(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{alice, 1}, {bob, 1}],
+                                    fun publish_implicit_sub_story/3).
+
+publish_open_explicit_sub(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun publish_open_explicit_sub_story/2).
+
+publish_self_notify(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{bob, 1}], fun publish_self_notify_story/2).
+
+send_last_item_on_caps(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun send_last_item_on_caps_story/2).
+
+send_last_item_on_implicit_sub(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{alice, 1}, {bob, 1}],
+                                    fun send_last_item_on_implicit_sub_story/3).
+
+%% Negative cases
+
+bad_request_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun bad_request_fails_story/1).
+
+configure_with_invalid_form_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun configure_with_invalid_form_fails_story/1).
+
+create_at_foreign_jid_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun create_at_foreign_jid_fails_story/2).
+
+create_duplicate_node_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun create_duplicate_node_fails_story/1).
+
+create_with_invalid_config_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun create_with_invalid_config_fails_story/1).
+
+delete_nonexistent_node_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun delete_nonexistent_node_fails_story/1).
+
+get_item_without_id_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun get_item_without_id_fails_story/1).
+
+manage_nonexistent_node_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun manage_nonexistent_node_fails_story/1).
+
+manage_foreign_node_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun manage_foreign_node_fails_story/2).
+
+publish_to_foreign_node_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun publish_to_foreign_node_fails_story/2).
+
+publish_with_invalid_items_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun publish_with_invalid_items_fails_story/1).
+
+publish_options_invalid_config_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun publish_options_invalid_config_fails_story/1).
+
+request_without_nodeid_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun request_without_nodeid_fails_story/1).
+
+subscribe_presence_required_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}],
+                        fun subscribe_presence_required_fails_story/2).
+
+subscribe_to_nonexistent_node_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun subscribe_to_nonexistent_node_fails_story/1).
+
+subscribe_with_invalid_jid_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}],
+                        fun subscribe_with_invalid_jid_fails_story/2).
+
+unsubscribe_implicit_fails(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{alice, 1}, {bob, 1}],
+                                    fun unsubscribe_implicit_fails_story/3).
+
+unsubscribe_foreign_jid_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun unsubscribe_foreign_jid_fails_story/2).
+
+%% Stream management
+
+send_last_item_on_implicit_sub_with_sm(ConfigIn) ->
+    Config0 = escalus_users:update_userspec(ConfigIn, alice, stream_management, true),
+    Config1 = escalus_users:update_userspec(Config0, bob, stream_management, true),
+    Config2 = set_caps(Config1),
+    escalus:fresh_story_with_config(Config2, [{alice, 1}, {bob, 1}],
+                                    fun send_last_item_on_implicit_sub_story/3).
+
+%% No mod_caps
+
+disco_info_no_caps(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun disco_info_no_caps_story/1).
+
+create_presence_and_publish_implicit_sub_no_caps(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}],
+                        fun create_presence_and_publish_implicit_sub_no_caps_story/2).
+
+%%--------------------------------------------------------------------
+%% Stories
+%%--------------------------------------------------------------------
+
+%% Disco
+
+disco_info_story(Alice) ->
+    %% XEP-0163 6.1 Account Owner Service Discovery
+    assert_disco_info(Alice, escalus_client:short_jid(Alice), true),
+
+    %% XEP-0030 8 Security Considerations
+    assert_no_disco_info(Alice, nonexistent_bare_jid()).
+
+disco_info_node_story(Alice, Bob, Kate) ->
+    NodeNS = random_node_ns(),
+    AliceJid = escalus_client:short_jid(Alice),
+    publish(Alice, ~"item1", pep_node(Alice, NodeNS), []),
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% XEP-0163 6.2 Contact Service Discovery
+    assert_disco_info_node(Alice, AliceJid, NodeNS),
+    assert_disco_info_node(Bob, AliceJid, NodeNS),
+
+    %% XEP-0030 7 Error Conditions
+    assert_no_disco_info_node(Alice, AliceJid, random_node_ns(), ~"item-not-found"),
+
+    %% XEP-0030 8 Security Considerations
+    assert_no_disco_info_node(Kate, AliceJid, NodeNS, ~"service-unavailable").
+
+disco_items_story(Alice, Bob, Kate) ->
+    NodeNS = random_node_ns(),
+    AliceJid = escalus_client:short_jid(Alice),
+    publish(Alice, ~"item1", pep_node(Alice, NodeNS), []),
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% XEP-0163 6.2 Contact Service Discovery
+    assert_disco_items(Alice, AliceJid, NodeNS),
+    assert_disco_items(Bob, AliceJid, NodeNS),
+    assert_no_disco_items(Kate, AliceJid),
+
+    %% XEP-0030 8 Security Considerations
+    assert_no_disco_items(Alice, nonexistent_bare_jid()).
+
+disco_items_node_story(Alice, Bob, Kate) ->
+    NodeNS = random_node_ns(),
+    AliceJid = escalus_client:short_jid(Alice),
+    publish(Alice, ~"item1", pep_node(Alice, NodeNS), []),
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% XEP-0030 7 Error Conditions
+    assert_no_disco_items_node(Alice, AliceJid, NodeNS, ~"item-not-found"),
+    assert_no_disco_items_node(Bob, AliceJid, NodeNS, ~"item-not-found"),
+
+    %% XEP-0030 8 Security Considerations
+    assert_no_disco_items_node(Kate, AliceJid, NodeNS, ~"service-unavailable").
+
+disco_items_open_story(Alice, Bob, Kate) ->
+    NodeNS = random_node_ns(),
+    AliceJid = escalus_client:short_jid(Alice),
+    PepNode = pep_node(Alice, NodeNS),
+    create_node(Alice, PepNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+    publish(Alice, ~"item1", PepNode, []),
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% XEP-0163 6.2 Contact Service Discovery
+    assert_disco_items(Alice, AliceJid, NodeNS),
+    assert_disco_items(Bob, AliceJid, NodeNS),
+    assert_disco_items(Kate, AliceJid, NodeNS).
+
+%% Basic cases
+
+create_and_delete_story(Alice, Bob) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+    subscribe(Bob, PepNode, []),
+
+    %% XEP-0060 6.5 Retrieve items
+    get_all_items(Alice, PepNode, [{expected_result, []}]),
+    get_item(Alice, PepNode, ~"item1", [{expected_result, []}]),
+
+    %% XEP-0060 8.2 Delete a Node
+    delete_node(Alice, PepNode, []),
+    receive_node_deletion_notification(Bob, PepNode, []),
+
+    %% Create + delete without subscribers - to exercise the no-subscribers path in the code
+    PepNodeNoSubs = pep_node(Alice),
+    create_node(Alice, PepNodeNoSubs, []),
+    delete_node(Alice, PepNodeNoSubs, []).
+
+create_with_empty_config_story(Alice) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, [{config, []}]),
+    get_configuration(Alice, PepNode, [{expected_result, [{~"pubsub#access_model", ~"presence"}]}]).
+
+create_and_configure_story(Alice) ->
+    PepNode = pep_node(Alice),
+    DefaultConfig = [{~"pubsub#access_model", ~"presence"}],
+    UpdatedConfig = [{~"pubsub#access_model", ~"open"}],
+    create_node(Alice, PepNode, []),
+
+    %% XEP-0060 8.2.5.1 Success (no-op)
+    set_configuration(Alice, PepNode, DefaultConfig, []),
+    get_configuration(Alice, PepNode, [{expected_result, DefaultConfig}]),
+
+    %% XEP-0060 8.2.5.1 Success
+    set_configuration(Alice, PepNode, UpdatedConfig, []),
+    get_configuration(Alice, PepNode, [{expected_result, UpdatedConfig}]).
+
+create_open_and_publish_both_subs_story(Config, Alice, Bob) ->
+    NodeNS = ?config(node_ns, Config),
+    PepNode = pep_node(Alice, NodeNS),
+    create_node(Alice, PepNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+
+    %% Set up implicit subscription
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% Set up explicit subscription with bare and full JID (to exercise all deduplication paths)
+    subscribe(Bob, PepNode, []),
+    subscribe(Bob, PepNode, [{jid_type, bare}]),
+
+    %% XEP-0163 4.3.2 Avoid duplicated notifications for overlapping recipients
+    publish(Alice, ~"item1", PepNode, []),
+    receive_item_notification(Bob, ~"item1", PepNode, []),
+    [] = escalus:wait_for_stanzas(Bob, 1, 500),
+
+    %% XEP-0060 6.5 Retrieve items
+    get_all_items(Bob, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Bob, PepNode, ~"item1", [{expected_result, [~"item1"]}]).
+
+create_open_and_publish_explicit_sub_story(Alice, Bob) ->
+    NodeNS = random_node_ns(),
+    PepNode = pep_node(Alice, NodeNS),
+    create_node(Alice, PepNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+
+    %% XEP-0163 4 Open access model with explicit subscription
+    subscribe(Bob, PepNode, []),
+    publish(Alice, ~"item1", PepNode, []),
+    receive_item_notification(Bob, ~"item1", PepNode, []),
+
+    %% XEP-0060 6.5 Retrieve items
+    get_all_items(Bob, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Bob, PepNode, ~"item1", [{expected_result, [~"item1"]}]),
+
+    %% XEP-0060 6.2.2 Success Case
+    unsubscribe(Bob, PepNode, []),
+    publish(Alice, ~"item2", PepNode, []),
+    [] = escalus:wait_for_stanzas(Bob, 1, 500).
+
+create_open_and_publish_implicit_sub_story(Config, Alice, Bob) ->
+    NodeNS = ?config(node_ns, Config),
+    PepNode = pep_node(Alice, NodeNS),
+    create_node(Alice, PepNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% XEP-0163 4 Open access model with implicit subscription
+    publish(Alice, ~"item1", PepNode, []),
+    receive_item_notification(Bob, ~"item1", PepNode, []),
+
+    %% XEP-0060 6.5 Retrieve items
+    get_all_items(Bob, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Bob, PepNode, ~"item1", [{expected_result, [~"item1"]}]).
+
+create_open_and_publish_no_sub_story(Config, Alice, Bob, Mike) ->
+    NodeNS = ?config(node_ns, Config),
+    PepNode = pep_node(Alice, NodeNS),
+    create_node(Alice, PepNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+    set_up_presence_subscription(Mike, Alice, 0),
+    publish(Alice, ~"item1", PepNode, []),
+
+    %% XEP-0163 4 Notification filtering
+    [] = escalus:wait_for_stanzas(Alice, 1, 500), % account owner without caps
+    escalus_assert:has_no_stanzas(Bob), % caps but no presence subscription
+    escalus_assert:has_no_stanzas(Mike), % presence subscription but no caps
+
+    %% XEP-0060 6.5 Retrieve items
+    get_all_items(Alice, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Alice, PepNode, ~"item1", [{expected_result, [~"item1"]}]),
+    get_all_items(Bob, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Bob, PepNode, ~"item1", [{expected_result, [~"item1"]}]),
+    get_all_items(Mike, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Mike, PepNode, ~"item1", [{expected_result, [~"item1"]}]).
+
+create_presence_and_publish_explicit_sub_story(Alice, Bob) ->
+    NodeNS = random_node_ns(),
+    PepNode = pep_node(Alice, NodeNS),
+    create_node(Alice, PepNode, []),
+
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% XEP-0163 4 (point 1) requires explicit subscriptions only for the 'open' model.
+    %% However, here we follow XEP-0060: 4.2 (table 3) says a 'subscribed' entity MUST receive
+    %% event notifications, and 12.2 (point 2) lists this trigger without access-model restrictions.
+    subscribe(Bob, PepNode, []),
+    publish(Alice, ~"item1", PepNode, []),
+    receive_item_notification(Bob, ~"item1", PepNode, []),
+
+    %% XEP-0060 6.2.2 Success Case
+    unsubscribe(Bob, PepNode, []),
+    publish(Alice, ~"item2", PepNode, []),
+    [] = escalus:wait_for_stanzas(Bob, 1, 500).
+
+create_presence_and_publish_implicit_sub_story(Config, Alice, Bob) ->
+    NodeNS = ?config(node_ns, Config),
+    PepNode = pep_node(Alice, NodeNS),
+    create_node(Alice, PepNode, []),
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% XEP-0163 4 Automatic subscription plus notification filtering
+    publish(Alice, ~"item1", PepNode, []),
+    receive_item_notification(Bob, ~"item1", PepNode, []),
+
+    %% XEP-0060 6.5 Retrieve items
+    get_all_items(Bob, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Bob, PepNode, ~"item1", [{expected_result, [~"item1"]}]).
+
+create_presence_and_publish_no_sub_story(Config, Alice, Bob, Mike) ->
+    NodeNS = ?config(node_ns, Config),
+    PepNode = pep_node(Alice, NodeNS),
+    create_node(Alice, PepNode, []),
+    set_up_presence_subscription(Mike, Alice, 0),
+    publish(Alice, ~"item1", PepNode, []),
+
+    %% XEP-0163 4 Notification filtering
+    [] = escalus:wait_for_stanzas(Alice, 1, 500), % account owner without caps
+    escalus_assert:has_no_stanzas(Bob), % caps but no presence subscription
+    escalus_assert:has_no_stanzas(Mike), % presence subscription but no caps
+
+    %% XEP-0060 6.5 Retrieve items
+    get_all_items(Alice, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Alice, PepNode, ~"item1", [{expected_result, [~"item1"]}]),
+    get_all_items(Bob, PepNode, [{expected_error_type, ~"auth"}]),
+    get_item(Bob, PepNode, ~"item1", [{expected_error_type, ~"auth"}]),
+    get_all_items(Mike, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Mike, PepNode, ~"item1", [{expected_result, [~"item1"]}]).
+
+publish_and_get_items_story(Alice) ->
+    PepNode = pep_node(Alice, random_node_ns()),
+    publish(Alice, ~"item0", PepNode, []),
+    publish(Alice, ~"item1", PepNode, []),
+    publish(Alice, ~"item2", PepNode, []),
+
+    %% XEP-0060 6.5 Request items
+    get_all_items(Alice, PepNode, [{expected_result, [~"item0", ~"item1", ~"item2"]}]),
+    get_item(Alice, PepNode, ~"item1", [{expected_result, [~"item1"]}]),
+    get_items(Alice, PepNode, [~"item1", ~"item404", ~"item0"],
+              [{expected_result, [~"item1", ~"item0"]}]).
+
+publish_implicit_sub_story(Config, Alice, Bob) ->
+    NodeNS = ?config(node_ns, Config),
+    PepNode = pep_node(Alice, NodeNS),
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% XEP-0163 3 Auto-create and publish an item
+    publish(Alice, ~"item1", PepNode, []),
+
+    %% XEP-0163 4.3.3 Publish generates a notification
+    receive_item_notification(Bob, ~"item1", PepNode, []),
+
+    %% XEP-0060 6.5 Retrieve items
+    get_all_items(Bob, PepNode, [{expected_result, [~"item1"]}]).
+
+publish_open_explicit_sub_story(Alice, Bob) ->
+    NodeNS = random_node_ns(),
+    PepNode = pep_node(Alice, NodeNS),
+    PublishOptions = [{~"pubsub#access_model", ~"open"}],
+    publish_with_options(Alice, ~"item0", PepNode, [], PublishOptions),
+    publish(Alice, ~"item1", PepNode, []),
+
+    %% XEP-0163 4.3.4 Bob can subscribe and receive the last item
+    subscribe(Bob, PepNode, [{expected_notification, {PepNode, ~"item1"}}]),
+
+    %% XEP-0060 6.1.6 Subsequent 'subscribe' returns the current subscription state
+    subscribe(Bob, PepNode, []),
+    [] = escalus:wait_for_stanzas(Bob, 1, 500),
+
+    %% XEP-0163 4.3.3 'publish' by Alice results in a notification to Bob
+    publish(Alice, ~"item2", PepNode, []),
+    receive_item_notification(Bob, ~"item2", PepNode, []),
+
+    %% XEP-0060 6.5 Bob can request all items
+    get_all_items(Bob, PepNode, [{expected_result, [~"item0", ~"item1", ~"item2"]}]).
+
+publish_self_notify_story(Config, Bob) ->
+    NodeNS = ?config(node_ns, Config),
+    PepNode = pep_node(Bob, NodeNS),
+
+    %% XEP-0163 4, Case 3 Entity is the account owner itself
+    publish(Bob, ~"item1", PepNode, [{expected_notification, {PepNode, ~"item1"}}]),
+
+    %% XEP-0060 6.5 Retrieve items
+    get_all_items(Bob, PepNode, [{expected_result, [~"item1"]}]),
+    get_item(Bob, PepNode, ~"item1", [{expected_result, [~"item1"]}]),
+
+    %% XEP-0060 7.1.2 Generated item ID
+    {Response, Msg} = publish(Bob, undefined, PepNode, [{expected_notification, PepNode}]),
+    GeneratedItemId = published_item_id(Response, PepNode),
+    check_item_notification(Msg, GeneratedItemId, PepNode, []),
+    get_item(Bob, PepNode, GeneratedItemId, [{expected_result, [GeneratedItemId]}]).
+
+send_last_item_on_caps_story(Alice, Bob) ->
+    NodeNS = random_node_ns(),
+    PepNode = pep_node(Alice, NodeNS),
+    publish(Alice, ~"item2", PepNode, []),
+
+    escalus_story:make_all_clients_friends([Alice, Bob]),
+
+    Features = features(NodeNS),
+    Caps = caps_helper:enable_new_caps(Bob, Features, v1),
+    caps_helper:receive_presence_with_caps(Alice, Bob, Caps),
+
+    receive_item_notification(Bob, ~"item2", PepNode, []),
+
+    %% Unchanged caps shouldn't trigger notifications
+    caps_helper:enable_caps(Bob, Features, v1),
+    ct:sleep(200),
+    escalus_assert:has_no_stanzas(Bob).
+
+send_last_item_on_implicit_sub_story(Config, Alice, Bob) ->
+    NodeNS = ?config(node_ns, Config),
+    PepNode = pep_node(Alice, NodeNS),
+    publish(Alice, ~"item1", PepNode, []), % previous item - not delivered
+    publish(Alice, ~"item2", PepNode, []), % last item
+    [Message] = set_up_presence_subscription(Bob, Alice, 1),
+    check_item_notification(Message, ~"item2", PepNode, []),
+    assert_delayed_notification(Message),
+
+    %% Bob can receive further notifications
+    publish(Alice, ~"item3", PepNode, []),
+    receive_item_notification(Bob, ~"item3", PepNode, []).
+
+%% Negative cases
+
+bad_request_fails_story(Alice) ->
+    AliceJid = escalus_utils:get_short_jid(Alice),
+    Opts = [{expected_error_type, {~"modify", ~"bad-request"}}],
+    send_generic_request(Alice, AliceJid, ~"set", ?NS_PUBSUB, ~"unknown-action", Opts),
+    send_generic_request(Alice, AliceJid, ~"get", ?NS_PUBSUB, ~"unknown-action", Opts),
+    send_generic_request(Alice, AliceJid, ~"set", ?NS_PUBSUB_OWNER, ~"unknown-action", Opts),
+    send_generic_request(Alice, AliceJid, ~"get", ?NS_PUBSUB_OWNER, ~"unknown-action", Opts),
+    send_generic_request(Alice, AliceJid, ~"set", ?NS_PUBSUB, {raw, ~"pubstub"}, Opts).
+
+configure_with_invalid_form_fails_story(Alice) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, []),
+
+    %% Malformed configuration form
+    UpdatedConfig = [{~"pubsub#access_model", ~"open"}],
+    Opts = [{expected_error_type, {~"modify", ~"bad-request"}},
+            {modify_request, fun form_helper:remove_form_types/1}],
+    set_configuration(Alice, PepNode, UpdatedConfig, Opts).
+
+create_at_foreign_jid_fails_story(Alice, Bob) ->
+    Opts = [{expected_error_type, {~"auth", ~"forbidden"}}],
+
+    %% XEP-0060 8.1 Create a Node, Example 128
+    create_node(Bob, pep_node(Alice), Opts),
+
+    %% XEP-0060 7.1.3.1 Insufficient Privileges (auto-create attempt)
+    publish(Bob, ~"item2", pep_node(Alice), Opts).
+
+create_duplicate_node_fails_story(Alice) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, []),
+
+    %% XEP-0060 8.1.3.2 Node Already Exists
+    Opts = [{expected_error_type, {~"cancel", ~"conflict"}}],
+    create_node(Alice, PepNode, Opts).
+
+create_with_invalid_config_fails_story(Alice) ->
+    InvalidOptionOpts = [{config, [{~"pubsub#definitely_invalid_option", ~"1"}]},
+                         {expected_error_type, {~"modify", ~"bad-request"}}],
+    create_node(Alice, pep_node(Alice), InvalidOptionOpts),
+
+    InvalidModelOpts = [{config, [{~"pubsub#access_model", ~"not-a-real-model"}]},
+                        {expected_error_type, {~"modify", ~"bad-request"}}],
+    create_node(Alice, pep_node(Alice), InvalidModelOpts),
+
+    %% Malformed create request with unexpected extra child
+    ExtraChildOpts = [{expected_error_type, {~"modify", ~"bad-request"}},
+                      {modify_request, fun pubsub_tools:add_unexpected_pubsub_child/1}],
+    create_node(Alice, pep_node(Alice), ExtraChildOpts),
+
+    %% Malformed create configuration form
+    PepNode = pep_node(Alice),
+    MalformedConfigOpts = [{config, [{~"pubsub#access_model", ~"open"}]},
+                           {expected_error_type, {~"modify", ~"bad-request"}},
+                           {modify_request, fun form_helper:remove_form_types/1}],
+    create_node(Alice, PepNode, MalformedConfigOpts),
+
+    UnsupportedModelOpts = [{config, [{~"pubsub#access_model", ~"authorize"}]},
+                            {expected_error_type,
+                             {~"modify", ~"not-acceptable", ~"unsupported-access-model"}}],
+    create_node(Alice, pep_node(Alice), UnsupportedModelOpts).
+
+delete_nonexistent_node_fails_story(Alice) ->
+    %% XEP-0060 8.2.4 Node Does Not Exist
+    Opts = [{expected_error_type, {~"cancel", ~"item-not-found"}}],
+    delete_node(Alice, pep_node(Alice), Opts).
+
+get_item_without_id_fails_story(Alice) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, []),
+
+    %% XEP-0060 6.5 Request an item: missing item ID
+    Opts = [{expected_error_type, {~"modify", ~"bad-request"}}],
+    get_items(Alice, PepNode, [undefined], Opts).
+
+manage_nonexistent_node_fails_story(Alice) ->
+    PepNode = pep_node(Alice),
+    Opts = [{expected_error_type, {~"cancel", ~"item-not-found"}}],
+
+    %% XEP-0060 8.2.3.5 Node Does Not Exist
+    get_configuration(Alice, PepNode, Opts),
+
+    %% XEP-0060 8.2.3.5 Node Does Not Exist: same missing-node condition applies to 'set'
+    set_configuration(Alice, PepNode, [{~"pubsub#access_model", ~"open"}], Opts),
+
+    %% XEP-0060 8.2.4 Node Does Not Exist
+    delete_node(Alice, PepNode, Opts).
+
+manage_foreign_node_fails_story(Alice, Bob) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, []),
+    Opts = [{expected_error_type, {~"auth", ~"forbidden"}}],
+
+    %% XEP-0060 8.5.3.1 Insufficient Privileges
+    get_configuration(Bob, PepNode, Opts),
+
+    %% XEP-0060 8.5.6.1 Insufficient Privileges
+    set_configuration(Bob, PepNode, [{~"pubsub#access_model", ~"open"}], Opts),
+
+    %% XEP-0060 8.4.3.1 Insufficient Privileges (existing node)
+    delete_node(Bob, PepNode, Opts),
+
+    %% XEP-0060 8.4.3.1 Insufficient Privileges (non-existent node)
+    delete_node(Bob, pep_node(Alice), Opts).
+
+publish_to_foreign_node_fails_story(Alice, Bob) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, []),
+
+    %% XEP-0060 7.1.3.1 Insufficient Privileges
+    publish(Bob, ~"item1", PepNode, [{expected_error_type, {~"auth", ~"forbidden"}}]).
+
+publish_with_invalid_items_fails_story(Alice) ->
+    PepNode = pep_node(Alice),
+
+    %% XEP-0060 7.1.3.4 Item Required
+    ItemRequiredOpts = [{with_payload, false},
+                        {expected_error_type, {~"modify", ~"bad-request", ~"item-required"}}],
+    publish(Alice, ~"item1", PepNode, ItemRequiredOpts),
+
+    %% XEP-0060 7.1.3.6 Payload Required
+    EmptyItem = item_el(~"item2", []),
+    PayloadRequiredOpts = [{expected_error_type, {~"modify", ~"bad-request", ~"payload-required"}}],
+    publish_raw(Alice, PepNode, [EmptyItem], PayloadRequiredOpts),
+
+    %% XEP-0060 7.1.3.6 Invalid Payload
+    Content = item_content(),
+    InvalidItem = item_el(~"item3", [Content, Content]),
+    InvalidPayloadOpts = [{expected_error_type, {~"modify", ~"bad-request", ~"invalid-payload"}}],
+    publish_raw(Alice, PepNode, [InvalidItem], InvalidPayloadOpts),
+
+    %% XEP-0060 7.1.3.5 Too Many Items
+    ItemEl = item_el(~"item4", [Content]),
+    BadRequestOpts = [{expected_error_type, {~"modify", ~"bad-request"}}],
+    publish_raw(Alice, PepNode, [ItemEl, ItemEl], BadRequestOpts),
+
+    %% Malformed publish request: direct child is not <item/>.
+    publish_raw(Alice, PepNode, [Content], BadRequestOpts).
+
+publish_options_invalid_config_fails_story(Alice) ->
+    PreconditionOpts = [{expected_error_type, {~"cancel", ~"conflict", ~"precondition-not-met"}}],
+
+    %% XEP-0060 7.1.5 Publishing Options: unmet publish-options precondition
+    UnknownOptionFields = [{~"pubsub#definitely_invalid_option", ~"1"}],
+    publish_with_options(Alice, ~"item1", pep_node(Alice), PreconditionOpts, UnknownOptionFields),
+
+    %% XEP-0060 7.1.5 Publishing Options: unmet publish-options precondition
+    InvalidAccessModelFields = [{~"pubsub#access_model", ~"not-a-real-model"}],
+    publish_with_options(Alice, ~"item1", pep_node(Alice),
+                         PreconditionOpts, InvalidAccessModelFields),
+
+    %% XEP-0060 7.1.5 Publishing Options: unmet publish-options precondition
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, []),
+    Fields = [{~"pubsub#access_model", ~"open"}],
+    publish_with_options(Alice, ~"item1", PepNode, PreconditionOpts, Fields),
+
+    %% Malformed publish-options request with unexpected extra child
+    MalformedOpts = [{expected_error_type, {~"modify", ~"bad-request"}},
+                     {modify_request, fun pubsub_tools:add_unexpected_pubsub_child/1}],
+    publish_with_options(Alice, ~"item1", pep_node(Alice), MalformedOpts, Fields),
+
+    %% Malformed publish-options form
+    MalformedFormOpts = [{expected_error_type, {~"modify", ~"bad-request"}},
+                         {modify_request, fun form_helper:remove_form_types/1}],
+    publish_with_options(Alice, ~"item1", pep_node(Alice), MalformedFormOpts, Fields).
+
+request_without_nodeid_fails_story(Alice) ->
+    MissingNode = pep_node(Alice, undefined),
+
+    %% XEP-0060 8.1.2.3 NodeID Required
+    CreateOpts = [{expected_error_type, {~"modify", ~"not-acceptable", ~"nodeid-required"}}],
+    create_node(Alice, MissingNode, CreateOpts),
+
+    %% XEP-0060 8.5.3.2 NodeID Required for 'get'
+    GetOpts = [{expected_error_type, {~"modify", ~"bad-request", ~"nodeid-required"}}],
+    get_configuration(Alice, MissingNode, GetOpts),
+
+    %% XEP-0060 8.5.3.2 NodeID Required for 'set'
+    SetOpts = [{expected_error_type, {~"modify", ~"bad-request", ~"nodeid-required"}}],
+    set_configuration(Alice, MissingNode, [{~"pubsub#access_model", ~"open"}], SetOpts).
+
+subscribe_presence_required_fails_story(Alice, Bob) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, []),
+
+    %% XEP-0060 6.1.3.2 Presence Subscription Required
+    Opts = [{expected_error_type, {~"auth", ~"not-authorized", ~"presence-subscription-required"}}],
+    subscribe(Bob, PepNode, Opts).
+
+subscribe_to_nonexistent_node_fails_story(Alice) ->
+    PepNode = pep_node(Alice),
+    Opts = [{expected_error_type, {~"cancel", ~"item-not-found"}}],
+
+    %% XEP-0060 6.1.3.4 Node Does Not Exist
+    subscribe(Alice, PepNode, Opts),
+
+    %% XEP-0060 6.2.3.4 Node Does Not Exist
+    unsubscribe(Alice, PepNode, Opts).
+
+subscribe_with_invalid_jid_fails_story(Alice, Bob) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+
+    %% XEP-0060 6.1.3.3 Invalid JID
+    InvalidJid = escalus_utils:get_short_jid(Alice),
+    Opts = [{subscriber_jid, InvalidJid},
+            {expected_error_type, {~"modify", ~"bad-request", ~"invalid-jid"}}],
+    subscribe(Bob, PepNode, Opts).
+
+unsubscribe_implicit_fails_story(Config, Alice, Bob) ->
+    NodeNS = ?config(node_ns, Config),
+    PepNode = pep_node(Alice, NodeNS),
+    create_node(Alice, PepNode, []),
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% XEP-0060 6.2.3.2 No Such Subscriber
+    Opts = [{expected_error_type, {~"cancel", ~"unexpected-request", ~"not-subscribed"}}],
+    unsubscribe(Bob, PepNode, Opts).
+
+unsubscribe_foreign_jid_fails_story(Alice, Bob) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+    subscribe(Bob, PepNode, []),
+
+    %% XEP-0060 6.2.3.1 Insufficient Privileges
+    Opts = [{subscriber_jid, escalus_utils:get_short_jid(Alice)},
+            {expected_error_type, {~"auth", ~"forbidden"}}],
+    unsubscribe(Bob, PepNode, Opts).
+
+%% No mod_caps
+
+disco_info_no_caps_story(Alice) ->
+    %% XEP-0163 6.1 Account Owner Service Discovery
+    assert_disco_info(Alice, escalus_client:short_jid(Alice), false).
+
+create_presence_and_publish_implicit_sub_no_caps_story(Alice, Bob) ->
+    PepNode = pep_node(Alice, random_node_ns()),
+    create_node(Alice, PepNode, []),
+    set_up_presence_subscription(Bob, Alice, 0),
+
+    %% Without mod_caps, caps-based implicit notifications are not delivered
+    publish(Alice, ~"item1", PepNode, []),
+    [] = escalus:wait_for_stanzas(Bob, 1, 500).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+%% Setup
+
+required_modules(pep) ->
+    [{mod_caps, default_mod_config(mod_caps)},
+     {mod_pubsub, default_mod_config(mod_pubsub)}];
+required_modules(pep_no_caps) ->
+    [{mod_pubsub, default_mod_config(mod_pubsub)}].
+
+set_caps(Config) ->
+    set_caps(Config, random_node_ns()).
+
+set_caps(Config, NS) ->
+    [{escalus_overrides, [{start_ready_clients, {?MODULE, start_caps_clients}}]},
+     {node_ns, NS} | Config].
+
+%% Implemented only for one resource per client, because it is enough
+start_caps_clients(Config, [{UserSpec, Resource}]) ->
+    {ok, Client} = escalus_client:start(Config, UserSpec, Resource),
+    exchange_initial_presence(Config, Client, is_caps_client(Client)),
+    [Client].
+
+exchange_initial_presence(Config, Client, true) ->
+    Features = features(proplists:get_value(node_ns, Config)),
+    caps_helper:enable_new_caps(Client, Features, v1);
+exchange_initial_presence(_Config, Client, false) ->
+    escalus_story:send_initial_presence(Client),
+    escalus:assert(is_presence, escalus:wait_for_stanza(Client)).
+
+is_caps_client(Client) ->
+    case escalus_client:username(Client) of
+        <<"bob", _/binary>> -> true;
+        _ -> false
+    end.
+
+set_up_presence_subscription(Subscriber, Owner, ExpectedMessageCount) ->
+    send_presence(Subscriber, ~"subscribe", Owner),
+    escalus:assert(is_iq, escalus_client:wait_for_stanza(Subscriber)),
+    escalus:assert(is_presence, escalus_client:wait_for_stanza(Owner)),
+    send_presence(Owner, ~"subscribed", Subscriber),
+    escalus:assert(is_iq, escalus_client:wait_for_stanza(Owner)),
+    Preds = [is_iq] ++ lists:duplicate(ExpectedMessageCount, is_message)
+        ++ lists:duplicate(2, is_presence),
+    Stanzas = escalus_client:wait_for_stanzas(Subscriber, length(Preds)),
+    escalus:assert_many(Preds, Stanzas),
+    lists:filter(fun escalus_pred:is_message/1, Stanzas). % return only messages
+
+send_presence(From, Type, To) ->
+    ToJid = escalus_client:short_jid(To),
+    Stanza = escalus_stanza:presence_direct(ToJid, Type),
+    escalus_client:send(From, Stanza).
+
+%% Disco helpers and assertions
+
+assert_no_disco_info(Client, OwnerJid) ->
+    Request = escalus_stanza:disco_info(OwnerJid),
+    escalus:send(Client, Request),
+    Stanza = escalus:wait_for_stanza(Client),
+    escalus:assert(is_iq_error, [Request], Stanza),
+    escalus:assert(is_error, [~"cancel", ~"service-unavailable"], Stanza),
+    escalus:assert(is_stanza_from, [OwnerJid], Stanza).
+
+assert_disco_info(Client, OwnerJid, HasCapsModule) ->
+    Request = escalus_stanza:disco_info(OwnerJid),
+    escalus:send(Client, Request),
+    Stanza = escalus:wait_for_stanza(Client),
+    escalus:assert(is_iq_result, [Request], Stanza),
+    ?assertNot(escalus_pred:has_identity(~"pubsub", ~"service", Stanza)),
+    escalus:assert(has_identity, [~"pubsub", ~"pep"], Stanza),
+    lists:foreach(fun(Feature) ->
+                          escalus:assert(has_feature, [Feature], Stanza)
+                  end, pep_disco_features(HasCapsModule)),
+    escalus:assert(is_stanza_from, [OwnerJid], Stanza).
+
+assert_no_disco_items(Client, OwnerJid) ->
+    ResultQuery = make_disco_items_query(Client, OwnerJid),
+    ?assertEqual([], ResultQuery#xmlel.children).
+
+assert_disco_items(Client, OwnerJid, NodeNS) ->
+    ResultQuery = make_disco_items_query(Client, OwnerJid),
+    Item = exml_query:subelement_with_attr(ResultQuery, ~"node", NodeNS),
+    ?assertEqual(jid:str_tolower(OwnerJid), exml_query:attr(Item, ~"jid")).
+
+assert_no_disco_items_node(Client, OwnerJid, NodeNS, ErrorCondition) ->
+    Request = escalus_stanza:disco_items(OwnerJid, NodeNS),
+    escalus:send(Client, Request),
+    Stanza = escalus:wait_for_stanza(Client),
+    escalus:assert(is_iq_error, [Request], Stanza),
+    escalus:assert(is_error, [~"cancel", ErrorCondition], Stanza),
+    escalus:assert(is_stanza_from, [OwnerJid], Stanza).
+
+assert_disco_info_node(Client, OwnerJid, NodeNS) ->
+    Request = escalus_stanza:disco_info(OwnerJid, NodeNS),
+    escalus:send(Client, Request),
+    Stanza = escalus:wait_for_stanza(Client),
+    escalus:assert(is_stanza_from, [OwnerJid], Stanza),
+    escalus:assert(is_iq_result, [Request], Stanza),
+    Query = exml_query:subelement(Stanza, ~"query"),
+    ?assertEqual(NodeNS, exml_query:attr(Query, ~"node")),
+    escalus:assert(has_identity, [~"pubsub", ~"leaf"], Stanza),
+    escalus:assert(has_feature, [?NS_PUBSUB], Stanza).
+
+assert_no_disco_info_node(Client, OwnerJid, NodeNS, ErrorCondition) ->
+    Request = escalus_stanza:disco_info(OwnerJid, NodeNS),
+    escalus:send(Client, Request),
+    Stanza = escalus:wait_for_stanza(Client),
+    escalus:assert(is_stanza_from, [OwnerJid], Stanza),
+    escalus:assert(is_iq_error, [Request], Stanza),
+    escalus:assert(is_error, [~"cancel", ErrorCondition], Stanza).
+
+assert_delayed_notification(Stanza) ->
+    DelayEl = exml_query:subelement(Stanza, ~"delay"),
+    escalus:assert(has_ns, [?NS_DELAY], DelayEl),
+    ?assertMatch(Stamp when is_binary(Stamp), exml_query:attr(DelayEl, ~"stamp")).
+
+make_disco_items_query(Client, OwnerJid) ->
+    Request = escalus_stanza:disco_items(OwnerJid),
+    escalus:send(Client, Request),
+    Stanza = escalus:wait_for_stanza(Client),
+    escalus:assert(is_stanza_from, [OwnerJid], Stanza),
+    escalus:assert(is_iq_result, [Request], Stanza),
+    exml_query:subelement(Stanza, ~"query").
+
+%% Nodes, features, jids
+
+pep_node(Client) ->
+    pep_node(Client, random_node_ns()).
+
+pep_node(Client, NodeName) ->
+    {escalus_utils:jid_to_lower(escalus_utils:get_short_jid(Client)), NodeName}.
+
+pep_disco_features(HasCapsModule) ->
+    [?NS_PUBSUB,
+     <<?NS_PUBSUB/binary, "#access-open">>,
+     <<?NS_PUBSUB/binary, "#access-presence">>,
+     <<?NS_PUBSUB/binary, "#auto-create">>,
+     <<?NS_PUBSUB/binary, "#config-node">>,
+     <<?NS_PUBSUB/binary, "#create-and-configure">>,
+     <<?NS_PUBSUB/binary, "#create-nodes">>,
+     <<?NS_PUBSUB/binary, "#delete-nodes">>,
+     <<?NS_PUBSUB/binary, "#item-ids">>,
+     <<?NS_PUBSUB/binary, "#last-published">>,
+     <<?NS_PUBSUB/binary, "#persistent-items">>,
+     <<?NS_PUBSUB/binary, "#publish">>,
+     <<?NS_PUBSUB/binary, "#publish-options">>,
+     <<?NS_PUBSUB/binary, "#retrieve-items">>,
+     <<?NS_PUBSUB/binary, "#subscribe">>] ++
+    case HasCapsModule of
+        true -> [<<?NS_PUBSUB/binary, "#filtered-notifications">>];
+        false -> []
+    end.
+
+features(NodeNS) ->
+    [NodeNS, ns_notify(NodeNS)].
+
+ns_notify(NS) ->
+    <<NS/binary, "+notify">>.
+
+random_node_ns() ->
+    base64:encode(crypto:strong_rand_bytes(16)).
+
+nonexistent_bare_jid() ->
+    <<"unknown@", (domain_helper:domain())/binary>>.

--- a/doc/configuration/Modules.md
+++ b/doc/configuration/Modules.md
@@ -71,7 +71,7 @@ Caches user information to reduce load on backend storage.
 ### [mod_caps](../modules/mod_caps.md)
 Implements [XEP-0115: Entity Capabilities](https://xmpp.org/extensions/xep-0115.html).
 It queries clients for their supported functionalities and caches them in Mnesia.
-This module tightly cooperates with [mod_pubsub_old](../modules/mod_pubsub_old.md) in order to deliver [PEP](https://xmpp.org/extensions/xep-0163.html) events to user's subscribers.
+It stores capabilities used for [PEP](https://xmpp.org/extensions/xep-0163.html) notification filtering.
 
 ### [mod_carboncopy](../modules/mod_carboncopy.md)
 Implements [XEP-0280: Message Carbons](http://xmpp.org/extensions/xep-0280.html) in order to keep all IM clients for a user engaged in a real-time conversation by carbon-copying all inbound and outbound messages to all interested resources (Full JIDs).
@@ -157,6 +157,9 @@ This module implements [XEP-0016: Privacy Lists](http://xmpp.org/extensions/xep-
 
 ### [mod_private](../modules/mod_private.md)
 Implements [XEP-0049: Private XML Storage](http://xmpp.org/extensions/xep-0049.html) to store and query private user data in XML format.
+
+### [mod_pubsub](../modules/mod_pubsub.md)
+Provides a focused [XEP-0163: Personal Eventing Protocol](https://xmpp.org/extensions/xep-0163.html) implementation for same-server users.
 
 ### [mod_pubsub_old](../modules/mod_pubsub_old.md)
 This extension implements [XEP-0060: Publish-Subscribe](http://www.xmpp.org/extensions/xep-0060.html). It is a pluggable implementation using behaviours provided by `node_*.erl` and `nodetree_*.erl` modules.

--- a/doc/configuration/database-backends-configuration.md
+++ b/doc/configuration/database-backends-configuration.md
@@ -93,7 +93,8 @@ Please refer to the [RDBMS options](outgoing-connections.md#rdbms-options) for m
 
 **Version notice**
 
-The required minimum version of MySQL is `8.0` because MongooseIM uses the JSON data type and the `INSERT INTO ... AS ...` query syntax.
+The required minimum version of MySQL is `8.0.14` because MongooseIM uses the JSON data type,
+the `INSERT INTO ... AS ...` query syntax, and lateral derived tables.
 
 ### PostgreSQL
 

--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -168,6 +168,7 @@ This hook is used by multiple modules, since removing a user requires many clean
 * [`mod_offline`](../modules/mod_offline.md) deletes the user's offline messages;
 * [`mod_privacy`](../modules/mod_privacy.md) removes the user's privacy lists;
 * [`mod_private`](../modules/mod_private.md) removes the user's private xml data storage;
+* [`mod_pubsub`](../modules/mod_pubsub.md) removes the user's PEP data;
 * [`mod_pubsub_old`](../modules/mod_pubsub_old.md) unsubscribes from publish/subscribe channels;
 * [`mod_roster`](../modules/mod_roster.md) removes the user's roster from the database;
 * [`mod_smart_markers`](../modules/mod_smart_markers.md) removes chat markers stored for the user;

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -1,0 +1,72 @@
+## Module description
+
+This module provides a lightweight, performance-focused implementation of [XEP-0163: Personal Eventing Protocol](https://xmpp.org/extensions/xep-0163.html), using selected parts of [XEP-0060: Publish-Subscribe](https://xmpp.org/extensions/xep-0060.html).
+It handles same-server PEP requests addressed to users' bare JIDs and does not expose a generic PubSub service on a `pubsub.@HOST@` domain.
+
+`mod_pubsub` stores nodes, subscriptions, and items in RDBMS tables.
+[mod_caps](mod_caps.md) should also be enabled for filtered PEP notifications.
+
+!!! Note
+    The goal is to gradually extend this lightweight implementation while phasing out [mod_pubsub_old](mod_pubsub_old.md).
+    Until the missing functionality is implemented here, deployments that need a generic PubSub component, collection nodes, plugin-based node implementations, or push-notification PubSub nodes still need the old module.
+
+## Supported functionality
+
+* [Automatic creation](https://xmpp.org/extensions/xep-0060.html#publisher-publish-autocreate) of PEP nodes on publish.
+* Explicit node [creation](https://xmpp.org/extensions/xep-0060.html#owner-create) and [deletion](https://xmpp.org/extensions/xep-0060.html#owner-delete).
+* [Node configuration](https://xmpp.org/extensions/xep-0060.html#owner-configure) and [publish options](https://xmpp.org/extensions/xep-0060.html#publisher-publish-options) with the [`pubsub#access_model`](https://xmpp.org/extensions/xep-0060.html#accessmodels) option.
+* The `open` and `presence` access models.
+* [Publishing](https://xmpp.org/extensions/xep-0060.html#publisher-publish) an item.
+* Retrieving [all items](https://xmpp.org/extensions/xep-0060.html#subscriber-retrieve-requestall) or [selected items by ID](https://xmpp.org/extensions/xep-0060.html#subscriber-retrieve-requestone).
+* Explicit [subscribe](https://xmpp.org/extensions/xep-0060.html#subscriber-subscribe) and [unsubscribe](https://xmpp.org/extensions/xep-0060.html#subscriber-unsubscribe).
+* [Implicit PEP subscriptions](https://xmpp.org/extensions/xep-0163.html#notify-autosubscribe) based on presence subscription and entity capabilities.
+* [Filtered item notifications](https://xmpp.org/extensions/xep-0163.html#notify-filterednotifications) with [mod_caps](mod_caps.md), and [node deletion notifications](https://xmpp.org/extensions/xep-0060.html#owner-delete-success).
+* [Last published item delivery](https://xmpp.org/extensions/xep-0163.html#notify-last), with [`urn:xmpp:delay`](https://xmpp.org/extensions/xep-0203.html) metadata.
+* Service discovery for [PEP support](https://xmpp.org/extensions/xep-0163.html#support-owner) on users' bare JIDs, [node-qualified disco info](https://xmpp.org/extensions/xep-0060.html#entity-info), and [disco items](https://xmpp.org/extensions/xep-0060.html#entity-nodes) listing discoverable PEP nodes.
+
+## Known omissions and limitations
+
+`mod_pubsub` is intended to grow over time, but it does not implement the full XEP-0060 feature set yet.
+Current intentional omissions and limitations are:
+
+* Access models other than `open` and `presence` are not supported.
+* Node and publish options other than `pubsub#access_model` are not supported.
+* [Subscription options](https://xmpp.org/extensions/xep-0060.html#subscriber-configure), [multiple subscriptions](https://xmpp.org/extensions/xep-0060.html#subscriber-subscribe-multi) for the same JID and node, and [collection nodes](https://xmpp.org/extensions/xep-0248.html) are not implemented.
+* [Affiliations](https://xmpp.org/extensions/xep-0060.html#owner-affiliations), [default node configuration requests](https://xmpp.org/extensions/xep-0060.html#owner-default), [purge](https://xmpp.org/extensions/xep-0060.html#owner-purge), [retract](https://xmpp.org/extensions/xep-0060.html#publisher-delete), and [subscription management by node owners](https://xmpp.org/extensions/xep-0060.html#owner-subscriptions) are not implemented.
+* [Result Set Management](https://xmpp.org/extensions/xep-0060.html#subscriber-retrieve-returnsome) is not implemented for item retrieval.
+
+## Options
+
+### `modules.mod_pubsub.backend`
+* **Syntax:** string, currently only `"rdbms"` is supported.
+* **Default:** `"rdbms"`
+* **Example:** `backend = "rdbms"`
+
+Database backend used to store PEP nodes, subscriptions, and items.
+The `rdbms` backend requires a `default` RDBMS connection pool in [`outgoing_pools`](../configuration/outgoing-connections.md#rdbms-options).
+
+### `modules.mod_pubsub.iqdisc.type`
+* **Syntax:** string, one of `"one_queue"`, `"no_queue"`, `"queues"`, `"parallel"`
+* **Default:** `"no_queue"`
+
+Strategy to handle incoming IQ stanzas.
+By default, IQ requests are handled by the C2S process of a sender.
+For details, please refer to [IQ processing policies](../configuration/Modules.md#iq-processing-policies).
+
+## Example Configuration
+
+It is recommended to start with the default options and enable [mod_caps](mod_caps.md) for filtered notifications:
+
+```toml
+[modules.mod_caps]
+
+[modules.mod_pubsub]
+```
+
+The example below shows a different configuration where IQ requests are handled by a pool of 50 workers:
+
+```toml
+[modules.mod_pubsub]
+  iqdisc.type = "queues"
+  iqdisc.workers = 50
+```

--- a/include/mod_pubsub.hrl
+++ b/include/mod_pubsub.hrl
@@ -1,0 +1,11 @@
+-record(pubsub_node, {node_key :: mod_pubsub:node_key(),
+                      config = #{access_model => presence} :: mod_pubsub:node_config()}).
+
+-record(subscription, {node_key :: mod_pubsub:node_key(),
+                       jid :: jid:jid()}).
+
+-record(item, {node_key :: mod_pubsub:node_key(),
+               id :: mod_pubsub:item_id(),
+               publisher_jid :: jid:jid(),
+               payload :: mod_pubsub:item_payload(),
+               published_at :: integer() | undefined}).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
       - 'mod_presence': 'modules/mod_presence.md'
       - 'mod_privacy': 'modules/mod_privacy.md'
       - 'mod_private': 'modules/mod_private.md'
+      - 'mod_pubsub': 'modules/mod_pubsub.md'
       - 'mod_pubsub_old': 'modules/mod_pubsub_old.md'
       - 'mod_push_service_mongoosepush': 'modules/mod_push_service_mongoosepush.md'
       - 'mod_register': 'modules/mod_register.md'

--- a/priv/cockroachdb.sql
+++ b/priv/cockroachdb.sql
@@ -356,6 +356,39 @@ CREATE INDEX i_inbox_timestamp ON inbox USING BTREE(lserver, luser, timestamp);
 CREATE INDEX i_inbox_us_box ON inbox USING BTREE(lserver, luser, box);
 CREATE INDEX i_inbox_box ON inbox (box) WHERE (box = 'bin');
 
+-- mod_pubsub
+
+CREATE TYPE pubsub_node_access_model AS ENUM('open', 'presence');
+
+CREATE TABLE pubsub_node (
+    service_jid VARCHAR(250) NOT NULL,
+    node_id VARCHAR(250) NOT NULL,
+    access_model pubsub_node_access_model NOT NULL,
+    PRIMARY KEY (service_jid, node_id)
+);
+
+CREATE TABLE pubsub_item (
+    service_jid VARCHAR(250) NOT NULL,
+    node_id VARCHAR(250) NOT NULL,
+    item_id VARCHAR(250) NOT NULL,
+    publisher_jid VARCHAR(250) NOT NULL,
+    payload TEXT NOT NULL,
+    published_at BIGINT NOT NULL,
+    PRIMARY KEY (service_jid, node_id, item_id),
+    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+);
+
+CREATE TABLE pubsub_subscription (
+    service_jid VARCHAR(250) NOT NULL,
+    node_id VARCHAR(250) NOT NULL,
+    subscriber_jid VARCHAR(250) NOT NULL,
+    PRIMARY KEY (service_jid, node_id, subscriber_jid),
+    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX i_pubsub_item_published_at ON pubsub_item USING btree (service_jid, node_id, published_at);
+
+-- mod_pubsub_old
 
 CREATE SEQUENCE pubsub_nodes_nidx;
 

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -397,6 +397,41 @@ CREATE INDEX i_inbox USING BTREE ON inbox(lserver, luser, timestamp);
 CREATE INDEX i_inbox_us_box USING BTREE ON inbox(lserver, luser, box);
 CREATE INDEX i_inbox_box USING BTREE ON inbox(box);
 
+-- mod_pubsub
+
+CREATE TABLE pubsub_node (
+    service_jid VARCHAR(250) NOT NULL,
+    node_id VARCHAR(250) NOT NULL,
+    access_model ENUM('open', 'presence') NOT NULL,
+    PRIMARY KEY (service_jid, node_id)
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE pubsub_item (
+    service_jid VARCHAR(250) NOT NULL,
+    node_id VARCHAR(250) NOT NULL,
+    item_id VARCHAR(250) NOT NULL,
+    publisher_jid VARCHAR(250) NOT NULL,
+    payload TEXT NOT NULL,
+    published_at BIGINT NOT NULL,
+    PRIMARY KEY (service_jid, node_id, item_id),
+    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE pubsub_subscription (
+    service_jid VARCHAR(250) NOT NULL,
+    node_id VARCHAR(250) NOT NULL,
+    subscriber_jid VARCHAR(250) NOT NULL,
+    PRIMARY KEY (service_jid, node_id, subscriber_jid),
+    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE INDEX i_pubsub_item_published_at USING BTREE ON pubsub_item(service_jid, node_id, published_at);
+
+-- mod_pubsub_old
+
 CREATE TABLE pubsub_nodes (
     nidx BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
     p_key VARCHAR(250)     NOT NULL,

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -339,6 +339,40 @@ CREATE INDEX i_inbox_timestamp ON inbox USING BTREE(lserver, luser, timestamp);
 CREATE INDEX i_inbox_us_box ON inbox USING BTREE(lserver, luser, box);
 CREATE INDEX i_inbox_box ON inbox (box) WHERE (box = 'bin');
 
+-- mod_pubsub
+
+CREATE TYPE pubsub_node_access_model AS ENUM('open', 'presence');
+
+CREATE TABLE pubsub_node (
+    service_jid VARCHAR(250) NOT NULL,
+    node_id VARCHAR(250) NOT NULL,
+    access_model pubsub_node_access_model NOT NULL,
+    PRIMARY KEY (service_jid, node_id)
+);
+
+CREATE TABLE pubsub_item (
+    service_jid VARCHAR(250) NOT NULL,
+    node_id VARCHAR(250) NOT NULL,
+    item_id VARCHAR(250) NOT NULL,
+    publisher_jid VARCHAR(250) NOT NULL,
+    payload TEXT NOT NULL,
+    published_at BIGINT NOT NULL,
+    PRIMARY KEY (service_jid, node_id, item_id),
+    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+);
+
+CREATE TABLE pubsub_subscription (
+    service_jid VARCHAR(250) NOT NULL,
+    node_id VARCHAR(250) NOT NULL,
+    subscriber_jid VARCHAR(250) NOT NULL,
+    PRIMARY KEY (service_jid, node_id, subscriber_jid),
+    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX i_pubsub_item_published_at ON pubsub_item USING btree (service_jid, node_id, published_at);
+
+-- mod_pubsub_old
+
 CREATE TABLE pubsub_nodes (
     nidx               BIGSERIAL PRIMARY KEY,
     p_key VARCHAR(250) NOT NULL,

--- a/src/config/mongoose_config_spec.erl
+++ b/src/config/mongoose_config_spec.erl
@@ -754,6 +754,7 @@ configurable_modules() ->
      mod_ping,
      mod_privacy,
      mod_private,
+     mod_pubsub,
      mod_pubsub_old,
      mod_push_service_mongoosepush,
      mod_register,

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -55,7 +55,10 @@
          set_presence/2,
          get_presence_type/1,
          maybe_get_handler/1,
-         get_old_priority/1
+         get_old_priority/1,
+         is_subscribed/3,
+         put_state_in_acc/2,
+         get_state_from_acc/1
         ]).
 
 -ignore_xref([am_i_subscribed_to_presence/3]). % unused but still exported for tests/debugging
@@ -729,9 +732,12 @@ is_available(#presences_state{available = Available}, Jid) ->
     sets:is_element(Jid, Available).
 
 -spec is_subscribed(state(), jid:jid(), subscription()) -> boolean().
-is_subscribed(#presences_state{subscriptions = Subs}, Jid, DesiredSub) ->
-    Sub = maps:get(Jid, Subs, '$imposible_status'),
-    both =:= Sub orelse DesiredSub =:= Sub.
+is_subscribed(#presences_state{subscriptions = Subscriptions}, Jid, DesiredSub) ->
+    case Subscriptions of
+        #{Jid := DesiredSub} -> true;
+        #{Jid := both} -> true;
+        _ -> false
+    end.
 
 -spec get_by_sub(state(), subscription()) -> subscriptions().
 get_by_sub(#presences_state{subscriptions = Subs}, DesiredStatus) ->
@@ -746,3 +752,17 @@ get(#presences_state{available = Value}, s_available) -> Value;
 get(#presences_state{pres_pri = Value}, priority) -> Value;
 get(#presences_state{pres_last = Value}, last) -> Value;
 get(#presences_state{pres_timestamp = Value}, timestamp) -> Value.
+
+-doc "Store presences state in Acc for later use by other modules (e.g. mod_pubsub)".
+-spec put_state_in_acc(mongoose_c2s:data(), mongoose_acc:t()) -> mongoose_acc:t().
+put_state_in_acc(C2SData, Acc) ->
+    case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
+        {ok, State} ->
+            mongoose_acc:set_permanent(?MODULE, state, State, Acc);
+        _ ->
+            Acc
+    end.
+
+-spec get_state_from_acc(mongoose_acc:t()) -> state() | undefined.
+get_state_from_acc(Acc) ->
+    mongoose_acc:get(?MODULE, state, undefined, Acc).

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -1,0 +1,633 @@
+-module(mod_pubsub).
+-moduledoc "Lightweight implementation of PEP (Personal Eventing Protocol) on top of PubSub".
+
+-behaviour(gen_mod).
+
+-xep([{xep, 60}, {version, "1.25.0"}, {status, partial}]).
+-xep([{xep, 163}, {version, "1.2.2"}, {status, partial}]).
+
+%% gen_mod callbacks
+-export([start/2, stop/1, hooks/1, config_spec/0, supported_features/0]).
+
+%% hook handlers
+-export([user_send_iq/3,
+         disco_sm_identity/3,
+         disco_sm_features/3,
+         disco_sm_items/3,
+         caps_recognised/3,
+         roster_out_subscription/3,
+         remove_user/3]).
+
+%% IQ handlers
+-export([iq_sm/5]).
+
+-include("mongoose.hrl").
+-include("jlib.hrl").
+-include("mongoose_ns.hrl").
+-include("mongoose_config_spec.hrl").
+-include("mod_pubsub.hrl").
+
+-type item() :: #item{}.
+-type pubsub_node() :: #pubsub_node{}.
+-type subscription() :: #subscription{}.
+-type node_key() :: {jid:jid(), node_id()}.
+-type node_id() :: binary().
+-type item_id() :: binary().
+-type item_ids() :: [item_id()].
+-type item_payload() :: exml:element().
+-type access_model() :: open | presence.
+-type node_config() :: #{access_model => access_model()}.
+-type error_reason() :: generic_error_reason() | {generic_error_reason(), binary()}.
+-type generic_error_reason() ::
+        bad_request | conflict | forbidden | not_acceptable | not_authorized |
+        unexpected_request | item_not_found.
+-type error_result() :: {error, error_reason()}.
+-type result(T) :: {ok, T} | error_result().
+-type ok_result() :: ok | error_result().
+
+-type iq_request() :: #{acc := mongoose_acc:t(),
+                        iq := jlib:iq(),
+                        from_jid := jid:jid(),
+                        service_jid := jid:jid()}.
+
+-type iq_action() ::
+        #{action := create, node_id := node_id(), config := node_config(),
+          result => ok}
+      | #{action := get_configuration, node_id := node_id(),
+          result => pubsub_node()}
+      | #{action := configure, node_id := node_id(), config := node_config(),
+          result => ok}
+      | #{action := delete, node_id := node_id(),
+          result => ok}
+      | #{action := subscribe, node_id := node_id(), subscriber_jid := jid:jid(),
+          result => ok}
+      | #{action := unsubscribe, node_id := node_id(), subscriber_jid := jid:jid(),
+          result => ok}
+      | #{action := get_items, node_id := node_id(),
+          item_ids => item_ids(),
+          result => [item()]}
+      | #{action := publish, node_id := node_id(), item_id := item_id(), payload := item_payload(),
+          config => node_config(),
+          result => item_id()}.
+
+-export_type([item/0, pubsub_node/0, subscription/0, node_key/0, node_id/0,
+              item_id/0, item_payload/0, access_model/0, node_config/0]).
+
+%% gen_mod callbacks
+
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, #{iqdisc := IQDisc} = Opts) ->
+    mod_pubsub_backend:start(HostType, Opts),
+    add_iq_handlers(HostType, IQDisc).
+
+-spec stop(mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    delete_iq_handlers(HostType),
+    mod_pubsub_backend:stop(HostType).
+
+-spec supported_features() -> [gen_mod:module_feature()].
+supported_features() ->
+    [dynamic_domains].
+
+-spec config_spec() -> mongoose_config_spec:config_section().
+config_spec() ->
+    #section{
+        items = #{~"backend" => #option{type = atom,
+                                        validate = {module, mod_pubsub_backend}},
+                  ~"iqdisc" => mongoose_config_spec:iqdisc()},
+        defaults = #{~"backend" => rdbms,
+                     ~"iqdisc" => no_queue}
+    }.
+
+-spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
+hooks(HostType) ->
+    [{user_send_iq, HostType, fun ?MODULE:user_send_iq/3, #{}, 50},
+     {disco_sm_identity, HostType, fun ?MODULE:disco_sm_identity/3, #{}, 75},
+     {disco_sm_features, HostType, fun ?MODULE:disco_sm_features/3, #{}, 75},
+     {disco_sm_items, HostType, fun ?MODULE:disco_sm_items/3, #{}, 75},
+     {caps_recognised, HostType, fun ?MODULE:caps_recognised/3, #{}, 50},
+     {roster_out_subscription, HostType, fun ?MODULE:roster_out_subscription/3, #{}, 50},
+     {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
+     {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50}].
+
+%% Hook handlers
+
+-spec user_send_iq(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
+          mongoose_c2s_hooks:result().
+user_send_iq(Acc, _Args = #{c2s_data := C2SData}, _Extra) ->
+    {_From, To, Stanza} = mongoose_acc:packet(Acc),
+    maybe
+        true ?= To#jid.luser =/= ~"", % Only PEP is handled now
+        IQ = #iq{} ?= jlib:iq_query_info(Stanza),
+        true ?= mod_pubsub_xml:is_iq_relevant(IQ),
+        Acc1 = mod_presence:put_state_in_acc(C2SData, Acc),
+        {ok, Acc1}
+    else
+        _ -> {ok, Acc}
+    end.
+
+-spec disco_sm_identity(DiscoAcc, mongoose_disco:sm_params(), gen_hook:extra()) ->
+          {ok, DiscoAcc} when DiscoAcc :: mongoose_disco:identity_acc().
+disco_sm_identity(DiscoAcc = #{to_jid := ToJid, node := ~""}, _, _) ->
+    case ejabberd_auth:does_user_exist(ToJid) of
+        true -> {ok, mongoose_disco:add_identities([pep_identity()], DiscoAcc)};
+        false -> {ok, DiscoAcc}
+    end;
+disco_sm_identity(DiscoAcc = #{host_type := HostType, from_jid := FromJid,
+                               to_jid := ToJid, node := NodeId},
+                  #{presence_subscribed := PresenceSubscribed}, _) ->
+    maybe
+        Node = #pubsub_node{} ?= mod_pubsub_backend:get_node(HostType, {ToJid, NodeId}),
+        true ?= can_discover_node(Node, FromJid, PresenceSubscribed),
+        {ok, mongoose_disco:add_identities([pep_node_identity()], DiscoAcc)}
+    else
+        _ -> {ok, DiscoAcc}
+    end.
+
+-spec disco_sm_features(DiscoAcc, mongoose_disco:sm_params(), gen_hook:extra()) ->
+          {ok, DiscoAcc} when DiscoAcc :: mongoose_disco:feature_acc().
+disco_sm_features(DiscoAcc = #{host_type := HostType, to_jid := ToJid, node := ~""}, _, _) ->
+    case ejabberd_auth:does_user_exist(ToJid) of
+        true -> {ok, mongoose_disco:add_features(pep_disco_features(HostType), DiscoAcc)};
+        false -> {ok, DiscoAcc}
+    end;
+disco_sm_features(DiscoAcc = #{host_type := HostType, from_jid := FromJid,
+                               to_jid := ToJid, node := NodeId},
+                  #{presence_subscribed := PresenceSubscribed}, _) ->
+    maybe
+        Node = #pubsub_node{} ?= mod_pubsub_backend:get_node(HostType, {ToJid, NodeId}),
+        true ?= can_discover_node(Node, FromJid, PresenceSubscribed),
+        {ok, mongoose_disco:add_features(pep_node_disco_features(), DiscoAcc)}
+    else
+        _ -> {ok, DiscoAcc}
+    end.
+
+-spec disco_sm_items(DiscoAcc, mongoose_disco:sm_params(), gen_hook:extra()) ->
+          {ok, DiscoAcc} when DiscoAcc :: mongoose_disco:item_acc().
+disco_sm_items(DiscoAcc = #{host_type := HostType, from_jid := FromJid,
+                            to_jid := ToJid, node := ~""},
+               #{presence_subscribed := PresenceSubscribed}, _) ->
+    case ejabberd_auth:does_user_exist(ToJid) of
+        true ->
+            Items = disco_items(HostType, ToJid, FromJid, PresenceSubscribed),
+            {ok, mongoose_disco:add_items(Items, DiscoAcc)};
+        false ->
+            {ok, DiscoAcc}
+    end;
+disco_sm_items(DiscoAcc, _, _) ->
+    {ok, DiscoAcc}.
+
+-spec caps_recognised(Acc, gen_hook:hook_params(), gen_hook:extra()) -> {ok, Acc} when
+      Acc :: mongoose_acc:t().
+caps_recognised(Acc, #{c2s_data := C2SData, features := Features}, _Extra) ->
+    SubscriberJid = mongoose_acc:from_jid(Acc),
+    Acc1 = mod_presence:put_state_in_acc(C2SData, Acc),
+    Owners = presence_subscriptions(s_to, Acc1),
+    lists:foreach(fun(OwnerJid) -> send_last_items(OwnerJid, SubscriberJid, Features) end, Owners),
+    {ok, Acc}.
+
+-spec roster_out_subscription(Acc, gen_hook:hook_params(), gen_hook:extra()) -> {ok, Acc} when
+      Acc :: mongoose_acc:t().
+roster_out_subscription(Acc, #{to := SubscriberJid, from := OwnerJid, type := subscribed}, _) ->
+    HostType = mongoose_acc:host_type(Acc),
+    RecipientJids = [jid:to_bare(SubscriberJid)],
+    lists:foreach(fun(Item = #item{node_key = NodeKey}) ->
+                          FilteredJids = filter_recipients(RecipientJids, NodeKey),
+                          broadcast_item(HostType, OwnerJid, FilteredJids, Item, true)
+                  end, mod_pubsub_backend:get_last_items(HostType, OwnerJid)),
+    {ok, Acc};
+roster_out_subscription(Acc, _, _) ->
+    {ok, Acc}.
+
+-spec remove_user(Acc, gen_hook:hook_params(), gen_hook:extra()) -> {ok, Acc} when
+      Acc :: mongoose_acc:t().
+remove_user(Acc, #{jid := ServiceJid}, _) ->
+    HostType = mongoose_acc:host_type(Acc),
+    mod_pubsub_backend:delete_nodes(HostType, ServiceJid),
+    {ok, Acc}.
+
+%% IQ handlers
+
+-spec iq_sm(mongoose_acc:t(), jid:jid(), jid:jid(), jlib:iq(), map()) ->
+    {mongoose_acc:t(), jlib:iq()}.
+iq_sm(Acc, From, To, IQ, _Extra) ->
+    Reply = mod_pubsub_xml:make_reply(handle_iq(Acc, From, To, IQ)),
+    make_iq_response(Acc, IQ, Reply).
+
+%% IQ helpers
+
+-spec add_iq_handlers(mongooseim:host_type(), gen_iq_handler:execution_type()) -> ok.
+add_iq_handlers(HostType, IQDisc) ->
+    ok = gen_iq_handler:add_iq_handler_for_domain(HostType, ?NS_PUBSUB, ejabberd_sm,
+                                                  fun ?MODULE:iq_sm/5, #{}, IQDisc),
+    ok = gen_iq_handler:add_iq_handler_for_domain(HostType, ?NS_PUBSUB_OWNER, ejabberd_sm,
+                                                  fun ?MODULE:iq_sm/5, #{}, IQDisc).
+
+-spec delete_iq_handlers(mongooseim:host_type()) -> ok.
+delete_iq_handlers(HostType) ->
+    gen_iq_handler:remove_iq_handler_for_domain(HostType, ?NS_PUBSUB, ejabberd_sm),
+    gen_iq_handler:remove_iq_handler_for_domain(HostType, ?NS_PUBSUB_OWNER, ejabberd_sm),
+    ok.
+
+-spec handle_iq(mongoose_acc:t(), jid:jid(), jid:jid(), jlib:iq()) -> iq_action() | error_result().
+handle_iq(Acc, From, To, IQ) ->
+    Request = #{acc => Acc, iq => IQ, from_jid => From, service_jid => To},
+    case mod_pubsub_xml:iq_action(IQ) of
+        {error, _} = Error ->
+            ?LOG_INFO(#{what => pubsub_iq_error, request => Request, error => Error}),
+            Error;
+        Action ->
+            ?LOG_DEBUG(#{what => pubsub_iq_action, request => Request, action => Action}),
+            perform_action(Request, Action)
+    end.
+
+-spec make_iq_response(mongoose_acc:t(), jlib:iq(), {result | error, [exml:child()]}) ->
+    {mongoose_acc:t(), jlib:iq()}.
+make_iq_response(Acc, IQ, {IQType, Els}) ->
+    {Acc, IQ#iq{type = IQType, sub_el = Els}}.
+
+%% Action helpers
+
+-spec perform_action(iq_request(), iq_action()) -> iq_action() | error_result().
+perform_action(Request, Action = #{action := create}) ->
+    #{acc := Acc, service_jid := ServiceJid} = Request,
+    #{node_id := NodeId, config := Config} = Action,
+    maybe
+        ok ?= assert_owner(Request),
+        HostType = mongoose_acc:host_type(Acc),
+        NodeKey = {ServiceJid, NodeId},
+        ok ?= assert_node_does_not_exist(HostType, NodeKey),
+        Node = #pubsub_node{node_key = NodeKey},
+        mod_pubsub_backend:set_node(HostType, apply_node_config(Node, Config)),
+        Action#{result => ok}
+    end;
+perform_action(Request, Action = #{action := get_configuration}) ->
+    #{acc := Acc, service_jid := ServiceJid} = Request,
+    #{node_id := NodeId} = Action,
+    maybe
+        ok ?= assert_owner(Request),
+        HostType = mongoose_acc:host_type(Acc),
+        NodeKey = {ServiceJid, NodeId},
+        {ok, Node} ?= get_node(HostType, NodeKey),
+        Action#{result => Node}
+    end;
+perform_action(Request, Action = #{action := configure}) ->
+    #{acc := Acc, service_jid := ServiceJid} = Request,
+    #{node_id := NodeId, config := Config} = Action,
+    maybe
+        ok ?= assert_owner(Request),
+        HostType = mongoose_acc:host_type(Acc),
+        NodeKey = {ServiceJid, NodeId},
+        {ok, Node} ?= get_node(HostType, NodeKey),
+        mod_pubsub_backend:set_node(HostType, apply_node_config(Node, Config)),
+        Action#{result => ok}
+    end;
+perform_action(Request, Action = #{action := delete}) ->
+    #{acc := Acc, service_jid := ServiceJid} = Request,
+    #{node_id := NodeId} = Action,
+    maybe
+        ok ?= assert_owner(Request),
+        HostType = mongoose_acc:host_type(Acc),
+        NodeKey = {ServiceJid, NodeId},
+        {ok, Node} ?= get_node(HostType, NodeKey),
+        Recipients = recipient_jids(Node, Request),
+        mod_pubsub_backend:delete_node(HostType, NodeKey),
+        broadcast_node_deletion(HostType, ServiceJid, Recipients, NodeId),
+        Action#{result => ok}
+    end;
+perform_action(Request, Action = #{action := subscribe}) ->
+    #{acc := Acc, service_jid := ServiceJid} = Request,
+    #{node_id := NodeId, subscriber_jid := SubscriberJid} = Action,
+    maybe
+        ok ?= assert_subscriber_jid(Request, SubscriberJid),
+        HostType = mongoose_acc:host_type(Acc),
+        NodeKey = {ServiceJid, NodeId},
+        {ok, Node = #pubsub_node{}} ?= get_node(HostType, NodeKey),
+        ok ?= assert_access(Node, Request),
+        set_subscription(HostType, NodeKey, SubscriberJid),
+        Action#{result => ok}
+    end;
+perform_action(Request, Action = #{action := unsubscribe}) ->
+    #{acc := Acc, service_jid := ServiceJid} = Request,
+    #{node_id := NodeId, subscriber_jid := SubscriberJid} = Action,
+    NodeKey = {ServiceJid, NodeId},
+    HostType = mongoose_acc:host_type(Acc),
+    maybe
+        {ok, #pubsub_node{}} ?= get_node(HostType, NodeKey),
+        ok ?= assert_can_unsubscribe(Request, SubscriberJid),
+        ok ?= delete_subscription(HostType, NodeKey, SubscriberJid),
+        Action#{result => ok}
+    end;
+perform_action(Request, Action = #{action := get_items}) ->
+    #{acc := Acc, service_jid := ServiceJid} = Request,
+    #{node_id := NodeId} = Action,
+    HostType = mongoose_acc:host_type(Acc),
+    NodeKey = {ServiceJid, NodeId},
+    maybe
+        {ok, Node} ?= get_node(HostType, NodeKey),
+        ok ?= assert_access(Node, Request),
+        Items = get_items(HostType, NodeKey, Action),
+        Action#{result => Items}
+    end;
+perform_action(Request, Action = #{action := publish}) ->
+    #{acc := Acc, from_jid := PublisherJid, service_jid := ServiceJid} = Request,
+    #{node_id := NodeId, item_id := ItemId, payload := Payload} = Action,
+    maybe
+        ok ?= assert_owner(Request),
+        HostType = mongoose_acc:host_type(Acc),
+        NodeKey = {ServiceJid, NodeId},
+        {ok, Node} ?= get_or_create_node(HostType, NodeKey, maps:get(config, Action, #{})),
+        Item = #item{node_key = NodeKey, id = ItemId, publisher_jid = PublisherJid,
+                     payload = Payload},
+        mod_pubsub_backend:set_item(HostType, Item),
+        Recipients = recipient_jids(Node, Request),
+        broadcast_item(HostType, jid:to_bare(PublisherJid), Recipients, Item, false),
+        Action#{result => ItemId}
+    end.
+
+%% Assertions
+
+-spec assert_owner(iq_request()) -> ok_result().
+assert_owner(Request) ->
+    case is_owner(Request) of
+        true -> ok;
+        false -> {error, forbidden}
+    end.
+
+-spec assert_node_does_not_exist(mongooseim:host_type(), node_key()) -> ok_result().
+assert_node_does_not_exist(HostType, NodeKey) ->
+    case mod_pubsub_backend:get_node(HostType, NodeKey) of
+        undefined -> ok;
+        _ -> {error, conflict}
+    end.
+
+-spec assert_subscriber_jid(iq_request(), jid:jid()) -> ok_result().
+assert_subscriber_jid(#{from_jid := FromJid}, SubscriberJid) ->
+    case jid:are_bare_equal(FromJid, SubscriberJid) of
+        true -> ok;
+        false -> {error, {bad_request, ~"invalid-jid"}}
+    end.
+
+-spec assert_can_unsubscribe(iq_request(), jid:jid()) -> ok_result().
+assert_can_unsubscribe(#{from_jid := FromJid}, SubscriberJid) ->
+    case jid:are_bare_equal(FromJid, SubscriberJid) of
+        true -> ok;
+        false -> {error, forbidden} % can't unsubscribe someone else
+    end.
+
+-spec assert_access(pubsub_node(), iq_request()) -> ok_result().
+assert_access(#pubsub_node{node_key = {OwnerJid, _}} = Node, #{acc := Acc} = Request) ->
+    case is_owner(Request) orelse is_open(Node) orelse is_subscribed_to_presence(OwnerJid, Acc) of
+        true -> ok;
+        false -> {error, {not_authorized, ~"presence-subscription-required"}}
+    end.
+
+%% Helpers for nodes, subscriptions, items
+
+-spec is_owner(iq_request()) -> boolean().
+is_owner(#{from_jid := FromJid, service_jid := ServiceJid}) ->
+    jid:are_bare_equal(FromJid, ServiceJid).
+
+-spec is_open(pubsub_node()) -> boolean().
+is_open(#pubsub_node{config = #{access_model := AccessModel}}) ->
+    AccessModel =:= open.
+
+-spec apply_node_config(pubsub_node(), node_config()) -> pubsub_node().
+apply_node_config(Node, Config) ->
+    Node#pubsub_node{config = maps:merge(Node#pubsub_node.config, Config)}.
+
+-spec get_node(mongooseim:host_type(), node_key()) -> result(pubsub_node()).
+get_node(HostType, NodeKey) ->
+    case mod_pubsub_backend:get_node(HostType, NodeKey) of
+        undefined -> {error, item_not_found};
+        Node -> {ok, Node}
+    end.
+
+-spec set_subscription(mongooseim:host_type(), node_key(), jid:jid()) -> ok.
+set_subscription(HostType, NodeKey, SubscriberJid) ->
+    case mod_pubsub_backend:get_subscription(HostType, NodeKey, SubscriberJid) of
+        undefined ->
+            Subscription = #subscription{node_key = NodeKey, jid = SubscriberJid},
+            mod_pubsub_backend:set_subscription(HostType, Subscription),
+            route_last_item_if_exists(HostType, NodeKey, SubscriberJid);
+        _Subscription ->
+            ok % already subscribed
+    end.
+
+-spec delete_subscription(mongooseim:host_type(), node_key(), jid:jid()) -> ok_result().
+delete_subscription(HostType, NodeKey, SubscriberJid) ->
+    case mod_pubsub_backend:delete_subscription(HostType, NodeKey, SubscriberJid) of
+        ok -> ok;
+        not_found -> {error, {unexpected_request, ~"not-subscribed"}}
+    end.
+
+-spec get_item(mongooseim:host_type(), node_key(), item_id()) -> [item()].
+get_item(HostType, NodeKey, ItemId) ->
+    case mod_pubsub_backend:get_item(HostType, NodeKey, ItemId) of
+        undefined -> [];
+        Item -> [Item]
+    end.
+
+-spec get_items(mongooseim:host_type(), node_key(), iq_action()) -> [item()].
+get_items(HostType, NodeKey, #{item_ids := ItemIds}) ->
+    lists:flatmap(fun(ItemId) -> get_item(HostType, NodeKey, ItemId) end, ItemIds);
+get_items(HostType, NodeKey, #{}) ->
+    mod_pubsub_backend:get_items(HostType, NodeKey).
+
+-spec get_or_create_node(mongooseim:host_type(), node_key(), node_config()) ->
+          result(pubsub_node()).
+get_or_create_node(HostType, NodeKey, Config) ->
+    case mod_pubsub_backend:get_node(HostType, NodeKey) of
+        undefined ->
+            Node = #pubsub_node{node_key = NodeKey},
+            mod_pubsub_backend:set_node(HostType, apply_node_config(Node, Config)),
+            {ok, Node};
+        Node = #pubsub_node{config = ExistingConfig} ->
+            case maps:with(maps:keys(Config), ExistingConfig) of
+                Config -> {ok, Node};
+                _ -> {error, {conflict, ~"precondition-not-met"}}
+            end
+    end.
+
+%% Notification helpers
+
+-spec recipient_jids(pubsub_node(), iq_request()) -> [jid:jid()].
+recipient_jids(Node, #{acc := Acc}) ->
+    Subs = lists:usort(implicit_subscribers(Node, Acc) ++ explicit_subscribers(Node, Acc)),
+    lists:foldl(fun drop_bare_jid_shadowed_by_full_jid/2, [], Subs).
+
+-spec implicit_subscribers(pubsub_node(), mongoose_acc:t()) -> [jid:jid()].
+implicit_subscribers(#pubsub_node{node_key = NodeKey = {OwnerJid, _}}, Acc) ->
+    filter_recipients([OwnerJid | presence_subscriptions(s_from, Acc)], NodeKey).
+
+-spec explicit_subscribers(pubsub_node(), mongoose_acc:t()) -> [jid:jid()].
+explicit_subscribers(#pubsub_node{node_key = NodeKey}, Acc) ->
+    HostType = mongoose_acc:host_type(Acc),
+    Subscriptions = mod_pubsub_backend:get_subscriptions(HostType, NodeKey),
+    [Jid || #subscription{jid = Jid} <- Subscriptions].
+
+-spec drop_bare_jid_shadowed_by_full_jid(jid:jid(), [jid:jid()]) -> [jid:jid()].
+drop_bare_jid_shadowed_by_full_jid(#jid{luser = U, lserver = S} = FullJid,
+                                   [#jid{luser = U, lserver = S, lresource = ~""} | Results]) ->
+    [FullJid | Results];
+drop_bare_jid_shadowed_by_full_jid(Jid, Results) ->
+    [Jid | Results].
+
+-spec filter_recipients([jid:jid()], node_key()) -> [jid:jid()].
+filter_recipients(RecipientJids, NodeKey) ->
+    Feature = notify_feature(NodeKey),
+    [RecipientJid#jid{lresource = LRes}
+     || RecipientJid <- RecipientJids,
+        {LRes, Features} <- resources_with_features(RecipientJid),
+        lists:member(Feature, Features)].
+
+-spec presence_subscriptions(s_from | s_to, mongoose_acc:t()) -> [jid:jid()].
+presence_subscriptions(Type, Acc) ->
+    case mod_presence:get_state_from_acc(Acc) of
+        undefined -> [];
+        State -> maps:keys(mod_presence:get(State, Type))
+    end.
+
+-spec broadcast_node_deletion(mongooseim:host_type(), jid:jid(), [jid:jid()], node_id()) -> ok.
+broadcast_node_deletion(_HostType, _FromJid, [], _Item) ->
+    ok;
+broadcast_node_deletion(HostType, FromJid, ToJids, NodeId) ->
+    Notification = mod_pubsub_xml:deletion_notification_message_el(NodeId),
+    broadcast_notification(HostType, FromJid, ToJids, Notification).
+
+-spec route_last_item_if_exists(mongooseim:host_type(), node_key(), jid:jid()) -> ok.
+route_last_item_if_exists(HostType, NodeKey = {ServiceJid, _}, SubscriberJid) ->
+    case mod_pubsub_backend:get_last_item(HostType, NodeKey) of
+        undefined ->
+            ok;
+        Item ->
+            Notification = mod_pubsub_xml:notification_message_el(Item, true),
+            route_notification(HostType, ServiceJid, SubscriberJid, Notification)
+    end.
+
+-spec send_last_items(jid:jid(), jid:jid(), [mod_caps:feature()]) -> ok.
+send_last_items(OwnerJid = #jid{lserver = LServer}, SubscriberJid, Features) ->
+    maybe
+        {ok, HostType} ?= mongoose_domain_api:get_domain_host_type(LServer),
+        ServiceJid = jid:to_bare(OwnerJid),
+        [send_last_item(HostType, ServiceJid, SubscriberJid, Item)
+         || Item <- mod_pubsub_backend:get_last_items(HostType, ServiceJid),
+            lists:member(notify_feature(Item#item.node_key), Features)]
+    end,
+    ok.
+
+-spec send_last_item(mongooseim:host_type(), jid:jid(), jid:jid(), item()) -> ok.
+send_last_item(HostType, ServiceJid, SubscriberJid, Item) ->
+    Notification = mod_pubsub_xml:notification_message_el(Item, true),
+    route_notification(HostType, ServiceJid, SubscriberJid, Notification).
+
+-spec broadcast_item(mongooseim:host_type(), jid:jid(), [jid:jid()], item(), boolean()) -> ok.
+broadcast_item(_HostType, _FromJid, [], _Item, _Delayed) ->
+    ok;
+broadcast_item(HostType, FromJid, ToJids, Item, Delayed) ->
+    Notification = mod_pubsub_xml:notification_message_el(Item, Delayed),
+    broadcast_notification(HostType, FromJid, ToJids, Notification).
+
+-spec broadcast_notification(mongooseim:host_type(), jid:jid(), [jid:jid()], exml:element()) -> ok.
+broadcast_notification(HostType, FromJid, ToJids, Notification) ->
+    lists:foreach(fun(ToJid) ->
+                          route_notification(HostType, FromJid, ToJid, Notification)
+                  end, ToJids).
+
+-spec notify_feature(node_key()) -> mod_caps:feature().
+notify_feature({_, NodeId}) ->
+    <<NodeId/binary, "+notify">>.
+
+-spec resources_with_features(jid:jid()) -> [{jid:lresource(), [mod_caps:feature()]}].
+resources_with_features(Jid = #jid{lserver = LServer}) ->
+    maybe
+        {ok, HostType} ?= mongoose_domain_api:get_domain_host_type(LServer),
+        true ?= gen_mod:is_loaded(HostType, mod_caps),
+        resources_with_features(HostType, Jid)
+    else
+        _ -> []
+    end.
+
+-spec resources_with_features(mongooseim:host_type(), jid:jid()) ->
+    [{jid:lresource(), [mod_caps:feature()]}].
+resources_with_features(HostType, Jid = #jid{lresource = ~""}) ->
+    mod_caps:get_resources_with_features(HostType, Jid);
+resources_with_features(HostType, Jid = #jid{lresource = LResource}) ->
+    [{LResource, mod_caps:get_features(HostType, Jid)}].
+
+-spec route_notification(mongooseim:host_type(), jid:jid(), jid:jid(), exml:element()) -> ok.
+route_notification(_HostType, FromJid, ToJid, Packet) ->
+    Acc = mongoose_acc:new(FromJid, ToJid, Packet, ?LOCATION),
+    mongoose_router:route(Acc),
+    ok.
+
+%% Disco helpers
+
+-spec disco_items(mongooseim:host_type(), jid:jid(), jid:jid(), boolean()) ->
+    [mongoose_disco:item()].
+disco_items(HostType, ServiceJid, FromJid, PresenceSubscribed) ->
+    Nodes = mod_pubsub_backend:get_nodes(HostType, ServiceJid),
+    [#{jid => jid:to_binary(ServiceJid), node => NodeId}
+     || Node = #pubsub_node{node_key = {_, NodeId}} <- Nodes,
+        can_discover_node(Node, FromJid, PresenceSubscribed)].
+
+-spec can_discover_node(pubsub_node(), jid:jid(), boolean()) -> boolean().
+can_discover_node(#pubsub_node{node_key = {OwnerJid, _}} = Node, FromJid, PresenceSubscribed) ->
+    jid:are_bare_equal(OwnerJid, FromJid) orelse is_open(Node) orelse PresenceSubscribed.
+
+-spec is_subscribed_to_presence(jid:jid(), mongoose_acc:t()) -> boolean().
+is_subscribed_to_presence(OwnerJid = #jid{lresource = ~""}, Acc) ->
+    case mod_presence:get_state_from_acc(Acc) of
+        undefined -> false;
+        PresencesState -> mod_presence:is_subscribed(PresencesState, OwnerJid, to)
+    end.
+
+-spec pep_identity() -> mongoose_disco:identity().
+pep_identity() ->
+    #{category => ~"pubsub", type => ~"pep"}.
+
+-spec pep_node_identity() -> mongoose_disco:identity().
+pep_node_identity() ->
+    #{category => ~"pubsub", type => ~"leaf"}.
+
+-spec pep_disco_features(mongooseim:host_type()) -> [mongoose_disco:feature()].
+pep_disco_features(HostType) ->
+    [?NS_PUBSUB | [pubsub_feature(Feature) || Feature <- pep_features(HostType)]].
+
+-spec pep_node_disco_features() -> [mongoose_disco:feature()].
+pep_node_disco_features() ->
+    [?NS_PUBSUB].
+
+-spec pep_features(mongooseim:host_type()) -> [binary()].
+pep_features(HostType) ->
+    lists:merge(pep_base_features(), pep_caps_features(HostType)).
+
+-doc "Sorted list of PEP-specific features".
+-spec pep_base_features() -> [binary()].
+pep_base_features() ->
+    [~"access-open",
+     ~"access-presence",
+     ~"auto-create",
+     ~"config-node",
+     ~"create-and-configure",
+     ~"create-nodes",
+     ~"delete-nodes",
+     ~"item-ids",
+     ~"last-published",
+     ~"persistent-items",
+     ~"publish",
+     ~"publish-options",
+     ~"retrieve-items",
+     ~"subscribe"].
+
+-doc "Sorted list of PEP-specific features requiring mod_caps".
+-spec pep_caps_features(mongooseim:host_type()) -> [binary()].
+pep_caps_features(HostType) ->
+    case gen_mod:is_loaded(HostType, mod_caps) of
+        true -> [~"filtered-notifications"];
+        false -> []
+    end.
+
+-spec pubsub_feature(binary()) -> mongoose_disco:feature().
+pubsub_feature(Feature) ->
+    <<(?NS_PUBSUB)/binary, "#", Feature/binary>>.

--- a/src/pubsub/mod_pubsub_backend.erl
+++ b/src/pubsub/mod_pubsub_backend.erl
@@ -1,0 +1,115 @@
+-module(mod_pubsub_backend).
+
+-include("mod_pubsub.hrl").
+
+-export([start/2, stop/1, set_node/2, get_node/2, get_nodes/2, delete_node/2, delete_nodes/2,
+         set_subscription/2, delete_subscription/3, get_subscriptions/2, get_subscription/3,
+         set_item/2, get_item/3, get_items/2, get_last_item/2, get_last_items/2]).
+
+-callback start(mongooseim:host_type()) -> ok.
+-callback stop(mongooseim:host_type()) -> ok.
+-callback set_node(mongooseim:host_type(), mod_pubsub:pubsub_node()) -> ok.
+-callback get_node(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    mod_pubsub:pubsub_node() | undefined.
+-callback get_nodes(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:pubsub_node()].
+-callback delete_node(mongooseim:host_type(), mod_pubsub:node_key()) -> ok.
+-callback delete_nodes(mongooseim:host_type(), jid:jid()) -> ok.
+-callback set_subscription(mongooseim:host_type(), mod_pubsub:subscription()) -> ok.
+-callback delete_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
+    ok | not_found.
+-callback get_subscriptions(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    [mod_pubsub:subscription()].
+-callback get_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
+    mod_pubsub:subscription() | undefined.
+-callback set_item(mongooseim:host_type(), mod_pubsub:item()) -> ok.
+-callback get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
+    mod_pubsub:item() | undefined.
+-callback get_items(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    [mod_pubsub:item()].
+-callback get_last_item(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    mod_pubsub:item() | undefined.
+-callback get_last_items(mongooseim:host_type(), jid:jid()) ->
+    [mod_pubsub:item()].
+
+%% Currently unused, but implemented for the sake of completeness, and for debugging/inspection
+-ignore_xref([get_last_item/2, get_subscription/3]).
+
+%% API: start/stop
+
+-spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
+start(HostType, Opts) ->
+    mongoose_backend:init(HostType, ?MODULE, tracked_funs(), Opts),
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType]).
+
+-spec stop(mongooseim:host_type()) -> ok.
+stop(HostType) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType]).
+
+%% API: nodes
+
+-spec set_node(mongooseim:host_type(), mod_pubsub:pubsub_node()) -> ok.
+set_node(HostType, Node) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Node]).
+
+-spec get_node(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    mod_pubsub:pubsub_node() | undefined.
+get_node(HostType, NodeKey) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
+
+-spec get_nodes(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:pubsub_node()].
+get_nodes(HostType, ServiceJid) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, ServiceJid]).
+
+-spec delete_nodes(mongooseim:host_type(), jid:jid()) -> ok.
+delete_nodes(HostType, ServiceJid) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, ServiceJid]).
+
+-spec delete_node(mongooseim:host_type(), mod_pubsub:node_key()) -> ok.
+delete_node(HostType, NodeKey) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
+
+%% API: items
+
+-spec set_subscription(mongooseim:host_type(), mod_pubsub:subscription()) -> ok.
+set_subscription(HostType, Subscription) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Subscription]).
+
+-spec get_subscriptions(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    [mod_pubsub:subscription()].
+get_subscriptions(HostType, NodeKey) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
+
+-spec delete_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) -> ok | not_found.
+delete_subscription(HostType, NodeKey, SubscriberJid) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, SubscriberJid]).
+
+-spec get_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
+    mod_pubsub:subscription() | undefined.
+get_subscription(HostType, NodeKey, SubscriberJid) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, SubscriberJid]).
+
+set_item(HostType, Item) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Item]).
+
+-spec get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
+    mod_pubsub:item() | undefined.
+get_item(HostType, NodeKey, ItemId) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, ItemId]).
+
+-spec get_items(mongooseim:host_type(), mod_pubsub:node_key()) -> [mod_pubsub:item()].
+get_items(HostType, NodeKey) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
+
+-spec get_last_item(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    mod_pubsub:item() | undefined.
+get_last_item(HostType, NodeKey) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
+
+-spec get_last_items(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:item()].
+get_last_items(HostType, ServiceJid) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, ServiceJid]).
+
+%% Helpers
+
+tracked_funs() ->
+    [set_node, delete_node, delete_nodes, set_subscription, delete_subscription, set_item].

--- a/src/pubsub/mod_pubsub_backend_rdbms.erl
+++ b/src/pubsub/mod_pubsub_backend_rdbms.erl
@@ -1,0 +1,276 @@
+-module(mod_pubsub_backend_rdbms).
+-moduledoc "RDBMS backend for PubSub (XEP-0060)".
+
+-behaviour(mod_pubsub_backend).
+
+-include_lib("exml/include/exml.hrl").
+-include("mod_pubsub.hrl").
+
+-export([start/1, stop/1, set_node/2, get_node/2, get_nodes/2, delete_node/2, delete_nodes/2,
+         set_subscription/2, delete_subscription/3, get_subscriptions/2, get_subscription/3,
+         set_item/2, get_item/3, get_items/2, get_last_item/2, get_last_items/2]).
+
+-spec start(mongooseim:host_type()) -> ok.
+start(HostType) ->
+    NodeFields = [~"service_jid", ~"node_id", ~"access_model"],
+    SubscriptionFields = [~"service_jid", ~"node_id", ~"subscriber_jid"],
+    KeyFields = [~"service_jid", ~"node_id", ~"item_id"],
+    UpdateFields = [~"publisher_jid", ~"payload", ~"published_at"],
+    rdbms_queries:prepare_upsert(HostType, pubsub_node_upsert, pubsub_node,
+                                 NodeFields, [~"access_model"], [~"service_jid", ~"node_id"]),
+    mongoose_rdbms:prepare(pubsub_get_node, pubsub_node,
+                           [service_jid, node_id], sql(get_node)),
+    mongoose_rdbms:prepare(pubsub_delete_node, pubsub_node,
+                           [service_jid, node_id], sql(delete_node)),
+    mongoose_rdbms:prepare(pubsub_delete_nodes, pubsub_node,
+                           [service_jid], sql(delete_nodes)),
+    mongoose_rdbms:prepare(pubsub_get_nodes, pubsub_node,
+                           [service_jid], sql(get_nodes)),
+    rdbms_queries:prepare_upsert(HostType, pubsub_subscription_upsert, pubsub_subscription,
+                                 SubscriptionFields, [], SubscriptionFields),
+    mongoose_rdbms:prepare(pubsub_delete_subscription, pubsub_subscription,
+                           [service_jid, node_id, subscriber_jid],
+                           sql(delete_subscription)),
+    mongoose_rdbms:prepare(pubsub_get_subscriptions, pubsub_subscription,
+                           [service_jid, node_id], sql(get_subscriptions)),
+    mongoose_rdbms:prepare(pubsub_get_subscriptions_for_jid, pubsub_subscription,
+                           [service_jid, node_id, subscriber_jid],
+                           sql(get_subscriptions_for_jid)),
+    rdbms_queries:prepare_upsert(HostType, pubsub_item_upsert, pubsub_item,
+                                 KeyFields ++ UpdateFields, UpdateFields, KeyFields),
+    mongoose_rdbms:prepare(pubsub_get_item, pubsub_item,
+                           [service_jid, node_id, item_id], sql(get_item)),
+    mongoose_rdbms:prepare(pubsub_get_items, pubsub_item,
+                           [service_jid, node_id], sql(get_items)),
+    mongoose_rdbms:prepare(pubsub_get_last_item, pubsub_item,
+                           [service_jid, node_id], sql(get_last_item)),
+    mongoose_rdbms:prepare(pubsub_get_last_items, pubsub_item,
+                           [service_jid], sql(get_last_items)),
+    ok.
+
+-spec stop(mongooseim:host_type()) -> ok.
+stop(_HostType) ->
+    ok.
+
+-spec set_node(mongooseim:host_type(), mod_pubsub:pubsub_node()) -> ok.
+set_node(HostType, #pubsub_node{node_key = {ServiceJid, NodeId},
+                                config = #{access_model := AccessModel}}) ->
+    Values = [jid:to_binary(ServiceJid), NodeId, atom_to_binary(AccessModel)],
+    {updated, _} = rdbms_queries:execute_upsert(HostType, pubsub_node_upsert, Values,
+                                                [atom_to_binary(AccessModel)]),
+    ok.
+
+-spec get_node(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    mod_pubsub:pubsub_node() | undefined.
+get_node(HostType, {ServiceJid, NodeId} = NodeKey) ->
+    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_node,
+                                             [jid:to_binary(ServiceJid), NodeId]) of
+        {selected, []} ->
+            undefined;
+        {selected, [{AccessModelBin}]} ->
+            #pubsub_node{node_key = NodeKey,
+                         config = #{access_model => binary_to_existing_atom(AccessModelBin)}}
+    end.
+
+-spec get_nodes(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:pubsub_node()].
+get_nodes(HostType, ServiceJid) ->
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_nodes,
+                                                           [jid:to_binary(ServiceJid)]),
+    [#pubsub_node{node_key = {ServiceJid, NodeId},
+                  config = #{access_model => binary_to_existing_atom(AccessModelBin)}}
+     || {NodeId, AccessModelBin} <- Rows].
+
+-spec delete_nodes(mongooseim:host_type(), jid:jid()) -> ok.
+delete_nodes(HostType, ServiceJid) ->
+    {updated, _} = mongoose_rdbms:execute_successfully(HostType, pubsub_delete_nodes,
+                                                       [jid:to_binary(ServiceJid)]),
+    ok.
+
+-spec delete_node(mongooseim:host_type(), mod_pubsub:node_key()) -> ok.
+delete_node(HostType, {ServiceJid, NodeId}) ->
+    Args = [jid:to_binary(ServiceJid), NodeId],
+    {updated, _} = mongoose_rdbms:execute_successfully(HostType, pubsub_delete_node, Args),
+    ok.
+
+-spec set_subscription(mongooseim:host_type(), mod_pubsub:subscription()) -> ok.
+set_subscription(HostType, #subscription{node_key = {ServiceJid, NodeId},
+                                         jid = SubscriberJid}) ->
+    Values = [jid:to_binary(ServiceJid), NodeId, jid:to_binary(SubscriberJid)],
+    {updated, _} = rdbms_queries:execute_upsert(HostType, pubsub_subscription_upsert,
+                                                Values, []),
+    ok.
+
+-spec get_subscriptions(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    [mod_pubsub:subscription()].
+get_subscriptions(HostType, {ServiceJid, NodeId} = NodeKey) ->
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_subscriptions,
+                                                           [jid:to_binary(ServiceJid), NodeId]),
+    [row_to_subscription(NodeKey, SubscriberJidBin) || {SubscriberJidBin} <- Rows].
+
+-spec get_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
+    mod_pubsub:subscription() | undefined.
+get_subscription(HostType, {ServiceJid, NodeId} = NodeKey, SubscriberJid) ->
+    Args = [jid:to_binary(ServiceJid), NodeId, jid:to_binary(SubscriberJid)],
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_subscriptions_for_jid,
+                                                           Args),
+    case Rows of
+        [{SubscriberJidBin}] -> row_to_subscription(NodeKey, SubscriberJidBin);
+        [] -> undefined
+    end.
+
+-spec delete_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) -> ok | not_found.
+delete_subscription(HostType, {ServiceJid, NodeId}, SubscriberJid) ->
+    Args = [jid:to_binary(ServiceJid), NodeId, jid:to_binary(SubscriberJid)],
+    case mongoose_rdbms:execute_successfully(HostType, pubsub_delete_subscription, Args) of
+        {updated, 1} -> ok;
+        {updated, 0} -> not_found
+    end.
+
+-spec set_item(mongooseim:host_type(), mod_pubsub:item()) -> ok.
+set_item(HostType, #item{node_key = {ServiceJid, NodeId},
+                         id = ItemId,
+                         publisher_jid = PublisherJid,
+                         payload = Payload}) ->
+    PublishedAt = os:system_time(microsecond),
+    PublisherJidBin = jid:to_binary(PublisherJid),
+    PayloadBin = encode_payload(Payload),
+    KeyValues = [jid:to_binary(ServiceJid), NodeId, ItemId],
+    UpdateValues = [PublisherJidBin, PayloadBin, PublishedAt],
+    InsertValues = KeyValues ++ UpdateValues,
+    {updated, _} = rdbms_queries:execute_upsert(HostType, pubsub_item_upsert,
+                                                InsertValues, UpdateValues),
+    ok.
+
+-spec get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
+    mod_pubsub:item() | undefined.
+get_item(HostType, {ServiceJid, NodeId} = NodeKey, ItemId) ->
+    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_item,
+                                             [jid:to_binary(ServiceJid), NodeId, ItemId]) of
+        {selected, []} ->
+            undefined;
+        {selected, [{PublisherJidBin, PayloadBin, PublishedAt}]} ->
+            row_to_item(HostType, NodeKey, ItemId, PublisherJidBin, PayloadBin, PublishedAt)
+    end.
+
+-spec get_items(mongooseim:host_type(), mod_pubsub:node_key()) -> [mod_pubsub:item()].
+get_items(HostType, {ServiceJid, NodeId} = NodeKey) ->
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_items,
+                                                           [jid:to_binary(ServiceJid), NodeId]),
+    [row_to_item(HostType, NodeKey, ItemId, PublisherJidBin, PayloadBin, PublishedAt)
+     || {ItemId, PublisherJidBin, PayloadBin, PublishedAt} <- Rows].
+
+-spec get_last_item(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    mod_pubsub:item() | undefined.
+get_last_item(HostType, {ServiceJid, NodeId} = NodeKey) ->
+    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_last_item,
+                                             [jid:to_binary(ServiceJid), NodeId]) of
+        {selected, []} ->
+            undefined;
+        {selected, [{ItemId, PublisherJidBin, PayloadBin, PublishedAt}]} ->
+            row_to_item(HostType, NodeKey, ItemId, PublisherJidBin, PayloadBin, PublishedAt)
+    end.
+
+-spec get_last_items(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:item()].
+get_last_items(HostType, ServiceJid) ->
+    ServiceJidBin = jid:to_binary(ServiceJid),
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_last_items,
+                                                           [ServiceJidBin]),
+    [row_to_item(HostType, {ServiceJid, NodeId}, ItemId, PublisherJidBin, PayloadBin, PublishedAt)
+     || {NodeId, ItemId, PublisherJidBin, PayloadBin, PublishedAt} <- Rows].
+
+-spec encode_payload(mod_pubsub:item_payload()) -> binary().
+encode_payload(Payload) ->
+    exml:to_binary(Payload).
+
+-spec decode_payload(mongooseim:host_type(), binary()) -> mod_pubsub:item_payload().
+decode_payload(HostType, PayloadBin) ->
+    {ok, Payload} = exml:parse(mongoose_rdbms:unescape_binary(HostType, PayloadBin)),
+    Payload.
+
+-spec row_to_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id(),
+                  binary(), binary(), integer()) -> mod_pubsub:item().
+row_to_item(HostType, NodeKey, ItemId, PublisherJidBin, PayloadBin, PublishedAt) ->
+    Payload = decode_payload(HostType, PayloadBin),
+    #item{node_key = NodeKey,
+          id = ItemId,
+          publisher_jid = jid:from_binary(PublisherJidBin),
+          payload = Payload,
+          published_at = PublishedAt}.
+
+-spec row_to_subscription(mod_pubsub:node_key(), binary()) -> mod_pubsub:subscription().
+row_to_subscription(NodeKey, SubscriberJidBin) ->
+    #subscription{node_key = NodeKey, jid = jid:from_binary(SubscriberJidBin)}.
+
+%% SQL queries
+
+sql(get_item) ->
+    ~"""
+     SELECT publisher_jid, payload, published_at
+     FROM pubsub_item
+     WHERE service_jid = ? AND node_id = ? AND item_id = ?
+     """;
+sql(get_items) ->
+    ~"""
+     SELECT item_id, publisher_jid, payload, published_at
+     FROM pubsub_item
+     WHERE service_jid = ? AND node_id = ?
+     ORDER BY published_at
+     """;
+sql(get_last_item) ->
+    ~"""
+     SELECT item_id, publisher_jid, payload, published_at
+     FROM pubsub_item WHERE service_jid = ? AND node_id = ?
+     ORDER BY published_at DESC LIMIT 1
+     """;
+sql(get_nodes) ->
+    ~"""
+     SELECT node_id, access_model
+     FROM pubsub_node
+     WHERE service_jid = ?
+     """;
+sql(get_subscriptions) ->
+    ~"""
+     SELECT subscriber_jid
+     FROM pubsub_subscription
+     WHERE service_jid = ? AND node_id = ?
+     """;
+sql(get_subscriptions_for_jid) ->
+    ~"""
+     SELECT subscriber_jid
+     FROM pubsub_subscription
+     WHERE service_jid = ? AND node_id = ? AND subscriber_jid = ?
+     """;
+sql(delete_subscription) ->
+    ~"""
+     DELETE FROM pubsub_subscription
+     WHERE service_jid = ? AND node_id = ? AND subscriber_jid = ?
+     """;
+sql(get_node) ->
+    ~"""
+     SELECT access_model
+     FROM pubsub_node
+     WHERE service_jid = ? AND node_id = ?
+     """;
+sql(delete_node) ->
+    ~"""
+     DELETE FROM pubsub_node
+     WHERE service_jid = ? AND node_id = ?
+     """;
+sql(delete_nodes) ->
+    ~"""
+     DELETE FROM pubsub_node
+     WHERE service_jid = ?
+     """;
+sql(get_last_items) ->
+    ~"""
+     SELECT n.node_id, i.item_id, i.publisher_jid, i.payload, i.published_at
+     FROM pubsub_node AS n
+     CROSS JOIN LATERAL (
+         SELECT item_id, publisher_jid, payload, published_at
+         FROM pubsub_item
+         WHERE service_jid = n.service_jid AND node_id = n.node_id
+         ORDER BY published_at DESC
+         LIMIT 1
+     ) AS i
+     WHERE n.service_jid = ?
+     """.

--- a/src/pubsub/mod_pubsub_xml.erl
+++ b/src/pubsub/mod_pubsub_xml.erl
@@ -1,0 +1,314 @@
+-module(mod_pubsub_xml).
+-moduledoc "XML element parsing and construction for mod_pubsub".
+
+%% XML Parsing
+-export([iq_action/1,
+         is_iq_relevant/1]).
+
+%% XML Construction
+-export([make_reply/1,
+         deletion_notification_message_el/1,
+         notification_message_el/2]).
+
+-include_lib("exml/include/exml.hrl").
+-include("jlib.hrl").
+-include("mongoose_ns.hrl").
+-include("mod_pubsub.hrl").
+
+-type error_reason() :: generic_error_reason() | {generic_error_reason(), binary()}.
+-type generic_error_reason() ::
+        bad_request | conflict | forbidden | not_acceptable | not_authorized |
+        unexpected_request | item_not_found.
+-type error_result() :: {error, error_reason()}.
+-type result(T) :: {ok, T} | {error, error_reason()}.
+-type iq_action() :: map().
+-type node_config_field() :: {access_model, mod_pubsub:access_model()}.
+-type item_ids() :: [mod_pubsub:item_id()].
+
+%% XML Parsing
+
+-spec is_iq_relevant(jlib:iq()) -> boolean().
+is_iq_relevant(#iq{xmlns = NS}) ->
+    NS =:= ?NS_PUBSUB orelse NS =:= ?NS_PUBSUB_OWNER.
+
+-spec iq_action(jlib:iq()) -> iq_action() | error_result().
+iq_action(#iq{type = IQType, xmlns = NS, sub_el = #xmlel{name = ~"pubsub", children = Children}}) ->
+    iq_action(IQType, NS, jlib:remove_cdata(Children));
+iq_action(_) ->
+    {error, bad_request}.
+
+-spec iq_action(get | set, binary(), [exml:element()]) -> iq_action() | error_result().
+iq_action(set, ?NS_PUBSUB, Children) ->
+    iq_pubsub_set(Children);
+iq_action(get, ?NS_PUBSUB, Children) ->
+    iq_pubsub_get(Children);
+iq_action(set, ?NS_PUBSUB_OWNER, Children) ->
+    iq_pubsub_owner_set(Children);
+iq_action(get, ?NS_PUBSUB_OWNER, Children) ->
+    iq_pubsub_owner_get(Children).
+
+-spec iq_pubsub_set([exml:element()]) -> iq_action() | error_result().
+iq_pubsub_set([#xmlel{name = ~"create", attrs = #{~"node" := NodeId}} | Rest]) ->
+    maybe
+        {ok, Config} ?= parse_create_config(Rest),
+        #{action => create, node_id => NodeId, config => Config}
+    end;
+iq_pubsub_set([#xmlel{name = ~"create"}]) ->
+    {error, {not_acceptable, ~"nodeid-required"}};
+iq_pubsub_set([#xmlel{name = ~"subscribe",
+                      attrs = #{~"node" := NodeId, ~"jid" := SubscriberJidBin}}]) ->
+    #{action => subscribe, node_id => NodeId, subscriber_jid => jid:from_binary(SubscriberJidBin)};
+iq_pubsub_set([#xmlel{name = ~"unsubscribe",
+                      attrs = #{~"node" := NodeId, ~"jid" := SubscriberJidBin}}]) ->
+    #{action => unsubscribe, node_id => NodeId, subscriber_jid => jid:from_binary(SubscriberJidBin)};
+iq_pubsub_set([El = #xmlel{name = ~"publish", attrs = #{~"node" := NodeId}} | Rest]) ->
+    maybe
+        {ok, Config} ?= parse_publish_options(Rest),
+        {ok, ItemOpts} ?= parse_item(El#xmlel.children),
+        ItemOpts#{action => publish, node_id => NodeId, config => Config}
+    end;
+iq_pubsub_set(_) ->
+    {error, bad_request}.
+
+-spec iq_pubsub_get([exml:element()]) -> iq_action() | error_result().
+iq_pubsub_get([#xmlel{name = ~"items", attrs = #{~"node" := NodeId}, children = []}]) ->
+    #{action => get_items, node_id => NodeId};
+iq_pubsub_get([#xmlel{name = ~"items", attrs = #{~"node" := NodeId}, children = Children}]) ->
+    maybe
+        {ok, ItemIds} ?= parse_requested_item_ids(Children),
+        #{action => get_items, node_id => NodeId, item_ids => ItemIds}
+    end;
+iq_pubsub_get(_) ->
+    {error, bad_request}.
+
+-spec iq_pubsub_owner_set([exml:element()]) -> iq_action() | error_result().
+iq_pubsub_owner_set([#xmlel{name = ~"delete", attrs = #{~"node" := NodeId}}]) ->
+    #{action => delete, node_id => NodeId};
+iq_pubsub_owner_set([ConfigureEl = #xmlel{name = ~"configure",
+                                          attrs = #{~"node" := NodeId}}]) ->
+    maybe
+        {ok, Config} ?= parse_configure_config(ConfigureEl),
+        #{action => configure, node_id => NodeId, config => Config}
+    end;
+iq_pubsub_owner_set([#xmlel{name = Name}]) when Name =:= ~"configure" ->
+    {error, {bad_request, ~"nodeid-required"}};
+iq_pubsub_owner_set(_) ->
+    {error, bad_request}.
+
+-spec iq_pubsub_owner_get([exml:element()]) -> iq_action() | error_result().
+iq_pubsub_owner_get([#xmlel{name = ~"configure", attrs = #{~"node" := NodeId}}]) ->
+    #{action => get_configuration, node_id => NodeId};
+iq_pubsub_owner_get([#xmlel{name = Name}]) when Name =:= ~"configure" ->
+    {error, {bad_request, ~"nodeid-required"}};
+iq_pubsub_owner_get(_) ->
+    {error, bad_request}.
+
+-spec parse_create_config([exml:element()]) -> result(mod_pubsub:node_config()).
+parse_create_config([ConfigureEl = #xmlel{name = ~"configure"}]) ->
+    parse_configure_config(ConfigureEl);
+parse_create_config([]) ->
+    {ok, #{access_model => presence}};
+parse_create_config(_) ->
+    {error, bad_request}.
+
+-spec parse_configure_config(exml:element()) -> result(mod_pubsub:node_config()).
+parse_configure_config(ConfigureEl) ->
+    parse_form_config(ConfigureEl, ?NS_PUBSUB_NODE_CONFIG).
+
+-spec parse_publish_options([exml:element()]) -> result(mod_pubsub:node_config()).
+parse_publish_options([PublishOptionsEl = #xmlel{name = ~"publish-options"}]) ->
+    case mongoose_data_forms:find_and_parse_form(PublishOptionsEl) of
+        #{type := ~"submit", kvs := KVs, ns := ?NS_PUBSUB_PUB_OPTIONS} ->
+            case parse_node_config(KVs) of
+                {ok, Config} -> {ok, Config};
+                {error, _} -> {error, {conflict, ~"precondition-not-met"}}
+            end;
+        _ ->
+            {error, bad_request}
+    end;
+parse_publish_options([]) ->
+    {ok, #{}};
+parse_publish_options(_) ->
+    {error, bad_request}.
+
+-spec parse_item([exml:child()]) ->
+    result(#{item_id := mod_pubsub:item_id(), payload := mod_pubsub:item_payload()}).
+parse_item([Item = #xmlel{name = ~"item", children = Children}]) ->
+    maybe
+        {ok, PayloadEl} ?= parse_payload(Children),
+        {ok, #{item_id => get_or_generate_item_id(Item), payload => PayloadEl}}
+    end;
+parse_item([]) ->
+    {error, {bad_request, ~"item-required"}};
+parse_item(_) ->
+    {error, bad_request}.
+
+get_or_generate_item_id(#xmlel{attrs = #{~"id" := ItemId}}) ->
+    ItemId;
+get_or_generate_item_id(_) ->
+    uuid:uuid_to_string(uuid:get_v4(), binary_standard).
+
+parse_payload([#xmlel{} = PayloadEl]) ->
+    {ok, PayloadEl};
+parse_payload([]) ->
+    {error, {bad_request, ~"payload-required"}};
+parse_payload(_) ->
+    {error, {bad_request, ~"invalid-payload"}}.
+
+-spec parse_requested_item_ids([exml:element()]) -> result(item_ids()).
+parse_requested_item_ids(Children) ->
+    parse_requested_item_ids(Children, []).
+
+-spec parse_requested_item_ids([exml:element()], item_ids()) -> result(item_ids()).
+parse_requested_item_ids([#xmlel{name = ~"item", attrs = #{~"id" := ItemId}} | Rest], Acc) ->
+    parse_requested_item_ids(Rest, [ItemId | Acc]);
+parse_requested_item_ids([], Acc) ->
+    {ok, lists:reverse(Acc)};
+parse_requested_item_ids(_, _) ->
+    {error, bad_request}.
+
+-spec parse_form_config(exml:element(), binary()) -> result(mod_pubsub:node_config()).
+parse_form_config(FormEl, NS) ->
+    case mongoose_data_forms:find_and_parse_form(FormEl) of
+        #{type := ~"submit", kvs := KVs, ns := NS} ->
+            parse_node_config(KVs);
+        _ ->
+            {error, bad_request}
+    end.
+
+-spec parse_node_config(mongoose_data_forms:kv_map()) -> result(mod_pubsub:node_config()).
+parse_node_config(KVs) ->
+    parse_node_config_fields(maps:to_list(KVs), []).
+
+-spec parse_node_config_fields([{binary(), [binary()]}], [node_config_field()]) ->
+          result(mod_pubsub:node_config()).
+parse_node_config_fields([{Key, Values} | Rest], ParsedKVs) ->
+    maybe
+        {ok, ParsedKV} ?= parse_node_config_field(Key, Values),
+        parse_node_config_fields(Rest, [ParsedKV | ParsedKVs])
+    end;
+parse_node_config_fields([], ParsedKVs) ->
+    {ok, maps:from_list(ParsedKVs)}.
+
+-spec parse_node_config_field(binary(), [binary()]) -> result(node_config_field()).
+parse_node_config_field(~"pubsub#access_model", Values) ->
+    maybe
+        {ok, AccessModel} ?= parse_access_model(Values),
+        {ok, {access_model, AccessModel}}
+    end;
+parse_node_config_field(_, _) ->
+    {error, bad_request}.
+
+-spec parse_access_model([binary()]) -> result(mod_pubsub:access_model()).
+parse_access_model([~"open"]) -> {ok, open};
+parse_access_model([~"presence"]) -> {ok, presence};
+parse_access_model([~"authorize"]) -> {error, {not_acceptable, ~"unsupported-access-model"}};
+parse_access_model(_) -> {error, bad_request}.
+
+%% XML Construction
+
+-spec make_reply(iq_action() | error_result()) -> {result | error, [exml:child()]}.
+make_reply({error, {GenericReason, PubSubReason}}) ->
+    {error, [exml:append_children(error_el(GenericReason), [pubsub_error_el(PubSubReason)])]};
+make_reply({error, Reason}) ->
+    {error, [error_el(Reason)]};
+make_reply(#{action := subscribe, node_id := NodeId, subscriber_jid := SubscriberJid, result := ok}) ->
+    {result, [pubsub_el([subscription_el(SubscriberJid, NodeId, ~"subscribed")])]};
+make_reply(#{action := _, result := ok}) ->
+    {result, []};
+make_reply(#{action := get_configuration, result := Node}) ->
+    {result, [pubsub_owner_el([configure_el(Node)])]};
+make_reply(#{action := get_items, node_id := NodeId, result := Items}) ->
+    {result, [pubsub_el([items_el(NodeId, [item_el(Item) || Item <- Items])])]};
+make_reply(#{action := publish, node_id := NodeId, result := ItemId}) ->
+    {result, [pubsub_el([publish_el(NodeId, [published_item_el(ItemId)])])]}.
+
+-spec error_el(generic_error_reason()) -> exml:element().
+error_el(bad_request) -> mongoose_xmpp_errors:bad_request();
+error_el(conflict) -> mongoose_xmpp_errors:conflict();
+error_el(forbidden) -> mongoose_xmpp_errors:forbidden();
+error_el(not_acceptable) -> mongoose_xmpp_errors:not_acceptable();
+error_el(not_authorized) -> mongoose_xmpp_errors:not_authorized();
+error_el(unexpected_request) -> mongoose_xmpp_errors:unexpected_request_cancel();
+error_el(item_not_found) -> mongoose_xmpp_errors:item_not_found().
+
+-spec pubsub_error_el(binary()) -> exml:element().
+pubsub_error_el(Reason) ->
+    #xmlel{name = Reason, attrs = #{~"xmlns" => ?NS_PUBSUB_ERRORS}}.
+
+-spec pubsub_el([exml:child()]) -> exml:element().
+pubsub_el(Children) ->
+    #xmlel{name = ~"pubsub", attrs = #{~"xmlns" => ?NS_PUBSUB}, children = Children}.
+
+-spec pubsub_owner_el([exml:child()]) -> exml:element().
+pubsub_owner_el(Children) ->
+    #xmlel{name = ~"pubsub", attrs = #{~"xmlns" => ?NS_PUBSUB_OWNER}, children = Children}.
+
+-spec configure_el(mod_pubsub:pubsub_node()) -> exml:element().
+configure_el(Node = #pubsub_node{node_key = {_, NodeId}}) ->
+    Fields = configure_fields(Node),
+    Form = mongoose_data_forms:form(#{type => ~"form", ns => ?NS_PUBSUB_NODE_CONFIG,
+                                      fields => Fields}),
+    #xmlel{name = ~"configure", attrs = #{~"node" => NodeId}, children = [Form]}.
+
+-spec configure_fields(mod_pubsub:pubsub_node()) -> [mongoose_data_forms:field()].
+configure_fields(#pubsub_node{config = #{access_model := AccessModel}}) ->
+    [#{var => ~"pubsub#access_model",
+       type => ~"list-single",
+       values => [atom_to_binary(AccessModel)],
+       options => [~"open", ~"presence"]}].
+
+-spec subscription_el(jid:jid(), mod_pubsub:node_id(), binary()) -> exml:element().
+subscription_el(SubscriberJid, NodeId, Subscription) ->
+    #xmlel{name = ~"subscription",
+           attrs = #{~"jid" => jid:to_binary(SubscriberJid),
+                     ~"node" => NodeId,
+                     ~"subscription" => Subscription}}.
+
+-spec items_el(mod_pubsub:node_id(), [exml:child()]) -> exml:element().
+items_el(NodeId, Children) ->
+    #xmlel{name = ~"items", attrs = #{~"node" => NodeId}, children = Children}.
+
+-spec publish_el(mod_pubsub:node_id(), [exml:child()]) -> exml:element().
+publish_el(NodeId, Children) ->
+    #xmlel{name = ~"publish", attrs = #{~"node" => NodeId}, children = Children}.
+
+-spec item_el(mod_pubsub:item()) -> exml:element().
+item_el(#item{id = ItemId, payload = Payload}) ->
+    #xmlel{name = ~"item", attrs = #{~"id" => ItemId}, children = [Payload]}.
+
+-spec published_item_el(mod_pubsub:item_id()) -> exml:element().
+published_item_el(ItemId) ->
+    #xmlel{name = ~"item", attrs = #{~"id" => ItemId}}.
+
+-spec deletion_notification_message_el(mod_pubsub:node_id()) -> exml:element().
+deletion_notification_message_el(NodeId) ->
+    event_message_el(#xmlel{name = ~"delete", attrs = #{~"node" => NodeId}}).
+
+-spec notification_message_el(mod_pubsub:item(), boolean()) -> exml:element().
+notification_message_el(#item{node_key = {_, NodeId}} = Item, Delayed) ->
+    DelayEls = delay_elements(Item, Delayed),
+    event_message_el(items_el(NodeId, [item_el(Item)]), DelayEls).
+
+-spec event_message_el(exml:element()) -> exml:element().
+event_message_el(EventEl) ->
+    event_message_el(EventEl, []).
+
+-spec event_message_el(exml:element(), [exml:element()]) -> exml:element().
+event_message_el(EventEl, ExtraElements) ->
+    #xmlel{name = ~"message",
+           attrs = #{~"type" => ~"headline"},
+           children = [#xmlel{name = ~"event",
+                              attrs = #{~"xmlns" => ?NS_PUBSUB_EVENT},
+                              children = [EventEl]} | ExtraElements]}.
+
+-spec delay_elements(mod_pubsub:item(), boolean()) -> [exml:element()].
+delay_elements(#item{node_key = {ServiceJid, _}, published_at = PublishedAt}, true) ->
+    [delay_el(ServiceJid, PublishedAt)];
+delay_elements(_Item, false) ->
+    [].
+
+-spec delay_el(jid:jid(), integer()) -> exml:element().
+delay_el(ServiceJid, PublishedAt) ->
+    Timestamp = calendar:system_time_to_rfc3339(PublishedAt, [{offset, "Z"}, {unit, microsecond}]),
+    jlib:timestamp_to_xml(Timestamp, ServiceJid, undefined).

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -456,6 +456,8 @@ all_modules() ->
                                                     keyfile => "priv/dc1.pem"})
                                    })
                       }),
+      mod_pubsub =>
+          mod_config(mod_pubsub, #{backend => rdbms, iqdisc => no_queue}),
       mod_pubsub_old =>
           mod_config(mod_pubsub_old, #{access_createnode => pubsub_createnode,
                                    backend => rdbms,
@@ -964,6 +966,8 @@ default_mod_config(mod_privacy) ->
     #{backend => mnesia};
 default_mod_config(mod_private) ->
     #{iqdisc => one_queue, backend => rdbms};
+default_mod_config(mod_pubsub) ->
+    #{backend => rdbms, iqdisc => no_queue};
 default_mod_config(mod_pubsub_old) ->
     #{iqdisc => one_queue, host => {prefix, <<"pubsub.">>}, backend => mnesia, access_createnode => all,
       max_items_node => 10, nodetree => nodetree_tree, ignore_pep_from_offline => true,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -217,6 +217,7 @@ groups() ->
                             mod_ping,
                             mod_privacy,
                             mod_private,
+                            mod_pubsub,
                             mod_pubsub_old,
                             mod_pubsub_old_pep_mapping,
                             mod_pubsub_old_default_node_config,
@@ -2521,6 +2522,15 @@ mod_private(_Config) ->
     T = fun(Opts) -> #{<<"modules">> => #{<<"mod_private">> => Opts}} end,
     P = [modules, mod_private],
     ?cfgh(P ++ [backend], rdbms, T(#{<<"backend">> => <<"rdbms">>})),
+    ?errh(T(#{<<"backend">> => <<"mysql">>})).
+
+mod_pubsub(_Config) ->
+    check_iqdisc(mod_pubsub),
+    check_module_defaults(mod_pubsub),
+    T = fun(Opts) -> #{<<"modules">> => #{<<"mod_pubsub">> => Opts}} end,
+    P = [modules, mod_pubsub],
+    ?cfgh(P ++ [backend], rdbms,
+          T(#{<<"backend">> => <<"rdbms">>})),
     ?errh(T(#{<<"backend">> => <<"mysql">>})).
 
 mod_pubsub_old(_Config) ->

--- a/test/config_parser_SUITE_data/modules.toml
+++ b/test/config_parser_SUITE_data/modules.toml
@@ -235,6 +235,10 @@
     namespace = "urn:xmpp:microblog:0"
     node = "mb"
 
+[modules.mod_pubsub]
+  backend = "rdbms"
+  iqdisc.type = "no_queue"
+
 [modules.mod_push_service_mongoosepush]
   pool_name = "mongoose_push_http"
   api_version = "v3"


### PR DESCRIPTION
## Summary

This PR adds a new `mod_pubsub` implementation focused on PEP, together with its RDBMS backend, configuration coverage, tests, and module documentation.

The intent is to introduce a lightweight, PEP-oriented PubSub path with a much smaller scope than the legacy implementation.

Note: this PR was reviewed with OpenAI Codex + GPT 5.4, and all findings have been resolved.

## Included changes

### 1. New `mod_pubsub` implementation
- Add a new `mod_pubsub` module supporting PEP
- Keep XML parsing and reply construction at the protocol boundary in `mod_pubsub_xml`
- Represent each IQ action as an `iq_action()` map that is:
  1. parsed from the request
  2. executed
  3. turned into a result or error reply

### 2. RDBMS backend
- Add the only supported backend for the new module: RDBMS
- Introduce tables for:
  - `pubsub_node`
  - `pubsub_item`
  - `pubsub_subscription`
- Store explicit subscriptions separately
- Delete items and subscriptions automatically when a node is deleted
- Index items per node by publish time for ordered retrieval

### 3. Configuration coverage
- Add tests covering `mod_pubsub` configuration options

### 4. New PEP test suite
- Add a dedicated test suite for the new implementation
- Keep a balance between:
  - fewer, more complete test cases
  - enough test parallelism
  - limited redundancy and CPU cost

### 5. Documentation
- Add documentation for the new `mod_pubsub` module

## Omissions

- Migration guide will be updated separately.
- More PEP features as well as a generic PubSub service will be added later - see the module doc for the exact list of currently supported features.
- GDPR tests for `mod_pubsub`.