### PR TITLE
MIM-2725 Allow changing reserved nicks by an admin

### DIFF
--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -1581,7 +1581,7 @@ admin_sets_reserved_nick(ConfigIn) ->
         %% Bob has no reserved nickname yet
         ?assert_equal(<<>>, get_nick(Bob)),
         %% Alice (owner) makes Bob a member and reserves a nickname for him
-        escalus:send(Alice, stanza_set_reserved_nick(Room, BobJID, <<"member">>, Nick)),
+        escalus:send(Alice, stanza_set_nicks(Room, [{BobJID, <<"member">>, Nick}])),
         escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
         %% Bob's reserved nickname is now set
         ?assert_equal(Nick, get_nick(Bob)),
@@ -1599,7 +1599,7 @@ admin_unsets_reserved_nick(ConfigIn) ->
         set_nick(Bob, Nick),
         ?assert_equal(Nick, get_nick(Bob)),
         %% Alice (owner) unsets Bob's reserved nickname
-        escalus:send(Alice, stanza_set_reserved_nick(Room, BobJID, <<"member">>, <<>>)),
+        escalus:send(Alice, stanza_set_nicks(Room, [{BobJID, <<"member">>, <<>>}])),
         escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
         ?assert_equal(<<>>, get_nick(Bob))
     end).
@@ -1614,7 +1614,7 @@ admin_sets_conflicting_reserved_nick(ConfigIn) ->
         %% Kate reserves the nickname first
         set_nick(Kate, Nick),
         %% Alice tries to give the same nickname to Bob
-        escalus:send(Alice, stanza_set_reserved_nick(Room, BobJID, <<"member">>, Nick)),
+        escalus:send(Alice, stanza_set_nicks(Room, [{BobJID, <<"member">>, Nick}])),
         escalus:assert(is_error, [<<"cancel">>, <<"conflict">>],
                        escalus:wait_for_stanza(Alice)),
         %% Bob's nickname stays unset
@@ -1630,7 +1630,7 @@ user_cannot_set_others_reserved_nick(ConfigIn) ->
         KateJID = escalus_utils:get_short_jid(Kate),
         Nick = fresh_nick_name(<<"katenick">>),
         %% Bob has no affiliation, so he cannot manage Kate's reserved nickname
-        escalus:send(Bob, stanza_set_reserved_nick(Room, KateJID, <<"none">>, Nick)),
+        escalus:send(Bob, stanza_set_nicks(Room, [{KateJID, <<"none">>, Nick}])),
         escalus:assert(is_error, [<<"auth">>, <<"forbidden">>],
                        escalus:wait_for_stanza(Bob)),
         ?assert_equal(<<>>, get_nick(Kate))
@@ -5481,12 +5481,15 @@ stanza_set_affiliations(Room, List) ->
         end, List),
     stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, Payload), Room).
 
-stanza_set_reserved_nick(Room, JID, Affiliation, Nick) ->
-    Item = #xmlel{name = <<"item">>,
-                  attrs = #{<<"jid">> => JID,
-                            <<"affiliation">> => Affiliation,
-                            <<"nick">> => Nick}},
-    stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, [Item]), Room).
+stanza_set_nicks(Room, List) ->
+    Payload = lists:map(
+        fun({JID, Affiliation, Nick}) ->
+            #xmlel{name = <<"item">>,
+                   attrs = #{<<"jid">> => JID,
+                             <<"affiliation">> => Affiliation,
+                             <<"nick">> => Nick}}
+        end, List),
+    stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, Payload), Room).
 
 stanza_role_list_request(Room, Role) ->
     Payload = [ #xmlel{name = <<"item">>,

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -187,6 +187,10 @@ groups() ->
                               admin_membership,
                               admin_membership_with_reason,
                               admin_member_list,
+                              admin_sets_reserved_nick,
+                              admin_unsets_reserved_nick,
+                              admin_sets_conflicting_reserved_nick,
+                              user_cannot_set_others_reserved_nick,
                               admin_remove_user,
                               admin_remove_user_from_offline_room,
                               admin_member_list_allowed,
@@ -1566,6 +1570,71 @@ admin_member_list(ConfigIn) ->
         Error = escalus:wait_for_stanza(Kate),
         escalus:assert(is_error, [<<"auth">>, <<"forbidden">>], Error)
   end).
+
+%% An admin can set another user's reserved nickname through the member list by including the 'nick' attribute
+admin_sets_reserved_nick(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, admin_room_opts(), UserSpecs, fun(Config, Alice, Bob) ->
+        Room = ?config(room, Config),
+        BobJID = escalus_utils:get_short_jid(Bob),
+        Nick = fresh_nick_name(<<"bobsnick">>),
+        %% Bob has no reserved nickname yet
+        ?assert_equal(<<>>, get_nick(Bob)),
+        %% Alice (owner) makes Bob a member and reserves a nickname for him
+        escalus:send(Alice, stanza_set_reserved_nick(Room, BobJID, <<"member">>, Nick)),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+        %% Bob's reserved nickname is now set
+        ?assert_equal(Nick, get_nick(Bob)),
+        unset_nick(Bob)
+    end).
+
+%% An admin can unset another user's reserved nickname with an empty 'nick'
+admin_unsets_reserved_nick(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}],
+    story_with_room(ConfigIn, admin_room_opts(), UserSpecs, fun(Config, Alice, Bob) ->
+        Room = ?config(room, Config),
+        BobJID = escalus_utils:get_short_jid(Bob),
+        Nick = fresh_nick_name(<<"bobsnick">>),
+        %% Bob reserves a nickname for himself
+        set_nick(Bob, Nick),
+        ?assert_equal(Nick, get_nick(Bob)),
+        %% Alice (owner) unsets Bob's reserved nickname
+        escalus:send(Alice, stanza_set_reserved_nick(Room, BobJID, <<"member">>, <<>>)),
+        escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+        ?assert_equal(<<>>, get_nick(Bob))
+    end).
+
+%% A reserved nickname already taken by another user cannot be assigned
+admin_sets_conflicting_reserved_nick(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}, {kate, 1}],
+    story_with_room(ConfigIn, admin_room_opts(), UserSpecs, fun(Config, Alice, Bob, Kate) ->
+        Room = ?config(room, Config),
+        BobJID = escalus_utils:get_short_jid(Bob),
+        Nick = fresh_nick_name(<<"bestnick">>),
+        %% Kate reserves the nickname first
+        set_nick(Kate, Nick),
+        %% Alice tries to give the same nickname to Bob
+        escalus:send(Alice, stanza_set_reserved_nick(Room, BobJID, <<"member">>, Nick)),
+        escalus:assert(is_error, [<<"cancel">>, <<"conflict">>],
+                       escalus:wait_for_stanza(Alice)),
+        %% Bob's nickname stays unset
+        ?assert_equal(<<>>, get_nick(Bob)),
+        unset_nick(Kate)
+    end).
+
+%% A non-admin user cannot change another user's reserved nickname
+user_cannot_set_others_reserved_nick(ConfigIn) ->
+    UserSpecs = [{alice, 1}, {bob, 1}, {kate, 1}],
+    story_with_room(ConfigIn, admin_room_opts(), UserSpecs, fun(Config, _Alice, Bob, Kate) ->
+        Room = ?config(room, Config),
+        KateJID = escalus_utils:get_short_jid(Kate),
+        Nick = fresh_nick_name(<<"katenick">>),
+        %% Bob has no affiliation, so he cannot manage Kate's reserved nickname
+        escalus:send(Bob, stanza_set_reserved_nick(Room, KateJID, <<"none">>, Nick)),
+        escalus:assert(is_error, [<<"auth">>, <<"forbidden">>],
+                       escalus:wait_for_stanza(Bob)),
+        ?assert_equal(<<>>, get_nick(Kate))
+    end).
 
 %% removing user from the system removes them from a room
 admin_remove_user(ConfigIn) ->
@@ -5411,6 +5480,13 @@ stanza_set_affiliations(Room, List) ->
                                       children = [#xmlcdata{content = Reason}]}]}
         end, List),
     stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, Payload), Room).
+
+stanza_set_reserved_nick(Room, JID, Affiliation, Nick) ->
+    Item = #xmlel{name = <<"item">>,
+                  attrs = #{<<"jid">> => JID,
+                            <<"affiliation">> => Affiliation,
+                            <<"nick">> => Nick}},
+    stanza_to_room(escalus_stanza:iq_set(?NS_MUC_ADMIN, [Item]), Room).
 
 stanza_role_list_request(Room, Role) ->
     Payload = [ #xmlel{name = <<"item">>,

--- a/src/muc/mod_muc.erl
+++ b/src/muc/mod_muc.erl
@@ -50,6 +50,8 @@
          create_instant_room/6,
          broadcast_service_message/2,
          can_use_nick/4,
+         set_nick/4,
+         unset_nick/3,
          room_jid_to_pid/1,
          get_vh_rooms/2,
          default_host/0]).

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -1409,28 +1409,15 @@ access_persistent(#state{access=Access}) ->
     AccessPersistent.
 
 
--dialyzer({no_match, set_affiliation/3}).
--spec set_affiliation(jid:jid(), mod_muc:affiliation(), state()) -> state().
-set_affiliation(JID, Affiliation, StateData)
-        when is_atom(Affiliation) ->
+-spec set_affiliation(jid:jid(),
+                      mod_muc:affiliation() | {mod_muc:affiliation(), term()},
+                      state()) -> state().
+set_affiliation(JID, none, StateData) ->
     LJID = jid:to_bare(jid:to_lower(JID)),
-    Affiliations = case Affiliation of
-               none -> maps:remove(LJID, StateData#state.affiliations);
-               _ -> maps:put(LJID, Affiliation, StateData#state.affiliations)
-           end,
-    StateData#state{affiliations = Affiliations}.
-
-
--spec set_affiliation_and_reason(jid:jid(), mod_muc:affiliation(), term(),
-                                 state()) -> state().
-set_affiliation_and_reason(JID, Affiliation, Reason, StateData)
-        when is_atom(Affiliation) ->
+    StateData#state{affiliations = maps:remove(LJID, StateData#state.affiliations)};
+set_affiliation(JID, AffOrAffReason, StateData) ->
     LJID = jid:to_bare(jid:to_lower(JID)),
-    Affiliations = case Affiliation of
-               none -> maps:remove(LJID, StateData#state.affiliations);
-               _ -> maps:put(LJID, {Affiliation, Reason}, StateData#state.affiliations)
-           end,
-    StateData#state{affiliations = Affiliations}.
+    StateData#state{affiliations = maps:put(LJID, AffOrAffReason, StateData#state.affiliations)}.
 
 
 -spec get_affiliation(jid:jid(), state()) -> mod_muc:affiliation().
@@ -2795,7 +2782,7 @@ process_admin_item_set_unsafe({JID, affiliation, owner, _}, _UJID, SD)
     SD;
 process_admin_item_set_unsafe({JID, affiliation, A, Reason}, _UJID, SD)
   when (A == admin) orelse (A == owner) ->
-    SD1 = set_affiliation_and_reason(JID, A, Reason, SD),
+    SD1 = set_affiliation(JID, {A, Reason}, SD),
     SD2 = set_role(JID, moderator, SD1),
     send_update_presence(JID, Reason, SD2),
     SD2;
@@ -2804,13 +2791,13 @@ process_admin_item_set_unsafe({JID, affiliation, member, Reason}, UJID, SD) ->
         true -> send_invitation(UJID, JID, Reason, SD);
         _ -> ok
     end,
-    SD1 = set_affiliation_and_reason(JID, member, Reason, SD),
+    SD1 = set_affiliation(JID, {member, Reason}, SD),
     SD2 = set_role(JID, participant, SD1),
     send_update_presence(JID, Reason, SD2),
     SD2;
 process_admin_item_set_unsafe({JID, affiliation, outcast, Reason}, _UJID, SD) ->
     safe_send_kickban_presence(JID, Reason, <<"301">>, outcast, SD),
-    set_affiliation_and_reason(JID, outcast, Reason, set_role(JID, none, SD));
+    set_affiliation(JID, {outcast, Reason}, set_role(JID, none, SD));
 process_admin_item_set_unsafe({JID, affiliation, none, Reason}, _UJID, SD) ->
     remove_user_from_room(JID, Reason, SD);
 process_admin_item_set_unsafe({JID, role, none, Reason}, _UJID, SD) ->
@@ -2831,10 +2818,10 @@ remove_user_from_room(JID, Reason, SD) ->
     case (SD#state.config)#config.members_only of
         true ->
             safe_send_kickban_presence(JID, Reason, <<"321">>, none, SD),
-            SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
+            SD1 = set_affiliation(JID, none, SD),
             set_role(JID, none, SD1);
         _ ->
-            SD1 = set_affiliation_and_reason(JID, none, Reason, SD),
+            SD1 = set_affiliation(JID, none, SD),
             send_update_presence(JID, Reason, SD1),
             SD1
     end.

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -2819,6 +2819,12 @@ process_admin_item_set_unsafe({JID, role, Role, Reason}, _UJID, SD) ->
     SD1 = set_role(JID, Role, SD),
     catch send_new_presence(JID, Reason, SD1),
     SD1;
+process_admin_item_set_unsafe({JID, nick, <<>>, _Reason}, _UJID, SD) ->
+    mod_muc:unset_nick(SD#state.host_type, SD#state.host, JID),
+    SD;
+process_admin_item_set_unsafe({JID, nick, Nick, _Reason}, _UJID, SD) ->
+    mod_muc:set_nick(SD#state.host_type, SD#state.host, JID, Nick),
+    SD;
 process_admin_item_set_unsafe({JID, affiliation, A, Reason}, _UJID, SD) ->
     SD1 = set_affiliation(JID, A, SD),
     send_update_presence(JID, Reason, SD1),
@@ -2837,7 +2843,7 @@ remove_user_from_room(JID, Reason, SD) ->
     end.
 
 -type res_row() :: {jid:simple_jid() | jid:jid(),
-                    'affiliation' | 'role', any(), any()}.
+                    'affiliation' | 'role' | 'nick', any(), any()}.
 -type find_changed_items_res() :: {'error', exml:element()} | {'result', [res_row()]}.
 -spec find_changed_items(jid:jid(), mod_muc:affiliation(), mod_muc:role(),
                          [exml:element()], state(), [res_row()]) ->
@@ -2916,15 +2922,46 @@ check_changed_item(UJID, UAffiliation, URole, JID, Item, Items, StateData, Res) 
                     false
             end,
             case CanChangeRA of
-                nothing -> find_changed_items(UJID, UAffiliation, URole, Items, StateData, Res);
-                true -> find_changed_items(UJID, UAffiliation, URole, Items, StateData,
-                                           [{jid:to_bare(JID), affiliation,
-                                             Affiliation, decode_reason(Item)} | Res]);
+                nothing -> check_reserved_nick(UJID, UAffiliation, URole, JID, Item, Items,
+                                               StateData, Res);
+                true ->
+                    AffRow = {jid:to_bare(JID), affiliation,
+                              Affiliation, decode_reason(Item)},
+                    check_reserved_nick(UJID, UAffiliation, URole, JID, Item, Items,
+                                        StateData, [AffRow | Res]);
                 cancel -> {error, mongoose_xmpp_errors:not_allowed()};
                 false -> {error, mongoose_xmpp_errors:forbidden()}
             end;
         Err -> Err
     end.
+
+-spec check_reserved_nick(jid:jid(), mod_muc:affiliation(), mod_muc:role(), jid:jid(),
+                          exml:element(), [exml:element()], state(), [res_row()]) ->
+    find_changed_items_res().
+check_reserved_nick(UJID, UAffiliation, URole, JID, Item, Items, StateData, Res) ->
+    case exml_query:attr(Item, <<"nick">>) of
+        undefined ->
+            find_changed_items(UJID, UAffiliation, URole, Items, StateData, Res);
+        Nick when UAffiliation =:= owner; UAffiliation =:= admin ->
+            case can_use_reserved_nick(JID, Nick, StateData) of
+                true ->
+                    Row = {jid:to_bare(JID), nick, Nick, decode_reason(Item)},
+                    find_changed_items(UJID, UAffiliation, URole, Items, StateData,
+                                       [Row | Res]);
+                false ->
+                    {error, mongoose_xmpp_errors:conflict()}
+            end;
+        _ ->
+            {error, mongoose_xmpp_errors:forbidden()}
+    end.
+
+-spec can_use_reserved_nick(jid:jid(), mod_muc:nick(), state()) -> boolean().
+can_use_reserved_nick(_JID, <<>>, _StateData) ->
+    %% Unsetting a reserved nickname is always allowed
+    true;
+can_use_reserved_nick(JID, Nick, StateData) ->
+    mod_muc:can_use_nick(StateData#state.host_type, StateData#state.host,
+                         jid:to_bare(JID), Nick).
 
 -spec is_owner(UJID ::jid:jid(), StateData :: state()) -> boolean().
 is_owner(UJID, StateData) ->

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -1409,12 +1409,15 @@ access_persistent(#state{access=Access}) ->
     AccessPersistent.
 
 
+-dialyzer({no_match, set_affiliation/3}).
 -spec set_affiliation(jid:jid(), mod_muc:affiliation(), state()) -> state().
 set_affiliation(JID, Affiliation, StateData)
-        when is_atom(Affiliation), Affiliation =/= none ->
-    %% Removing an affiliation (setting it to 'none') goes through set_affiliation_and_reason/4
+        when is_atom(Affiliation) ->
     LJID = jid:to_bare(jid:to_lower(JID)),
-    Affiliations = maps:put(LJID, Affiliation, StateData#state.affiliations),
+    Affiliations = case Affiliation of
+               none -> maps:remove(LJID, StateData#state.affiliations);
+               _ -> maps:put(LJID, Affiliation, StateData#state.affiliations)
+           end,
     StateData#state{affiliations = Affiliations}.
 
 

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -2790,14 +2790,6 @@ process_admin_item_set_unsafe({JID, affiliation, owner, _}, _UJID, SD)
     %% If the provided JID does not have username,
     %% ignore the affiliation completely
     SD;
-process_admin_item_set_unsafe({JID, role, none, Reason}, _UJID, SD) ->
-    safe_send_kickban_presence(JID, Reason, <<"307">>, SD),
-    set_role(JID, none, SD);
-process_admin_item_set_unsafe({JID, affiliation, none, Reason}, _UJID, SD) ->
-    remove_user_from_room(JID, Reason, SD);
-process_admin_item_set_unsafe({JID, affiliation, outcast, Reason}, _UJID, SD) ->
-    safe_send_kickban_presence(JID, Reason, <<"301">>, outcast, SD),
-    set_affiliation_and_reason(JID, outcast, Reason, set_role(JID, none, SD));
 process_admin_item_set_unsafe({JID, affiliation, A, Reason}, _UJID, SD)
   when (A == admin) orelse (A == owner) ->
     SD1 = set_affiliation_and_reason(JID, A, Reason, SD),
@@ -2813,6 +2805,14 @@ process_admin_item_set_unsafe({JID, affiliation, member, Reason}, UJID, SD) ->
     SD2 = set_role(JID, participant, SD1),
     send_update_presence(JID, Reason, SD2),
     SD2;
+process_admin_item_set_unsafe({JID, affiliation, outcast, Reason}, _UJID, SD) ->
+    safe_send_kickban_presence(JID, Reason, <<"301">>, outcast, SD),
+    set_affiliation_and_reason(JID, outcast, Reason, set_role(JID, none, SD));
+process_admin_item_set_unsafe({JID, affiliation, none, Reason}, _UJID, SD) ->
+    remove_user_from_room(JID, Reason, SD);
+process_admin_item_set_unsafe({JID, role, none, Reason}, _UJID, SD) ->
+    safe_send_kickban_presence(JID, Reason, <<"307">>, SD),
+    set_role(JID, none, SD);
 process_admin_item_set_unsafe({JID, role, Role, Reason}, _UJID, SD) ->
     SD1 = set_role(JID, Role, SD),
     catch send_new_presence(JID, Reason, SD1),

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -2801,7 +2801,7 @@ process_admin_item_set_unsafe({JID, affiliation, outcast, Reason}, _UJID, SD) ->
     safe_send_kickban_presence(JID, Reason, <<"301">>, outcast, SD),
     set_affiliation_and_reason(JID, outcast, Reason, set_role(JID, none, SD));
 process_admin_item_set_unsafe({JID, affiliation, A, Reason}, _UJID, SD)
-  when (A == admin) or (A == owner) ->
+  when (A == admin) orelse (A == owner) ->
     SD1 = set_affiliation_and_reason(JID, A, Reason, SD),
     SD2 = set_role(JID, moderator, SD1),
     send_update_presence(JID, Reason, SD2),
@@ -2824,11 +2824,7 @@ process_admin_item_set_unsafe({JID, nick, <<>>, _Reason}, _UJID, SD) ->
     SD;
 process_admin_item_set_unsafe({JID, nick, Nick, _Reason}, _UJID, SD) ->
     mod_muc:set_nick(SD#state.host_type, SD#state.host, JID, Nick),
-    SD;
-process_admin_item_set_unsafe({JID, affiliation, A, Reason}, _UJID, SD) ->
-    SD1 = set_affiliation(JID, A, SD),
-    send_update_presence(JID, Reason, SD1),
-    SD1.
+    SD.
 
 remove_user_from_room(JID, Reason, SD) ->
     case (SD#state.config)#config.members_only of

--- a/src/muc/mod_muc_room.erl
+++ b/src/muc/mod_muc_room.erl
@@ -1411,12 +1411,10 @@ access_persistent(#state{access=Access}) ->
 
 -spec set_affiliation(jid:jid(), mod_muc:affiliation(), state()) -> state().
 set_affiliation(JID, Affiliation, StateData)
-        when is_atom(Affiliation) ->
+        when is_atom(Affiliation), Affiliation =/= none ->
+    %% Removing an affiliation (setting it to 'none') goes through set_affiliation_and_reason/4
     LJID = jid:to_bare(jid:to_lower(JID)),
-    Affiliations = case Affiliation of
-               none -> maps:remove(LJID, StateData#state.affiliations);
-               _ -> maps:put(LJID, Affiliation, StateData#state.affiliations)
-           end,
+    Affiliations = maps:put(LJID, Affiliation, StateData#state.affiliations),
     StateData#state{affiliations = Affiliations}.
 
 


### PR DESCRIPTION
This PR lets an admin change another user's reserved nickname through the member list.

Per [XEP-0045 §9.5 "Modifying the Member List"](https://xmpp.org/extensions/xep-0045.html#modifymember), a member-list item may carry a `nick` attribute alongside `affiliation` + `jid` when the reserved nickname is being modified (empty string unsets it). MongooseIM previously ignored that attribute.