### PR TITLE
MIM-2739 Add migration notes about mod_pubsub and mod_pubsub_old

### DIFF
--- a/doc/migrations/6.7.0_6.x.x.md
+++ b/doc/migrations/6.7.0_6.x.x.md
@@ -12,6 +12,18 @@ If you need message history, enable and configure `mod_mam` instead.
 
 System message translations are no longer supported. Remove `service_translations` from your services configuration and keep message strings in English.
 
+### `mod_pubsub` renamed to `mod_pubsub_old` and deprecated
+
+The previous PubSub implementation is now available as [`mod_pubsub_old`](../modules/mod_pubsub_old.md) and is deprecated.
+The [`mod_pubsub`](../modules/mod_pubsub.md) name now refers to a new, performance-focused implementation that supports only selected PEP functionality.
+
+If your existing configuration uses the old PubSub module name, choose one of the following migration paths:
+
+* Update the configuration to use [`mod_pubsub_old`](../modules/mod_pubsub_old.md) instead of `mod_pubsub` if you need the old implementation's full PubSub feature set, generic PubSub component, collection nodes, plugin-based node implementations, or push-notification PubSub nodes.
+  If you monitor PubSub metrics, update your dashboards and alerts to use the [`mod_pubsub_old` metric names](../modules/mod_pubsub_old.md#overall-pubsub-action-metrics).
+
+* Use the new [`mod_pubsub`](../modules/mod_pubsub.md) for better performance if your deployment only needs the selected PEP features described in its module documentation.
+
 ## Metrics
 
 The changes to metrics and instrumentation are listed below.

--- a/doc/modules/mod_pubsub_old.md
+++ b/doc/modules/mod_pubsub_old.md
@@ -1,3 +1,6 @@
+!!! warning
+    `mod_pubsub_old` is deprecated. Use [`mod_pubsub`](mod_pubsub.md) for better performance if your deployment only needs the selected PEP features supported by the new implementation.
+
 ## What is PubSub?
 
 PubSub is a design pattern which mostly promotes a loose coupling between two kinds of entities - publishers and subscribers.


### PR DESCRIPTION
- Old `mod_pubsub` is moved to `mod_pubsub_old`.
- `mod_pubsub_old` is deprecated.
- The user can use either `mod_pubsub_old` or `mod_pubsub` now.

