### PR TITLE
Hints support for push notifications

### DIFF
--- a/big_tests/tests/mongoose_push_mock.erl
+++ b/big_tests/tests/mongoose_push_mock.erl
@@ -42,9 +42,9 @@ wait_for_push_request(Token, Timeout) ->
 
 init(Req, State) ->
     Token = cowboy_req:binding(token, Req),
+    ct:pal("PUSH NOTIFICATION: ~p", [Token]),
     {ok, Body, Req2} = cowboy_req:read_body(Req),
     [{_, Subscriber, {RespStatus, RespBody} = Resp}] = ets:lookup(mongoose_push_mock_subscribers, Token),
     Subscriber ! {push_request, Token, Body, Resp},
     Req3 = cowboy_req:reply(RespStatus, #{}, RespBody, Req2),
     {ok, Req3, State}.
-

--- a/big_tests/tests/mongoose_push_mock.erl
+++ b/big_tests/tests/mongoose_push_mock.erl
@@ -42,7 +42,6 @@ wait_for_push_request(Token, Timeout) ->
 
 init(Req, State) ->
     Token = cowboy_req:binding(token, Req),
-    ct:pal("PUSH NOTIFICATION: ~p", [Token]),
     {ok, Body, Req2} = cowboy_req:read_body(Req),
     [{_, Subscriber, {RespStatus, RespBody} = Resp}] = ets:lookup(mongoose_push_mock_subscribers, Token),
     Subscriber ! {push_request, Token, Body, Resp},

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -8,6 +8,7 @@
 
 -define(RPC_SPEC, distributed_helper:mim()).
 -define(SESSION_KEY, publish_service).
+-define(JINGLE_SESSION_ID, <<"ca3cf894-5325-482f-a412-a6e9f832298d">>).
 
 -import(muc_light_helper,
         [
@@ -68,7 +69,8 @@ groups() ->
           [
               immediate_notification,
               double_notification_with_two_sessions_in_resume,
-              hints_filtering
+              hints_filtering,
+              bodiless_messages
           ]},
          {pm_msg_notifications, [],
           [
@@ -471,7 +473,29 @@ hints_filtering(Config) ->
             escalus:send(Alice, add_message_hint(Msg, <<"no-store">>)),
             ?assertExit({test_case_failed, _}, wait_for_push_request(FcmDeviceToken, 500)),
             ?assertExit({test_case_failed, _}, wait_for_push_request(ApnsDeviceToken, 1))
+        end).
 
+bodiless_messages(Config) ->
+        escalus:fresh_story(
+        Config, [{bob, 1}, {alice, 1}],
+        fun(Bob, Alice) ->
+            #{device_token := FcmDeviceToken} =
+                 enable_push_for_user(Bob, <<"fcm">>, [{<<"silent">>, <<"true">>}], Config),
+            #{device_token := ApnsDeviceToken} =
+                 enable_push_for_user(Bob, <<"apns">>, [{<<"silent">>, <<"true">>}], Config),
+            become_unavailable(Bob),
+            Msg = dummy_jingle_propose_message(Bob),
+            %% bodiless message with store hint should pass
+            escalus:send(Alice, add_message_hint(Msg, <<"store">>)),
+            {ApnsNotification, _} = wait_for_push_request(ApnsDeviceToken),
+            {FcmNotification, _} = wait_for_push_request(FcmDeviceToken),
+            AliceJID = bare_jid(Alice),
+            assert_jingle_push_notification(ApnsNotification, <<"apns">>, AliceJID, <<"propose">>),
+            assert_jingle_push_notification(FcmNotification, <<"fcm">>, AliceJID,  <<"propose">>),
+            %% bodiless message with no-copy hint should be blocked
+            escalus:send(Alice, add_message_hint(Msg, <<"no-copy">>)),
+            ?assertExit({test_case_failed, _}, wait_for_push_request(FcmDeviceToken, 500)),
+            ?assertExit({test_case_failed, _}, wait_for_push_request(ApnsDeviceToken, 1))
         end).
 
 add_message_hint(#xmlel{children = Children} = Msg, HintType) when is_binary(HintType) ->
@@ -479,6 +503,18 @@ add_message_hint(#xmlel{children = Children} = Msg, HintType) when is_binary(Hin
                        attrs = #{<<"xmlns">> => <<"urn:xmpp:hints">>},
                        children = []},
     Msg#xmlel{children = [MsgHintEl | Children]}.
+
+dummy_jingle_propose_message(Recipient) ->
+    Propose = #xmlel{name = <<"propose">>,
+                     attrs = #{<<"xmlns">> => "urn:xmpp:jingle-message:0",
+                               <<"id">> => ?JINGLE_SESSION_ID},
+                     children = [
+                        #xmlel{name = <<"description">>,
+                               attrs = #{<<"xmlns">> => <<"urn:xmpp:jingle:apps:rtp:1">>,
+                                         <<"media">> => <<"audio">>}}]},
+    #xmlel{name = <<"message">>,
+           attrs = #{<<"type">> => <<"chat">>, <<"to">> => escalus_utils:get_jid(Recipient)},
+           children = [Propose]}.
 
 verify_notification(DeviceToken, Service, EnableOpts, Jid, Msg) ->
     verify_notification(DeviceToken, Service, EnableOpts, [{Jid, Msg}]).
@@ -527,6 +563,16 @@ pm_msg_notify_on_fcm(Config, EnableOpts) ->
             assert_push_notification(Notification, <<"fcm">>, EnableOpts, SenderJID)
 
         end).
+
+assert_jingle_push_notification(Notification, Service, SenderJID, JingleMessageType) ->
+
+    ?assertMatch(#{<<"service">> := Service}, Notification),
+
+    Data = maps:get(<<"data">>, Notification, undefined),
+
+    ?assertMatch(#{<<"message-sender">> := SenderJID}, Data),
+    ?assertMatch(#{<<"jingle-message">> := JingleMessageType}, Data),
+    ?assertMatch(#{<<"jingle-session-id">> := ?JINGLE_SESSION_ID}, Data).
 
 assert_push_notification(Notification, Service, EnableOpts, SenderJID) ->
     assert_push_notification(Notification, Service, EnableOpts, SenderJID, []).

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -45,6 +45,7 @@ basic_groups() ->
      {group, failure_cases_v3},
      {group, failure_cases_v2},
      {group, integration_with_sm_and_offline_storage},
+     {group, enhanced_integration_with_sm_and_filtering},
      {group, enhanced_integration_with_sm},
      {group, disco}
     ].
@@ -62,6 +63,12 @@ groups() ->
           [
               immediate_notification,
               double_notification_with_two_sessions_in_resume
+          ]},
+         {enhanced_integration_with_sm_and_filtering,[],
+          [
+              immediate_notification,
+              double_notification_with_two_sessions_in_resume,
+              hints_filtering
           ]},
          {pm_msg_notifications, [],
           [
@@ -134,7 +141,7 @@ init_per_suite(Config) ->
     %% if the worker dies first it passes ETS ownership to heir process,
     %% which is the supervisor process not expecting this message
     %%
-    %% [error] 2026-03-31T18:54:49.467092+02:00 mongooseim@localhost 
+    %% [error] 2026-03-31T18:54:49.467092+02:00 mongooseim@localhost
     %% Supervisor received unexpected message: {'ETS-TRANSFER',mongoose_wpool_http,
     %%                                     <10782.4892.0>,testing}
     %%
@@ -442,6 +449,36 @@ double_notification_with_two_sessions_in_resume(Config) ->
     ?assertExit({test_case_failed, _}, wait_for_push_request(APNSDevice2, 500)),
 
     escalus_connection:stop(Bob).
+
+hints_filtering(Config) ->
+        escalus:fresh_story(
+        Config, [{bob, 1}, {alice, 1}],
+        fun(Bob, Alice) ->
+            #{device_token := FcmDeviceToken} =
+                 enable_push_for_user(Bob, <<"fcm">>, [], Config),
+            #{device_token := ApnsDeviceToken} =
+                 enable_push_for_user(Bob, <<"apns">>, [], Config),
+            become_unavailable(Bob),
+            Msg = escalus_stanza:chat_to(Bob, <<"OH, HAI!">>),
+            %% message with no-copy hint should pass
+            escalus:send(Alice, add_message_hint(Msg, <<"no-copy">>)),
+            {ApnsNotification, _} = wait_for_push_request(ApnsDeviceToken),
+            {FcmNotification, _} = wait_for_push_request(FcmDeviceToken),
+            AliceJID = bare_jid(Alice),
+            assert_push_notification(ApnsNotification, <<"apns">>, [], AliceJID, []),
+            assert_push_notification(FcmNotification, <<"fcm">>, [], AliceJID, []),
+            %% message with no-store hint should be blocked
+            escalus:send(Alice, add_message_hint(Msg, <<"no-store">>)),
+            ?assertExit({test_case_failed, _}, wait_for_push_request(FcmDeviceToken, 500)),
+            ?assertExit({test_case_failed, _}, wait_for_push_request(ApnsDeviceToken, 1))
+
+        end).
+
+add_message_hint(#xmlel{children = Children} = Msg, HintType) when is_binary(HintType) ->
+    MsgHintEl = #xmlel{name = HintType,
+                       attrs = #{<<"xmlns">> => <<"urn:xmpp:hints">>},
+                       children = []},
+    Msg#xmlel{children = [MsgHintEl | Children]}.
 
 verify_notification(DeviceToken, Service, EnableOpts, Jid, Msg) ->
     verify_notification(DeviceToken, Service, EnableOpts, [{Jid, Msg}]).
@@ -1043,6 +1080,12 @@ required_modules_for_group(enhanced_integration_with_sm, API, PubSubHost) ->
       config_parser_helper:mod_config(mod_stream_management,
                                       #{ack_freq => never, backend => MemBackend})} |
      required_modules(API, PubSubHost, enhanced_plugin_module_opts())];
+required_modules_for_group(enhanced_integration_with_sm_and_filtering, API, PubSubHost) ->
+    MemBackend = ct_helper:get_internal_database(),
+    [{mod_stream_management,
+      config_parser_helper:mod_config(mod_stream_management,
+                                      #{ack_freq => never, backend => MemBackend})} |
+     required_modules(API, PubSubHost, hints_plugin_module_opts())];
 required_modules_for_group(_, API, PubSubHost) ->
     required_modules(API, PubSubHost).
 
@@ -1079,6 +1122,9 @@ push_opts(ExtraOpts) ->
 
 enhanced_plugin_module_opts() ->
     #{plugin_module => mod_event_pusher_push_plugin_enhanced}.
+
+hints_plugin_module_opts() ->
+    #{plugin_module => mod_event_pusher_push_plugin_hints}.
 
 muc_light_opts() ->
     mod_config(mod_muc_light, #{backend => mongoose_helper:mnesia_or_rdbms_backend(),

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -506,7 +506,7 @@ add_message_hint(#xmlel{children = Children} = Msg, HintType) when is_binary(Hin
 
 dummy_jingle_propose_message(Recipient) ->
     Propose = #xmlel{name = <<"propose">>,
-                     attrs = #{<<"xmlns">> => "urn:xmpp:jingle-message:0",
+                     attrs = #{<<"xmlns">> => <<"urn:xmpp:jingle-message:0">>,
                                <<"id">> => ?JINGLE_SESSION_ID},
                      children = [
                         #xmlel{name = <<"description">>,

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -27,6 +27,7 @@ groups() ->
          {allocate, [], [allocate_basic_node]},
          {pubsub_publish, [], [
                                publish_fails_with_invalid_item,
+                               publish_fails_when_missing_mandatory_fields,
                                publish_fails_with_no_options,
                                publish_succeeds_with_valid_options,
                                push_node_can_be_configured_to_whitelist_publishers
@@ -133,6 +134,33 @@ publish_fails_with_invalid_item(Config) ->
                               {<<"service">>, <<"apns">>}
                              ],
             Opts = [{with_payload, Item},
+                    {expected_error_type, {<<"modify">>, <<"bad-request">>}}],
+            pubsub_tools:publish_with_options(Alice, <<"itemid">>, Node, Opts, PublishOptions),
+
+            ok
+
+        end).
+
+publish_fails_when_missing_mandatory_fields(Config) ->
+    escalus:story(
+        Config, [{alice, 1}],
+        fun(Alice) ->
+            Node = push_pubsub_node(),
+            pubsub_tools:create_node(Alice, Node, [{type, <<"push">>}]),
+
+            ContentFields = [
+                {<<"message-count">>, <<"1">>},
+                %% last-message-sender is mandatory for non-silent notifications
+                % {<<"last-message-sender">>, <<"senderId">>},
+                {<<"last-message-body">>, <<"message body">>}
+            ],
+
+            PublishOptions = [
+                              {<<"device_id">>, <<"sometoken">>},
+                              {<<"service">>, <<"apns">>}
+                             ],
+
+            Opts = [{with_payload, notification_el(ContentFields)},
                     {expected_error_type, {<<"modify">>, <<"bad-request">>}}],
             pubsub_tools:publish_with_options(Alice, <<"itemid">>, Node, Opts, PublishOptions),
 

--- a/include/mongoose_ns.hrl
+++ b/include/mongoose_ns.hrl
@@ -116,6 +116,7 @@
 -define(NS_RETRACT_TOMBSTONE,   <<"urn:xmpp:message-retract:0#tombstone">>).
 
 -define(JINGLE_NS, <<"urn:xmpp:jingle:1">>).
+-define(JINGLE_MSG_NS, <<"urn:xmpp:jingle-message:0">>).
 
 -define(NS_DATA_VALIDATE, <<"http://jabber.org/protocol/xdata-validate">>).
 

--- a/src/event_pusher/mod_event_pusher_push_plugin_hints.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_hints.erl
@@ -58,7 +58,6 @@ bodiless_message_notification_processors() ->
 maybe_prepare_bodiless_notification(Processors, Acc, _Event) ->
     {From, _To, Packet} = mongoose_acc:packet(Acc),
     SenderId = jid:to_bare_binary(jid:to_lower(From)),
-    Processors = bodiless_message_notification_processors(),
     case prepare_bodiless_notification(Processors, Packet) of
         skip -> skip;
         ContentFields -> [{<<"message-sender">>, SenderId} | ContentFields]

--- a/src/event_pusher/mod_event_pusher_push_plugin_hints.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_hints.erl
@@ -1,0 +1,30 @@
+-module(mod_event_pusher_push_plugin_hints).
+-behavior(mod_event_pusher_push_plugin).
+
+-include("mod_event_pusher_events.hrl").
+
+%% API
+-export([should_publish/3, prepare_notification/2]).
+
+%%--------------------------------------------------------------------
+%% mod_event_pusher_push_plugin callbacks
+%%--------------------------------------------------------------------
+
+-spec prepare_notification(Acc :: mongoose_acc:t(),
+                           Event :: mod_event_pusher:event()) ->
+                              mod_event_pusher_push_plugin:push_payload() | skip.
+prepare_notification(Acc, Event) ->
+    {_From, _To, Packet} = mongoose_acc:packet(Acc),
+    NoStore = exml_query:path(Packet, [{element_with_ns, <<"no-store">>, ?NS_HINTS}], false),
+    case NoStore of
+        false ->
+            mod_event_pusher_push_plugin_defaults:prepare_notification(Acc, Event);
+        _ -> skip
+    end.
+
+-spec should_publish(Acc :: mongoose_acc:t(),
+                     Event :: mod_event_pusher:event(),
+                     Services :: [mod_event_pusher_push:publish_service()]) ->
+                        [mod_event_pusher_push:publish_service()].
+should_publish(Acc, Event, Services) ->
+    mod_event_pusher_push_plugin_enhanced:should_publish(Acc, Event, Services).

--- a/src/event_pusher/mod_event_pusher_push_plugin_hints.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_hints.erl
@@ -17,8 +17,7 @@ prepare_notification(Acc, Event) ->
     {_From, _To, Packet} = mongoose_acc:packet(Acc),
     NoStore = exml_query:path(Packet, [{element_with_ns, <<"no-store">>, ?NS_HINTS}], false),
     case NoStore of
-        false ->
-            mod_event_pusher_push_plugin_defaults:prepare_notification(Acc, Event);
+        false -> maybe_prepare_notification(Acc, Event);
         _ -> skip
     end.
 
@@ -28,3 +27,56 @@ prepare_notification(Acc, Event) ->
                         [mod_event_pusher_push:publish_service()].
 should_publish(Acc, Event, Services) ->
     mod_event_pusher_push_plugin_enhanced:should_publish(Acc, Event, Services).
+
+%%--------------------------------------------------------------------
+%% local functions
+%%--------------------------------------------------------------------
+
+maybe_prepare_notification(Acc, Event) ->
+    case mod_event_pusher_push_plugin_defaults:prepare_notification(Acc, Event) of
+        %% if message is skipped by default plugin then it must be bodiless
+        skip -> maybe_prepare_bodiless_notification(Acc, Event);
+        Notification -> Notification
+    end.
+
+maybe_prepare_bodiless_notification(Acc, Event) ->
+    %% send notification for bodiless message only if it has store hint
+    {_From, _To, Packet} = mongoose_acc:packet(Acc),
+    Store = exml_query:path(Packet, [{element_with_ns, <<"store">>, ?NS_HINTS}], false),
+    case Store of
+        false -> skip;
+        _ ->
+            Processors = bodiless_message_notification_processors(),
+            maybe_prepare_bodiless_notification(Processors, Acc, Event)
+    end.
+
+bodiless_message_notification_processors() ->
+    [   %% add custom processors for different message types here
+        fun maybe_jingle_message_notification/1
+    ].
+
+maybe_prepare_bodiless_notification(Processors, Acc, _Event) ->
+    {From, _To, Packet} = mongoose_acc:packet(Acc),
+    SenderId = jid:to_bare_binary(jid:to_lower(From)),
+    Processors = bodiless_message_notification_processors(),
+    case prepare_bodiless_notification(Processors, Packet) of
+        skip -> skip;
+        ContentFields -> [{<<"message-sender">>, SenderId} | ContentFields]
+    end.
+
+prepare_bodiless_notification([], _Packet) -> skip;
+prepare_bodiless_notification([Processor | T], Packet) ->
+    case Processor(Packet) of
+        skip -> prepare_bodiless_notification(T, Packet);
+        ContentFields -> ContentFields
+    end.
+
+maybe_jingle_message_notification(Packet) ->
+    case exml_query:path(Packet, [{element_with_ns, ?JINGLE_MSG_NS}]) of
+        #xmlel{name = Action, attrs = #{<<"id">> := Id}} ->
+            %% This is the bare minimum that each jingle message has
+            %% add sub-elements processing if necessary.
+            [{<<"jingle-message">>, Action},
+             {<<"jingle-session-id">>, Id}];
+        _ -> skip
+    end.

--- a/src/event_pusher/mod_event_pusher_push_plugin_hints.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_hints.erl
@@ -1,5 +1,5 @@
 -module(mod_event_pusher_push_plugin_hints).
--behavior(mod_event_pusher_push_plugin).
+-behaviour(mod_event_pusher_push_plugin).
 
 -include("mod_event_pusher_events.hrl").
 

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -211,9 +211,9 @@ make_notification(Notification0, Options) ->
     JSON = maps:merge(NotificationParams, DataOrAlert),
     jiffy:encode(JSON).
 
-%% normalize Notification recursively
+%% at the moment there's only one field to normalize
 normalize_notification(#{<<"message-count">> := MC} = N) when is_binary(MC) ->
-    normalize_notification(N#{<<"message-count">> := binary_to_integer(MC)});
+    N#{<<"message-count">> := binary_to_integer(MC)};
 normalize_notification(Notification) -> Notification.
 
 -spec call(mongooseim:host_type(), M :: atom(), F :: atom(), A :: [any()]) -> any().

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -182,7 +182,7 @@ http_notification(HostType, post, URL, ReqHeaders, Payload) ->
 %%--------------------------------------------------------------------
 
 %% Create notification for API v2 and v3
-make_notification(Notification_, Options) ->
+make_notification(Notification0, Options) ->
     RequiredParameters = #{service => maps:get(<<"service">>, Options)},
     %% The full list of supported optional parameters can be found here:
     %%    https://github.com/esl/MongoosePush/blob/master/README.md#request
@@ -195,7 +195,7 @@ make_notification(Notification_, Options) ->
     OptionalParameters = maps:with(OptionalKeys, Options),
     NotificationParams = maps:merge(RequiredParameters, OptionalParameters),
 
-    Notification = normalize_notification(Notification_),
+    Notification = normalize_notification(Notification0),
 
     DataOrAlert = case Options of
                       #{<<"silent">> := <<"true">>} ->

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -101,13 +101,8 @@ push_notifications(AccIn,
     ProtocolVersion = gen_mod:get_module_opt(HostType, ?MODULE, api_version),
     Path = <<ProtocolVersion/binary, "/notification/", DeviceId/binary>>,
     Fun = fun(Notification) ->
-            ReqHeaders = [{<<"content-type">>, <<"application/json">>}],
-            {ok, JSON} =
-                make_notification(Notification, Options),
-            Payload = jiffy:encode(JSON),
-            call(HostType, ?MODULE, http_notification,
-                 [HostType, post, Path, ReqHeaders, Payload])
-        end,
+              send_push_notification(HostType, Notification, Options, Path)
+          end,
     {ok, send_push_notifications(Notifications, Fun, ok)}.
 
 send_push_notifications([], _, Result) ->
@@ -127,6 +122,22 @@ send_push_notifications([Notification | Notifications], Fun, Result) ->
             send_push_notifications(Notifications, Fun, Other)
     end.
 
+send_push_notification(HostType, Notification, Options, Path) ->
+    ReqHeaders = [{<<"content-type">>, <<"application/json">>}],
+    try make_notification(Notification, Options) of
+        Payload ->
+            call(HostType, ?MODULE, http_notification,
+                 [HostType, post, Path, ReqHeaders, Payload])
+    catch
+        C:R:S ->
+            Info = #{what => make_notification_failed,
+                     text => <<"Error making push notification">>,
+                     notification => Notification,
+                     options => Options},
+            Error = Info#{class => C, reason => R, stacktrace => S},
+            ?LOG_ERROR(Error),
+            {ok, {error, make_notification_failed}}
+    end.
 
 %%--------------------------------------------------------------------
 %% Module API
@@ -197,7 +208,8 @@ make_notification(Notification_, Options) ->
                           OptionalAlert = maps:with([<<"click_action">>, <<"sound">>], Options),
                           #{alert => maps:merge(BasicAlert, OptionalAlert)}
                   end,
-    {ok, maps:merge(NotificationParams, DataOrAlert)}.
+    JSON = maps:merge(NotificationParams, DataOrAlert),
+    jiffy:encode(JSON).
 
 %% normalize Notification recursively
 normalize_notification(#{<<"message-count">> := MC} = N) when is_binary(MC) ->

--- a/src/mod_push_service_mongoosepush.erl
+++ b/src/mod_push_service_mongoosepush.erl
@@ -171,7 +171,7 @@ http_notification(HostType, post, URL, ReqHeaders, Payload) ->
 %%--------------------------------------------------------------------
 
 %% Create notification for API v2 and v3
-make_notification(Notification, Options) ->
+make_notification(Notification_, Options) ->
     RequiredParameters = #{service => maps:get(<<"service">>, Options)},
     %% The full list of supported optional parameters can be found here:
     %%    https://github.com/esl/MongoosePush/blob/master/README.md#request
@@ -184,21 +184,25 @@ make_notification(Notification, Options) ->
     OptionalParameters = maps:with(OptionalKeys, Options),
     NotificationParams = maps:merge(RequiredParameters, OptionalParameters),
 
-    MessageCount = binary_to_integer(maps:get(<<"message-count">>, Notification)),
+    Notification = normalize_notification(Notification_),
 
     DataOrAlert = case Options of
                       #{<<"silent">> := <<"true">>} ->
-                          Data = Notification#{<<"message-count">> := MessageCount},
-                          #{data => Data};
+                          #{data => Notification};
                       _ ->
                           BasicAlert = #{body => maps:get(<<"last-message-body">>, Notification),
                                          title => maps:get(<<"last-message-sender">>, Notification),
                                          tag => maps:get(<<"last-message-sender">>, Notification),
-                                         badge => MessageCount},
+                                         badge => maps:get(<<"message-count">>, Notification)},
                           OptionalAlert = maps:with([<<"click_action">>, <<"sound">>], Options),
                           #{alert => maps:merge(BasicAlert, OptionalAlert)}
                   end,
     {ok, maps:merge(NotificationParams, DataOrAlert)}.
+
+%% normalize Notification recursively
+normalize_notification(#{<<"message-count">> := MC} = N) when is_binary(MC) ->
+    normalize_notification(N#{<<"message-count">> := binary_to_integer(MC)});
+normalize_notification(Notification) -> Notification.
 
 -spec call(mongooseim:host_type(), M :: atom(), F :: atom(), A :: [any()]) -> any().
 call(HostType, M, F, A) ->


### PR DESCRIPTION
this PR introduces a new push plugin: mod_event_pusher_push_plugin_hints.erl

this plugin introduces a basic support of message hints:
* messages with `no-store` hint are not reported, because device cannot fetch such messages from the server anyway.
* bodiless messages with `store` hint are processed by the plugin, currently only basic support for jingle messages is added ([XEP-353](https://xmpp.org/extensions/xep-0353.html))
* messages with body a reported as usual.

at the moment push service supports jingle message reporting only for silent notifications. also push service now properly propagates `make_notification` failures to push_notifications hook. previously it was just crashing, and gen_hook just ignored the crash.
