### PR TITLE
MIM-2639 XEP version bump

### DIFF
--- a/big_tests/tests/vcard_SUITE.erl
+++ b/big_tests/tests/vcard_SUITE.erl
@@ -277,18 +277,8 @@ user_doesnt_exist(Config) ->
       fun(Client) ->
               Domain = domain(),
               BadJID = <<"nonexistent@", Domain/binary>>,
-              Res = escalus:send_and_wait(Client,
-                        escalus_stanza:vcard_request(BadJID)),
-          case
-          escalus_pred:is_error(<<"cancel">>,
-              <<"item-not-found">>,
-              Res) of
-              true ->
-                  ok;
-              _ ->
-                  [] = Res#xmlel.children,
-                  ct:comment("empty result instead of error")
-          end
+              Res = escalus:send_and_wait(Client, escalus_stanza:vcard_request(BadJID)),
+              escalus:assert(is_error, [<<"cancel">>, <<"item-not-found">>], Res)
       end).
 
 update_other_card(Config) ->

--- a/doc/modules/mod_mam.md
+++ b/doc/modules/mod_mam.md
@@ -5,7 +5,7 @@ It enables a service to store all user messages for one-to-one chats as well as 
 It uses [XEP-0059: Result Set Management](http://xmpp.org/extensions/xep-0059.html) for paging.
 It is a highly customizable module, that requires some skill and knowledge to operate properly and efficiently.
 
-MongooseIM is compatible with MAM 0.4-1.1.0.
+MongooseIM is compatible with MAM 0.4-1.1.3.
 
 Configure MAM with different storage backends:
 
@@ -75,7 +75,7 @@ Database backend to use.
 * **Default:** `false`
 * **Example:** `no_stanzaid_element = true`
 
-Do not add a `<stanza-id/>` element from MAM v1.1.0.
+Do not add a `<stanza-id/>` element from MAM v1.1.3.
 
 _This setting may be overridden by `mod_stanzaid`._
 

--- a/src/http_upload/mod_http_upload.erl
+++ b/src/http_upload/mod_http_upload.erl
@@ -19,7 +19,7 @@
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).
 
--xep([{xep, 363}, {version, "1.1.0"}]).
+-xep([{xep, 363}, {version, "1.2.0"}]).
 
 -include("jlib.hrl").
 -include("mongoose.hrl").

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -17,7 +17,7 @@
 -module(mod_mam).
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).
--xep([{xep, 313}, {version, "1.1.0"}, {legacy_versions, ["0.5"]}]).
+-xep([{xep, 313}, {version, "1.1.3"}, {legacy_versions, ["0.5"]}]).
 -xep([{xep, 441}, {version, "0.2.0"}]).
 -xep([{xep, 424}, {version, "0.3.0"}]).
 -xep([{xep, 431}, {version, "0.2.0"}]).

--- a/src/mod_bind2.erl
+++ b/src/mod_bind2.erl
@@ -12,7 +12,7 @@
 %% state or the carbons tag in the session info, before the session is actually established, so that
 %% session establishment is atomic to changes in the c2s data.
 -module(mod_bind2).
--xep([{xep, 386}, {version, "0.4.0"}, {status, partial}]).
+-xep([{xep, 386}, {version, "1.1.0"}, {status, partial}]).
 
 -include("jlib.hrl").
 

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -25,7 +25,7 @@
 
 -module(mod_disco).
 -author('alexey@process-one.net').
--xep([{xep, 30}, {version, "2.5rc3"}]).
+-xep([{xep, 30}, {version, "2.5.0"}]).
 -xep([{xep, 157}, {version, "1.1.1"}]).
 -behaviour(gen_mod).
 -behaviour(mongoose_module_metrics).

--- a/src/mod_sasl2.erl
+++ b/src/mod_sasl2.erl
@@ -11,7 +11,7 @@
 %% most recent from the accumulator, modify that one, and reinsert, otherwise it can override
 %% updates made by previous handlers.
 -module(mod_sasl2).
--xep([{xep, 388}, {version, "0.4.0"}, {status, partial}]).
+-xep([{xep, 388}, {version, "1.0.4"}, {status, partial}]).
 
 -include("jlib.hrl").
 -include("mongoose_logger.hrl").

--- a/src/mongoose_data_forms.erl
+++ b/src/mongoose_data_forms.erl
@@ -1,5 +1,5 @@
 -module(mongoose_data_forms).
--xep([{xep, 4}, {version, "2.13.1"}]).
+-xep([{xep, 4}, {version, "2.13.2"}]).
 -xep([{xep, 68}, {version, "1.3.0"}]).
 
 %% Form processing

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -53,7 +53,7 @@
 -xep([{xep, 277}, {version, "0.6.5"}]).
 
 %% https://xmpp.org/extensions/xep-0384.html#server-side
--xep([{xep, 384}, {version, "0.8.3"}]).
+-xep([{xep, 384}, {version, "0.9.1"}]).
 
 -xep([{xep, 402}, {version, "1.2.0"}]).
 

--- a/src/stream_management/mod_stream_management.erl
+++ b/src/stream_management/mod_stream_management.erl
@@ -1,5 +1,5 @@
 -module(mod_stream_management).
--xep([{xep, 198}, {version, "1.6.1"}]).
+-xep([{xep, 198}, {version, "1.6.3"}]).
 -behaviour(gen_mod).
 -behaviour(gen_statem).
 -behaviour(mongoose_module_metrics).

--- a/src/vcard/mod_vcard.erl
+++ b/src/vcard/mod_vcard.erl
@@ -32,7 +32,7 @@
 
 -module(mod_vcard).
 -author('alexey@process-one.net').
--xep([{xep, 54}, {version, "1.2"}]).
+-xep([{xep, 54}, {version, "1.3.0"}]).
 -xep([{xep, 55}, {version, "1.3"}]).
 -behaviour(gen_mod).
 -behaviour(gen_server).

--- a/src/vcard/mod_vcard_ldap.erl
+++ b/src/vcard/mod_vcard_ldap.erl
@@ -133,7 +133,8 @@ remove_user(_HostType, _LUser, _LServer) ->
     %% removing user = delete all user info
     ok.
 
--spec get_vcard(mongooseim:host_type(), jid:luser(), jid:lserver()) -> {ok, [exml:element()]}.
+-spec get_vcard(mongooseim:host_type(), jid:luser(), jid:lserver()) ->
+          {ok, [exml:element()]} | {error, exml:element()}.
 get_vcard(HostType, LUser, LServer) ->
     State = get_state(HostType, LServer),
     JID = jid:make_bare(LUser, LServer),
@@ -145,10 +146,10 @@ get_vcard(HostType, LUser, LServer) ->
                     VCard = ldap_attributes_to_vcard(Attributes, VCardMap, {LUser, LServer}),
                     {ok, VCard};
                 _ ->
-                    {ok, []}
+                    {error, mongoose_xmpp_errors:item_not_found()}
             end;
         _ ->
-            {ok, []}
+            {error, mongoose_xmpp_errors:item_not_found()}
     end.
 
 -spec set_vcard(mongooseim:host_type(), jid:luser(), jid:lserver(), exml:element(), mod_vcard:vcard_search()) ->


### PR DESCRIPTION
This PR bumps XEP version wherever it's straightforward to do so. It also unifies `mod_vcard_ldap` behavior in case of a missing vCard with other backends, as the XEP explicitly states:

> If no vCard exists or the user does not exist, the server MUST return a stanza error.

Some XEPs were skipped as they require more work and new tickets were created.

Extra: Message Retraction PR will follow after this one.