### PR TITLE
MIM-2699 Make router_no_route_found a global metric

### DIFF
--- a/big_tests/tests/dynamic_domains_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_SUITE.erl
@@ -30,7 +30,7 @@ groups() ->
 init_per_suite(Config0) ->
     Config = cluster_nodes(?CLUSTER_NODES, Config0),
     insert_domains(?TEST_NODES, ?DOMAINS),
-    instrument_helper:start([{router_no_route_found, #{host_type => ?HOST_TYPE}}]),
+    instrument_helper:start([{router_no_route_found, #{}}]),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config0) ->
@@ -104,7 +104,7 @@ no_route(Config) ->
             escalus:send(Alice, WrongServerMsg),
 
             escalus_assert:has_no_stanzas(Bob),
-            instrument_helper:wait_and_assert(router_no_route_found, #{host_type => ?HOST_TYPE},
+            instrument_helper:wait_and_assert(router_no_route_found, #{},
                 fun(#{count := 1, to := To}) -> jid:to_binary(To) =:= WrongJID end)
         end,
     escalus:story(Config, [{alice3, 1}, {bob3, 1}], StoryFn).

--- a/doc/migrations/6.7.0_6.x.x.md
+++ b/doc/migrations/6.7.0_6.x.x.md
@@ -7,3 +7,13 @@ The following features are removed or deprecated.
 The `mod_muc_log` module was removed in this release. Delete `mod_muc_log` from your configured modules list and remove any `mod_muc_log` options.
 Also remove `modules.mod_muc.default_room.logging` option.
 If you need message history, enable and configure `mod_mam` instead.
+
+## Metrics
+
+The changes to metrics and instrumentation are listed below.
+
+### `router_no_route_found` is now a global metric
+
+The `router_no_route_found` metric is no longer scoped by `host_type`.
+This event can be emitted when routing reaches the end of the routing chain, where the stanza's host type can be unknown.
+See [Sessions and routing](../operation-and-maintenance/MongooseIM-metrics.md#sessions-and-routing) for more information.

--- a/doc/operation-and-maintenance/MongooseIM-metrics.md
+++ b/doc/operation-and-maintenance/MongooseIM-metrics.md
@@ -175,7 +175,7 @@ Since Exometer doesn't support labels, in such cases the host type is a part of 
     | `c2s_message_processed_time` | `host_type` | histogram | Processing time for incoming c2s stanzas. |
     | `sm_message_bounced_count` | `host_type` | counter | A `service-unavailable` error is sent, because the message recipient is offline. |
     | `router_stanza_dropped_count` | `host_type` | counter | A stanza is dropped due to an AMP rule or a `filter_local_packet` processing flow. |
-    | `router_no_route_found_count` | `host_type` | counter | It is not possible to route a stanza (all routing handlers failed). |
+    | `router_no_route_found_count` | - | counter | It is not possible to route a stanza (all routing handlers failed). |
 
 === "Exometer"
 
@@ -190,7 +190,7 @@ Since Exometer doesn't support labels, in such cases the host type is a part of 
     | `[HostType, c2s_message_processing_time`] | histogram | Processing time for incoming c2s stanzas. |
     | `[HostType, sm_message_bounced, count]` | spiral | A `service-unavailable` error is sent, because the message recipient is offline. |
     | `[HostType, router_stanza_dropped, count]` | spiral | A stanza is dropped due to an AMP rule or a `filter_local_packet` processing flow. |
-    | `[HostType, router_no_route_found, count]` | spiral | It is not possible to route a stanza (all routing handlers failed). |
+    | `[global, router_no_route_found, count]` | spiral | It is not possible to route a stanza (all routing handlers failed). |
 
 ### Connection pools
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -225,6 +225,7 @@ nav:
       - '6.4.0 to 6.5.0': 'migrations/6.4.0_6.5.0.md'
       - '6.5.0 to 6.6.0': 'migrations/6.5.0_6.6.0.md'
       - '6.6.0 to 6.7.0': 'migrations/6.6.0_6.7.0.md'
+      - '6.7.0 to 6.x.x': 'migrations/6.7.0_6.x.x.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - 'Contributions to the Ecosystem': 'Contributions.md'
   - 'MongooseIM History': 'History.md'

--- a/src/mongoose_router.erl
+++ b/src/mongoose_router.erl
@@ -102,14 +102,12 @@ drop_stanza(Acc) ->
 
 -spec instrumentation() -> [mongoose_instrument:spec()].
 instrumentation() ->
-    lists:flatmap(fun instrumentation/1, ?ALL_HOST_TYPES).
+    [{router_no_route_found, #{}, #{metrics => #{count => spiral}}} |
+     lists:flatmap(fun instrumentation/1, ?ALL_HOST_TYPES)].
 
 -spec instrumentation(mongooseim:host_type()) -> [mongoose_instrument:spec()].
 instrumentation(HostType) ->
-    [{router_stanza_dropped, #{host_type => HostType},
-      #{metrics => #{count => spiral}}},
-     {router_no_route_found, #{host_type => HostType},
-      #{metrics => #{count => spiral}}}].
+    [{router_stanza_dropped, #{host_type => HostType}, #{metrics => #{count => spiral}}}].
 
 -spec route(From   :: jid:jid(),
             To     :: jid:jid(),
@@ -117,9 +115,8 @@ instrumentation(HostType) ->
             Packet :: exml:element(),
             [xmpp_router:t()]) -> mongoose_acc:t().
 route(_From, To, Acc, _Packet, []) ->
-    HT = mongoose_acc:host_type(Acc),
-    ?LOG_ERROR(#{what => no_more_routing_modules, acc => Acc, host_type => HT}),
-    mongoose_instrument:execute(router_no_route_found, #{host_type => HT}, #{count => 1, to => To}),
+    ?LOG_WARNING(#{what => no_more_routing_modules, acc => Acc}),
+    mongoose_instrument:execute(router_no_route_found, #{}, #{count => 1, to => To}),
     mongoose_acc:append(router, result, {error, out_of_modules}, Acc);
 route(OrigFrom, OrigTo, Acc0, OrigPacket, [M | Tail]) ->
     try xmpp_router:call_filter(M, OrigFrom, OrigTo, Acc0, OrigPacket) of

--- a/test/component_reg_SUITE.erl
+++ b/test/component_reg_SUITE.erl
@@ -21,10 +21,6 @@ init_per_suite(Config) ->
                                 {mongooseim_helper, start_link_loaded_hooks, []},
                                 {mongoose_router, start, []}]).
 
-init_per_testcase(_, Config) ->
-    mongoose_router:start(),
-    Config.
-
 end_per_suite(Config) ->
     async_helper:stop_all(Config),
     mnesia:stop(),


### PR DESCRIPTION
The host type can be undefined at this point.

Also: lower the log level to WARNING as there is nothing broken with the system itself if a routing module is not found.
Actually, this situation happens whenever an incoming stanza has a unknown destination domain, and S2S is disabled.
