### PR TITLE
MIM-2746 User/domain removal and GDPR data retrieval for pubsub

### DIFF
--- a/big_tests/dynamic_domains.spec
+++ b/big_tests/dynamic_domains.spec
@@ -27,8 +27,8 @@
 
 {suites, "tests", gdpr_SUITE}.
 {skip_groups, "tests", gdpr_SUITE,
- [retrieve_personal_data_pubsub,
-  remove_personal_data_pubsub],
+ [retrieve_personal_data_pubsub_old,
+  remove_personal_data_pubsub_old],
  "mod_pubsub_old doesn't support dynamic domains"}.
 
 {suites, "tests", graphql_SUITE}.

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -10,6 +10,8 @@
                         secondary_domain/0]).
 -import(config_parser_helper, [mod_config/2]).
 -import(muc_helper, [get_member_list/2]).
+-import(pubsub_tools, [create_node/3, delete_node/3, get_items/3, publish/4, subscribe/3,
+                       receive_item_notification/4]).
 
 -include("mam_helper.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -35,6 +37,7 @@ all() ->
      {group, last_removal},
      {group, broadcast_removal},
      {group, push_removal},
+     {group, pubsub_removal},
      {group, blocklist_removal},
      {group, removal_failures}
     ].
@@ -61,6 +64,7 @@ groups() ->
      {broadcast_removal, [], [broadcast_removal]},
      {push_removal, [], [push_removal,
                          push_removal_keeps_other_domain_subscriptions]},
+     {pubsub_removal, [], [pep_removal]},
      {blocklist_removal, [], [blocklist_removal]},
      {removal_failures, [], [removal_stops_if_handler_fails]}
     ].
@@ -182,6 +186,8 @@ group_to_modules(broadcast_removal) ->
 group_to_modules(push_removal) ->
     PushOpts = #{backend => rdbms},
     [{mod_event_pusher, #{push => config_parser_helper:config([modules, mod_event_pusher, push], PushOpts)}}];
+group_to_modules(pubsub_removal) ->
+    [{mod_pubsub, mod_config(mod_pubsub, #{backend => rdbms})}];
 group_to_modules(blocklist_removal) ->
     [{mod_blocklist, #{backend => rdbms}}].
 
@@ -584,6 +590,38 @@ push_removal_keeps_other_domain_subscriptions(Config) ->
         ?assertMatch([_], AliceBisServicesAfter)
     end).
 
+pep_removal(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {alice_bis, 1}], fun(Alice, AliceBis) ->
+        RemovedNode = pep_node(Alice),
+        create_node(Alice, RemovedNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+        publish(Alice, ~"item0", RemovedNode, []),
+
+        OtherNode = pep_node(AliceBis),
+        create_node(AliceBis, OtherNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+        subscribe(Alice, OtherNode, []),
+
+        %% Get items and test cross-domain subscriptions before removal
+        get_items(AliceBis, RemovedNode, [{expected_result, [~"item0"]}]),
+        publish(AliceBis, ~"item1", OtherNode, []),
+        receive_item_notification(Alice, ~"item1", OtherNode, []),
+        get_items(AliceBis, OtherNode, [{expected_result, [~"item1"]}]),
+
+        run_remove_domain(),
+
+        %% Removed node should not exist
+        NotFoundOpts = [{expected_error_type, {~"cancel", ~"item-not-found"}}],
+        get_items(AliceBis, RemovedNode, NotFoundOpts),
+
+        %% Removed user's subscription should not exist
+        publish(AliceBis, ~"item2", OtherNode, []),
+        [] = escalus:wait_for_stanzas(Alice, 1, 500),
+
+        %% Items on another node should not be deleted
+        get_items(AliceBis, OtherNode, [{expected_result, [~"item1", ~"item2"]}]),
+
+        delete_node(AliceBis, OtherNode, [])
+    end).
+
 blocklist_removal(Config) ->
     escalus_fresh:story(Config, [{alice, 1}], fun(Alice) ->
         HostType = host_type(),
@@ -691,6 +729,9 @@ block_muclight_user(Bob, Alice) ->
     BlocklistChange = [{user, deny, AliceJIDBin}],
     escalus:send(Bob, muc_light_helper:stanza_blocking_set(BlocklistChange)),
     escalus:assert(is_iq_result, escalus:wait_for_stanza(Bob)).
+
+pep_node(Client) ->
+    pep_SUITE:pep_node(Client, pep_SUITE:random_node_ns()).
 
 my_banana(NS) ->
     #xmlel{

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -30,11 +30,12 @@
          remove_roster/1,
          retrieve_offline/1,
          remove_offline/1,
-         retrieve_pubsub_payloads/1,
-         retrieve_created_pubsub_nodes/1,
-         retrieve_all_pubsub_data/1,
-         dont_retrieve_other_user_pubsub_payload/1,
-         retrieve_pubsub_subscriptions/1,
+         retrieve_pubsub_data/1,
+         retrieve_pubsub_old_payloads/1,
+         retrieve_created_pubsub_old_nodes/1,
+         retrieve_all_pubsub_old_data/1,
+         dont_retrieve_other_user_pubsub_old_payload/1,
+         retrieve_pubsub_old_subscriptions/1,
          retrieve_private_xml/1,
          dont_retrieve_other_user_private_xml/1,
          retrieve_multiple_private_xmls/1,
@@ -46,12 +47,13 @@
          remove_inbox_muclight/1,
          remove_inbox_muc/1,
          retrieve_logs/1,
-         remove_pubsub_all_data/1,
-         remove_pubsub_dont_remove_node_when_only_publisher/1,
-         remove_pubsub_subscriptions/1,
-         remove_pubsub_dont_remove_flat_pubsub_node/1,
-         remove_pubsub_push_node/1,
-         remove_pubsub_pep_node/1
+         remove_pubsub_user/1,
+         remove_pubsub_old_all_data/1,
+         remove_pubsub_old_dont_remove_node_when_only_publisher/1,
+         remove_pubsub_old_subscriptions/1,
+         remove_pubsub_old_dont_remove_flat_pubsub_node/1,
+         remove_pubsub_old_push_node/1,
+         remove_pubsub_old_pep_node/1
         ]).
 
 -import(mongooseimctl_helper, [mongooseimctl/3]).
@@ -88,6 +90,7 @@ groups() ->
                                    retrieve_inbox,
                                    retrieve_logs,
                                    {group, retrieve_personal_data_pubsub},
+                                   {group, retrieve_personal_data_pubsub_old},
                                    {group, retrieve_personal_data_private_xml},
                                    {group, retrieve_personal_data_mam},
                                    {group, retrieve_personal_data_inbox}
@@ -99,12 +102,15 @@ groups() ->
         retrieve_inbox_muc
     ]},
      {retrieve_personal_data_pubsub, [], [
-                                          retrieve_pubsub_payloads,
-                                          dont_retrieve_other_user_pubsub_payload,
-                                          retrieve_pubsub_subscriptions,
-                                          retrieve_created_pubsub_nodes,
-                                          retrieve_all_pubsub_data
+                                          retrieve_pubsub_data
                                          ]},
+     {retrieve_personal_data_pubsub_old, [], [
+                                              retrieve_pubsub_old_payloads,
+                                              dont_retrieve_other_user_pubsub_old_payload,
+                                              retrieve_pubsub_old_subscriptions,
+                                              retrieve_created_pubsub_old_nodes,
+                                              retrieve_all_pubsub_old_data
+                                             ]},
      {retrieve_personal_data_private_xml, [], [
                                                retrieve_private_xml,
                                                dont_retrieve_other_user_private_xml,
@@ -129,13 +135,16 @@ groups() ->
      {remove_personal_data_mam_cassandra, [], mam_removal_testcases()},
      {remove_personal_data_mam_elasticsearch, [], mam_removal_testcases()},
      {remove_personal_data_pubsub, [], [
-                                        remove_pubsub_subscriptions,
-                                        remove_pubsub_dont_remove_node_when_only_publisher,
-                                        remove_pubsub_dont_remove_flat_pubsub_node,
-                                        remove_pubsub_push_node,
-                                        remove_pubsub_pep_node,
-                                        remove_pubsub_all_data
-                                       ]}
+                                        remove_pubsub_user
+                                       ]},
+     {remove_personal_data_pubsub_old, [], [
+                                            remove_pubsub_old_subscriptions,
+                                            remove_pubsub_old_dont_remove_node_when_only_publisher,
+                                            remove_pubsub_old_dont_remove_flat_pubsub_node,
+                                            remove_pubsub_old_push_node,
+                                            remove_pubsub_old_pep_node,
+                                            remove_pubsub_old_all_data
+                                           ]}
     ].
 
 removal_testcases() ->
@@ -148,6 +157,7 @@ removal_testcases() ->
         dont_remove_other_user_private_xml,
         {group, remove_personal_data_inbox},
         {group, remove_personal_data_pubsub},
+        {group, remove_personal_data_pubsub_old},
         {group, remove_personal_data_mam}
     ].
 
@@ -190,9 +200,18 @@ end_per_suite(Config) ->
 init_per_group(GN, Config) when GN =:= remove_personal_data_mam_rdbms;
                                 GN =:= retrieve_personal_data_mam_rdbms ->
     try_backend_for_mam(Config, rdbms);
+init_per_group(GN, Config) when GN =:= retrieve_personal_data_pubsub_old;
+                                GN =:= remove_personal_data_pubsub_old ->
+    [{group, GN} | Config];
 init_per_group(GN, Config) when GN =:= retrieve_personal_data_pubsub;
                                 GN =:= remove_personal_data_pubsub ->
-    [{group, GN} | Config];
+    case mongoose_helper:is_rdbms_enabled(host_type()) of
+        true ->
+            dynamic_modules:ensure_modules(host_type(), pubsub_required_modules()),
+            [{group, GN} | Config];
+        false ->
+            {skip, require_rdbms}
+    end;
 init_per_group(GN, Config) when GN =:= retrieve_personal_data_mam_cassandra;
                                 GN =:= remove_personal_data_mam_cassandra->
     try_backend_for_mam(Config, cassandra);
@@ -209,6 +228,10 @@ init_per_group(retrieve_personal_data_private_xml, Config) ->
 init_per_group(_GN, Config) ->
     Config.
 
+end_per_group(GN, Config) when GN =:= retrieve_personal_data_pubsub;
+                               GN =:= remove_personal_data_pubsub ->
+    dynamic_modules:restore_modules(Config),
+    Config;
 end_per_group(_GN, Config) ->
     Config.
 
@@ -289,17 +312,17 @@ init_per_testcase(remove_roster = CN, Config) ->
     escalus:init_per_testcase(CN, Config);
 init_per_testcase(CN, Config) ->
     maybe
-        ok ?= maybe_set_up_pubsub(proplists:get_value(group, Config)),
+        ok ?= maybe_set_up_pubsub_old(proplists:get_value(group, Config)),
         escalus:init_per_testcase(CN, Config)
     end.
 
-maybe_set_up_pubsub(GN) when GN =:= retrieve_personal_data_pubsub;
-                             GN =:= remove_personal_data_pubsub ->
+maybe_set_up_pubsub_old(GN) when GN =:= retrieve_personal_data_pubsub_old;
+                                 GN =:= remove_personal_data_pubsub_old ->
     maybe
         ok ?= caps_helper:check_backend(),
-        dynamic_modules:ensure_modules(host_type(), pubsub_required_modules())
+        dynamic_modules:ensure_modules(host_type(), pubsub_old_required_modules())
     end;
-maybe_set_up_pubsub(_GN) ->
+maybe_set_up_pubsub_old(_GN) ->
     ok.
 
 end_per_testcase(CN, Config) when CN =:= retrieve_mam_muc_light;
@@ -412,9 +435,9 @@ offline_required_modules() ->
 mod_offline_config(Backend) ->
     config_parser_helper:mod_config(mod_offline, #{backend => Backend}).
 
-pubsub_required_modules() ->
-    pubsub_required_modules([<<"flat">>, <<"pep">>, <<"push">>]).
-pubsub_required_modules(Plugins) ->
+pubsub_old_required_modules() ->
+    pubsub_old_required_modules([<<"flat">>, <<"pep">>, <<"push">>]).
+pubsub_old_required_modules(Plugins) ->
     HostPattern = subhost_pattern("pubsub.@HOST@"),
     PubsubConfig = mod_config(mod_pubsub_old, #{backend => mongoose_helper:mnesia_or_rdbms_backend(),
                                             host => HostPattern,
@@ -422,6 +445,9 @@ pubsub_required_modules(Plugins) ->
                                             plugins => Plugins}),
     [{mod_caps, default_mod_config(mod_caps)},
      {mod_pubsub_old, PubsubConfig}].
+
+pubsub_required_modules() ->
+    [{mod_pubsub, default_mod_config(mod_pubsub)}].
 
 is_mim2_started() ->
     #{node := Node} = distributed_helper:mim2(),
@@ -998,7 +1024,57 @@ remove_offline(Config) ->
               Alice, [{offline, ["timestamp","from", "to", "packet"],[]}])
         end).
 
-retrieve_pubsub_payloads(Config) ->
+retrieve_pubsub_data(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        AliceNodeId = <<"urn:gdpr:alice">>,
+        BobNodeId = <<"urn:gdpr:bob">>,
+        AliceNode = make_pep_node_info(Alice, AliceNodeId),
+        BobNode = make_pep_node_info(Bob, BobNodeId),
+        {BinItem, StringItem} = item_content(<<"ItemData">>),
+
+        pubsub_tools:create_node(Alice, AliceNode, []),
+        pubsub_tools:publish(Alice, <<"Item1">>, AliceNode, [{with_payload, BinItem}]),
+
+        pubsub_tools:create_node(Bob, BobNode, [{config, [{<<"pubsub#access_model">>, <<"open">>}]}]),
+        pubsub_tools:subscribe(Alice, BobNode, [{jid_type, bare}]),
+
+        Dir = retrieve_all_personal_data(Alice, Config),
+        validate_personal_data(Dir, "pubsub_items",
+                               ["node_id", "item_id", "publisher_jid", "payload"],
+                               [pubsub_items_row_map(Alice, AliceNodeId, "Item1", StringItem)],
+                               ["node_id", "item_id"]),
+        validate_personal_data(Dir, "pubsub_nodes", ["node_id", "access_model"],
+                               [pubsub_nodes_row_map(AliceNodeId, "presence")],
+                               ["node_id"]),
+        validate_personal_data(Dir, "pubsub_subscriptions",
+                               ["service_jid", "node_id", "subscriber_jid"],
+                               [pubsub_subscriptions_row_map(Bob, BobNodeId, Alice)],
+                               ["service_jid", "node_id"])
+    end).
+
+remove_pubsub_user(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        AliceNodeId = <<"urn:gdpr:alice">>,
+        BobNodeId = <<"urn:gdpr:bob">>,
+        AliceNode = make_pep_node_info(Alice, AliceNodeId),
+        BobNode = make_pep_node_info(Bob, BobNodeId),
+        {BinItem, StringItem} = item_content(<<"ItemData">>),
+
+        pubsub_tools:create_node(Alice, AliceNode, []),
+        pubsub_tools:publish(Alice, <<"Item1">>, AliceNode, [{with_payload, BinItem}]),
+
+        pubsub_tools:create_node(Bob, BobNode, [{config, [{<<"pubsub#access_model">>, <<"open">>}]}]),
+        pubsub_tools:subscribe(Alice, BobNode, [{jid_type, bare}]),
+
+        unregister(Alice, Config),
+
+        assert_personal_data_via_rpc(
+            Alice, [{pubsub_items, ["node_id", "item_id", "publisher_jid", "payload"], []},
+                    {pubsub_nodes, ["node_id", "access_model"], []},
+                    {pubsub_subscriptions, ["service_jid", "node_id", "subscriber_jid"], []}])
+    end).
+
+retrieve_pubsub_old_payloads(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
         [Node1={_,NodeName1}, Node2={_,NodeName2}] = pubsub_tools:create_node_names(2),
         {BinItem1, StringItem1} = item_content(<<"Item1Data">>),
@@ -1011,17 +1087,17 @@ retrieve_pubsub_payloads(Config) ->
         pubsub_tools:publish(Alice, <<"Item3">>, Node1, [{with_payload, BinItem3}]),
         pubsub_tools:publish(Alice, <<"OtherItem">>, Node2, [{with_payload, BinOther}]),
 
-        ExpectedItems = [pubsub_payloads_row_map(NodeName1, "Item1", StringItem1),
-                         pubsub_payloads_row_map(NodeName1, "Item2", StringItem2),
-                         pubsub_payloads_row_map(NodeName1, "Item3", StringItem3),
-                         pubsub_payloads_row_map(NodeName2, "OtherItem", StringOther)],
+        ExpectedItems = [pubsub_old_payloads_row_map(NodeName1, "Item1", StringItem1),
+                         pubsub_old_payloads_row_map(NodeName1, "Item2", StringItem2),
+                         pubsub_old_payloads_row_map(NodeName1, "Item3", StringItem3),
+                         pubsub_old_payloads_row_map(NodeName2, "OtherItem", StringOther)],
 
         retrieve_and_validate_personal_data(Alice, Config, "pubsub_payloads",
                                             ["node_name", "item_id", "payload"],
                                             ExpectedItems, ["item_id"])
                                               end).
 
-dont_retrieve_other_user_pubsub_payload(Config) ->
+dont_retrieve_other_user_pubsub_old_payload(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         [Node1={_,NodeName1}] = pubsub_tools:create_node_names(1),
         pubsub_tools:create_nodes([{Alice, Node1, []}]),
@@ -1036,16 +1112,16 @@ dont_retrieve_other_user_pubsub_payload(Config) ->
 
         retrieve_and_validate_personal_data(
             Alice, Config, "pubsub_payloads", ["node_name", "item_id", "payload"],
-            [pubsub_payloads_row_map(NodeName1, "Item1", StringItem1)]),
+            [pubsub_old_payloads_row_map(NodeName1, "Item1", StringItem1)]),
 
         retrieve_and_validate_personal_data(
             Bob, Config, "pubsub_payloads", ["node_name","item_id", "payload"],
-            [pubsub_payloads_row_map(NodeName1, "Item2", StringItem2)]),
+            [pubsub_old_payloads_row_map(NodeName1, "Item2", StringItem2)]),
 
         pubsub_tools:delete_node(Alice, Node1, [])
                                               end).
 
-retrieve_created_pubsub_nodes(Config) ->
+retrieve_created_pubsub_old_nodes(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         [Node1={_,NodeName1}, Node2={_,NodeName2}, Node3={_,NodeName3}] =
         pubsub_tools:create_node_names(3),
@@ -1065,20 +1141,20 @@ retrieve_created_pubsub_nodes(Config) ->
 
         retrieve_and_validate_personal_data(
             Alice, Config, "pubsub_nodes", ExpectedHeader,
-            [pubsub_nodes_row_map(NodeNS, "pep"),
-             pubsub_nodes_row_map(NodeName1, "flat"),
-             pubsub_nodes_row_map(NodeName2, "flat")]),
+            [pubsub_old_nodes_row_map(NodeNS, "pep"),
+             pubsub_old_nodes_row_map(NodeName1, "flat"),
+             pubsub_old_nodes_row_map(NodeName2, "flat")]),
 
         retrieve_and_validate_personal_data(
             Bob, Config, "pubsub_nodes", ExpectedHeader,
-            [pubsub_nodes_row_map(NodeName3, "push")]),
+            [pubsub_old_nodes_row_map(NodeName3, "push")]),
 
 
         Nodes = [{Alice, PepNode}, {Alice, Node1}, {Alice, Node2}, {Bob, Node3}],
         [pubsub_tools:delete_node(User, Node, []) || {User, Node} <- Nodes]
                                                         end).
 
-remove_pubsub_subscriptions(Config) ->
+remove_pubsub_old_subscriptions(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
             Node = pubsub_tools:pubsub_node(),
             pubsub_tools:create_node(Alice, Node, []),
@@ -1092,18 +1168,18 @@ remove_pubsub_subscriptions(Config) ->
                                           {pubsub_subscriptions,["node_name"],[]}])
         end).
 
-retrieve_pubsub_subscriptions(Config) ->
+retrieve_pubsub_old_subscriptions(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
             Node = {_Domain, NodeName} = pubsub_tools:pubsub_node(),
             pubsub_tools:create_node(Alice, Node, []),
             pubsub_tools:subscribe(Bob, Node, [{subid, true}]),
             retrieve_and_validate_personal_data(Bob, Config, "pubsub_subscriptions", ["node_name"],
-                [pubsub_subscription_row_map(NodeName)]),
+                [pubsub_old_subscription_row_map(NodeName)]),
 
             pubsub_tools:delete_node(Alice, Node, [])
         end).
 
-remove_pubsub_dont_remove_flat_pubsub_node(Config) ->
+remove_pubsub_old_dont_remove_flat_pubsub_node(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
         Node1 = {_,NodeName} = pubsub_tools:pubsub_node_with_num(1),
         pubsub_tools:create_nodes([{Alice, Node1, []}]),
@@ -1116,7 +1192,7 @@ remove_pubsub_dont_remove_flat_pubsub_node(Config) ->
                                       {pubsub_subscriptions,["node_name"],[]}])
         end).
 
-remove_pubsub_push_node(Config) ->
+remove_pubsub_old_push_node(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         [Node] = pubsub_tools:create_node_names(1),
         pubsub_tools:create_nodes([{Alice, Node, [{type, <<"push">>}]}]),
@@ -1140,7 +1216,7 @@ remove_pubsub_push_node(Config) ->
                                              {pubsub_subscriptions,["node_name"],[]}])
         end).
 
-remove_pubsub_pep_node(Config) ->
+remove_pubsub_old_pep_node(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun(Alice) ->
         NodeName = <<"myns">>,
         PepNode = make_pep_node_info(Alice, NodeName),
@@ -1156,7 +1232,7 @@ remove_pubsub_pep_node(Config) ->
                                              {pubsub_subscriptions,["node_name"],[]}])
         end).
 
-remove_pubsub_dont_remove_node_when_only_publisher(Config) ->
+remove_pubsub_old_dont_remove_node_when_only_publisher(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         Node1 = {_,NodeName} = pubsub_tools:pubsub_node_with_num(1),
         pubsub_tools:create_nodes([{Alice, Node1, []}]),
@@ -1172,7 +1248,7 @@ remove_pubsub_dont_remove_node_when_only_publisher(Config) ->
                                       {pubsub_subscriptions,["node_name"],[]}])
         end).
 
-remove_pubsub_all_data(Config) ->
+remove_pubsub_old_all_data(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         [Node1={_,Name1}, Node2={_,Name2}, Node3={_,Name3}, Node4={_,Name4}]
             = pubsub_tools:create_node_names(4),
@@ -1235,7 +1311,7 @@ remove_pubsub_all_data(Config) ->
         [[Name2]] = Subs
       end).
 
-retrieve_all_pubsub_data(Config) ->
+retrieve_all_pubsub_old_data(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
         [Node1={_,NodeName1}, Node2={_,NodeName2}, Node3={_,NodeName3}] =
         pubsub_tools:create_node_names(3),
@@ -1257,27 +1333,27 @@ retrieve_all_pubsub_data(Config) ->
         %% Bob has one subscription, one node created and one payload sent
         retrieve_and_validate_personal_data(
             Bob, Config, "pubsub_subscriptions", ["node_name"],
-            [pubsub_subscription_row_map(NodeName2)]),
+            [pubsub_old_subscription_row_map(NodeName2)]),
 
         retrieve_and_validate_personal_data(
             Bob, Config, "pubsub_nodes", ["node_name", "type"],
-            [pubsub_nodes_row_map(NodeName3, "flat")]),
+            [pubsub_old_nodes_row_map(NodeName3, "flat")]),
 
         retrieve_and_validate_personal_data(
             Bob, Config, "pubsub_payloads", ["node_name", "item_id", "payload"],
-            [pubsub_payloads_row_map(NodeName1, "Item3", StringItem3)]),
+            [pubsub_old_payloads_row_map(NodeName1, "Item3", StringItem3)]),
 
         %% Alice has two nodes created and two payloads sent
         retrieve_and_validate_personal_data(
             Alice, Config, "pubsub_nodes", ["node_name", "type"],
-            [pubsub_nodes_row_map(NodeName1, "flat"),
-             pubsub_nodes_row_map(NodeName2, "flat")]),
+            [pubsub_old_nodes_row_map(NodeName1, "flat"),
+             pubsub_old_nodes_row_map(NodeName2, "flat")]),
         retrieve_and_validate_personal_data(
             Alice, Config, "pubsub_payloads", ["node_name", "item_id","payload"],
-            [pubsub_payloads_row_map(NodeName1, "Item1", StringItem1),
-             pubsub_payloads_row_map(NodeName2, "Item2", StringItem2)]),
+            [pubsub_old_payloads_row_map(NodeName1, "Item1", StringItem1),
+             pubsub_old_payloads_row_map(NodeName2, "Item2", StringItem2)]),
 
-        dynamic_modules:ensure_modules(host_type(), pubsub_required_modules()),
+        dynamic_modules:ensure_modules(host_type(), pubsub_old_required_modules()),
         Nodes = [{Alice, Node1}, {Alice, Node2}, {Bob, Node3}],
         [pubsub_tools:delete_node(User, Node, []) || {User, Node} <- Nodes]
       end).
@@ -1745,14 +1821,28 @@ is_file_to_be_deleted(Filename) ->
         end,
     DeletableRegexes).
 
-pubsub_payloads_row_map(Node, ItemId, Payload) ->
+pubsub_old_payloads_row_map(Node, ItemId, Payload) ->
     #{"node_name" => binary_to_list(Node), "item_id" => ItemId, "payload" => Payload}.
 
-pubsub_nodes_row_map(Node, Type) ->
+pubsub_old_nodes_row_map(Node, Type) ->
     #{"node_name" => binary_to_list(Node), "type" => Type}.
 
-pubsub_subscription_row_map(Node) ->
+pubsub_old_subscription_row_map(Node) ->
     #{"node_name" => binary_to_list(Node)}.
+
+pubsub_items_row_map(Publisher, NodeId, ItemId, Payload) ->
+    #{"node_id" => binary_to_list(NodeId),
+      "item_id" => ItemId,
+      "publisher_jid" => [{jid, escalus_client:full_jid(Publisher)}],
+      "payload" => Payload}.
+
+pubsub_nodes_row_map(NodeId, AccessModel) ->
+    #{"node_id" => binary_to_list(NodeId), "access_model" => AccessModel}.
+
+pubsub_subscriptions_row_map(Service, NodeId, Subscriber) ->
+    #{"service_jid" => [{jid, escalus_client:short_jid(Service)}],
+      "node_id" => binary_to_list(NodeId),
+      "subscriber_jid" => [{jid, escalus_client:short_jid(Subscriber)}]}.
 
 make_pep_node_info(Client, NodeName) ->
     {escalus_utils:jid_to_lower(escalus_utils:get_short_jid(Client)), NodeName}.

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -103,6 +103,7 @@ basic_tests() ->
      publish_implicit_sub,
      publish_open_explicit_sub,
      publish_self_notify,
+     remove_user_deletes_nodes_and_subscriptions,
      send_last_item_on_caps,
      send_last_item_on_implicit_sub].
 
@@ -207,6 +208,10 @@ publish_open_explicit_sub(Config) ->
 
 publish_self_notify(Config) ->
     escalus:fresh_story_with_config(set_caps(Config), [{bob, 1}], fun publish_self_notify_story/2).
+
+remove_user_deletes_nodes_and_subscriptions(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun remove_user_deletes_nodes_and_subscriptions_story/3).
 
 send_last_item_on_caps(Config) ->
     escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun send_last_item_on_caps_story/2).
@@ -623,6 +628,37 @@ publish_self_notify_story(Config, Bob) ->
     GeneratedItemId = published_item_id(Response, PepNode),
     check_item_notification(Msg, GeneratedItemId, PepNode, []),
     get_item(Bob, PepNode, GeneratedItemId, [{expected_result, [GeneratedItemId]}]).
+
+remove_user_deletes_nodes_and_subscriptions_story(Config, Alice, Bob) ->
+    AliceNode = pep_node(Alice),
+    create_node(Alice, AliceNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+    publish(Alice, ~"item0", AliceNode, []),
+
+    BobNode = pep_node(Bob),
+    create_node(Bob, BobNode, [{config, [{~"pubsub#access_model", ~"open"}]}]),
+    subscribe(Alice, BobNode, [{jid_type, bare}]),
+
+    %% Get items and test subscriptions before removal
+    get_items(Bob, AliceNode, [{expected_result, [~"item0"]}]),
+    publish(Bob, ~"item1", BobNode, []),
+    receive_item_notification(Alice, ~"item1", BobNode, []),
+
+    AliceSpec = escalus_users:get_userspec(Config, alice),
+    escalus_client:stop(Config, Alice),
+    escalus_users:delete_user(Config, {alice, AliceSpec}),
+    escalus_users:create_user(Config, {alice, AliceSpec}),
+    {ok, Alice2} = escalus_client:start(Config, AliceSpec, ~"after-removal"),
+
+    %% Removed node should not exist
+    NotFoundOpts = [{expected_error_type, {~"cancel", ~"item-not-found"}}],
+    get_items(Bob, AliceNode, NotFoundOpts),
+
+    %% Removed user's subscription should not exist
+    publish(Bob, ~"item2", BobNode, []),
+    [] = escalus:wait_for_stanzas(Alice2, 1, 500),
+
+    %% Items on another node should not be deleted
+    get_items(Bob, BobNode, [{expected_result, [~"item1", ~"item2"]}]).
 
 send_last_item_on_caps_story(Alice, Bob) ->
     NodeNS = random_node_ns(),

--- a/priv/cockroachdb.sql
+++ b/priv/cockroachdb.sql
@@ -399,6 +399,9 @@ CREATE TABLE pubsub_subscription (
         REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
 );
 
+CREATE INDEX i_pubsub_subscription_subscriber ON pubsub_subscription USING btree
+    (subscriber_domain, subscriber_user);
+
 -- mod_pubsub_old
 
 CREATE SEQUENCE pubsub_nodes_nidx;

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -441,6 +441,9 @@ CREATE TABLE pubsub_subscription (
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
 
+CREATE INDEX i_pubsub_subscription_subscriber USING BTREE
+    ON pubsub_subscription(subscriber_domain, subscriber_user);
+
 -- mod_pubsub_old
 
 CREATE TABLE pubsub_nodes (

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -382,6 +382,9 @@ CREATE TABLE pubsub_subscription (
         REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
 );
 
+CREATE INDEX i_pubsub_subscription_subscriber ON pubsub_subscription USING btree
+    (subscriber_domain, subscriber_user);
+
 -- mod_pubsub_old
 
 CREATE TABLE pubsub_nodes (

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -16,7 +16,9 @@
          disco_sm_items/3,
          caps_recognised/3,
          roster_out_subscription/3,
-         remove_user/3]).
+         get_personal_data/3,
+         remove_user/3,
+         remove_domain/3]).
 
 %% IQ handlers
 -export([iq_sm/5]).
@@ -111,7 +113,9 @@ hooks(HostType) ->
      {disco_sm_items, HostType, fun ?MODULE:disco_sm_items/3, #{}, 75},
      {caps_recognised, HostType, fun ?MODULE:caps_recognised/3, #{}, 50},
      {roster_out_subscription, HostType, fun ?MODULE:roster_out_subscription/3, #{}, 50},
+     {get_personal_data, HostType, fun ?MODULE:get_personal_data/3, #{}, 50},
      {remove_user, HostType, fun ?MODULE:remove_user/3, #{}, 50},
+     {remove_domain, HostType, fun ?MODULE:remove_domain/3, #{}, 50},
      {anonymous_purge, HostType, fun ?MODULE:remove_user/3, #{}, 50}].
 
 %% Hook handlers
@@ -203,12 +207,45 @@ roster_out_subscription(Acc, #{to := SubscriberJid, from := OwnerJid, type := su
 roster_out_subscription(Acc, _, _) ->
     {ok, Acc}.
 
+-spec get_personal_data(Acc, #{jid := jid:jid()}, #{host_type := mongooseim:host_type()}) ->
+          {ok, Acc} when Acc :: gdpr:personal_data().
+get_personal_data(Acc, #{jid := Jid}, #{host_type := HostType}) ->
+    Items = mod_pubsub_backend:get_user_items(HostType, Jid),
+    Nodes = mod_pubsub_backend:get_nodes(HostType, Jid),
+    Subscriptions = mod_pubsub_backend:get_user_subscriptions(HostType, Jid),
+    {ok, [{pubsub_items, ["node_id", "item_id", "publisher_jid", "payload"],
+           lists:map(fun item_to_personal_data/1, Items)},
+          {pubsub_nodes, ["node_id", "access_model"],
+           lists:map(fun node_to_personal_data/1, Nodes)},
+          {pubsub_subscriptions, ["service_jid", "node_id", "subscriber_jid"],
+           lists:map(fun subscription_to_personal_data/1, Subscriptions)} | Acc]}.
+
 -spec remove_user(Acc, gen_hook:hook_params(), gen_hook:extra()) -> {ok, Acc} when
       Acc :: mongoose_acc:t().
 remove_user(Acc, #{jid := ServiceJid}, _) ->
     HostType = mongoose_acc:host_type(Acc),
-    mod_pubsub_backend:delete_nodes(HostType, ServiceJid),
+    mod_pubsub_backend:remove_user(HostType, ServiceJid),
     {ok, Acc}.
+
+-spec remove_domain(Acc, #{domain := jid:lserver()}, gen_hook:extra()) -> {ok, Acc} when
+      Acc :: mongoose_domain_api:remove_domain_acc().
+remove_domain(Acc, #{domain := Domain}, #{host_type := HostType}) ->
+    mod_pubsub_backend:remove_domain(HostType, Domain),
+    {ok, Acc}.
+
+-spec item_to_personal_data(item()) -> gdpr:entry().
+item_to_personal_data(#item{node_key = {_, NodeId}, id = ItemId,
+                            publisher_jid = PublisherJid, payload = Payload}) ->
+    [NodeId, ItemId, jid:to_binary(PublisherJid), exml:to_binary(Payload)].
+
+-spec node_to_personal_data(pubsub_node()) -> gdpr:entry().
+node_to_personal_data(#pubsub_node{node_key = {_, NodeId},
+                                   config = #{access_model := AccessModel}}) ->
+    [NodeId, atom_to_binary(AccessModel)].
+
+-spec subscription_to_personal_data(subscription()) -> gdpr:entry().
+subscription_to_personal_data(#subscription{node_key = {ServiceJid, NodeId}, jid = SubscriberJid}) ->
+    [jid:to_binary(ServiceJid), NodeId, jid:to_binary(SubscriberJid)].
 
 %% IQ handlers
 

--- a/src/pubsub/mod_pubsub_backend.erl
+++ b/src/pubsub/mod_pubsub_backend.erl
@@ -2,9 +2,12 @@
 
 -include("mod_pubsub.hrl").
 
--export([start/2, stop/1, set_node/2, get_node/2, get_nodes/2, delete_node/2, delete_nodes/2,
-         set_subscription/2, delete_subscription/3, get_subscriptions/2, get_subscription/3,
-         set_item/2, delete_item/3, get_item/3, get_items/2, get_last_item/2, get_last_items/2]).
+-export([start/2, stop/1, set_node/2, get_node/2, get_nodes/2, delete_node/2,
+         remove_user/2, remove_domain/2,
+         set_subscription/2, delete_subscription/3, get_subscriptions/2,
+         get_user_subscriptions/2, get_subscription/3,
+         set_item/2, delete_item/3, get_item/3, get_items/2, get_user_items/2,
+         get_last_item/2, get_last_items/2]).
 
 -callback start(mongooseim:host_type()) -> ok.
 -callback stop(mongooseim:host_type()) -> ok.
@@ -13,11 +16,14 @@
     mod_pubsub:pubsub_node() | undefined.
 -callback get_nodes(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:pubsub_node()].
 -callback delete_node(mongooseim:host_type(), mod_pubsub:node_key()) -> ok.
--callback delete_nodes(mongooseim:host_type(), jid:jid()) -> ok.
+-callback remove_user(mongooseim:host_type(), jid:jid()) -> ok.
+-callback remove_domain(mongooseim:host_type(), jid:lserver()) -> ok.
 -callback set_subscription(mongooseim:host_type(), mod_pubsub:subscription()) -> ok.
 -callback delete_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
     ok | not_found.
 -callback get_subscriptions(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    [mod_pubsub:subscription()].
+-callback get_user_subscriptions(mongooseim:host_type(), jid:jid()) ->
     [mod_pubsub:subscription()].
 -callback get_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
     mod_pubsub:subscription() | undefined.
@@ -27,6 +33,8 @@
 -callback get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
     mod_pubsub:item() | undefined.
 -callback get_items(mongooseim:host_type(), mod_pubsub:node_key()) ->
+    [mod_pubsub:item()].
+-callback get_user_items(mongooseim:host_type(), jid:jid()) ->
     [mod_pubsub:item()].
 -callback get_last_item(mongooseim:host_type(), mod_pubsub:node_key()) ->
     mod_pubsub:item() | undefined.
@@ -51,7 +59,7 @@ stop(HostType) ->
 
 -spec set_node(mongooseim:host_type(), mod_pubsub:pubsub_node()) -> ok.
 set_node(HostType, Node) ->
-    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Node]).
+    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Node]).
 
 -spec get_node(mongooseim:host_type(), mod_pubsub:node_key()) ->
     mod_pubsub:pubsub_node() | undefined.
@@ -62,29 +70,38 @@ get_node(HostType, NodeKey) ->
 get_nodes(HostType, ServiceJid) ->
     mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, ServiceJid]).
 
--spec delete_nodes(mongooseim:host_type(), jid:jid()) -> ok.
-delete_nodes(HostType, ServiceJid) ->
-    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, ServiceJid]).
-
 -spec delete_node(mongooseim:host_type(), mod_pubsub:node_key()) -> ok.
 delete_node(HostType, NodeKey) ->
-    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
+    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
+
+-spec remove_user(mongooseim:host_type(), jid:jid()) -> ok.
+remove_user(HostType, ServiceJid) ->
+    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, ServiceJid]).
+
+-spec remove_domain(mongooseim:host_type(), jid:lserver()) -> ok.
+remove_domain(HostType, Domain) ->
+    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Domain]).
 
 %% API: items
 
 -spec set_subscription(mongooseim:host_type(), mod_pubsub:subscription()) -> ok.
 set_subscription(HostType, Subscription) ->
-    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Subscription]).
+    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Subscription]).
 
 -spec get_subscriptions(mongooseim:host_type(), mod_pubsub:node_key()) ->
     [mod_pubsub:subscription()].
 get_subscriptions(HostType, NodeKey) ->
     mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
 
+-spec get_user_subscriptions(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:subscription()].
+get_user_subscriptions(HostType, Jid) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Jid]).
+
 -spec delete_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
           ok | not_found.
 delete_subscription(HostType, NodeKey, SubscriberJid) ->
-    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, SubscriberJid]).
+    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME,
+                                  [HostType, NodeKey, SubscriberJid]).
 
 -spec get_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
     mod_pubsub:subscription() | undefined.
@@ -92,12 +109,12 @@ get_subscription(HostType, NodeKey, SubscriberJid) ->
     mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, SubscriberJid]).
 
 set_item(HostType, Item) ->
-    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Item]).
+    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Item]).
 
 -spec delete_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
           ok | not_found.
 delete_item(HostType, NodeKey, ItemId) ->
-    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, ItemId]).
+    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, ItemId]).
 
 -spec get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
     mod_pubsub:item() | undefined.
@@ -107,6 +124,10 @@ get_item(HostType, NodeKey, ItemId) ->
 -spec get_items(mongooseim:host_type(), mod_pubsub:node_key()) -> [mod_pubsub:item()].
 get_items(HostType, NodeKey) ->
     mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
+
+-spec get_user_items(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:item()].
+get_user_items(HostType, Jid) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Jid]).
 
 -spec get_last_item(mongooseim:host_type(), mod_pubsub:node_key()) ->
     mod_pubsub:item() | undefined.
@@ -120,5 +141,5 @@ get_last_items(HostType, ServiceJid) ->
 %% Helpers
 
 tracked_funs() ->
-    [set_node, delete_node, delete_nodes, set_subscription, delete_subscription,
+    [set_node, delete_node, remove_user, remove_domain, set_subscription, delete_subscription,
      set_item, delete_item].

--- a/src/pubsub/mod_pubsub_backend_rdbms.erl
+++ b/src/pubsub/mod_pubsub_backend_rdbms.erl
@@ -7,34 +7,46 @@
 -include("jlib.hrl").
 -include("mod_pubsub.hrl").
 
--export([start/1, stop/1, set_node/2, get_node/2, get_nodes/2, delete_node/2, delete_nodes/2,
-         set_subscription/2, delete_subscription/3, get_subscriptions/2, get_subscription/3,
-         set_item/2, delete_item/3, get_item/3, get_items/2, get_last_item/2, get_last_items/2]).
+-export([start/1, stop/1, set_node/2, get_node/2, get_nodes/2, delete_node/2,
+         remove_user/2, remove_domain/2,
+         set_subscription/2, delete_subscription/3, get_subscriptions/2,
+         get_user_subscriptions/2, get_subscription/3,
+         set_item/2, delete_item/3, get_item/3, get_items/2, get_user_items/2,
+         get_last_item/2, get_last_items/2]).
 
 -spec start(mongooseim:host_type()) -> ok.
 start(HostType) ->
     NodeJid = [service_domain, service_user],
     NodeKey = NodeJid ++ [node_id],
-    SubscriberJid = [subscriber_domain, subscriber_user, subscriber_resource],
-    SubscriptionKey = NodeKey ++ SubscriberJid,
+    SubscriberBareJid = [subscriber_domain, subscriber_user],
+    SubscriptionKey = NodeKey ++ SubscriberBareJid ++ [subscriber_resource],
     ItemKey = NodeKey ++ [item_id],
-    PublisherJid = [publisher_domain, publisher_user, publisher_resource],
-    ItemUpdateFields = PublisherJid ++ [payload, published_at],
+    PublisherFullJid = [publisher_domain, publisher_user, publisher_resource],
+    ItemUpdateFields = PublisherFullJid ++ [payload, published_at],
     prepare_upsert(HostType, pubsub_node_upsert, pubsub_node, [access_model], NodeKey),
     mongoose_rdbms:prepare(pubsub_get_node, pubsub_node, NodeKey, sql(get_node)),
     mongoose_rdbms:prepare(pubsub_delete_node, pubsub_node, NodeKey, sql(delete_node)),
     mongoose_rdbms:prepare(pubsub_delete_nodes, pubsub_node, NodeJid, sql(delete_nodes)),
+    mongoose_rdbms:prepare(pubsub_delete_domain_nodes, pubsub_node,
+                           [service_domain], sql(delete_domain_nodes)),
     mongoose_rdbms:prepare(pubsub_get_nodes, pubsub_node, NodeJid, sql(get_nodes)),
     prepare_upsert(HostType, pubsub_subscription_upsert, pubsub_subscription, [], SubscriptionKey),
     mongoose_rdbms:prepare(pubsub_delete_subscription, pubsub_subscription,
                            SubscriptionKey, sql(delete_subscription)),
+    mongoose_rdbms:prepare(pubsub_delete_user_subscriptions, pubsub_subscription,
+                           SubscriberBareJid, sql(delete_user_subscriptions)),
+    mongoose_rdbms:prepare(pubsub_delete_domain_subscriptions, pubsub_subscription,
+                           [subscriber_domain], sql(delete_domain_subscriptions)),
     mongoose_rdbms:prepare(pubsub_get_subscriptions, pubsub_subscription,
                            NodeKey, sql(get_subscriptions)),
-    mongoose_rdbms:prepare(pubsub_get_subscriptions_for_jid, pubsub_subscription,
-                           SubscriptionKey, sql(get_subscriptions_for_jid)),
+    mongoose_rdbms:prepare(pubsub_get_user_subscriptions, pubsub_subscription,
+                           SubscriberBareJid, sql(get_user_subscriptions)),
+    mongoose_rdbms:prepare(pubsub_get_subscription, pubsub_subscription,
+                           SubscriptionKey, sql(get_subscription)),
     prepare_upsert(HostType, pubsub_item_upsert, pubsub_item, ItemUpdateFields, ItemKey),
     mongoose_rdbms:prepare(pubsub_get_item, pubsub_item, ItemKey, sql(get_item)),
     mongoose_rdbms:prepare(pubsub_get_items, pubsub_item, NodeKey, sql(get_items)),
+    mongoose_rdbms:prepare(pubsub_get_user_items, pubsub_item, NodeJid, sql(get_user_items)),
     mongoose_rdbms:prepare(pubsub_get_last_item, pubsub_item, NodeKey, sql(get_last_item)),
     mongoose_rdbms:prepare(pubsub_get_last_items, pubsub_item, NodeJid, sql(get_last_items)),
     mongoose_rdbms:prepare(pubsub_delete_item, pubsub_item, ItemKey, sql(delete_item)),
@@ -81,16 +93,39 @@ get_nodes(HostType, ServiceJid) ->
                   config = #{access_model => binary_to_existing_atom(AccessModelBin)}}
      || {NodeId, AccessModelBin} <- Rows].
 
--spec delete_nodes(mongooseim:host_type(), jid:jid()) -> ok.
-delete_nodes(HostType, ServiceJid) ->
-    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser],
-    {updated, _} = mongoose_rdbms:execute_successfully(HostType, pubsub_delete_nodes, Args),
-    ok.
-
 -spec delete_node(mongooseim:host_type(), mod_pubsub:node_key()) -> ok.
 delete_node(HostType, {ServiceJid, NodeId}) ->
     Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId],
     {updated, _} = mongoose_rdbms:execute_successfully(HostType, pubsub_delete_node, Args),
+    ok.
+
+-spec remove_user(mongooseim:host_type(), jid:jid()) -> ok.
+remove_user(HostType, ServiceJid) ->
+    F = fun() -> remove_user_t(HostType, ServiceJid) end,
+    {atomic, ok} = mongoose_rdbms:sql_transaction(HostType, F),
+    ok.
+
+-spec remove_user_t(mongooseim:host_type(), jid:jid()) -> ok.
+remove_user_t(HostType, #jid{lserver = Domain, luser = User}) ->
+    {updated, _} =
+        mongoose_rdbms:execute_successfully(HostType, pubsub_delete_nodes, [Domain, User]),
+    {updated, _} =
+        mongoose_rdbms:execute_successfully(HostType, pubsub_delete_user_subscriptions,
+                                            [Domain, User]),
+    ok.
+
+-spec remove_domain(mongooseim:host_type(), jid:lserver()) -> ok.
+remove_domain(HostType, Domain) ->
+    F = fun() -> remove_domain_t(HostType, Domain) end,
+    {atomic, ok} = mongoose_rdbms:sql_transaction(HostType, F),
+    ok.
+
+-spec remove_domain_t(mongooseim:host_type(), jid:lserver()) -> ok.
+remove_domain_t(HostType, Domain) ->
+    {updated, _} =
+        mongoose_rdbms:execute_successfully(HostType, pubsub_delete_domain_nodes, [Domain]),
+    {updated, _} =
+        mongoose_rdbms:execute_successfully(HostType, pubsub_delete_domain_subscriptions, [Domain]),
     ok.
 
 -spec set_subscription(mongooseim:host_type(), mod_pubsub:subscription()) -> ok.
@@ -108,12 +143,21 @@ get_subscriptions(HostType, {ServiceJid, NodeId} = NodeKey) ->
     [row_to_subscription(NodeKey, SubscriberDomain, SubscriberUser, SubscriberResource)
      || {SubscriberDomain, SubscriberUser, SubscriberResource} <- Rows].
 
+-spec get_user_subscriptions(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:subscription()].
+get_user_subscriptions(HostType, #jid{lserver = SubscriberDomain, luser = SubscriberUser}) ->
+    Args = [SubscriberDomain, SubscriberUser],
+    {selected, Rows} =
+        mongoose_rdbms:execute_successfully(HostType, pubsub_get_user_subscriptions, Args),
+    [row_to_subscription({jid:make_noprep(ServiceUser, ServiceDomain, <<>>), NodeId},
+                         SubscriberDomain, SubscriberUser, SubscriberResource)
+     || {ServiceDomain, ServiceUser, NodeId, SubscriberResource} <- Rows].
+
 -spec get_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
     mod_pubsub:subscription() | undefined.
 get_subscription(HostType, {ServiceJid, NodeId} = NodeKey, SubscriberJid) ->
     Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId,
             SubscriberJid#jid.lserver, SubscriberJid#jid.luser, SubscriberJid#jid.lresource],
-    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_subscriptions_for_jid,
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_subscription,
                                                            Args),
     case Rows of
         [{SubscriberDomain, SubscriberUser, SubscriberResource}] ->
@@ -173,6 +217,15 @@ get_items(HostType, {ServiceJid, NodeId} = NodeKey) ->
     [row_to_item(HostType, NodeKey, ItemId, PublisherDomain, PublisherUser, PublisherResource,
                  PayloadBin, PublishedAt)
      || {ItemId, PublisherDomain, PublisherUser, PublisherResource, PayloadBin, PublishedAt}
+            <- Rows].
+
+-spec get_user_items(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:item()].
+get_user_items(HostType, ServiceJid) ->
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser],
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_user_items, Args),
+    [row_to_item(HostType, {ServiceJid, NodeId}, ItemId, PublisherDomain, PublisherUser,
+                 PublisherResource, PayloadBin, PublishedAt)
+     || {NodeId, ItemId, PublisherDomain, PublisherUser, PublisherResource, PayloadBin, PublishedAt}
             <- Rows].
 
 -spec get_last_item(mongooseim:host_type(), mod_pubsub:node_key()) ->
@@ -239,6 +292,14 @@ sql(get_items) ->
      WHERE service_domain = ? AND service_user = ? AND node_id = ?
      ORDER BY published_at
      """;
+sql(get_user_items) ->
+    ~"""
+     SELECT node_id, item_id, publisher_domain, publisher_user, publisher_resource,
+            payload, published_at
+     FROM pubsub_item
+     WHERE service_domain = ? AND service_user = ?
+     ORDER BY node_id, published_at
+     """;
 sql(get_last_item) ->
     ~"""
      SELECT item_id, publisher_domain, publisher_user, publisher_resource, payload, published_at
@@ -258,7 +319,14 @@ sql(get_subscriptions) ->
      FROM pubsub_subscription
      WHERE service_domain = ? AND service_user = ? AND node_id = ?
      """;
-sql(get_subscriptions_for_jid) ->
+sql(get_user_subscriptions) ->
+    ~"""
+     SELECT service_domain, service_user, node_id, subscriber_resource
+     FROM pubsub_subscription
+     WHERE subscriber_domain = ? AND subscriber_user = ?
+     ORDER BY service_domain, service_user, node_id
+     """;
+sql(get_subscription) ->
     ~"""
      SELECT subscriber_domain, subscriber_user, subscriber_resource
      FROM pubsub_subscription
@@ -286,6 +354,21 @@ sql(delete_nodes) ->
     ~"""
      DELETE FROM pubsub_node
      WHERE service_domain = ? AND service_user = ?
+     """;
+sql(delete_domain_nodes) ->
+    ~"""
+     DELETE FROM pubsub_node
+     WHERE service_domain = ?
+     """;
+sql(delete_user_subscriptions) ->
+    ~"""
+     DELETE FROM pubsub_subscription
+     WHERE subscriber_domain = ? AND subscriber_user = ?
+     """;
+sql(delete_domain_subscriptions) ->
+    ~"""
+     DELETE FROM pubsub_subscription
+     WHERE subscriber_domain = ?
      """;
 sql(get_last_items) ->
     ~"""


### PR DESCRIPTION
## Summary

This PR adds GDPR data retrieval and removal support for the new RDBMS-backed `mod_pubsub` implementation.

It extends `mod_pubsub` with hooks for:

- retrieving personal PubSub data: owned nodes, published items, and subscriptions
- removing a user's PubSub nodes and subscriptions
- removing PubSub data for a deleted domain

The backend API now exposes the needed operations for user/domain cleanup and user-scoped data retrieval, with RDBMS queries prepared for the new paths.

## Details

- Add `get_personal_data`, `remove_user`, and `remove_domain` hook handling to `mod_pubsub`.
- Add backend functions for:
  - `remove_user/2`
  - `remove_domain/2`
  - `get_user_items/2`
  - `get_user_subscriptions/2`
- Remove the old `delete_nodes/2` API in favor of `remove_user/2`.
- Fix missing `call_tracked` in `mod_pubsub_backend`.
- Add RDBMS queries for user/domain cleanup and user-scoped item/subscription lookup.
- Add `i_pubsub_subscription_subscriber` on `(subscriber_domain, subscriber_user)` for efficient subscription lookup/removal by subscriber.
- Split GDPR tests so the new `mod_pubsub` paths are tested separately from `mod_pubsub_old`.
- Add coverage for:
  - GDPR retrieval of new PubSub items, nodes, and subscriptions
  - GDPR user removal for new PubSub data
  - PEP user removal deleting owned nodes and subscriptions
  - domain removal cleaning PEP nodes/subscriptions without touching data from other domains

