### PR TITLE
MIM-2746 Split pubsub jids

### DIFF
--- a/priv/cockroachdb.sql
+++ b/priv/cockroachdb.sql
@@ -361,32 +361,43 @@ CREATE INDEX i_inbox_box ON inbox (box) WHERE (box = 'bin');
 CREATE TYPE pubsub_node_access_model AS ENUM('open', 'presence');
 
 CREATE TABLE pubsub_node (
-    service_jid VARCHAR(250) NOT NULL,
-    node_id VARCHAR(250) NOT NULL,
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
     access_model pubsub_node_access_model NOT NULL,
-    PRIMARY KEY (service_jid, node_id)
+    PRIMARY KEY (service_domain, service_user, node_id)
 );
 
 CREATE TABLE pubsub_item (
-    service_jid VARCHAR(250) NOT NULL,
-    node_id VARCHAR(250) NOT NULL,
-    item_id VARCHAR(250) NOT NULL,
-    publisher_jid VARCHAR(250) NOT NULL,
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    item_id VARCHAR(125) NOT NULL,
+    publisher_domain VARCHAR(125) NOT NULL,
+    publisher_user VARCHAR(125) NOT NULL,
+    publisher_resource VARCHAR(125) NOT NULL,
     payload TEXT NOT NULL,
     published_at BIGINT NOT NULL,
-    PRIMARY KEY (service_jid, node_id, item_id),
-    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+    PRIMARY KEY (service_domain, service_user, node_id, item_id),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
 );
+
+CREATE INDEX i_pubsub_item_published_at ON pubsub_item USING btree
+    (service_domain, service_user, node_id, published_at);
 
 CREATE TABLE pubsub_subscription (
-    service_jid VARCHAR(250) NOT NULL,
-    node_id VARCHAR(250) NOT NULL,
-    subscriber_jid VARCHAR(250) NOT NULL,
-    PRIMARY KEY (service_jid, node_id, subscriber_jid),
-    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    subscriber_domain VARCHAR(125) NOT NULL,
+    subscriber_user VARCHAR(125) NOT NULL,
+    subscriber_resource VARCHAR(125) NOT NULL,
+    PRIMARY KEY (service_domain, service_user, node_id,
+                 subscriber_domain, subscriber_user, subscriber_resource),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
 );
-
-CREATE INDEX i_pubsub_item_published_at ON pubsub_item USING btree (service_jid, node_id, published_at);
 
 -- mod_pubsub_old
 

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -400,35 +400,46 @@ CREATE INDEX i_inbox_box USING BTREE ON inbox(box);
 -- mod_pubsub
 
 CREATE TABLE pubsub_node (
-    service_jid VARCHAR(250) NOT NULL,
-    node_id VARCHAR(250) NOT NULL,
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
     access_model ENUM('open', 'presence') NOT NULL,
-    PRIMARY KEY (service_jid, node_id)
+    PRIMARY KEY (service_domain, service_user, node_id)
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE pubsub_item (
-    service_jid VARCHAR(250) NOT NULL,
-    node_id VARCHAR(250) NOT NULL,
-    item_id VARCHAR(250) NOT NULL,
-    publisher_jid VARCHAR(250) NOT NULL,
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    item_id VARCHAR(125) NOT NULL,
+    publisher_domain VARCHAR(125) NOT NULL,
+    publisher_user VARCHAR(125) NOT NULL,
+    publisher_resource VARCHAR(125) NOT NULL,
     payload TEXT NOT NULL,
     published_at BIGINT NOT NULL,
-    PRIMARY KEY (service_jid, node_id, item_id),
-    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+    PRIMARY KEY (service_domain, service_user, node_id, item_id),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
+
+CREATE INDEX i_pubsub_item_published_at USING BTREE
+    ON pubsub_item(service_domain, service_user, node_id, published_at);
 
 CREATE TABLE pubsub_subscription (
-    service_jid VARCHAR(250) NOT NULL,
-    node_id VARCHAR(250) NOT NULL,
-    subscriber_jid VARCHAR(250) NOT NULL,
-    PRIMARY KEY (service_jid, node_id, subscriber_jid),
-    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    subscriber_domain VARCHAR(125) NOT NULL,
+    subscriber_user VARCHAR(125) NOT NULL,
+    subscriber_resource VARCHAR(125) NOT NULL,
+    PRIMARY KEY (service_domain, service_user, node_id,
+                 subscriber_domain, subscriber_user, subscriber_resource),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;
-
-CREATE INDEX i_pubsub_item_published_at USING BTREE ON pubsub_item(service_jid, node_id, published_at);
 
 -- mod_pubsub_old
 

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -344,32 +344,43 @@ CREATE INDEX i_inbox_box ON inbox (box) WHERE (box = 'bin');
 CREATE TYPE pubsub_node_access_model AS ENUM('open', 'presence');
 
 CREATE TABLE pubsub_node (
-    service_jid VARCHAR(250) NOT NULL,
-    node_id VARCHAR(250) NOT NULL,
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
     access_model pubsub_node_access_model NOT NULL,
-    PRIMARY KEY (service_jid, node_id)
+    PRIMARY KEY (service_domain, service_user, node_id)
 );
 
 CREATE TABLE pubsub_item (
-    service_jid VARCHAR(250) NOT NULL,
-    node_id VARCHAR(250) NOT NULL,
-    item_id VARCHAR(250) NOT NULL,
-    publisher_jid VARCHAR(250) NOT NULL,
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    item_id VARCHAR(125) NOT NULL,
+    publisher_domain VARCHAR(125) NOT NULL,
+    publisher_user VARCHAR(125) NOT NULL,
+    publisher_resource VARCHAR(125) NOT NULL,
     payload TEXT NOT NULL,
     published_at BIGINT NOT NULL,
-    PRIMARY KEY (service_jid, node_id, item_id),
-    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+    PRIMARY KEY (service_domain, service_user, node_id, item_id),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
 );
+
+CREATE INDEX i_pubsub_item_published_at ON pubsub_item USING btree
+    (service_domain, service_user, node_id, published_at);
 
 CREATE TABLE pubsub_subscription (
-    service_jid VARCHAR(250) NOT NULL,
-    node_id VARCHAR(250) NOT NULL,
-    subscriber_jid VARCHAR(250) NOT NULL,
-    PRIMARY KEY (service_jid, node_id, subscriber_jid),
-    FOREIGN KEY (service_jid, node_id) REFERENCES pubsub_node(service_jid, node_id) ON DELETE CASCADE
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    subscriber_domain VARCHAR(125) NOT NULL,
+    subscriber_user VARCHAR(125) NOT NULL,
+    subscriber_resource VARCHAR(125) NOT NULL,
+    PRIMARY KEY (service_domain, service_user, node_id,
+                 subscriber_domain, subscriber_user, subscriber_resource),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
 );
-
-CREATE INDEX i_pubsub_item_published_at ON pubsub_item USING btree (service_jid, node_id, published_at);
 
 -- mod_pubsub_old
 

--- a/src/pubsub/mod_pubsub_backend_rdbms.erl
+++ b/src/pubsub/mod_pubsub_backend_rdbms.erl
@@ -4,6 +4,7 @@
 -behaviour(mod_pubsub_backend).
 
 -include_lib("exml/include/exml.hrl").
+-include("jlib.hrl").
 -include("mod_pubsub.hrl").
 
 -export([start/1, stop/1, set_node/2, get_node/2, get_nodes/2, delete_node/2, delete_nodes/2,
@@ -12,42 +13,40 @@
 
 -spec start(mongooseim:host_type()) -> ok.
 start(HostType) ->
-    NodeFields = [~"service_jid", ~"node_id", ~"access_model"],
-    SubscriptionFields = [~"service_jid", ~"node_id", ~"subscriber_jid"],
-    KeyFields = [~"service_jid", ~"node_id", ~"item_id"],
-    UpdateFields = [~"publisher_jid", ~"payload", ~"published_at"],
-    rdbms_queries:prepare_upsert(HostType, pubsub_node_upsert, pubsub_node,
-                                 NodeFields, [~"access_model"], [~"service_jid", ~"node_id"]),
-    mongoose_rdbms:prepare(pubsub_get_node, pubsub_node,
-                           [service_jid, node_id], sql(get_node)),
-    mongoose_rdbms:prepare(pubsub_delete_node, pubsub_node,
-                           [service_jid, node_id], sql(delete_node)),
-    mongoose_rdbms:prepare(pubsub_delete_nodes, pubsub_node,
-                           [service_jid], sql(delete_nodes)),
-    mongoose_rdbms:prepare(pubsub_get_nodes, pubsub_node,
-                           [service_jid], sql(get_nodes)),
-    rdbms_queries:prepare_upsert(HostType, pubsub_subscription_upsert, pubsub_subscription,
-                                 SubscriptionFields, [], SubscriptionFields),
+    NodeJid = [service_domain, service_user],
+    NodeKey = NodeJid ++ [node_id],
+    SubscriberJid = [subscriber_domain, subscriber_user, subscriber_resource],
+    SubscriptionKey = NodeKey ++ SubscriberJid,
+    ItemKey = NodeKey ++ [item_id],
+    PublisherJid = [publisher_domain, publisher_user, publisher_resource],
+    ItemUpdateFields = PublisherJid ++ [payload, published_at],
+    prepare_upsert(HostType, pubsub_node_upsert, pubsub_node, [access_model], NodeKey),
+    mongoose_rdbms:prepare(pubsub_get_node, pubsub_node, NodeKey, sql(get_node)),
+    mongoose_rdbms:prepare(pubsub_delete_node, pubsub_node, NodeKey, sql(delete_node)),
+    mongoose_rdbms:prepare(pubsub_delete_nodes, pubsub_node, NodeJid, sql(delete_nodes)),
+    mongoose_rdbms:prepare(pubsub_get_nodes, pubsub_node, NodeJid, sql(get_nodes)),
+    prepare_upsert(HostType, pubsub_subscription_upsert, pubsub_subscription, [], SubscriptionKey),
     mongoose_rdbms:prepare(pubsub_delete_subscription, pubsub_subscription,
-                           [service_jid, node_id, subscriber_jid],
-                           sql(delete_subscription)),
+                           SubscriptionKey, sql(delete_subscription)),
     mongoose_rdbms:prepare(pubsub_get_subscriptions, pubsub_subscription,
-                           [service_jid, node_id], sql(get_subscriptions)),
+                           NodeKey, sql(get_subscriptions)),
     mongoose_rdbms:prepare(pubsub_get_subscriptions_for_jid, pubsub_subscription,
-                           [service_jid, node_id, subscriber_jid],
-                           sql(get_subscriptions_for_jid)),
-    rdbms_queries:prepare_upsert(HostType, pubsub_item_upsert, pubsub_item,
-                                 KeyFields ++ UpdateFields, UpdateFields, KeyFields),
-    mongoose_rdbms:prepare(pubsub_get_item, pubsub_item,
-                           [service_jid, node_id, item_id], sql(get_item)),
-    mongoose_rdbms:prepare(pubsub_get_items, pubsub_item,
-                           [service_jid, node_id], sql(get_items)),
-    mongoose_rdbms:prepare(pubsub_get_last_item, pubsub_item,
-                           [service_jid, node_id], sql(get_last_item)),
-    mongoose_rdbms:prepare(pubsub_get_last_items, pubsub_item,
-                           [service_jid], sql(get_last_items)),
-    mongoose_rdbms:prepare(pubsub_delete_item, pubsub_item,
-                           [service_jid, node_id, item_id], sql(delete_item)),
+                           SubscriptionKey, sql(get_subscriptions_for_jid)),
+    prepare_upsert(HostType, pubsub_item_upsert, pubsub_item, ItemUpdateFields, ItemKey),
+    mongoose_rdbms:prepare(pubsub_get_item, pubsub_item, ItemKey, sql(get_item)),
+    mongoose_rdbms:prepare(pubsub_get_items, pubsub_item, NodeKey, sql(get_items)),
+    mongoose_rdbms:prepare(pubsub_get_last_item, pubsub_item, NodeKey, sql(get_last_item)),
+    mongoose_rdbms:prepare(pubsub_get_last_items, pubsub_item, NodeJid, sql(get_last_items)),
+    mongoose_rdbms:prepare(pubsub_delete_item, pubsub_item, ItemKey, sql(delete_item)),
+    ok.
+
+-spec prepare_upsert(mongooseim:host_type(), mongoose_rdbms:query_name(), atom(), [atom()],
+                     [atom()]) -> ok.
+prepare_upsert(HostType, QueryName, TableName, UpdateFields, KeyFields) ->
+    UpdateBin = lists:map(fun atom_to_binary/1, UpdateFields),
+    KeyBin = lists:map(fun atom_to_binary/1, KeyFields),
+    rdbms_queries:prepare_upsert(HostType, QueryName, TableName,
+                                 KeyBin ++ UpdateBin, UpdateBin, KeyBin),
     ok.
 
 -spec stop(mongooseim:host_type()) -> ok.
@@ -57,7 +56,7 @@ stop(_HostType) ->
 -spec set_node(mongooseim:host_type(), mod_pubsub:pubsub_node()) -> ok.
 set_node(HostType, #pubsub_node{node_key = {ServiceJid, NodeId},
                                 config = #{access_model := AccessModel}}) ->
-    Values = [jid:to_binary(ServiceJid), NodeId, atom_to_binary(AccessModel)],
+    Values = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, atom_to_binary(AccessModel)],
     {updated, _} = rdbms_queries:execute_upsert(HostType, pubsub_node_upsert, Values,
                                                 [atom_to_binary(AccessModel)]),
     ok.
@@ -65,8 +64,8 @@ set_node(HostType, #pubsub_node{node_key = {ServiceJid, NodeId},
 -spec get_node(mongooseim:host_type(), mod_pubsub:node_key()) ->
     mod_pubsub:pubsub_node() | undefined.
 get_node(HostType, {ServiceJid, NodeId} = NodeKey) ->
-    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_node,
-                                             [jid:to_binary(ServiceJid), NodeId]) of
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId],
+    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_node, Args) of
         {selected, []} ->
             undefined;
         {selected, [{AccessModelBin}]} ->
@@ -76,53 +75,56 @@ get_node(HostType, {ServiceJid, NodeId} = NodeKey) ->
 
 -spec get_nodes(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:pubsub_node()].
 get_nodes(HostType, ServiceJid) ->
-    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_nodes,
-                                                           [jid:to_binary(ServiceJid)]),
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser],
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_nodes, Args),
     [#pubsub_node{node_key = {ServiceJid, NodeId},
                   config = #{access_model => binary_to_existing_atom(AccessModelBin)}}
      || {NodeId, AccessModelBin} <- Rows].
 
 -spec delete_nodes(mongooseim:host_type(), jid:jid()) -> ok.
 delete_nodes(HostType, ServiceJid) ->
-    {updated, _} = mongoose_rdbms:execute_successfully(HostType, pubsub_delete_nodes,
-                                                       [jid:to_binary(ServiceJid)]),
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser],
+    {updated, _} = mongoose_rdbms:execute_successfully(HostType, pubsub_delete_nodes, Args),
     ok.
 
 -spec delete_node(mongooseim:host_type(), mod_pubsub:node_key()) -> ok.
 delete_node(HostType, {ServiceJid, NodeId}) ->
-    Args = [jid:to_binary(ServiceJid), NodeId],
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId],
     {updated, _} = mongoose_rdbms:execute_successfully(HostType, pubsub_delete_node, Args),
     ok.
 
 -spec set_subscription(mongooseim:host_type(), mod_pubsub:subscription()) -> ok.
-set_subscription(HostType, #subscription{node_key = {ServiceJid, NodeId},
-                                         jid = SubscriberJid}) ->
-    Values = [jid:to_binary(ServiceJid), NodeId, jid:to_binary(SubscriberJid)],
-    {updated, _} = rdbms_queries:execute_upsert(HostType, pubsub_subscription_upsert,
-                                                Values, []),
+set_subscription(HostType, #subscription{node_key = {ServiceJid, NodeId}, jid = SubscriberJid}) ->
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId,
+            SubscriberJid#jid.lserver, SubscriberJid#jid.luser, SubscriberJid#jid.lresource],
+    {updated, _} = rdbms_queries:execute_upsert(HostType, pubsub_subscription_upsert, Args, []),
     ok.
 
 -spec get_subscriptions(mongooseim:host_type(), mod_pubsub:node_key()) ->
     [mod_pubsub:subscription()].
 get_subscriptions(HostType, {ServiceJid, NodeId} = NodeKey) ->
-    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_subscriptions,
-                                                           [jid:to_binary(ServiceJid), NodeId]),
-    [row_to_subscription(NodeKey, SubscriberJidBin) || {SubscriberJidBin} <- Rows].
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId],
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_subscriptions, Args),
+    [row_to_subscription(NodeKey, SubscriberDomain, SubscriberUser, SubscriberResource)
+     || {SubscriberDomain, SubscriberUser, SubscriberResource} <- Rows].
 
 -spec get_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
     mod_pubsub:subscription() | undefined.
 get_subscription(HostType, {ServiceJid, NodeId} = NodeKey, SubscriberJid) ->
-    Args = [jid:to_binary(ServiceJid), NodeId, jid:to_binary(SubscriberJid)],
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId,
+            SubscriberJid#jid.lserver, SubscriberJid#jid.luser, SubscriberJid#jid.lresource],
     {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_subscriptions_for_jid,
                                                            Args),
     case Rows of
-        [{SubscriberJidBin}] -> row_to_subscription(NodeKey, SubscriberJidBin);
+        [{SubscriberDomain, SubscriberUser, SubscriberResource}] ->
+            row_to_subscription(NodeKey, SubscriberDomain, SubscriberUser, SubscriberResource);
         [] -> undefined
     end.
 
 -spec delete_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) -> ok | not_found.
 delete_subscription(HostType, {ServiceJid, NodeId}, SubscriberJid) ->
-    Args = [jid:to_binary(ServiceJid), NodeId, jid:to_binary(SubscriberJid)],
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId,
+            SubscriberJid#jid.lserver, SubscriberJid#jid.luser, SubscriberJid#jid.lresource],
     case mongoose_rdbms:execute_successfully(HostType, pubsub_delete_subscription, Args) of
         {updated, 1} -> ok;
         {updated, 0} -> not_found
@@ -134,10 +136,10 @@ set_item(HostType, #item{node_key = {ServiceJid, NodeId},
                          publisher_jid = PublisherJid,
                          payload = Payload}) ->
     PublishedAt = os:system_time(microsecond),
-    PublisherJidBin = jid:to_binary(PublisherJid),
     PayloadBin = encode_payload(Payload),
-    KeyValues = [jid:to_binary(ServiceJid), NodeId, ItemId],
-    UpdateValues = [PublisherJidBin, PayloadBin, PublishedAt],
+    KeyValues = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, ItemId],
+    UpdateValues = [PublisherJid#jid.lserver, PublisherJid#jid.luser,
+                    PublisherJid#jid.lresource, PayloadBin, PublishedAt],
     InsertValues = KeyValues ++ UpdateValues,
     {updated, _} = rdbms_queries:execute_upsert(HostType, pubsub_item_upsert,
                                                 InsertValues, UpdateValues),
@@ -146,7 +148,7 @@ set_item(HostType, #item{node_key = {ServiceJid, NodeId},
 -spec delete_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
           ok | not_found.
 delete_item(HostType, {ServiceJid, NodeId}, ItemId) ->
-    Args = [jid:to_binary(ServiceJid), NodeId, ItemId],
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, ItemId],
     case mongoose_rdbms:execute_successfully(HostType, pubsub_delete_item, Args) of
         {updated, 1} -> ok;
         {updated, 0} -> not_found
@@ -155,39 +157,45 @@ delete_item(HostType, {ServiceJid, NodeId}, ItemId) ->
 -spec get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
     mod_pubsub:item() | undefined.
 get_item(HostType, {ServiceJid, NodeId} = NodeKey, ItemId) ->
-    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_item,
-                                             [jid:to_binary(ServiceJid), NodeId, ItemId]) of
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, ItemId],
+    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_item, Args) of
         {selected, []} ->
             undefined;
-        {selected, [{PublisherJidBin, PayloadBin, PublishedAt}]} ->
-            row_to_item(HostType, NodeKey, ItemId, PublisherJidBin, PayloadBin, PublishedAt)
+        {selected, [{PublisherDomain, PublisherUser, PublisherResource, PayloadBin, PublishedAt}]} ->
+            row_to_item(HostType, NodeKey, ItemId, PublisherDomain, PublisherUser,
+                        PublisherResource, PayloadBin, PublishedAt)
     end.
 
 -spec get_items(mongooseim:host_type(), mod_pubsub:node_key()) -> [mod_pubsub:item()].
 get_items(HostType, {ServiceJid, NodeId} = NodeKey) ->
-    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_items,
-                                                           [jid:to_binary(ServiceJid), NodeId]),
-    [row_to_item(HostType, NodeKey, ItemId, PublisherJidBin, PayloadBin, PublishedAt)
-     || {ItemId, PublisherJidBin, PayloadBin, PublishedAt} <- Rows].
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId],
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_items, Args),
+    [row_to_item(HostType, NodeKey, ItemId, PublisherDomain, PublisherUser, PublisherResource,
+                 PayloadBin, PublishedAt)
+     || {ItemId, PublisherDomain, PublisherUser, PublisherResource, PayloadBin, PublishedAt}
+            <- Rows].
 
 -spec get_last_item(mongooseim:host_type(), mod_pubsub:node_key()) ->
     mod_pubsub:item() | undefined.
 get_last_item(HostType, {ServiceJid, NodeId} = NodeKey) ->
-    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_last_item,
-                                             [jid:to_binary(ServiceJid), NodeId]) of
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId],
+    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_last_item, Args) of
         {selected, []} ->
             undefined;
-        {selected, [{ItemId, PublisherJidBin, PayloadBin, PublishedAt}]} ->
-            row_to_item(HostType, NodeKey, ItemId, PublisherJidBin, PayloadBin, PublishedAt)
+        {selected, [{ItemId, PublisherDomain, PublisherUser, PublisherResource, PayloadBin,
+                     PublishedAt}]} ->
+            row_to_item(HostType, NodeKey, ItemId, PublisherDomain, PublisherUser,
+                        PublisherResource, PayloadBin, PublishedAt)
     end.
 
 -spec get_last_items(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:item()].
 get_last_items(HostType, ServiceJid) ->
-    ServiceJidBin = jid:to_binary(ServiceJid),
-    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_last_items,
-                                                           [ServiceJidBin]),
-    [row_to_item(HostType, {ServiceJid, NodeId}, ItemId, PublisherJidBin, PayloadBin, PublishedAt)
-     || {NodeId, ItemId, PublisherJidBin, PayloadBin, PublishedAt} <- Rows].
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser],
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_last_items, Args),
+    [row_to_item(HostType, {ServiceJid, NodeId}, ItemId, PublisherDomain, PublisherUser,
+                 PublisherResource, PayloadBin, PublishedAt)
+     || {NodeId, ItemId, PublisherDomain, PublisherUser, PublisherResource, PayloadBin,
+         PublishedAt} <- Rows].
 
 -spec encode_payload(mod_pubsub:item_payload()) -> binary().
 encode_payload(Payload) ->
@@ -199,94 +207,104 @@ decode_payload(HostType, PayloadBin) ->
     Payload.
 
 -spec row_to_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id(),
-                  binary(), binary(), integer()) -> mod_pubsub:item().
-row_to_item(HostType, NodeKey, ItemId, PublisherJidBin, PayloadBin, PublishedAt) ->
+                  jid:lserver(), jid:luser(), jid:lresource(), binary(), integer()) ->
+    mod_pubsub:item().
+row_to_item(HostType, NodeKey, ItemId, PublisherDomain, PublisherUser, PublisherResource,
+            PayloadBin, PublishedAt) ->
     Payload = decode_payload(HostType, PayloadBin),
     #item{node_key = NodeKey,
           id = ItemId,
-          publisher_jid = jid:from_binary(PublisherJidBin),
+          publisher_jid = jid:make_noprep(PublisherUser, PublisherDomain, PublisherResource),
           payload = Payload,
           published_at = PublishedAt}.
 
--spec row_to_subscription(mod_pubsub:node_key(), binary()) -> mod_pubsub:subscription().
-row_to_subscription(NodeKey, SubscriberJidBin) ->
-    #subscription{node_key = NodeKey, jid = jid:from_binary(SubscriberJidBin)}.
+-spec row_to_subscription(mod_pubsub:node_key(), jid:lserver(), jid:luser(), jid:lresource()) ->
+    mod_pubsub:subscription().
+row_to_subscription(NodeKey, SubscriberDomain, SubscriberUser, SubscriberResource) ->
+    #subscription{node_key = NodeKey,
+                  jid = jid:make_noprep(SubscriberUser, SubscriberDomain, SubscriberResource)}.
 
 %% SQL queries
 
 sql(get_item) ->
     ~"""
-     SELECT publisher_jid, payload, published_at
+     SELECT publisher_domain, publisher_user, publisher_resource, payload, published_at
      FROM pubsub_item
-     WHERE service_jid = ? AND node_id = ? AND item_id = ?
+     WHERE service_domain = ? AND service_user = ? AND node_id = ? AND item_id = ?
      """;
 sql(get_items) ->
     ~"""
-     SELECT item_id, publisher_jid, payload, published_at
+     SELECT item_id, publisher_domain, publisher_user, publisher_resource, payload, published_at
      FROM pubsub_item
-     WHERE service_jid = ? AND node_id = ?
+     WHERE service_domain = ? AND service_user = ? AND node_id = ?
      ORDER BY published_at
      """;
 sql(get_last_item) ->
     ~"""
-     SELECT item_id, publisher_jid, payload, published_at
-     FROM pubsub_item WHERE service_jid = ? AND node_id = ?
+     SELECT item_id, publisher_domain, publisher_user, publisher_resource, payload, published_at
+     FROM pubsub_item
+     WHERE service_domain = ? AND service_user = ? AND node_id = ?
      ORDER BY published_at DESC LIMIT 1
      """;
 sql(get_nodes) ->
     ~"""
      SELECT node_id, access_model
      FROM pubsub_node
-     WHERE service_jid = ?
+     WHERE service_domain = ? AND service_user = ?
      """;
 sql(get_subscriptions) ->
     ~"""
-     SELECT subscriber_jid
+     SELECT subscriber_domain, subscriber_user, subscriber_resource
      FROM pubsub_subscription
-     WHERE service_jid = ? AND node_id = ?
+     WHERE service_domain = ? AND service_user = ? AND node_id = ?
      """;
 sql(get_subscriptions_for_jid) ->
     ~"""
-     SELECT subscriber_jid
+     SELECT subscriber_domain, subscriber_user, subscriber_resource
      FROM pubsub_subscription
-     WHERE service_jid = ? AND node_id = ? AND subscriber_jid = ?
+     WHERE service_domain = ? AND service_user = ? AND node_id = ?
+       AND subscriber_domain = ? AND subscriber_user = ? AND subscriber_resource = ?
      """;
 sql(delete_subscription) ->
     ~"""
      DELETE FROM pubsub_subscription
-     WHERE service_jid = ? AND node_id = ? AND subscriber_jid = ?
+     WHERE service_domain = ? AND service_user = ? AND node_id = ?
+       AND subscriber_domain = ? AND subscriber_user = ? AND subscriber_resource = ?
      """;
 sql(get_node) ->
     ~"""
      SELECT access_model
      FROM pubsub_node
-     WHERE service_jid = ? AND node_id = ?
+     WHERE service_domain = ? AND service_user = ? AND node_id = ?
      """;
 sql(delete_node) ->
     ~"""
      DELETE FROM pubsub_node
-     WHERE service_jid = ? AND node_id = ?
+     WHERE service_domain = ? AND service_user = ? AND node_id = ?
      """;
 sql(delete_nodes) ->
     ~"""
      DELETE FROM pubsub_node
-     WHERE service_jid = ?
+     WHERE service_domain = ? AND service_user = ?
      """;
 sql(get_last_items) ->
     ~"""
-     SELECT n.node_id, i.item_id, i.publisher_jid, i.payload, i.published_at
+     SELECT n.node_id, i.item_id, i.publisher_domain, i.publisher_user, i.publisher_resource,
+            i.payload, i.published_at
      FROM pubsub_node AS n
      CROSS JOIN LATERAL (
-         SELECT item_id, publisher_jid, payload, published_at
+         SELECT item_id, publisher_domain, publisher_user, publisher_resource, payload, published_at
          FROM pubsub_item
-         WHERE service_jid = n.service_jid AND node_id = n.node_id
+         WHERE service_domain = n.service_domain
+           AND service_user = n.service_user
+           AND node_id = n.node_id
          ORDER BY published_at DESC
          LIMIT 1
      ) AS i
-     WHERE n.service_jid = ?
+     WHERE n.service_domain = ? AND n.service_user = ?
      """;
 sql(delete_item) ->
     ~"""
      DELETE FROM pubsub_item
-     WHERE service_jid = ? AND node_id = ? AND item_id = ?
+     WHERE service_domain = ? AND service_user = ? AND node_id = ? AND item_id = ?
      """.


### PR DESCRIPTION
## Summary

Split PubSub JID columns in the RDBMS schema and backend.

This replaces full JID columns in the new `mod_pubsub` tables with separate user/domain/resource fields where appropriate:

- `service_jid` -> `service_domain`, `service_user`
- `subscriber_jid` -> `subscriber_domain`, `subscriber_user`, `subscriber_resource`
- `publisher_jid` -> `publisher_domain`, `publisher_user`, `publisher_resource`

## Motivation

This prepares the PubSub RDBMS backend for user/domain removal and GDPR-related operations, where querying by individual JID parts is more practical than parsing complete JID strings stored in the database.

Although publisher user/domain are redundant for current PEP behavior, they are stored explicitly to keep the item publisher round-trippable and to make the schema ready for future generic PubSub support.

## Details

- Updates `pubsub_node`, `pubsub_item`, and `pubsub_subscription` schemas for MySQL, PostgreSQL, and CockroachDB.
- Keeps PubSub key columns at `VARCHAR(125)` to satisfy MySQL/InnoDB composite key size limits with `utf8mb4`.
- Updates `mod_pubsub_backend_rdbms` queries and prepared statements to use split JID fields.
- Reconstructs publisher and subscriber JIDs with `jid:make_noprep/3`.
- Keeps the `pubsub_item` published-at index next to the related table definition.
- Refactors PubSub upsert preparation to share key/update field handling.


