### PR TITLE
MIM-2730 Align `muc#roomconfig_allowinvites` with XEP

### DIFF
--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -173,7 +173,8 @@ groups() ->
                                   moderator_voice_forbidden,
                                   moderator_voice_not_occupant,
                                   moderator_voice_nonick,
-                                  voice_approval_with_invalid_role
+                                  voice_approval_with_invalid_role,
+                                  moderator_invite
                                  ]},
          {admin, [parallel], [
                               admin_ban,
@@ -1179,6 +1180,34 @@ voice_approval_with_invalid_role(ConfigIn) ->
 
         %% Bob receives no role-change presence (was not promoted)
         escalus_assert:has_no_stanzas(Bob)
+    end).
+
+%%  A moderator may always invite, even with allow_user_invites disabled
+moderator_invite(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}, {kate, 1}],
+    story_with_room(ConfigIn, moderator_room_opts(), UserSpecs, fun(Config, Alice, Bob, Kate) ->
+        Room = ?config(room, Config),
+        %% Alice joins room
+        escalus:send(Alice, stanza_muc_enter_room(Room, <<"alice">>)),
+        escalus:wait_for_stanzas(Alice, 2),
+        %% Bob joins room as a visitor
+        escalus:send(Bob, stanza_muc_enter_room(Room, <<"bob">>)),
+        escalus:wait_for_stanzas(Bob, 3),
+        %% Skip Bob's presence
+        escalus:wait_for_stanza(Alice),
+
+        %% Alice grants Bob the moderator role
+        escalus:send(Alice, stanza_set_roles(Room, [{<<"bob">>, <<"moderator">>}])),
+        %% Skip Bob's new presence
+        escalus:wait_for_stanza(Bob),
+
+        %% Bob, now a moderator, invites Kate even though allow_user_invites is false
+        escalus:send(Bob, stanza_mediated_invitation(Room, Kate)),
+
+        %% Kate receives the invitation
+        Inv = escalus:wait_for_stanza(Kate),
+        is_invitation(Inv),
+        escalus:assert(is_stanza_from, [room_address(Room)], Inv)
     end).
 
 %%--------------------------------------------------------------------

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -201,7 +201,8 @@ groups() ->
                                   admin_mo_revoke,
                                   admin_mo_invite,
                                   admin_mo_invite_with_reason,
-                                  admin_mo_invite_mere
+                                  admin_mo_invite_mere,
+                                  admin_mo_invite_allowed
                                  ]},
          {occupant, [parallel], [
                                  %nick registration in a room is not implemented and will not be tested
@@ -2147,6 +2148,32 @@ admin_mo_invite_mere(ConfigIn) ->
         Error = escalus:wait_for_stanza(Bob),
         escalus:assert(is_error, [<<"auth">>, <<"forbidden">>], Error),
         escalus:assert(is_stanza_from, [room_address(?config(room, Config))], Error)
+    end).
+
+%%  A member may invite when allow_user_invites is enabled
+admin_mo_invite_allowed(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}, {kate, 1}],
+    RoomOpts = admin_mo_room_opts() ++ [{allow_user_invites, true}],
+    story_with_room(ConfigIn, RoomOpts, UserSpecs, fun(Config, Alice, Bob, Kate) ->
+        %% Make Bob a member
+        Items = [{escalus_utils:get_short_jid(Bob), <<"member">>}],
+        escalus:send(Alice, stanza_set_affiliations(?config(room,Config), Items)),
+        escalus:wait_for_stanza(Alice),
+
+        %% Bob gets an invitation
+        escalus:wait_for_stanza(Bob),
+
+        %% Bob joins room
+        escalus:send(Bob, stanza_muc_enter_room(?config(room, Config), <<"bob">>)),
+        escalus:wait_for_stanzas(Bob, 2),
+
+        %% Bob invites Kate
+        escalus:send(Bob, stanza_mediated_invitation(?config(room,Config), Kate)),
+
+        %% Kate receives the invitation
+        Inv = escalus:wait_for_stanza(Kate),
+        is_invitation(Inv),
+        escalus:assert(is_stanza_from, [room_address(?config(room, Config))], Inv)
     end).
 
 %%--------------------------------------------------------------------

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -3324,7 +3324,7 @@ get_config(StateData, From) ->
      boolxfield(<<"Allow users to query other users">>,
              <<"allow_query_users">>,
               Config#config.allow_query_users),
-     boolxfield(<<"Allow users to send invites">>,
+     boolxfield(<<"Allow members to invite others">>,
              <<"muc#roomconfig_allowinvites">>,
               Config#config.allow_user_invites),
      boolxfield(<<"Allow users to enter room with multiple sessions">>,
@@ -3857,10 +3857,10 @@ check_invitation(FromJID, Els, StateData) ->
 -spec unsafe_check_invitation(jid:jid(), [exml:child()], state()) -> {ok, [jid:jid()]}.
 unsafe_check_invitation(FromJID, Els,
                         StateData=#state{host=Host, server_host=ServerHost, jid=RoomJID}) ->
-    FAffiliation = get_affiliation(FromJID, StateData),
-    CanInvite = (StateData#state.config)#config.allow_user_invites
-                orelse (FAffiliation == admin)
-                orelse (FAffiliation == owner),
+    FRole = get_role(FromJID, StateData),
+    CanInvite = (FRole == moderator)
+                orelse (lists:member(FRole, [participant, visitor])
+                        andalso (StateData#state.config)#config.allow_user_invites),
     case CanInvite of
         false ->
             throw({error, mongoose_xmpp_errors:forbidden()});


### PR DESCRIPTION
This PR renames the config field to *"Allow members to invite others"* and gates inviting by role per [XEP-0045 (Table 3)](https://xmpp.org/extensions/xep-0045.html#table-3) instead of affiliation:

- Moderators may always invite.
- Participants/visitors may invite only when `allow_user_invites` is enabled.
- Others may never invite.