### PR TITLE
MIM-2736 Update and fix the codecov uploader script

### DIFF
--- a/tools/circle-upload-codecov.sh
+++ b/tools/circle-upload-codecov.sh
@@ -2,17 +2,17 @@
 
 set -eo pipefail
 
-PLATFORM=$(uname -m)
-[ $PLATFORM == "x86_64" ] && PLATFORM=linux
-BASE_URL="https://uploader.codecov.io/latest/$PLATFORM"
+[ $(uname -m) == "x86_64" ] && PLATFORM=linux || PLATFORM=linux-arm64
+BASE_URL="https://cli.codecov.io/latest/$PLATFORM"
 
 # Source: https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --import
 curl -Os "${BASE_URL}/codecov"
 curl -Os "${BASE_URL}/codecov.SHA256SUM"
 curl -Os "${BASE_URL}/codecov.SHA256SUM.sig"
-gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
 shasum -a 256 -c codecov.SHA256SUM
 
 chmod +x codecov
-./tools/retry.sh ./codecov -t ${CODECOV_TOKEN} -e PRESET --nonZero
+./tools/retry.sh ./codecov upload-coverage \
+                 -f codecov.json --disable-search -n $CIRCLE_JOB --plugin noop -Z


### PR DESCRIPTION
- Use the latest instructions from [1] including the new URL format
- Change the script to use the default keyring - it's both simpler and the original version didn't work because `gpg --verify` used the wrong keyring

Also, update the command to use the new CLI.
- Include only 'codecov.json', and skip searching for other files
- Disable unused plugins causing warnings
- Get rid of the PRESET env variable, and pass the CI job name instead - the env vars were not visible anywhere, while the name is displayed in the web UI.

[1] https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader

See the generated report with named uploads: https://app.codecov.io/gh/esl/MongooseIM/commit/6572dc429fcb221111233a32beee00bf80181eeb

