### PR TITLE
Use `.joined` marker instead of Mnesia files

### DIFF
--- a/tools/circleci-prepare-mongooseim-docker.sh
+++ b/tools/circleci-prepare-mongooseim-docker.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 set -e
-# master from 2026-01-13
-MIM_DOCKER_VERSION=c2987fef0e436a80962b077a261cda3f2dcb453c
+# master from 2026-05-22
+MIM_DOCKER_VERSION=b0c5507c3d6bb4e85167718368fbe21910417574
 
 # We use output of generate_vsn, because it does not contain illegal characters, returns
 # git tag when building from tag itself, and is unique in any other case


### PR DESCRIPTION
This PR bumps the mongoose-docker repository to include esl/mongooseim-docker#63.

MIM-790