### PR TITLE
Pin `emicklei/zazkia` to version 0.6

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -162,7 +162,7 @@ containers:
       - BASE32DEC: "__PYTHON2_BASE32_DEC__"
     entrypoint: *ENTRYPOINT
   - &cassandra_proxy_container
-    image: emicklei/zazkia
+    image: emicklei/zazkia:0.6
     environment:
       - OLD_ENTRYPOINT: "./zazkia -v -f /data/zazkia-routes.json"
       - ENV_FILE_CFG_PATH: "/data/zazkia-routes.json"

--- a/tools/setup-db.sh
+++ b/tools/setup-db.sh
@@ -187,7 +187,7 @@ function setup_db(){
         CASSANDRA_IP=$($DOCKER inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $NAME)
         echo "Connecting TCP proxy to Cassandra on $CASSANDRA_IP..."
 
-        IMAGE2=emicklei/zazkia
+        IMAGE2=emicklei/zazkia:0.6
         # Circle CI version of this container does not need replace-ip.sh
         # (so, it does not define ENV_FILE_REPLACE_IP_PATH)
         $DOCKER run -d --name=$PROXY_NAME \


### PR DESCRIPTION
The latest `emicklei/zazkia` image no longer ships with linux/amd64 support, so this PR pins it to the most recent version that still works on that architecture.

Failing workflow: https://app.circleci.com/pipelines/gh/esl/MongooseIM/15344/workflows/0e706316-a776-45e2-91f3-11591f748820/jobs/310382