### PR TITLE
MIM-2699 Coverage boost and code fixes

### DIFF
--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -132,9 +132,9 @@ register_one_component(Config) ->
     CheckServer = fun(#{lserver := S}) -> S =:= ComponentAddr end,
 
     %% Expect events for handshake, but not for 'start stream'.
-    instrument_helper:assert(xmpp_element_out, labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_out, xmpp_element_labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
-    instrument_helper:assert(xmpp_element_in, labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_in, xmpp_element_labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
 
     instrument_helper:assert(component_auth_failed, #{}, FullCheckF,
@@ -148,10 +148,10 @@ register_one_component(Config) ->
     verify_component(Config, Component, ComponentAddr),
 
     % Message from Alice
-    instrument_helper:assert(xmpp_element_out, labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_out, xmpp_element_labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS1}),
     % Reply to Alice
-    instrument_helper:assert(xmpp_element_in, labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_in, xmpp_element_labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS1}),
 
     component_helper:disconnect_component(Component, ComponentAddr).
@@ -203,9 +203,9 @@ intercomponent_communication(_Config) ->
                          S > 0 andalso LServer =:= CompAddr1 orelse LServer =:= CompAddr2
                  end,
     CheckBytes = fun(#{byte_size := S}) -> S > 0 end,
-    instrument_helper:assert(xmpp_element_out, labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_out, xmpp_element_labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
-    instrument_helper:assert(xmpp_element_in, labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_in, xmpp_element_labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
     instrument_helper:assert(tcp_data_in, labels(), CheckBytes,
         #{min_timestamp => TS}),
@@ -261,10 +261,10 @@ register_two_components(Config) ->
                     S > 0 andalso LServer =:= CompAddr1 orelse LServer =:= CompAddr2
              end,
     % Msg to Alice, msg to Bob
-    instrument_helper:assert(xmpp_element_in, labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_in, xmpp_element_labels(), FullCheckF,
         #{expected_count => 2, min_timestamp => TS}),
     % Msg from Bob, msg from Alice
-    instrument_helper:assert(xmpp_element_out, labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_out, xmpp_element_labels(), FullCheckF,
         #{expected_count => 2, min_timestamp => TS}),
 
     component_helper:disconnect_component(Comp1, CompAddr1),
@@ -728,6 +728,11 @@ events() ->
 %% Component connections do not provide a real host type
 labels() ->
     #{connection_type => component}.
+
+%% Must mention empty host_type explicitly, because instrument_helper asserts on exact
+%% label list.
+xmpp_element_labels() ->
+    #{connection_type => component, host_type => <<>>}.
 
 %%--------------------------------------------------------------------
 %% Stanzas

--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -20,6 +20,7 @@
 -include_lib("escalus/include/escalus.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("exml/include/exml_stream.hrl").
 
 -import(distributed_helper, [mim/0]).
 
@@ -30,6 +31,7 @@
 all() ->
     [
      {group, xep0114},
+     {group, check_from_disabled},
      {group, subdomain},
      {group, hidden_components},
      {group, distributed}
@@ -37,7 +39,13 @@ all() ->
 
 groups() ->
     [{xep0114, [parallel], xep0114_tests()},
-     {subdomain, [], [register_subdomain]},
+     {check_from_disabled, [], [
+                                %% Duplicated here to cover extra code paths
+                                intercomponent_communication,
+                                deliver_stanza_with_custom_from_domain]},
+     {subdomain, [], [register_subdomain,
+                      deliver_stanza_from_subdomain_component,
+                      from_jid_is_validated_for_subdomain_component]},
      {hidden_components, [], [disco_with_hidden_component]},
      {distributed, [], [register_in_cluster,
                         register_same_on_both
@@ -57,7 +65,11 @@ xep0114_tests() ->
      try_registering_component_twice,
      try_registering_existing_host,
      disco_components,
-     kick_old_component_on_conflict
+     kick_old_component_on_conflict,
+     component_sends_unexpected_stanza_name,
+     component_sends_stanza_with_invalid_to_jid,
+     component_sends_stanza_with_invalid_from_jid,
+     iq_and_presence_are_routed_from_component
      ].
 
 %%--------------------------------------------------------------------
@@ -74,8 +86,12 @@ end_per_suite(Config) ->
 init_per_group(xep0114, Config) ->
     instrument_helper:start(events()),
     Config;
+init_per_group(check_from_disabled, Config) ->
+    setup_mim_config(Config, "false"),
+    instrument_helper:start(events()),
+    Config;
 init_per_group(subdomain, Config) ->
-    add_domain(Config),
+    setup_mim_config(Config, "true"),
     Config;
 init_per_group(distributed, Config) ->
     distributed_helper:add_node_to_cluster(Config);
@@ -84,6 +100,9 @@ init_per_group(_GroupName, Config) ->
 
 end_per_group(xep0114, _Config) ->
     instrument_helper:stop();
+end_per_group(check_from_disabled, Config) ->
+    instrument_helper:stop(),
+    restore_domain(Config);
 end_per_group(subdomain, Config) ->
     restore_domain(Config);
 end_per_group(distributed, Config) ->
@@ -157,7 +176,7 @@ register_one_component_tls(Config) ->
 
     component_helper:disconnect_component(Component, ComponentAddr).
 
-dirty_disconnect(Config) ->
+dirty_disconnect(_Config) ->
     %% Given one connected component, kill the connection and reconnect
     CompSpec = component_helper:spec(component1),
     {Component, Addr, _} = component_helper:connect_component(CompSpec),
@@ -165,7 +184,7 @@ dirty_disconnect(Config) ->
     {Component1, Addr, _} = component_helper:connect_component(CompSpec),
     component_helper:disconnect_component(Component1, Addr).
 
-intercomponent_communication(Config) ->
+intercomponent_communication(_Config) ->
     %% Given two connected components
     CompSpec1 = component_helper:spec(component1),
     CompSpec2 = component_helper:spec(component2),
@@ -183,10 +202,15 @@ intercomponent_communication(Config) ->
     FullCheckF = fun(#{byte_size := S, lserver := LServer}) ->
                          S > 0 andalso LServer =:= CompAddr1 orelse LServer =:= CompAddr2
                  end,
+    CheckBytes = fun(#{byte_size := S}) -> S > 0 end,
     instrument_helper:assert(xmpp_element_out, ht_labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
     instrument_helper:assert(xmpp_element_in, ht_labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
+    instrument_helper:assert(tcp_data_in, labels(), CheckBytes,
+        #{min_timestamp => TS}),
+    instrument_helper:assert(tcp_data_out, labels(), CheckBytes,
+        #{min_timestamp => TS}),
 
     component_helper:disconnect_component(Comp1, CompAddr1),
     component_helper:disconnect_component(Comp2, CompAddr2).
@@ -246,7 +270,7 @@ register_two_components(Config) ->
     component_helper:disconnect_component(Comp1, CompAddr1),
     component_helper:disconnect_component(Comp2, CompAddr2).
 
-try_registering_with_wrong_password(Config) ->
+try_registering_with_wrong_password(_Config) ->
     %% Given a component with a wrong password
     TS = instrument_helper:timestamp(),
     CompSpec1 = component_helper:spec(component1),
@@ -263,7 +287,7 @@ try_registering_with_wrong_password(Config) ->
         ok
     end.
 
-try_registering_component_twice(Config) ->
+try_registering_component_twice(_Config) ->
     %% Given two components with the same name
     CompSpec1 = component_helper:spec(component1),
     {Comp1, Addr, _} = component_helper:connect_component(CompSpec1),
@@ -280,7 +304,7 @@ try_registering_component_twice(Config) ->
 
     component_helper:disconnect_component(Comp1, Addr).
 
-try_registering_existing_host(Config) ->
+try_registering_existing_host(_Config) ->
     %% Given a external vjud component
     Component = component_helper:spec(vjud_component),
 
@@ -361,6 +385,68 @@ disco_with_hidden_component(Config) ->
     component_helper:disconnect_component(Comp1, Addr1),
     component_helper:disconnect_component(HComp, HAddr).
 
+component_sends_unexpected_stanza_name(Config) ->
+    CompSpec = component_helper:spec(component1),
+    {Comp, CompAddr, _} = component_helper:connect_component(CompSpec),
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        BadStanza = #xmlel{name = <<"foo">>,
+                           attrs = #{<<"from">> => CompAddr,
+                                     <<"to">> => escalus_client:full_jid(Alice)}},
+        escalus:send(Comp, BadStanza),
+        Err = escalus:wait_for_stanza(Comp),
+        escalus:assert(is_error, [<<"modify">>, <<"bad-request">>], Err),
+        Msg = escalus_stanza:chat_to(Alice, <<"still alive">>),
+        escalus:send(Comp, escalus_stanza:from(Msg, CompAddr)),
+        Reply = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_chat_message, [<<"still alive">>], Reply)
+    end),
+    component_helper:disconnect_component(Comp, CompAddr).
+
+component_sends_stanza_with_invalid_to_jid(_Config) ->
+    CompSpec = component_helper:spec(component1),
+    {Comp, CompAddr, _} = component_helper:connect_component(CompSpec),
+    BadStanza = escalus_stanza:from(
+                  escalus_stanza:chat_to(<<"@@@">>, <<"Hi">>),
+                  CompAddr),
+    escalus:send(Comp, BadStanza),
+    Err = escalus:wait_for_stanza(Comp),
+    escalus:assert(is_error, [<<"modify">>, <<"bad-request">>], Err),
+    component_helper:disconnect_component(Comp, CompAddr).
+
+component_sends_stanza_with_invalid_from_jid(_Config) ->
+    CompSpec = component_helper:spec(component1),
+    {Comp, CompAddr, _} = component_helper:connect_component(CompSpec),
+    BadStanza = escalus_stanza:from(
+                  escalus_stanza:chat_to(<<"alice@localhost">>, <<"Hi">>),
+                  <<"@@@">>),
+    escalus:send(Comp, BadStanza),
+    Err = escalus:wait_for_stanza(Comp),
+    escalus:assert(is_error, [<<"modify">>, <<"bad-request">>], Err),
+    component_helper:disconnect_component(Comp, CompAddr).
+
+iq_and_presence_are_routed_from_component(Config) ->
+    CompSpec = component_helper:spec(component1),
+    {Comp, CompAddr, _} = component_helper:connect_component(CompSpec),
+    try
+        escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+            Presence = #xmlel{name = <<"presence">>,
+                              attrs = #{<<"from">> => CompAddr,
+                                        <<"to">> => escalus_client:full_jid(Alice)}},
+            escalus:send(Comp, Presence),
+            RoutedPresence = escalus:wait_for_stanza(Alice),
+            escalus:assert(is_presence, [], RoutedPresence),
+            escalus:assert(is_stanza_from, [CompAddr], RoutedPresence),
+
+            Server = escalus_client:server(Alice),
+            DiscoIq = escalus_stanza:service_discovery(Server),
+            escalus:send(Comp, escalus_stanza:from(DiscoIq, CompAddr)),
+            RoutedIq = escalus:wait_for_stanza(Comp),
+            escalus:assert(is_iq_result, [DiscoIq], RoutedIq)
+        end)
+    after
+        component_helper:disconnect_component(Comp, CompAddr)
+    end.
+
 register_subdomain(Config) ->
     %% Given one connected component
     CompSpec1 = component_helper:spec(component1),
@@ -391,6 +477,58 @@ register_subdomain(Config) ->
         end),
 
     component_helper:disconnect_component(Comp, Addr).
+
+deliver_stanza_from_subdomain_component(Config) ->
+    CompSpec = component_helper:spec(component1),
+    {Comp, Addr, _Name} = component_helper:connect_component_subdomain(CompSpec),
+    try
+        escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+                Msg = escalus_stanza:chat_to(Alice, <<"Stanza from subdomain component">>),
+                escalus:send(Comp, escalus_stanza:from(Msg, Addr)),
+                GotStanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(is_chat_message, [<<"Stanza from subdomain component">>], GotStanza),
+                escalus:assert(is_stanza_from, [Addr], GotStanza)
+            end)
+    after
+        component_helper:disconnect_component(Comp, Addr)
+    end.
+
+deliver_stanza_with_custom_from_domain(Config) ->
+    CompSpec = component_helper:spec(component1),
+    {Comp, Addr, _Name} = component_helper:connect_component_subdomain(CompSpec),
+    CustomFrom = <<"other.localhost">>,
+    ?assertNotEqual(Addr, CustomFrom),
+    try
+        escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+                Msg = escalus_stanza:chat_to(Alice, <<"Stanza with custom from domain">>),
+                escalus:send(Comp, escalus_stanza:from(Msg, CustomFrom)),
+                GotStanza = escalus:wait_for_stanza(Alice),
+                escalus:assert(is_chat_message, [<<"Stanza with custom from domain">>], GotStanza),
+                escalus:assert(is_stanza_from, [CustomFrom], GotStanza)
+            end)
+    after
+        component_helper:disconnect_component(Comp, Addr)
+    end.
+
+from_jid_is_validated_for_subdomain_component(Config) ->
+    CompSpec = component_helper:spec(component1),
+    {Comp, Addr, _} = component_helper:connect_component_subdomain(CompSpec),
+    try
+        escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+            OutsideFrom = <<"user@other.localhost">>,
+            Msg1 = escalus_stanza:chat_to(Alice, <<"rejected by subdomain check">>),
+            escalus:send(Comp, escalus_stanza:from(Msg1, OutsideFrom)),
+            Err1 = escalus:wait_for_stanza(Comp),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>], Err1),
+
+            Msg2 = escalus_stanza:chat_to(Alice, <<"also rejected">>),
+            escalus:send(Comp, escalus_stanza:from(Msg2, <<"@@@">>)),
+            Err2 = escalus:wait_for_stanza(Comp),
+            escalus:assert(is_error, [<<"modify">>, <<"bad-request">>], Err2)
+        end)
+    after
+        component_helper:disconnect_component(Comp, Addr)
+    end.
 
 
 register_in_cluster(Config) ->
@@ -571,10 +709,11 @@ verify_component(Config, Component, ComponentAddr) ->
                 escalus:assert(is_stanza_from, [ComponentAddr], Reply2)
         end).
 
-add_domain(Config) ->
+setup_mim_config(Config, CheckFrom) ->
     Hosts = {hosts, "\"localhost\", \"sogndal\""},
+    VarsToChange = [Hosts, {component_check_from, CheckFrom}],
     ejabberd_node_utils:backup_config_file(Config),
-    ejabberd_node_utils:modify_config_file([Hosts], Config),
+    ejabberd_node_utils:modify_config_file(VarsToChange, Config),
     ejabberd_node_utils:restart_application(mongooseim),
     ok.
 
@@ -590,7 +729,12 @@ events() ->
 labels() ->
     #{connection_type => component}.
 
-%% XMPP element metric labels include host_type, but components don't have host types
+%% XMPP element metric labels include host_type, but component connection-level
+%% events (xmpp_element_in/out emitted from the socket handlers) are not tied to
+%% a single host type, so the label is the empty binary. Note: per-stanza routing
+%% always resolves a host type for the accumulator (falling back to
+%% hd(?ALL_HOST_TYPES) when no domain matches), but that value is not propagated
+%% to these connection-level instrumentation events.
 ht_labels() ->
     (labels())#{host_type => <<>>}.
 

--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -132,9 +132,9 @@ register_one_component(Config) ->
     CheckServer = fun(#{lserver := S}) -> S =:= ComponentAddr end,
 
     %% Expect events for handshake, but not for 'start stream'.
-    instrument_helper:assert(xmpp_element_out, ht_labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_out, labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
-    instrument_helper:assert(xmpp_element_in, ht_labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_in, labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
 
     instrument_helper:assert(component_auth_failed, #{}, FullCheckF,
@@ -148,10 +148,10 @@ register_one_component(Config) ->
     verify_component(Config, Component, ComponentAddr),
 
     % Message from Alice
-    instrument_helper:assert(xmpp_element_out, ht_labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_out, labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS1}),
     % Reply to Alice
-    instrument_helper:assert(xmpp_element_in, ht_labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_in, labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS1}),
 
     component_helper:disconnect_component(Component, ComponentAddr).
@@ -203,9 +203,9 @@ intercomponent_communication(_Config) ->
                          S > 0 andalso LServer =:= CompAddr1 orelse LServer =:= CompAddr2
                  end,
     CheckBytes = fun(#{byte_size := S}) -> S > 0 end,
-    instrument_helper:assert(xmpp_element_out, ht_labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_out, labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
-    instrument_helper:assert(xmpp_element_in, ht_labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_in, labels(), FullCheckF,
         #{expected_count => 1, min_timestamp => TS}),
     instrument_helper:assert(tcp_data_in, labels(), CheckBytes,
         #{min_timestamp => TS}),
@@ -261,10 +261,10 @@ register_two_components(Config) ->
                     S > 0 andalso LServer =:= CompAddr1 orelse LServer =:= CompAddr2
              end,
     % Msg to Alice, msg to Bob
-    instrument_helper:assert(xmpp_element_in, ht_labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_in, labels(), FullCheckF,
         #{expected_count => 2, min_timestamp => TS}),
     % Msg from Bob, msg from Alice
-    instrument_helper:assert(xmpp_element_out, ht_labels(), FullCheckF,
+    instrument_helper:assert(xmpp_element_out, labels(), FullCheckF,
         #{expected_count => 2, min_timestamp => TS}),
 
     component_helper:disconnect_component(Comp1, CompAddr1),
@@ -725,18 +725,9 @@ restore_domain(Config) ->
 events() ->
     instrument_helper:declared_events(mongoose_component_listener, [#{}]).
 
-%% Data metrics have only the connection_type label
+%% Component connections do not provide a real host type
 labels() ->
     #{connection_type => component}.
-
-%% XMPP element metric labels include host_type, but component connection-level
-%% events (xmpp_element_in/out emitted from the socket handlers) are not tied to
-%% a single host type, so the label is the empty binary. Note: per-stanza routing
-%% always resolves a host type for the accumulator (falling back to
-%% hd(?ALL_HOST_TYPES) when no domain matches), but that value is not propagated
-%% to these connection-level instrumentation events.
-ht_labels() ->
-    (labels())#{host_type => <<>>}.
 
 %%--------------------------------------------------------------------
 %% Stanzas

--- a/big_tests/tests/mod_blocking_SUITE.erl
+++ b/big_tests/tests/mod_blocking_SUITE.erl
@@ -35,6 +35,7 @@ all() ->
         {group, offline},
         {group, errors},
         {group, pushes},
+        {group, notify},
         {group, muc},
         {group, muc_light}
     ].
@@ -780,51 +781,57 @@ client_gets_block_iq(C) ->
 flush(User) ->
     escalus:wait_for_stanzas(User, 10, 100).
 
-add_sample_contact(Alice, Bob) ->
-    escalus:send(Alice, escalus_stanza:roster_add_contact(Bob,
-        [<<"friends">>],
-        <<"Bobby">>)),
+add_sample_contact(RosterOwner, ClientToAdd) ->
+    AddContact = escalus_stanza:roster_add_contact(ClientToAdd, [<<"friends">>], <<"MyFriend">>),
+    escalus:send(RosterOwner, AddContact),
 
-    Received = escalus:wait_for_stanzas(Alice, 2),
+    Received = escalus:wait_for_stanzas(RosterOwner, 2),
     escalus:assert_many([is_roster_set, is_iq_result], Received),
+    RosterPush = hd([Stanza || Stanza <- Received, escalus_pred:is_roster_set(Stanza)]),
+    escalus:assert(count_roster_items, [1], RosterPush),
+    escalus:send(RosterOwner, escalus_stanza:iq_result(RosterPush)).
 
-    Result = hd([R || R <- Received, escalus_pred:is_roster_set(R)]),
-    escalus:assert(count_roster_items, [1], Result),
-    escalus:send(Alice, escalus_stanza:iq_result(Result)).
+subscribe(Subscriber, Contact) ->
+    ContactBareJID = escalus_utils:get_short_jid(Contact),
+    SubscriberBareJID = escalus_utils:get_short_jid(Subscriber),
 
-
-subscribe(Bob, Alice) ->
-    %% Bob adds Alice as a contact
-    add_sample_contact(Bob, Alice),
-    %% He subscribes to her presences
-    escalus:send(Bob, escalus_stanza:presence_direct(alice, <<"subscribe">>)),
-    PushReq = escalus:wait_for_stanza(Bob),
+    %% Subscriber adds the contact to their roster.
+    add_sample_contact(Subscriber, Contact),
+    
+    %% Subscriber asks to receive the contact's presences.
+    escalus:send(Subscriber, escalus_stanza:presence_direct(ContactBareJID, <<"subscribe">>)),
+    PushReq = escalus:wait_for_stanza(Subscriber),
     escalus:assert(is_roster_set, PushReq),
-    escalus:send(Bob, escalus_stanza:iq_result(PushReq)),
-    %% Alice receives subscription request
-    Received = escalus:wait_for_stanza(Alice),
+    escalus:send(Subscriber, escalus_stanza:iq_result(PushReq)),
+    
+    %% Contact receives the subscription request.
+    Received = escalus:wait_for_stanza(Contact),
     escalus:assert(is_presence_with_type, [<<"subscribe">>], Received),
-    %% Alice adds new contact to his roster
-    escalus:send(Alice, escalus_stanza:roster_add_contact(Bob,
-        [<<"enemies">>],
-        <<"Bob">>)),
-    PushReqB = escalus:wait_for_stanza(Alice),
+
+    %% Contact adds the subscriber to their roster.
+    AddContact = escalus_stanza:roster_add_contact(Subscriber, [<<"enemies">>], <<"MyEnemy">>),
+    escalus:send(Contact, AddContact),
+    PushReqB = escalus:wait_for_stanza(Contact),
     escalus:assert(is_roster_set, PushReqB),
-    escalus:send(Alice, escalus_stanza:iq_result(PushReqB)),
-    escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
-    %% Alice sends subscribed presence
-    escalus:send(Alice, escalus_stanza:presence_direct(bob, <<"subscribed">>)),
-    %% Bob receives subscribed
-    Stanzas = escalus:wait_for_stanzas(Bob, 2),
+    escalus:send(Contact, escalus_stanza:iq_result(PushReqB)),
+    escalus:assert(is_iq_result, escalus:wait_for_stanza(Contact)),
+
+    %% Contact confirms the subscription.
+    escalus:send(Contact, escalus_stanza:presence_direct(SubscriberBareJID, <<"subscribed">>)),
+
+    %% Subscriber receives the confirmation.
+    Stanzas = escalus:wait_for_stanzas(Subscriber, 2),
     check_subscription_stanzas(Stanzas, <<"subscribed">>),
-    escalus:assert(is_presence, escalus:wait_for_stanza(Bob)),
-    %% Alice receives roster push
-    PushReqB1 = escalus:wait_for_stanza(Alice),
+    escalus:assert(is_presence, escalus:wait_for_stanza(Subscriber)),
+    
+    %% Contact receives the roster push.
+    PushReqB1 = escalus:wait_for_stanza(Contact),
     escalus:assert(is_roster_set, PushReqB1),
-    %% Alice sends presence
-    escalus:send(Alice, escalus_stanza:presence(<<"available">>)),
-    escalus:assert(is_presence, escalus:wait_for_stanza(Bob)),
-    escalus:assert(is_presence, escalus:wait_for_stanza(Alice)),
+    
+    %% Contact publishes availability.
+    escalus:send(Contact, escalus_stanza:presence(<<"available">>)),
+    escalus:assert(is_presence, escalus:wait_for_stanza(Subscriber)),
+    escalus:assert(is_presence, escalus:wait_for_stanza(Contact)),
     ok.
 
 

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -108,6 +108,7 @@ all() -> [
           {group, admin},
           {group, admin_membersonly},
           {group, occupant},
+          {group, occupant_no_parallel},
           {group, owner},
           {group, owner_no_parallel},
           {group, room_management},
@@ -171,7 +172,8 @@ groups() ->
                                   moderator_voice_approval_errors,
                                   moderator_voice_forbidden,
                                   moderator_voice_not_occupant,
-                                  moderator_voice_nonick
+                                  moderator_voice_nonick,
+                                  voice_approval_with_invalid_role
                                  ]},
          {admin, [parallel], [
                               admin_ban,
@@ -239,6 +241,10 @@ groups() ->
                                  send_and_receive_private_message_client_with_x_elem,
                                  send_and_receive_private_message_client_without_x_elem,
                                  send_private_groupchat,
+                                 route_chat_to_room,
+                                 route_error_message_to_room,
+                                 route_unknown_message_type_to_room,
+                                 iq_reply_to_nick,
                                  change_nickname,
                                  deny_nickname_change_conflict,
                                  change_availability_status,
@@ -249,6 +255,9 @@ groups() ->
                                  exit_room_with_status,
                                  kicked_after_sending_malformed_presence
                                 ]},
+         {occupant_no_parallel, [], [
+                                     groupchat_traffic_rate_limit_exceeded
+                                    ]},
          {owner, [parallel], [
                               %% fails, see testcase
                               cant_enter_locked_room,
@@ -432,6 +441,10 @@ init_per_group(register_over_s2s, Config) ->
 init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob, kate])).
 
+required_modules(traffic_rate_limit) ->
+    #{mod_muc := OrigOpts} = dynamic_modules:get_current_modules(host_type()),
+    Opts = OrigOpts#{min_message_interval => 5},
+    [{mod_muc, Opts}];
 required_modules(http_auth) ->
     #{mod_muc := OrigOpts} = dynamic_modules:get_current_modules(host_type()),
     #{default_room := DefRoomOpts} = OrigOpts,
@@ -551,6 +564,10 @@ init_per_testcase(CaseName = create_instant_persistent_room, Config) ->
     ConfigWithModules = dynamic_modules:save_modules(host_type(), Config),
     dynamic_modules:ensure_modules(host_type(), required_modules(persistent_by_default)),
     escalus:init_per_testcase(CaseName, ConfigWithModules);
+init_per_testcase(CaseName = groupchat_traffic_rate_limit_exceeded, Config) ->
+    ConfigWithModules = dynamic_modules:save_modules(host_type(), Config),
+    dynamic_modules:ensure_modules(host_type(), required_modules(traffic_rate_limit)),
+    escalus:init_per_testcase(CaseName, ConfigWithModules);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
@@ -618,6 +635,9 @@ end_per_testcase(CaseName = room_creation_not_allowed, Config) ->
     restore_config_option(Config, [{access, host_type()}, muc_create]),
     escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName = create_instant_persistent_room, Config) ->
+    dynamic_modules:restore_modules(Config),
+    escalus:end_per_testcase(CaseName, Config);
+end_per_testcase(CaseName = groupchat_traffic_rate_limit_exceeded, Config) ->
     dynamic_modules:restore_modules(Config),
     escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(CaseName = acl_deny, Config) ->
@@ -1141,6 +1161,41 @@ moderator_voice_nonick(ConfigIn) ->
             Error)
 
     end).
+
+voice_approval_with_invalid_role(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, moderator_room_opts(), UserSpecs, fun(Config, Alice, Bob) ->
+        %% Alice joins room as moderator (owner)
+        escalus:send(Alice, stanza_muc_enter_room(?config(room, Config), <<"alice">>)),
+        escalus:wait_for_stanzas(Alice, 2),
+        %% Bob joins room as visitor (moderated, members_by_default=false)
+        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
+        escalus:wait_for_stanzas(Bob, 3),
+        %% Skip Bob's presence notification to Alice
+        escalus:wait_for_stanza(Alice),
+
+        %% Bob sends a voice request form
+        escalus:send(Bob, stanza_voice_request_form(?config(room, Config))),
+        VoiceRequest = escalus:wait_for_stanza(Alice),
+        true = is_message_form(VoiceRequest),
+
+        %% Alice approves with an invalid role value ("bogus-role") and allow=true
+        Fields = [#{var => <<"muc#role">>, values => [<<"bogus-role">>], type => <<"list-single">>},
+                  #{var => <<"muc#jid">>, values => [escalus_utils:get_short_jid(Bob)], type => <<"jid-single">>},
+                  #{var => <<"muc#roomnick">>, values => [<<"bob">>], type => <<"text-single">>},
+                  #{var => <<"muc#request_allow">>, values => [<<"true">>], type => <<"boolean">>}],
+        BadApproval = stanza_message_to_room(?config(room, Config),
+                          [form_helper:form(#{fields => Fields, ns => ?NS_MUC_REQUEST})]),
+        escalus:send(Alice, BadApproval),
+
+        %% Alice receives an error reply
+        ApprovalErr = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_error, [<<"modify">>, <<"bad-request">>], ApprovalErr),
+
+        %% Bob receives no role-change presence (was not promoted)
+        escalus_assert:has_no_stanzas(Bob)
+    end).
+
 %%--------------------------------------------------------------------
 %%  Admin use case tests
 %%
@@ -2780,6 +2835,125 @@ send_private_groupchat(ConfigIn) ->
 
         escalus_assert:has_no_stanzas(Bob),
         escalus_assert:has_no_stanzas(Kate)
+    end).
+
+route_chat_to_room(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, [], UserSpecs, fun(Config, Alice, Bob) ->
+        escalus:send(Alice, stanza_muc_enter_room(?config(room, Config), <<"alice">>)),
+        escalus:wait_for_stanzas(Alice, 2),
+        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
+        escalus:wait_for_stanzas(Bob, 3),
+        escalus:wait_for_stanza(Alice),
+
+        RoomAddress = room_address(?config(room, Config)),
+        %% Bob sends a chat message to the bare room JID (not to a nick)
+        ChatMsg = escalus_stanza:chat_to(RoomAddress, <<"hello room">>),
+        escalus:send(Bob, ChatMsg),
+
+        %% Bob receives not-acceptable error - private messages to conference not allowed
+        Err = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_error, [<<"modify">>, <<"not-acceptable">>], Err),
+        escalus:assert(is_stanza_from, [RoomAddress], Err),
+
+        %% Bob remains in the room: a subsequent groupchat round-trips normally
+        escalus:send(Bob, escalus_stanza:groupchat_to(RoomAddress, <<"check">>)),
+        escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanza(Alice)
+    end).
+
+route_error_message_to_room(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}, {kate, 1}],
+    story_with_room(ConfigIn, [], UserSpecs, fun(Config, Alice, Bob, Kate) ->
+        escalus:send(Alice, stanza_muc_enter_room(?config(room, Config), <<"alice">>)),
+        escalus:wait_for_stanzas(Alice, 2),
+        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
+        escalus:wait_for_stanzas(Bob, 3),
+        escalus:wait_for_stanza(Alice),
+
+        %% Bob (occupant) sends type="error" message -> expulsion branch
+        ErrMsgBob = #xmlel{name = <<"message">>,
+                           attrs = #{<<"type">> => <<"error">>,
+                                     <<"to">> => room_address(?config(room, Config))}},
+        escalus:send(Bob, ErrMsgBob),
+
+        %% Bob receives his own unavailable presence - he was expelled
+        BobUnavailable = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_presence_with_type, [<<"unavailable">>], BobUnavailable),
+        escalus:assert(is_stanza_from, [room_address(?config(room, Config), <<"bob">>)], BobUnavailable),
+
+        %% Alice also sees Bob's departure
+        AliceSeesBobGone = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_presence_with_type, [<<"unavailable">>], AliceSeesBobGone),
+        escalus:assert(is_stanza_from, [room_address(?config(room, Config), <<"bob">>)], AliceSeesBobGone),
+
+        %% Kate (non-occupant) sends type="error" message -> silent drop
+        ErrMsgKate = #xmlel{name = <<"message">>,
+                            attrs = #{<<"type">> => <<"error">>,
+                                      <<"to">> => room_address(?config(room, Config))}},
+        escalus:send(Kate, ErrMsgKate),
+
+        %% Kate receives nothing - the stanza was silently dropped
+        escalus_assert:has_no_stanzas(Kate),
+
+        %% Room is still operational: Alice's sentinel works
+        escalus:send(Alice, escalus_stanza:groupchat_to(room_address(?config(room, Config)), <<"sentinel-2">>)),
+        escalus:wait_for_stanza(Alice)
+    end).
+
+route_unknown_message_type_to_room(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, [], UserSpecs, fun(Config, Alice, Bob) ->
+        escalus:send(Alice, stanza_muc_enter_room(?config(room, Config), <<"alice">>)),
+        escalus:wait_for_stanzas(Alice, 2),
+        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
+        escalus:wait_for_stanzas(Bob, 3),
+        escalus:wait_for_stanza(Alice),
+
+        %% Bob sends a headline message to the room - falls through to the catch-all clause
+        HeadlineMsg = #xmlel{name = <<"message">>,
+                             attrs = #{<<"type">> => <<"headline">>,
+                                       <<"to">> => room_address(?config(room, Config))}},
+        escalus:send(Bob, HeadlineMsg),
+
+        %% Bob receives not-acceptable error with "Improper message type" text
+        Err = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_error, [<<"modify">>, <<"not-acceptable">>], Err),
+        escalus:assert(is_stanza_from, [room_address(?config(room, Config))], Err),
+
+        %% Bob remains in the room: a subsequent groupchat round-trips normally
+        escalus:send(Bob, escalus_stanza:groupchat_to(room_address(?config(room, Config)), <<"sentinel">>)),
+        escalus:wait_for_stanza(Bob),
+        escalus:wait_for_stanza(Alice)
+    end).
+
+iq_reply_to_nick(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, [], UserSpecs, fun(Config, Alice, Bob) ->
+        escalus:send(Alice, stanza_muc_enter_room(?config(room, Config), <<"alice">>)),
+        escalus:wait_for_stanzas(Alice, 2),
+        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
+        escalus:wait_for_stanzas(Bob, 3),
+        escalus:wait_for_stanza(Alice),
+
+        BobNickJID = room_address(?config(room, Config), <<"bob">>),
+        AliceNickJID = room_address(?config(room, Config), <<"alice">>),
+
+        IqGet = escalus_stanza:to(escalus_stanza:iq_get(?NS_DISCO_INFO, []), BobNickJID),
+        escalus:send(Alice, IqGet),
+
+        ForwardedReq = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_iq_get, [], ForwardedReq),
+        escalus:assert(is_stanza_from, [AliceNickJID], ForwardedReq),
+
+        escalus:send(Bob, escalus_stanza:iq_result(ForwardedReq)),
+
+        ForwardedResult = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_iq_result, [ForwardedReq], ForwardedResult),
+        escalus:assert(is_stanza_from, [BobNickJID], ForwardedResult),
+
+        escalus_assert:has_no_stanzas(Bob),
+        escalus_assert:has_no_stanzas(Alice)
     end).
 
 %Examples  49, 50
@@ -5027,6 +5201,34 @@ check_message_route_to_offline_room(Config) ->
         %% Check that we receive the mecked pid instead of a real one
         P = ?FAKEPID,
         ?assertReceivedMatch(P, 3000)
+    end).
+
+groupchat_traffic_rate_limit_exceeded(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, [], UserSpecs, fun(Config, Alice, Bob) ->
+        escalus:send(Alice, stanza_muc_enter_room(?config(room, Config), <<"alice">>)),
+        escalus:wait_for_stanzas(Alice, 2),
+        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
+        escalus:wait_for_stanzas(Bob, 3),
+        escalus:wait_for_stanza(Alice),
+
+        RoomAddress = room_address(?config(room, Config)),
+        %% First message is delivered normally (message=undefined, time elapsed)
+        escalus:send(Bob, escalus_stanza:groupchat_to(RoomAddress, <<"first">>)),
+        escalus:wait_for_stanza(Bob),   %% Bob's own reflection
+        escalus:wait_for_stanza(Alice), %% Alice receives it
+
+        escalus:send(Bob, escalus_stanza:groupchat_to(RoomAddress, <<"second">>)),
+
+        %% Third message while second is still queued
+        escalus:send(Bob, escalus_stanza:groupchat_to(RoomAddress, <<"third">>)),
+
+        %% Bob receives resource-constraint error for the third message
+        RateLimitErr = escalus:wait_for_stanza(Bob),
+        escalus:assert(is_error, [<<"wait">>, <<"resource-constraint">>], RateLimitErr),
+
+        %% Alice does not receive the rate-limited third message
+        escalus_assert:has_no_stanzas(Alice)
     end).
 
 %%--------------------------------------------------------------------

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -145,7 +145,10 @@ groups() ->
                               disco_rooms,
                               disco_info,
                               disco_items,
-                              disco_items_nonpublic
+                              disco_items_nonpublic,
+                              service_vcard,
+                              service_unique_room_id,
+                              service_unknown_iq_error
                              ]},
          {disco_with_mam, [parallel], [
                                        disco_features_with_mam,
@@ -3250,6 +3253,42 @@ disco_items_nonpublic(ConfigIn) ->
         escalus:send(Bob, stanza_to_room(escalus_stanza:iq_get(?NS_DISCO_ITEMS,[]), RoomName)),
         Error = escalus:wait_for_stanza(Bob),
         escalus:assert(is_error, [<<"auth">>, <<"forbidden">>], Error)
+    end).
+
+service_vcard(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        Res = escalus:send_iq_and_wait_for_result(Alice, muc_helper:stanza_service_get_vcard()),
+        escalus:assert(is_stanza_from, [muc_helper:muc_host()], Res),
+        [VCard] = exml_query:subelements(Res, <<"vCard">>),
+        ?NS_VCARD = exml_query:attr(VCard, <<"xmlns">>),
+        <<"ejabberd/mod_muc">> = exml_query:path(VCard, [{element, <<"FN">>}, cdata]),
+        ?assertNotEqual(undefined, exml_query:subelement(VCard, <<"URL">>)),
+        ?assertNotEqual(undefined, exml_query:subelement(VCard, <<"DESC">>))
+    end).
+
+service_unique_room_id(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        Res1 = escalus:send_iq_and_wait_for_result(Alice, muc_helper:stanza_service_get_unique()),
+        escalus:assert(is_stanza_from, [muc_helper:muc_host()], Res1),
+        [Unique1] = exml_query:subelements(Res1, <<"unique">>),
+        ?NS_MUC_UNIQUE = exml_query:attr(Unique1, <<"xmlns">>),
+        Id1 = exml_query:cdata(Unique1),
+        ?assertNotEqual(<<"">>, Id1),
+        Res2 = escalus:send_iq_and_wait_for_result(Alice, muc_helper:stanza_service_get_unique()),
+        [Unique2] = exml_query:subelements(Res2, <<"unique">>),
+        Id2 = exml_query:cdata(Unique2),
+        ?assertNotEqual(Id1, Id2)
+    end).
+
+service_unknown_iq_error(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
+        UnknownIQ = escalus_stanza:setattr(
+                      escalus_stanza:iq_get(<<"urn:example:unknown">>, []),
+                      <<"to">>, muc_helper:muc_host()),
+        escalus:send(Alice, UnknownIQ),
+        Error = escalus:wait_for_stanza(Alice),
+        escalus:assert(is_error, [<<"cancel">>, <<"feature-not-implemented">>], Error),
+        escalus:assert(is_stanza_from, [muc_helper:muc_host()], Error)
     end).
 
 probe_metrics_are_updated(Config) ->

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -242,7 +242,8 @@ groups() ->
                                  send_and_receive_private_message_client_without_x_elem,
                                  send_private_groupchat,
                                  route_chat_to_room,
-                                 route_error_message_to_room,
+                                 route_error_message_to_room_from_occupant,
+                                 route_error_message_to_room_from_non_occupant,
                                  route_unknown_message_type_to_room,
                                  iq_reply_to_nick,
                                  change_nickname,
@@ -362,7 +363,7 @@ init_per_suite(Config) ->
     Config3 = dynamic_modules:save_modules(host_type(), Config2),
     Config4 = backup_and_set_config_option(Config3, [instrumentation, probe_interval], 1),
     dynamic_modules:restart(host_type(), mod_disco, default_mod_config(mod_disco)),
-    muc_helper:load_muc(),
+    muc_helper:load_muc(domain_helper:host_type(), #{}),
     mongoose_helper:ensure_muc_clean(),
     Config4.
 
@@ -422,7 +423,8 @@ init_per_group(G, Config) when G =:= http_auth_no_server;
         _ -> ok
     end,
     ConfigWithModules = dynamic_modules:save_modules(host_type(), Config),
-    dynamic_modules:ensure_modules(host_type(), required_modules(http_auth)),
+    muc_helper:load_muc(host_type(), #{http_auth_pool => muc_http_auth_test,
+                                       default_room => #{password_protected => true}}),
     ConfigWithModules;
 init_per_group(hibernation, Config) ->
     Config1 = dynamic_modules:save_modules(host_type(), Config),
@@ -440,22 +442,6 @@ init_per_group(register_over_s2s, Config) ->
     escalus:create_users(Config2, Users);
 init_per_group(_GroupName, Config) ->
     escalus:create_users(Config, escalus:get_users([alice, bob, kate])).
-
-required_modules(traffic_rate_limit) ->
-    #{mod_muc := OrigOpts} = dynamic_modules:get_current_modules(host_type()),
-    Opts = OrigOpts#{min_message_interval => 5},
-    [{mod_muc, Opts}];
-required_modules(http_auth) ->
-    #{mod_muc := OrigOpts} = dynamic_modules:get_current_modules(host_type()),
-    #{default_room := DefRoomOpts} = OrigOpts,
-    Opts = OrigOpts#{http_auth_pool => muc_http_auth_test,
-                     default_room => DefRoomOpts#{password_protected => true}},
-    [{mod_muc, Opts}];
-required_modules(persistent_by_default) ->
-    #{mod_muc := OrigOpts} = dynamic_modules:get_current_modules(host_type()),
-    #{default_room := DefRoomOpts} = OrigOpts,
-    Opts = OrigOpts#{default_room => DefRoomOpts#{persistent => true}},
-    [{mod_muc, Opts}].
 
 handle_http_auth(Req) ->
     Qs = cowboy_req:parse_qs(Req),
@@ -562,11 +548,11 @@ init_per_testcase(CaseName = room_creation_not_allowed, Config) ->
     escalus:init_per_testcase(CaseName, Config1);
 init_per_testcase(CaseName = create_instant_persistent_room, Config) ->
     ConfigWithModules = dynamic_modules:save_modules(host_type(), Config),
-    dynamic_modules:ensure_modules(host_type(), required_modules(persistent_by_default)),
+    muc_helper:load_muc(host_type(), #{default_room => #{persistent => true}}),
     escalus:init_per_testcase(CaseName, ConfigWithModules);
 init_per_testcase(CaseName = groupchat_traffic_rate_limit_exceeded, Config) ->
     ConfigWithModules = dynamic_modules:save_modules(host_type(), Config),
-    dynamic_modules:ensure_modules(host_type(), required_modules(traffic_rate_limit)),
+    muc_helper:load_muc(host_type(), #{min_message_interval => 5}),
     escalus:init_per_testcase(CaseName, ConfigWithModules);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
@@ -2862,9 +2848,9 @@ route_chat_to_room(ConfigIn) ->
         escalus:wait_for_stanza(Alice)
     end).
 
-route_error_message_to_room(ConfigIn) ->
-    UserSpecs = [{alice, 1}, {bob, 1}, {kate, 1}],
-    story_with_room(ConfigIn, [], UserSpecs, fun(Config, Alice, Bob, Kate) ->
+route_error_message_to_room_from_occupant(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, [], UserSpecs, fun(Config, Alice, Bob) ->
         escalus:send(Alice, stanza_muc_enter_room(?config(room, Config), <<"alice">>)),
         escalus:wait_for_stanzas(Alice, 2),
         escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
@@ -2885,7 +2871,14 @@ route_error_message_to_room(ConfigIn) ->
         %% Alice also sees Bob's departure
         AliceSeesBobGone = escalus:wait_for_stanza(Alice),
         escalus:assert(is_presence_with_type, [<<"unavailable">>], AliceSeesBobGone),
-        escalus:assert(is_stanza_from, [room_address(?config(room, Config), <<"bob">>)], AliceSeesBobGone),
+        escalus:assert(is_stanza_from, [room_address(?config(room, Config), <<"bob">>)], AliceSeesBobGone)
+    end).
+
+route_error_message_to_room_from_non_occupant(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {kate, 1}],
+    story_with_room(ConfigIn, [], UserSpecs, fun(Config, Alice, Kate) ->
+        escalus:send(Alice, stanza_muc_enter_room(?config(room, Config), <<"alice">>)),
+        escalus:wait_for_stanzas(Alice, 2),
 
         %% Kate (non-occupant) sends type="error" message -> silent drop
         ErrMsgKate = #xmlel{name = <<"message">>,

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -52,6 +52,9 @@ foreach_recipient(Users, VerifyFun) ->
               VerifyFun(escalus:wait_for_stanza(Recipient))
       end, Users).
 
+load_muc() ->
+    load_muc(domain_helper:host_type(), #{}).
+
 load_muc(HostType, ExtraOpts) ->
     MucHostPattern = ct:get_config({hosts, mim, muc_service_pattern}),
     ct:log("Starting MUC for ~p with extra opts ~p", [HostType, ExtraOpts]),

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -52,22 +52,25 @@ foreach_recipient(Users, VerifyFun) ->
               VerifyFun(escalus:wait_for_stanza(Recipient))
       end, Users).
 
-load_muc() ->
-    load_muc(domain_helper:host_type()).
-
-load_muc(HostType) ->
-    Backend = muc_backend(),
+load_muc(HostType, ExtraOpts) ->
     MucHostPattern = ct:get_config({hosts, mim, muc_service_pattern}),
-    ct:log("Starting MUC for ~p", [HostType]),
-    Opts = #{host => subhost_pattern(MucHostPattern), backend => Backend,
-             online_backend => muc_online_backend(),
-             hibernate_timeout => 2000,
-             hibernated_room_check_interval => 1000,
-             hibernated_room_timeout => 2000,
-             access => muc, access_create => muc_create},
+    ct:log("Starting MUC for ~p with extra opts ~p", [HostType, ExtraOpts]),
+    DefaultOpts = #{host => subhost_pattern(MucHostPattern), backend => muc_backend(),
+                    online_backend => muc_online_backend(),
+                    hibernate_timeout => 2000,
+                    hibernated_room_check_interval => 1000,
+                    hibernated_room_timeout => 2000,
+                    access => muc, access_create => muc_create},
+    Opts = merge_muc_opts(DefaultOpts, ExtraOpts),
     LogOpts = #{outdir => "/tmp/muclogs", access_log => muc},
-    dynamic_modules:start(HostType, mod_muc, make_opts(Opts)),
-    dynamic_modules:start(HostType, mod_muc_log, make_log_opts(LogOpts)).
+    dynamic_modules:ensure_modules(HostType, [{mod_muc, make_opts(Opts)},
+                                              {mod_muc_log, make_log_opts(LogOpts)}]).
+
+merge_muc_opts(BaseOpts, #{default_room := ExtraDefaultRoom} = ExtraOpts) ->
+    BaseDefaultRoom = maps:get(default_room, config_parser_helper:default_mod_config(mod_muc)),
+    maps:merge(BaseOpts, ExtraOpts#{default_room => maps:merge(BaseDefaultRoom, ExtraDefaultRoom)});
+merge_muc_opts(BaseOpts, ExtraOpts) ->
+    maps:merge(BaseOpts, ExtraOpts).
 
 unload_muc() ->
     HostType = domain_helper:host_type(),

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -16,6 +16,10 @@
 
 -export_type([verify_fun/0]).
 
+-spec make_opts(ExtraOpts :: map()) -> map().
+make_opts(ExtraOpts) ->
+    config_parser_helper:config([modules, mod_muc], ExtraOpts).
+
 -spec foreach_occupant(
         Users :: [escalus:client()], Stanza :: #xmlel{}, VerifyFun :: verify_fun()) -> ok.
 foreach_occupant(Users, Stanza, VerifyFun) ->
@@ -63,7 +67,7 @@ load_muc(HostType, ExtraOpts) ->
     CustomOpts = maps:merge(DefaultOpts, ExtraOpts),
     CustomLogOpts = #{outdir => "/tmp/muclogs", access_log => muc},
 
-    MUCOpts = config_parser_helper:config([modules, mod_muc], CustomOpts),
+    MUCOpts = make_opts(CustomOpts),
     MUCLogOpts = config_parser_helper:config([modules, mod_muc_log], CustomLogOpts),
     dynamic_modules:ensure_modules(HostType, [{mod_muc, MUCOpts},
                                               {mod_muc_log, MUCLogOpts}]).

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -16,13 +16,6 @@
 
 -export_type([verify_fun/0]).
 
-%% Extend default opts with new ExtraOpts
-make_opts(ExtraOpts) ->
-    config_parser_helper:mod_config(mod_muc, ExtraOpts).
-
-make_log_opts(ExtraOpts) ->
-    config_parser_helper:mod_config(mod_muc_log, ExtraOpts).
-
 -spec foreach_occupant(
         Users :: [escalus:client()], Stanza :: #xmlel{}, VerifyFun :: verify_fun()) -> ok.
 foreach_occupant(Users, Stanza, VerifyFun) ->
@@ -67,16 +60,13 @@ load_muc(HostType, ExtraOpts) ->
                     hibernated_room_check_interval => 1000,
                     hibernated_room_timeout => 2000,
                     access => muc, access_create => muc_create},
-    Opts = merge_muc_opts(DefaultOpts, ExtraOpts),
-    LogOpts = #{outdir => "/tmp/muclogs", access_log => muc},
-    dynamic_modules:ensure_modules(HostType, [{mod_muc, make_opts(Opts)},
-                                              {mod_muc_log, make_log_opts(LogOpts)}]).
+    CustomOpts = maps:merge(DefaultOpts, ExtraOpts),
+    CustomLogOpts = #{outdir => "/tmp/muclogs", access_log => muc},
 
-merge_muc_opts(BaseOpts, #{default_room := ExtraDefaultRoom} = ExtraOpts) ->
-    BaseDefaultRoom = maps:get(default_room, config_parser_helper:default_mod_config(mod_muc)),
-    maps:merge(BaseOpts, ExtraOpts#{default_room => maps:merge(BaseDefaultRoom, ExtraDefaultRoom)});
-merge_muc_opts(BaseOpts, ExtraOpts) ->
-    maps:merge(BaseOpts, ExtraOpts).
+    MUCOpts = config_parser_helper:config([modules, mod_muc], CustomOpts),
+    MUCLogOpts = config_parser_helper:config([modules, mod_muc_log], CustomLogOpts),
+    dynamic_modules:ensure_modules(HostType, [{mod_muc, MUCOpts},
+                                              {mod_muc_log, MUCLogOpts}]).
 
 unload_muc() ->
     HostType = domain_helper:host_type(),

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -53,7 +53,10 @@ foreach_recipient(Users, VerifyFun) ->
       end, Users).
 
 load_muc() ->
-    load_muc(domain_helper:host_type(), #{}).
+    load_muc(domain_helper:host_type()).
+
+load_muc(HostType) ->
+    load_muc(HostType, #{}).
 
 load_muc(HostType, ExtraOpts) ->
     MucHostPattern = ct:get_config({hosts, mim, muc_service_pattern}),

--- a/big_tests/tests/muc_helper.erl
+++ b/big_tests/tests/muc_helper.erl
@@ -282,6 +282,12 @@ stanza_get_features() ->
     escalus_stanza:setattr(escalus_stanza:iq_get(?NS_DISCO_INFO, []), <<"to">>,
                            muc_host()).
 
+stanza_service_get_vcard() ->
+    escalus_stanza:setattr(escalus_stanza:iq_get(?NS_VCARD, []), <<"to">>, muc_host()).
+
+stanza_service_get_unique() ->
+    escalus_stanza:setattr(escalus_stanza:iq_get(?NS_MUC_UNIQUE, []), <<"to">>, muc_host()).
+
 has_features(#xmlel{children = [ Query ]} = _Iq, Features) ->
     %%<iq from='chat.shakespeare.lit'
     %%  id='lx09df27'

--- a/doc/open-extensions/muc_light.md
+++ b/doc/open-extensions/muc_light.md
@@ -1528,9 +1528,8 @@ and MUST include a status code 321 (i.e. user leaving due to affiliation change)
 #### 8.1.8. Blocking functionality
 
 The blocking functionality uses a small subset of the Privacy Lists protocol.
-Stanzas MUST be addressed to the sender's bare JID (the `to` attribute may be skipped).
+Stanzas MUST be addressed to the MUC Light service bare JID.
 The privacy list name MUST be equal to "urn:xmpp:muclight:0".
-Obviously, this method won't work properly in XMPP Server Federation, because privacy stanzas are handled by sender's server and the MUC Light Blocking functionality is handled by a MUC Light service server.
 As opposed to XEP-0016, it is allowed to send "delta" privacy lists.
 
 ##### 8.1.8.1. Request blocking list
@@ -1538,7 +1537,7 @@ As opposed to XEP-0016, it is allowed to send "delta" privacy lists.
 **Retrieving blocking list**
 
 ```xml
-<iq from='crone1@shakespeare.lit/desktop' type='get' id='comp-getlist'>
+<iq from='crone1@shakespeare.lit/desktop' type='get' id='comp-getlist' to='coven.shakespeare.lit'>
     <query xmlns='jabber:iq:privacy'>
         <list name='urn:xmpp:muclight:0'/>
     </query>
@@ -1546,7 +1545,7 @@ As opposed to XEP-0016, it is allowed to send "delta" privacy lists.
 ```
 
 ```xml
-<iq type='result' id='comp-getlist' to='crone1@shakespeare.lit/desktop'>
+<iq type='result' id='comp-getlist' to='crone1@shakespeare.lit/desktop' from='coven.shakespeare.lit'>
     <query xmlns='jabber:iq:privacy'>
         <list name='urn:xmpp:muclight:0'>
             <item type='jid'
@@ -1569,7 +1568,7 @@ In order to block a room, the client MUST deny a room bare JID in privacy list.
 **Blocking a room**
 
 ```xml
-<iq from='crone1@shakespeare.lit/desktop' type='set' id='comp-blockroom'>
+<iq from='crone1@shakespeare.lit/desktop' type='set' id='comp-blockroom' to='coven.shakespeare.lit'>
     <query xmlns='jabber:iq:privacy'>
         <list name='urn:xmpp:muclight:0'>
             <item type='jid'
@@ -1582,7 +1581,7 @@ In order to block a room, the client MUST deny a room bare JID in privacy list.
 ```
 
 ```xml
-<iq type='result' id='comp-blockroom' to='crone1@shakespeare.lit/desktop' />
+<iq type='result' id='comp-blockroom' to='crone1@shakespeare.lit/desktop' from='coven.shakespeare.lit' />
 ```
 
 ##### 8.1.8.3. Blocking a user
@@ -1592,7 +1591,7 @@ In order to block a room, the client MUST deny a service JID with user's bare JI
 **Blocking a user**
 
 ```xml
-<iq from='crone1@shakespeare.lit/desktop' type='set' id='comp-blockuser'>
+<iq from='crone1@shakespeare.lit/desktop' type='set' id='comp-blockuser' to='coven.shakespeare.lit'>
     <query xmlns='jabber:iq:privacy'>
         <list name='urn:xmpp:muclight:0'>
             <item type='jid'
@@ -1605,7 +1604,7 @@ In order to block a room, the client MUST deny a service JID with user's bare JI
 ```
 
 ```xml
-<iq type='result' id='comp-blockuser' to='crone1@shakespeare.lit/desktop' />
+<iq type='result' id='comp-blockuser' to='crone1@shakespeare.lit/desktop' from='coven.shakespeare.lit' />
 ```
 
 ##### 8.1.8.4. Unblocking
@@ -1613,7 +1612,7 @@ In order to block a room, the client MUST deny a service JID with user's bare JI
 **Unblocking**
 
 ```xml
-<iq from='crone1@shakespeare.lit/desktop' type='get' id='comp-getlist'>
+<iq from='crone1@shakespeare.lit/desktop' type='get' id='comp-getlist' to='coven.shakespeare.lit'>
     <query xmlns='jabber:iq:privacy'>
         <list name='urn:xmpp:muclight:0'>
             <item type='jid'
@@ -1630,7 +1629,7 @@ In order to block a room, the client MUST deny a service JID with user's bare JI
 ```
 
 ```xml
-<iq type='result' id='comp-getlist' to='crone1@shakespeare.lit/desktop' />
+<iq type='result' id='comp-getlist' to='crone1@shakespeare.lit/desktop' from='coven.shakespeare.lit' />
 ```
 
 #### 8.1.9. Creating a room

--- a/rel/mim1.vars-toml.config
+++ b/rel/mim1.vars-toml.config
@@ -80,6 +80,9 @@
   "[[listen.component]]
   port = {{ component_port }}
   access = \"all\"
+  {{#component_check_from}}
+  check_from = {{{component_check_from}}}
+  {{/component_check_from}}
   shaper = \"fast\"
   ip_address = \"127.0.0.1\"
   password = \"secret\"

--- a/src/component/mongoose_component_connection.erl
+++ b/src/component/mongoose_component_connection.erl
@@ -238,35 +238,25 @@ create_proof(StreamId, Password) ->
 %% 'from' attribute MUST match the hostname of the component. However, this is the only restriction
 %% on 'from' addresses, and the component MAY send stanzas from any user at its hostname.
 -spec handle_stream_established(data(), exml:element()) -> fsm_res().
-handle_stream_established(StateData, #xmlel{name = Name} = El) ->
-    #component_data{lserver = LServer, listener_opts = #{check_from := CheckFrom}} = StateData,
+handle_stream_established(#component_data{lserver = LServer} = StateData,
+                          #xmlel{name = Name} = El) ->
     NewEl = jlib:remove_attr(<<"xmlns">>, El),
     FromJid = jid:from_binary(exml_query:attr(El, <<"from">>, <<>>)),
-    IsValidFromJid =
-        case {CheckFrom, FromJid} of
-            %% The default is the standard behaviour in XEP-0114
-            {true, #jid{lserver = FromLServer}} ->
-                FromLServer =:= LServer;
-            %% If the admin does not want to check the from field when accept packets from any
-            %% address. In this case, the component can send packet of behalf of the server users.
-            _ ->
-                true
-        end,
-    ToJid = jid:from_binary(exml_query:attr(El, <<"to">>, <<>>)),
-    IsStanza = (<<"iq">> =:= Name)
-        orelse (<<"message">> =:= Name)
-        orelse (<<"presence">> =:= Name),
-    case IsStanza andalso IsValidFromJid andalso (error =/= ToJid) of
-        true ->
-            Acc = element_to_origin_accum(StateData, FromJid, ToJid, NewEl),
-            mongoose_router:route(Acc);
-        false ->
+    ToJidBin = exml_query:attr(El, <<"to">>, <<>>),
+    maybe
+        ok ?= check_routable_stanza(Name),
+        {ok, ToJid} ?= jid_from_binary(ToJidBin),
+        {ok, HostType} ?= valid_from_jid_to_host_type(StateData, FromJid, ToJid),
+        Acc = element_to_origin_accum(StateData, HostType, FromJid, ToJid, NewEl),
+        mongoose_router:route(Acc)
+    else
+        BadRequestReason ->
             ?LOG_INFO(#{what => comp_bad_request,
-                        text => <<"Not valid Name or error in FromJid or ToJid">>,
-                        stanza_name => Name, from_jid => FromJid, to_jid => ToJid}),
+                        text => <<"Bad request from component, sending error reply">>,
+                        reason => BadRequestReason, component => LServer,
+                        stanza_name => Name, from_jid => FromJid, to_jid => ToJidBin}),
             Err = jlib:make_error_reply(NewEl, mongoose_xmpp_errors:bad_request()),
-            send_xml(StateData, Err),
-            error
+            send_xml(StateData, Err)
     end,
     keep_state_and_data.
 
@@ -366,9 +356,10 @@ handle_route(StateData = #component_data{}, _, Acc) ->
     end,
     keep_state_and_data.
 
--spec element_to_origin_accum(data(), jid:jid(), jid:jid(), exml:element()) -> mongoose_acc:t().
-element_to_origin_accum(StateData, FromJid, ToJid, El) ->
-    Params = #{host_type => undefined,
+-spec element_to_origin_accum(data(), mongooseim:host_type(), jid:jid(), jid:jid(),
+                              exml:element()) -> mongoose_acc:t().
+element_to_origin_accum(StateData, HostType, FromJid, ToJid, El) ->
+    Params = #{host_type => HostType,
                lserver => StateData#component_data.lserver,
                location => ?LOCATION,
                element => El,
@@ -376,7 +367,72 @@ element_to_origin_accum(StateData, FromJid, ToJid, El) ->
                to_jid => ToJid,
                origin => xmpp_component},
     Acc = mongoose_acc:new(Params),
-    mongoose_acc:set_permanent(component, [{module, ?MODULE}, {origin_jid, 'TODO'}], Acc).
+    mongoose_acc:set_permanent(component, [{module, ?MODULE}, {origin_jid, FromJid}], Acc).
+
+-spec check_routable_stanza(binary()) -> ok | unexpected_stanza_name.
+check_routable_stanza(<<"iq">>) -> ok;
+check_routable_stanza(<<"message">>) -> ok;
+check_routable_stanza(<<"presence">>) -> ok;
+check_routable_stanza(_) -> unexpected_stanza_name.
+
+-spec jid_from_binary(binary()) -> {ok, jid:jid()} | invalid_jid.
+jid_from_binary(Bin) ->
+    case jid:from_binary(Bin) of
+        error -> invalid_jid;
+        #jid{} = Jid -> {ok, Jid}
+    end.
+
+-spec valid_from_jid_to_host_type(data(), jid:jid() | error, jid:jid()) ->
+    {ok, mongooseim:host_type()} | invalid_from_jid.
+valid_from_jid_to_host_type(#component_data{listener_opts = #{check_from := false}} = SD,
+                            #jid{lserver = FromLServer}, ToJid) ->
+    %% When check_from is disabled, accept any sender JID and try every host-type
+    %% resolution strategy available for the current #component_data{} and #jid{} values.
+    Steps = [fun() -> host_type_from_subdomain_parent(SD, FromLServer) end,
+             fun() -> mongoose_domain_api:get_host_type(FromLServer) end,
+             fun() -> mongoose_domain_api:get_host_type(ToJid#jid.lserver) end,
+             fun() -> {ok, hd(?ALL_HOST_TYPES)} end],
+    first_ok(Steps);
+valid_from_jid_to_host_type(#component_data{is_subdomain = true} = SD,
+                            #jid{lserver = FromLServer}, _ToJid) ->
+    %% For subdomain components, accept the sender only when the #jid.lserver value
+    %% starts with the prefix configured in #component_data.lserver, then resolve the
+    %% host type from the parent domain part of that subdomain.
+    case host_type_from_subdomain_parent(SD, FromLServer) of
+        {ok, _} = Ok -> Ok;
+        {error, _} -> invalid_from_jid
+    end;
+valid_from_jid_to_host_type(#component_data{lserver = LServer}, #jid{lserver = LServer}, ToJid) ->
+    %% For regular components, accept the sender only when #jid.lserver matches
+    %% #component_data.lserver exactly. Resolve the host type from the recipient JID,
+    %% then fall back to any configured host type. We intentionally do not resolve by
+    %% sender domain here, because a non-subdomain component hostname may be outside
+    %% the set of registered MIM domains.
+    Steps = [fun() -> mongoose_domain_api:get_host_type(ToJid#jid.lserver) end,
+             fun() -> {ok, hd(?ALL_HOST_TYPES)} end],
+    first_ok(Steps);
+valid_from_jid_to_host_type(_, _, _) ->
+    invalid_from_jid.
+
+%% Assumes that at least one of the predicates will succeed
+-spec first_ok([fun(() -> {ok, term()} | {error, term()})]) -> {ok, term()}.
+first_ok([F | Rest]) ->
+    case F() of
+        {ok, _} = Ok -> Ok;
+        _ -> first_ok(Rest)
+    end.
+
+-spec host_type_from_subdomain_parent(data(), jid:lserver()) ->
+    {ok, mongooseim:host_type()} | {error, not_found}.
+host_type_from_subdomain_parent(#component_data{lserver = Prefix, is_subdomain = true},
+                                FromLServer) ->
+    FullPrefix = <<Prefix/binary, ".">>,
+    case string:prefix(FromLServer, FullPrefix) of
+        nomatch -> {error, not_found};
+        Parent -> mongoose_domain_api:get_host_type(Parent)
+    end;
+host_type_from_subdomain_parent(_, _) ->
+    {error, not_found}.
 
 -spec stream_start_error(data(), exml:element()) -> fsm_res().
 stream_start_error(StateData, Error) ->

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -47,8 +47,6 @@
          remove_user/3,
          remove_domain/3,
          add_rooms_to_roster/3,
-         process_iq_get/3,
-         process_iq_set/3,
          is_muc_room_owner/3,
          can_access_room/3,
          acc_room_affiliations/3,
@@ -283,7 +281,6 @@ schema_field_types() ->
 
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
-    Codec = host_type_to_codec(HostType),
     Roster = gen_mod:get_module_opt(HostType, ?MODULE, rooms_in_rosters),
     [{is_muc_room_owner, HostType, fun ?MODULE:is_muc_room_owner/3, #{}, 50},
      {can_access_room, HostType, fun ?MODULE:can_access_room/3, #{}, 50},
@@ -295,13 +292,6 @@ hooks(HostType) ->
      {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
      {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
      {disco_local_items, HostType, fun ?MODULE:disco_local_items/3, #{}, 50}] ++
-    case Codec of
-        legacy ->
-            [{privacy_iq_get, HostType, fun ?MODULE:process_iq_get/3, #{}, 1},
-             {privacy_iq_set, HostType, fun ?MODULE:process_iq_set/3, #{}, 1}];
-        _ ->
-            []
-    end ++
     case Roster of
         false -> [];
         true -> [{roster_get, HostType, fun ?MODULE:add_rooms_to_roster/3, #{}, 50}]
@@ -461,61 +451,6 @@ make_roster_item({{RoomU, RoomS}, RoomName, RoomVersion}) ->
             subscription = to,
             groups = [?NS_MUC_LIGHT],
             xs = [VerEl] }.
-
--spec process_iq_get(Acc, Params, Extra) -> {ok | stop, Acc} when
-    Acc :: mongoose_acc:t(),
-    Params :: map(),
-    Extra :: gen_hook:extra().
-process_iq_get(Acc, #{from := #jid{lserver = FromS} = From, to := To, iq := IQ}, #{host_type := HostType}) ->
-    MUCHost = server_host_to_muc_host(HostType, FromS),
-    case {mod_muc_light_codec_backend:decode(From, To, IQ, Acc),
-          gen_mod:get_module_opt(HostType, ?MODULE, blocking)} of
-        {{ok, {get, #blocking{} = Blocking}}, true} ->
-            Items = mod_muc_light_db_backend:get_blocking(HostType, jid:to_lus(From), MUCHost),
-            mod_muc_light_codec_backend:encode(
-              {get, Blocking#blocking{ items = Items }}, From, To,
-              fun(_, _, Packet) -> put(encode_res, Packet) end,
-              Acc),
-            #xmlel{ children = ResponseChildren } = erase(encode_res),
-            Result = {result, ResponseChildren},
-            {stop, mongoose_acc:set(hook, result, Result, Acc)};
-        {{ok, {get, #blocking{}}}, false} ->
-            Result = {error, mongoose_xmpp_errors:bad_request()},
-            {stop, mongoose_acc:set(hook, result, Result, Acc)};
-        _ ->
-            Result = {error, mongoose_xmpp_errors:bad_request()},
-            {ok, mongoose_acc:set(hook, result, Result, Acc)}
-    end.
-
-%% Blocking is done using your local domain
--spec process_iq_set(Acc, Params, Extra) -> {ok | stop, Acc} when
-    Acc :: mongoose_acc:t(),
-    Params :: map(),
-    Extra :: gen_hook:extra().
-process_iq_set(Acc, #{from := #jid{ lserver = FromS } = From, to := To, iq := IQ}, _Extra) ->
-    HostType = mod_muc_light_utils:acc_to_host_type(Acc),
-    MUCHost = server_host_to_muc_host(HostType, FromS),
-    case {mod_muc_light_codec_backend:decode(From, To, IQ, Acc),
-          gen_mod:get_module_opt(HostType, ?MODULE, blocking)} of
-        {{ok, {set, #blocking{ items = Items }} = Blocking}, true} ->
-            RouteFun = fun(_, _, Packet) -> put(encode_res, Packet) end,
-            ConditionFun = fun({_, _, {WhoU, WhoS}}) -> WhoU =:= <<>> orelse WhoS =:= <<>> end,
-            case lists:any(ConditionFun, Items) of
-                true ->
-                    {stop, mongoose_acc:set(hook, result,
-                                            {error, mongoose_xmpp_errors:bad_request()}, Acc)};
-                false ->
-                    ok = mod_muc_light_db_backend:set_blocking(HostType, jid:to_lus(From), MUCHost, Items),
-                    mod_muc_light_codec_backend:encode(Blocking, From, To, RouteFun, Acc),
-                    #xmlel{ children = ResponseChildren } = erase(encode_res),
-                    {stop, mongoose_acc:set(hook, result, {result, ResponseChildren}, Acc)}
-            end;
-        {{ok, {set, #blocking{}}}, false} ->
-            {stop, mongoose_acc:set(hook, result,
-                                    {error, mongoose_xmpp_errors:bad_request()}, Acc)};
-        _ ->
-            {ok, mongoose_acc:set(hook, result, {error, mongoose_xmpp_errors:bad_request()}, Acc)}
-    end.
 
 -spec is_muc_room_owner(Acc, Params, Extra) -> {ok, Acc} when
     Acc :: boolean(),


### PR DESCRIPTION
This PR extends test coverage, fixes component routing and ensures that `mongoose_acc` for stanzas from components always has some host type set.

* `component_SUITE` - communication with subdomain components was not tested at all and turned out it was broken
* `mod_blocking_SUITE`
  * one test was not run at all and it was most probably an oversight, as there was no e.g. tombstone comment that would indicate it's disabled for some reason; it worked fine after minor fixes
  * `add_sample_contact` and `subscribe` have most lines changes but these are merely a refactor to make them more generic and fix invalid argument names (Alice and Bob were swapped by mistake); core fix in them was to use real Alice and Bob JIDs instead of generic `alice` and `bob` handles, as these helpers are used in fresh story
* `muc_SUITE`
  * Some error paths are covered now
  * IQ routing between participants
  * stanza rate limiting test
  * unique room username generation
  * vCard of MUC service
* MUC Light - legacy codec mode was documented to expect privacy IQ sent to server's bare JID but the implementation was changed a few years ago to expect it sent to the service JID; I decoded to update the doc and remove untested code as I tried to execute it and it didn't work for some reason; most likely it's a good idea to get rid of "legacy" codec anyway.