### PR TITLE
MIM-2707 Support max_items in PEP

### DIFF
--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -90,6 +90,7 @@ basic_tests() ->
     [create_and_delete,
      create_with_empty_config,
      create_and_configure,
+     create_and_configure_with_max_items,
      create_open_and_publish_both_subs,
      create_open_and_publish_explicit_sub,
      create_open_and_publish_implicit_sub,
@@ -97,12 +98,15 @@ basic_tests() ->
      create_presence_and_publish_explicit_sub,
      create_presence_and_publish_implicit_sub,
      create_presence_and_publish_no_sub,
+     create_with_max_items_and_publish,
+     create_with_max_items_zero_and_publish,
      publish_and_get_items,
      publish_and_retract_item,
      publish_and_retract_item_with_notify,
      publish_implicit_sub,
      publish_open_explicit_sub,
      publish_self_notify,
+     publish_with_max_items,
      remove_user_deletes_nodes_and_subscriptions,
      send_last_item_on_caps,
      send_last_item_on_implicit_sub].
@@ -189,6 +193,16 @@ create_with_empty_config(Config) ->
 create_and_configure(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun create_and_configure_story/1).
 
+create_and_configure_with_max_items(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun create_and_configure_with_max_items_story/1).
+
+create_with_max_items_and_publish(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun create_with_max_items_and_publish_story/1).
+
+create_with_max_items_zero_and_publish(Config) ->
+    escalus:fresh_story_with_config(set_caps(Config), [{bob, 1}],
+                                    fun create_with_max_items_zero_and_publish_story/2).
+
 publish_and_get_items(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun publish_and_get_items_story/1).
 
@@ -209,6 +223,9 @@ publish_open_explicit_sub(Config) ->
 
 publish_self_notify(Config) ->
     escalus:fresh_story_with_config(set_caps(Config), [{bob, 1}], fun publish_self_notify_story/2).
+
+publish_with_max_items(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun publish_with_max_items_story/1).
 
 remove_user_deletes_nodes_and_subscriptions(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
@@ -395,12 +412,13 @@ create_and_delete_story(Alice, Bob) ->
 create_with_empty_config_story(Alice) ->
     PepNode = pep_node(Alice),
     create_node(Alice, PepNode, [{config, []}]),
-    get_configuration(Alice, PepNode, [{expected_result, [{~"pubsub#access_model", ~"presence"}]}]).
+    get_configuration(Alice, PepNode, [{expected_result, [{~"pubsub#access_model", ~"presence"},
+                                                          {~"pubsub#max_items", ~"max"}]}]).
 
 create_and_configure_story(Alice) ->
     PepNode = pep_node(Alice),
-    DefaultConfig = [{~"pubsub#access_model", ~"presence"}],
-    UpdatedConfig = [{~"pubsub#access_model", ~"open"}],
+    DefaultConfig = [{~"pubsub#access_model", ~"presence"}, {~"pubsub#max_items", ~"max"}],
+    UpdatedConfig = [{~"pubsub#access_model", ~"open"}, {~"pubsub#max_items", ~"10"}],
     create_node(Alice, PepNode, []),
 
     %% XEP-0060 8.2.5.1 Success (no-op)
@@ -410,6 +428,19 @@ create_and_configure_story(Alice) ->
     %% XEP-0060 8.2.5.1 Success
     set_configuration(Alice, PepNode, UpdatedConfig, []),
     get_configuration(Alice, PepNode, [{expected_result, UpdatedConfig}]).
+
+create_and_configure_with_max_items_story(Alice) ->
+    PepNode = pep_node(Alice, random_node_ns()),
+    create_node(Alice, PepNode, []),
+    [publish(Alice, ItemId, PepNode, []) || ItemId <- [~"item0", ~"item1", ~"item2"]],
+    get_items(Alice, PepNode, [{expected_result, [~"item0", ~"item1", ~"item2"]}]),
+
+    %% XEP-0060 8.2 Configure a Node: reconfiguring max_items limits already persisted items
+    set_configuration(Alice, PepNode, [{~"pubsub#max_items", ~"2"}], []),
+    get_items(Alice, PepNode, [{expected_result, [~"item1", ~"item2"]}]),
+
+    set_configuration(Alice, PepNode, [{~"pubsub#max_items", ~"0"}], []),
+    get_items(Alice, PepNode, [{expected_result, []}]).
 
 create_open_and_publish_both_subs_story(Config, Alice, Bob) ->
     NodeNS = ?config(node_ns, Config),
@@ -528,11 +559,25 @@ create_presence_and_publish_no_sub_story(Config, Alice, Bob, Mike) ->
     get_items(Bob, PepNode, [{expected_error_type, ~"auth"}]),
     get_items(Mike, PepNode, [{expected_result, [~"item1"]}]).
 
+create_with_max_items_and_publish_story(Alice) ->
+    PepNode = pep_node(Alice, random_node_ns()),
+    create_node(Alice, PepNode, [{config, [{~"pubsub#max_items", ~"2"}]}]),
+    [publish(Alice, ItemId, PepNode, []) || ItemId <- [~"item0", ~"item1", ~"item2"]],
+
+    %% XEP-0060 6.5 Request items: node stores only the configured number of items
+    get_items(Alice, PepNode, [{expected_result, [~"item1", ~"item2"]}]).
+
+create_with_max_items_zero_and_publish_story(Config, Bob) ->
+    PepNode = pep_node(Bob, ?config(node_ns, Config)),
+    create_node(Bob, PepNode, [{config, [{~"pubsub#max_items", ~"0"}]}]),
+
+    %% XEP-0060 7.1 Publish still notifies, but no items are persisted
+    publish(Bob, ~"item1", PepNode, [{expected_notification, {PepNode, ~"item1"}}]),
+    get_items(Bob, PepNode, [{expected_result, []}]).
+
 publish_and_get_items_story(Alice) ->
     PepNode = pep_node(Alice, random_node_ns()),
-    publish(Alice, ~"item0", PepNode, []),
-    publish(Alice, ~"item1", PepNode, []),
-    publish(Alice, ~"item2", PepNode, []),
+    [publish(Alice, ItemId, PepNode, []) || ItemId <- [~"item0", ~"item1", ~"item2"]],
 
     %% XEP-0060 6.5 Request items
     get_items(Alice, PepNode, [{expected_result, [~"item0", ~"item1", ~"item2"]}]),
@@ -546,10 +591,7 @@ publish_and_get_items_story(Alice) ->
 publish_and_retract_item_story(Config, Alice, Bob) ->
     NodeNS = ?config(node_ns, Config),
     PepNode = pep_node(Alice, NodeNS),
-    publish(Alice, ~"item1", PepNode, []),
-    publish(Alice, ~"item2", PepNode, []),
-    publish(Alice, ~"item3", PepNode, []),
-    publish(Alice, ~"item4", PepNode, []),
+    [publish(Alice, ItemId, PepNode, []) || ItemId <- [~"item1", ~"item2", ~"item3", ~"item4"]],
 
     %% XEP-0060 7.2 Retract an item
     retract_item(Alice, PepNode, ~"item4", []),
@@ -635,6 +677,15 @@ publish_self_notify_story(Config, Bob) ->
     GeneratedItemId = published_item_id(Response, PepNode),
     check_item_notification(Msg, GeneratedItemId, PepNode, []),
     get_item(Bob, PepNode, GeneratedItemId, [{expected_result, [GeneratedItemId]}]).
+
+publish_with_max_items_story(Alice) ->
+    PepNode = pep_node(Alice, random_node_ns()),
+    PublishOptions = [{~"pubsub#max_items", ~"1"}],
+    publish_with_options(Alice, ~"item0", PepNode, [], PublishOptions),
+    publish(Alice, ~"item1", PepNode, []),
+
+    %% XEP-0060 7.1.5 Publishing Options: auto-created node keeps publish-options config
+    get_items(Alice, PepNode, [{expected_result, [~"item1"]}]).
 
 remove_user_deletes_nodes_and_subscriptions_story(Config, Alice, Bob) ->
     AliceNode = pep_node(Alice),
@@ -744,6 +795,13 @@ create_with_invalid_config_fails_story(Alice) ->
     InvalidModelOpts = [{config, [{~"pubsub#access_model", ~"not-a-real-model"}]},
                         {expected_error_type, {~"modify", ~"bad-request"}}],
     create_node(Alice, pep_node(Alice), InvalidModelOpts),
+
+    InvalidMaxItemsOpts = [{expected_error_type, {~"modify", ~"bad-request"}}],
+    lists:foreach(fun(MaxItems) ->
+                          create_node(Alice, pep_node(Alice),
+                                      [{config, [{~"pubsub#max_items", MaxItems}]}
+                                       | InvalidMaxItemsOpts])
+                  end, [~"-1", ~"abc", [~"1", ~"2"]]),
 
     %% Malformed create request with unexpected extra child
     ExtraChildOpts = [{expected_error_type, {~"modify", ~"bad-request"}},

--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -115,6 +115,7 @@ negative_tests() ->
      create_with_invalid_config_fails,
      delete_nonexistent_node_fails,
      get_item_without_id_fails,
+     get_items_with_invalid_max_items_fails,
      manage_nonexistent_node_fails,
      manage_foreign_node_fails,
      publish_to_foreign_node_fails,
@@ -242,6 +243,9 @@ delete_nonexistent_node_fails(Config) ->
 
 get_item_without_id_fails(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun get_item_without_id_fails_story/1).
+
+get_items_with_invalid_max_items_fails(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun get_items_with_invalid_max_items_fails_story/1).
 
 manage_nonexistent_node_fails(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun manage_nonexistent_node_fails_story/1).
@@ -534,7 +538,10 @@ publish_and_get_items_story(Alice) ->
     get_items(Alice, PepNode, [{expected_result, [~"item0", ~"item1", ~"item2"]}]),
     get_item(Alice, PepNode, ~"item1", [{expected_result, [~"item1"]}]),
     get_items(Alice, PepNode, [{item_ids, [~"item1", ~"item404", ~"item0"]},
-                               {expected_result, [~"item1", ~"item0"]}]).
+                               {expected_result, [~"item1", ~"item0"]}]),
+
+    %% XEP-0060 6.5.7 Requesting the Most Recent Items
+    get_items(Alice, PepNode, [{max_items, ~"2"}, {expected_result, [~"item1", ~"item2"]}]).
 
 publish_and_retract_item_story(Config, Alice, Bob) ->
     NodeNS = ?config(node_ns, Config),
@@ -768,6 +775,19 @@ get_item_without_id_fails_story(Alice) ->
     Opts = [{expected_error_type, {~"modify", ~"bad-request"}}],
     get_item(Alice, PepNode, undefined, Opts),
     get_items(Alice, PepNode, [{item_ids, [undefined, ~"item1"]} | Opts]).
+
+get_items_with_invalid_max_items_fails_story(Alice) ->
+    PepNode = pep_node(Alice),
+    create_node(Alice, PepNode, []),
+
+    %% XEP-0060 6.5.7 Requesting the Most Recent Items: max_items must be positive
+    Opts = [{expected_error_type, {~"modify", ~"bad-request"}}],
+    lists:foreach(fun(MaxItems) ->
+                          get_items(Alice, PepNode, [{max_items, MaxItems} | Opts])
+                  end, [~"abc", ~"-10", ~"0"]),
+
+    %% Cannot request most recent items and specific items at the same time
+    get_items(Alice, PepNode, [{max_items, ~"2"}, {item_ids, [~"item1"]} | Opts]).
 
 manage_nonexistent_node_fails_story(Alice) ->
     PepNode = pep_node(Alice),

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -14,23 +14,28 @@ It handles same-server PEP requests addressed to users' bare JIDs and does not e
 
 * [Automatic creation](https://xmpp.org/extensions/xep-0060.html#publisher-publish-autocreate) of PEP nodes on publish.
 * Explicit node [creation](https://xmpp.org/extensions/xep-0060.html#owner-create) and [deletion](https://xmpp.org/extensions/xep-0060.html#owner-delete).
-* [Node configuration](https://xmpp.org/extensions/xep-0060.html#owner-configure) and [publish options](https://xmpp.org/extensions/xep-0060.html#publisher-publish-options) with the [`pubsub#access_model`](https://xmpp.org/extensions/xep-0060.html#accessmodels) option.
-* The `open` and `presence` access models.
+* [Node configuration](https://xmpp.org/extensions/xep-0060.html#owner-configure) and [publish options](https://xmpp.org/extensions/xep-0060.html#publisher-publish-options), with supported options described below.
 * [Publishing](https://xmpp.org/extensions/xep-0060.html#publisher-publish) and [retracting](https://xmpp.org/extensions/xep-0060.html#publisher-delete) an item.
-* Retrieving [all items](https://xmpp.org/extensions/xep-0060.html#subscriber-retrieve-requestall) or [selected items by ID](https://xmpp.org/extensions/xep-0060.html#subscriber-retrieve-requestone).
+* Retrieving [all items](https://xmpp.org/extensions/xep-0060.html#subscriber-retrieve-requestall), [selected items by ID](https://xmpp.org/extensions/xep-0060.html#subscriber-retrieve-requestone), or the [most recent N items](https://xmpp.org/extensions/xep-0060.html#subscriber-retrieve-requestrecent).
 * Explicit [subscribe](https://xmpp.org/extensions/xep-0060.html#subscriber-subscribe) and [unsubscribe](https://xmpp.org/extensions/xep-0060.html#subscriber-unsubscribe).
 * [Implicit PEP subscriptions](https://xmpp.org/extensions/xep-0163.html#notify-autosubscribe) based on presence subscription and entity capabilities.
 * [Filtered item notifications](https://xmpp.org/extensions/xep-0163.html#notify-filterednotifications) with [mod_caps](mod_caps.md), and [node deletion notifications](https://xmpp.org/extensions/xep-0060.html#owner-delete-success).
 * [Last published item delivery](https://xmpp.org/extensions/xep-0163.html#notify-last), with [`urn:xmpp:delay`](https://xmpp.org/extensions/xep-0203.html) metadata.
 * Service discovery for [PEP support](https://xmpp.org/extensions/xep-0163.html#support-owner) on users' bare JIDs, [node-qualified disco info](https://xmpp.org/extensions/xep-0060.html#entity-info), and [disco items](https://xmpp.org/extensions/xep-0060.html#entity-nodes) listing discoverable PEP nodes.
 
-## Known omissions and limitations
+### Node configuration options
+
+`mod_pubsub` supports the following node configuration and publish options:
+
+* [`pubsub#access_model`](https://xmpp.org/extensions/xep-0060.html#accessmodels): controls who can access a node. Supported values are `open` and `presence`.
+* `pubsub#max_items`: controls how many published items are stored for later retrieval. It defaults to `max`, which stores all published items. A non-negative integer limits stored items for the node; when the limit is exceeded, the oldest stored item is removed. `0` allows publish notifications but does not persist items for later retrieval.
+
+### Known omissions and limitations
 
 `mod_pubsub` is intended to grow over time, but it does not implement the full XEP-0060 feature set yet.
 Current intentional omissions and limitations are:
 
-* Access models other than `open` and `presence` are not supported.
-* Node and publish options other than `pubsub#access_model` are not supported.
+* Node and publish options other than the [supported node configuration options](#node-configuration-options) are not supported.
 * [Subscription options](https://xmpp.org/extensions/xep-0060.html#subscriber-configure), [multiple subscriptions](https://xmpp.org/extensions/xep-0060.html#subscriber-subscribe-multi) for the same JID and node, and [collection nodes](https://xmpp.org/extensions/xep-0248.html) are not implemented.
 * [Affiliations](https://xmpp.org/extensions/xep-0060.html#owner-affiliations), [default node configuration requests](https://xmpp.org/extensions/xep-0060.html#owner-default), [purge](https://xmpp.org/extensions/xep-0060.html#owner-purge), and [subscription management by node owners](https://xmpp.org/extensions/xep-0060.html#owner-subscriptions) are not implemented.
 * [Result Set Management](https://xmpp.org/extensions/xep-0060.html#subscriber-retrieve-returnsome) is not implemented for item retrieval.

--- a/include/mod_pubsub.hrl
+++ b/include/mod_pubsub.hrl
@@ -1,5 +1,6 @@
 -record(pubsub_node, {node_key :: mod_pubsub:node_key(),
-                      config = #{access_model => presence} :: mod_pubsub:node_config()}).
+                      config = #{access_model => presence,
+                                 max_items => max} :: mod_pubsub:node_config()}).
 
 -record(subscription, {node_key :: mod_pubsub:node_key(),
                        jid :: jid:jid()}).

--- a/priv/cockroachdb.sql
+++ b/priv/cockroachdb.sql
@@ -365,6 +365,7 @@ CREATE TABLE pubsub_node (
     service_user VARCHAR(125) NOT NULL,
     node_id VARCHAR(125) NOT NULL,
     access_model pubsub_node_access_model NOT NULL,
+    max_items BIGINT,
     PRIMARY KEY (service_domain, service_user, node_id)
 );
 

--- a/priv/mysql.sql
+++ b/priv/mysql.sql
@@ -404,6 +404,7 @@ CREATE TABLE pubsub_node (
     service_user VARCHAR(125) NOT NULL,
     node_id VARCHAR(125) NOT NULL,
     access_model ENUM('open', 'presence') NOT NULL,
+    max_items BIGINT,
     PRIMARY KEY (service_domain, service_user, node_id)
 ) CHARACTER SET utf8mb4
   ROW_FORMAT=DYNAMIC;

--- a/priv/pg.sql
+++ b/priv/pg.sql
@@ -348,6 +348,7 @@ CREATE TABLE pubsub_node (
     service_user VARCHAR(125) NOT NULL,
     node_id VARCHAR(125) NOT NULL,
     access_model pubsub_node_access_model NOT NULL,
+    max_items BIGINT,
     PRIMARY KEY (service_domain, service_user, node_id)
 );
 

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -37,9 +37,10 @@
 -type item_id() :: binary().
 -type get_items_opts() :: #{} | #{max_items := max_items()} | #{item_ids := [item_id()]}.
 -type max_items() :: pos_integer().
+-type max_items_node() :: max | non_neg_integer().
 -type item_payload() :: exml:element().
 -type access_model() :: open | presence.
--type node_config() :: #{access_model => access_model()}.
+-type node_config() :: #{access_model => access_model(), max_items => max_items_node()}.
 -type error_reason() :: generic_error_reason() | {generic_error_reason(), binary()}.
 -type generic_error_reason() ::
         bad_request | conflict | forbidden | not_acceptable | not_authorized |
@@ -75,7 +76,7 @@
           result => item_id()}.
 
 -export_type([item/0, pubsub_node/0, subscription/0, node_key/0, node_id/0, item_id/0,
-              get_items_opts/0, max_items/0, item_payload/0,
+              get_items_opts/0, max_items/0, max_items_node/0, item_payload/0,
               access_model/0, node_config/0, generic_error_reason/0, error_reason/0,
               error_result/0, result/1, ok_result/0, iq_request/0, iq_action/0]).
 
@@ -392,7 +393,7 @@ perform_action(Request, Action = #{action := publish}) ->
         {ok, Node} ?= get_or_create_node(HostType, NodeKey, maps:get(config, Action, #{})),
         Item = #item{node_key = NodeKey, id = ItemId, publisher_jid = PublisherJid,
                      payload = Payload},
-        mod_pubsub_backend:set_item(HostType, Item),
+        maybe_set_item(HostType, Item, maps:get(max_items, Node#pubsub_node.config)),
         Recipients = recipient_jids(Node, Request),
         broadcast_item(HostType, jid:to_bare(PublisherJid), Recipients, Item, false),
         Action#{result => ItemId}
@@ -478,6 +479,12 @@ delete_subscription(HostType, NodeKey, SubscriberJid) ->
 get_items(HostType, NodeKey, #{opts := Opts}) ->
     mod_pubsub_backend:get_items(HostType, NodeKey, Opts).
 
+-spec maybe_set_item(mongooseim:host_type(), item(), max_items_node()) -> ok.
+maybe_set_item(_HostType, _Item, 0) ->
+    ok;
+maybe_set_item(HostType, Item, MaxItems) ->
+    mod_pubsub_backend:set_item(HostType, Item, MaxItems).
+
 -spec delete_item(mongooseim:host_type(), node_key(), item_id()) -> ok_result().
 delete_item(HostType, NodeKey, ItemId) ->
     case mod_pubsub_backend:delete_item(HostType, NodeKey, ItemId) of
@@ -491,8 +498,9 @@ get_or_create_node(HostType, NodeKey, Config) ->
     case mod_pubsub_backend:get_node(HostType, NodeKey) of
         undefined ->
             Node = #pubsub_node{node_key = NodeKey},
-            mod_pubsub_backend:set_node(HostType, apply_node_config(Node, Config)),
-            {ok, Node};
+            ConfiguredNode = apply_node_config(Node, Config),
+            mod_pubsub_backend:set_node(HostType, ConfiguredNode),
+            {ok, ConfiguredNode};
         Node = #pubsub_node{config = ExistingConfig} ->
             case maps:with(maps:keys(Config), ExistingConfig) of
                 Config -> {ok, Node};

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -35,7 +35,8 @@
 -type node_key() :: {jid:jid(), node_id()}.
 -type node_id() :: binary().
 -type item_id() :: binary().
--type item_ids() :: [item_id()].
+-type get_items_opts() :: #{} | #{max_items := max_items()} | #{item_ids := [item_id()]}.
+-type max_items() :: pos_integer().
 -type item_payload() :: exml:element().
 -type access_model() :: open | presence.
 -type node_config() :: #{access_model => access_model()}.
@@ -65,8 +66,7 @@
           result => ok}
       | #{action := unsubscribe, node_id := node_id(), subscriber_jid := jid:jid(),
           result => ok}
-      | #{action := get_items, node_id := node_id(),
-          item_ids => item_ids(),
+      | #{action := get_items, node_id := node_id(), opts := get_items_opts(),
           result => [item()]}
       | #{action := retract, node_id := node_id(), item_id := item_id(), notify := boolean(),
           result => ok}
@@ -74,10 +74,10 @@
           config => node_config(),
           result => item_id()}.
 
--export_type([item/0, pubsub_node/0, subscription/0, node_key/0, node_id/0,
-              item_id/0, item_ids/0, item_payload/0, access_model/0, node_config/0,
-              generic_error_reason/0, error_reason/0, error_result/0, result/1,
-              ok_result/0, iq_request/0, iq_action/0]).
+-export_type([item/0, pubsub_node/0, subscription/0, node_key/0, node_id/0, item_id/0,
+              get_items_opts/0, max_items/0, item_payload/0,
+              access_model/0, node_config/0, generic_error_reason/0, error_reason/0,
+              error_result/0, result/1, ok_result/0, iq_request/0, iq_action/0]).
 
 %% gen_mod callbacks
 
@@ -474,18 +474,9 @@ delete_subscription(HostType, NodeKey, SubscriberJid) ->
         not_found -> {error, {unexpected_request, ~"not-subscribed"}}
     end.
 
--spec get_item(mongooseim:host_type(), node_key(), item_id()) -> [item()].
-get_item(HostType, NodeKey, ItemId) ->
-    case mod_pubsub_backend:get_item(HostType, NodeKey, ItemId) of
-        undefined -> [];
-        Item -> [Item]
-    end.
-
 -spec get_items(mongooseim:host_type(), node_key(), iq_action()) -> [item()].
-get_items(HostType, NodeKey, #{item_ids := ItemIds}) ->
-    lists:flatmap(fun(ItemId) -> get_item(HostType, NodeKey, ItemId) end, ItemIds);
-get_items(HostType, NodeKey, #{}) ->
-    mod_pubsub_backend:get_items(HostType, NodeKey).
+get_items(HostType, NodeKey, #{opts := Opts}) ->
+    mod_pubsub_backend:get_items(HostType, NodeKey, Opts).
 
 -spec delete_item(mongooseim:host_type(), node_key(), item_id()) -> ok_result().
 delete_item(HostType, NodeKey, ItemId) ->

--- a/src/pubsub/mod_pubsub_backend.erl
+++ b/src/pubsub/mod_pubsub_backend.erl
@@ -6,7 +6,7 @@
          remove_user/2, remove_domain/2,
          set_subscription/2, delete_subscription/3, get_subscriptions/2,
          get_user_subscriptions/2, get_subscription/3,
-         set_item/2, delete_item/3, get_item/3, get_items/2, get_user_items/2,
+         set_item/2, delete_item/3, get_items/3, get_user_items/2,
          get_last_item/2, get_last_items/2]).
 
 -callback start(mongooseim:host_type()) -> ok.
@@ -30,9 +30,7 @@
 -callback set_item(mongooseim:host_type(), mod_pubsub:item()) -> ok.
 -callback delete_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
     ok | not_found.
--callback get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
-    mod_pubsub:item() | undefined.
--callback get_items(mongooseim:host_type(), mod_pubsub:node_key()) ->
+-callback get_items(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:get_items_opts()) ->
     [mod_pubsub:item()].
 -callback get_user_items(mongooseim:host_type(), jid:jid()) ->
     [mod_pubsub:item()].
@@ -116,14 +114,10 @@ set_item(HostType, Item) ->
 delete_item(HostType, NodeKey, ItemId) ->
     mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, ItemId]).
 
--spec get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
-    mod_pubsub:item() | undefined.
-get_item(HostType, NodeKey, ItemId) ->
-    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, ItemId]).
-
--spec get_items(mongooseim:host_type(), mod_pubsub:node_key()) -> [mod_pubsub:item()].
-get_items(HostType, NodeKey) ->
-    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey]).
+-spec get_items(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:get_items_opts()) ->
+    [mod_pubsub:item()].
+get_items(HostType, NodeKey, Opts) ->
+    mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, Opts]).
 
 -spec get_user_items(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:item()].
 get_user_items(HostType, Jid) ->

--- a/src/pubsub/mod_pubsub_backend.erl
+++ b/src/pubsub/mod_pubsub_backend.erl
@@ -6,7 +6,7 @@
          remove_user/2, remove_domain/2,
          set_subscription/2, delete_subscription/3, get_subscriptions/2,
          get_user_subscriptions/2, get_subscription/3,
-         set_item/2, delete_item/3, get_items/3, get_user_items/2,
+         set_item/3, delete_item/3, get_items/3, get_user_items/2,
          get_last_item/2, get_last_items/2]).
 
 -callback start(mongooseim:host_type()) -> ok.
@@ -27,7 +27,7 @@
     [mod_pubsub:subscription()].
 -callback get_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
     mod_pubsub:subscription() | undefined.
--callback set_item(mongooseim:host_type(), mod_pubsub:item()) -> ok.
+-callback set_item(mongooseim:host_type(), mod_pubsub:item(), mod_pubsub:max_items_node()) -> ok.
 -callback delete_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
     ok | not_found.
 -callback get_items(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:get_items_opts()) ->
@@ -106,8 +106,9 @@ delete_subscription(HostType, NodeKey, SubscriberJid) ->
 get_subscription(HostType, NodeKey, SubscriberJid) ->
     mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, SubscriberJid]).
 
-set_item(HostType, Item) ->
-    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Item]).
+-spec set_item(mongooseim:host_type(), mod_pubsub:item(), mod_pubsub:max_items_node()) -> ok.
+set_item(HostType, Item, MaxItems) ->
+    mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Item, MaxItems]).
 
 -spec delete_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
           ok | not_found.

--- a/src/pubsub/mod_pubsub_backend_rdbms.erl
+++ b/src/pubsub/mod_pubsub_backend_rdbms.erl
@@ -11,7 +11,7 @@
          remove_user/2, remove_domain/2,
          set_subscription/2, delete_subscription/3, get_subscriptions/2,
          get_user_subscriptions/2, get_subscription/3,
-         set_item/2, delete_item/3, get_item/3, get_items/2, get_user_items/2,
+         set_item/2, delete_item/3, get_items/3, get_user_items/2,
          get_last_item/2, get_last_items/2]).
 
 -spec start(mongooseim:host_type()) -> ok.
@@ -46,6 +46,8 @@ start(HostType) ->
     prepare_upsert(HostType, pubsub_item_upsert, pubsub_item, ItemUpdateFields, ItemKey),
     mongoose_rdbms:prepare(pubsub_get_item, pubsub_item, ItemKey, sql(get_item)),
     mongoose_rdbms:prepare(pubsub_get_items, pubsub_item, NodeKey, sql(get_items)),
+    mongoose_rdbms:prepare(pubsub_get_items_limit, pubsub_item,
+                           NodeKey ++ [limit], sql(get_items_limit)),
     mongoose_rdbms:prepare(pubsub_get_user_items, pubsub_item, NodeJid, sql(get_user_items)),
     mongoose_rdbms:prepare(pubsub_get_last_item, pubsub_item, NodeKey, sql(get_last_item)),
     mongoose_rdbms:prepare(pubsub_get_last_items, pubsub_item, NodeJid, sql(get_last_items)),
@@ -198,26 +200,41 @@ delete_item(HostType, {ServiceJid, NodeId}, ItemId) ->
         {updated, 0} -> not_found
     end.
 
--spec get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
-    mod_pubsub:item() | undefined.
-get_item(HostType, {ServiceJid, NodeId} = NodeKey, ItemId) ->
-    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, ItemId],
-    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_item, Args) of
-        {selected, []} ->
-            undefined;
-        {selected, [{PublisherDomain, PublisherUser, PublisherResource, PayloadBin, PublishedAt}]} ->
-            row_to_item(HostType, NodeKey, ItemId, PublisherDomain, PublisherUser,
-                        PublisherResource, PayloadBin, PublishedAt)
-    end.
-
--spec get_items(mongooseim:host_type(), mod_pubsub:node_key()) -> [mod_pubsub:item()].
-get_items(HostType, {ServiceJid, NodeId} = NodeKey) ->
-    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId],
-    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_items, Args),
-    [row_to_item(HostType, NodeKey, ItemId, PublisherDomain, PublisherUser, PublisherResource,
-                 PayloadBin, PublishedAt)
+-spec get_items(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:get_items_opts()) ->
+          [mod_pubsub:item()].
+get_items(HostType, NodeKey, #{item_ids := ItemIds}) ->
+    lists:flatmap(fun(ItemId) -> get_item(HostType, NodeKey, ItemId) end, ItemIds);
+get_items(HostType, {ServiceJid, NodeId}, Opts) ->
+    Rows = get_item_rows(HostType, {ServiceJid, NodeId}, Opts),
+    [row_to_item(HostType, {ServiceJid, NodeId}, ItemId, PublisherDomain, PublisherUser,
+                 PublisherResource, PayloadBin, PublishedAt)
      || {ItemId, PublisherDomain, PublisherUser, PublisherResource, PayloadBin, PublishedAt}
             <- Rows].
+
+-spec get_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
+          [mod_pubsub:item()].
+get_item(HostType, {ServiceJid, NodeId} = NodeKey, ItemId) ->
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, ItemId],
+    {selected, Results} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_item, Args),
+    case Results of
+        [] ->
+            [];
+        [{PublisherDomain, PublisherUser, PublisherResource, PayloadBin, PublishedAt}] ->
+            [row_to_item(HostType, NodeKey, ItemId, PublisherDomain, PublisherUser,
+                         PublisherResource, PayloadBin, PublishedAt)]
+    end.
+
+-spec get_item_rows(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:get_items_opts()) ->
+          [{mod_pubsub:item_id(), jid:lserver(), jid:luser(), jid:lresource(), binary(),
+            integer()}].
+get_item_rows(HostType, {ServiceJid, NodeId}, #{max_items := MaxItems}) ->
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, MaxItems],
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_items_limit, Args),
+    lists:reverse(Rows);
+get_item_rows(HostType, {ServiceJid, NodeId}, #{}) ->
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId],
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_items, Args),
+    Rows.
 
 -spec get_user_items(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:item()].
 get_user_items(HostType, ServiceJid) ->
@@ -277,6 +294,43 @@ row_to_subscription(NodeKey, SubscriberDomain, SubscriberUser, SubscriberResourc
     #subscription{node_key = NodeKey,
                   jid = jid:make_noprep(SubscriberUser, SubscriberDomain, SubscriberResource)}.
 
+-spec row_to_node(mod_pubsub:node_key(), binary(), null | non_neg_integer()) ->
+    mod_pubsub:pubsub_node().
+row_to_node(NodeKey, AccessModelBin, MaxItems) ->
+    #pubsub_node{node_key = NodeKey,
+                 config = #{access_model => binary_to_existing_atom(AccessModelBin),
+                            max_items => max_items_node_from_sql(MaxItems)}}.
+
+-spec max_items_node_to_sql(mod_pubsub:max_items_node()) -> null | non_neg_integer().
+max_items_node_to_sql(max) ->
+    null;
+max_items_node_to_sql(MaxItems) ->
+    MaxItems.
+
+-spec max_items_node_from_sql(null | non_neg_integer()) -> mod_pubsub:max_items_node().
+max_items_node_from_sql(null) ->
+    max;
+max_items_node_from_sql(MaxItems) ->
+    MaxItems.
+
+-spec delete_extra_item(mongooseim:host_type(), mod_pubsub:node_key(),
+                        max | pos_integer()) -> ok.
+delete_extra_item(_HostType, _NodeKey, max) ->
+    ok;
+delete_extra_item(HostType, NodeKey, MaxItems) ->
+    case get_extra_item_id(HostType, NodeKey, MaxItems) of
+        [ItemId] -> ok = delete_item(HostType, NodeKey, ItemId);
+        [] -> ok
+    end.
+
+-spec get_extra_item_id(mongooseim:host_type(), mod_pubsub:node_key(),
+                        pos_integer()) -> [mod_pubsub:item_id()].
+get_extra_item_id(HostType, {ServiceJid, NodeId}, MaxItems) ->
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, MaxItems],
+    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_extra_item_id,
+                                                           Args),
+    [ItemId || {ItemId} <- Rows].
+
 %% SQL queries
 
 sql(get_item) ->
@@ -292,6 +346,8 @@ sql(get_items) ->
      WHERE service_domain = ? AND service_user = ? AND node_id = ?
      ORDER BY published_at
      """;
+sql(get_items_limit) ->
+    <<(sql(get_items))/binary, " DESC LIMIT ?">>;
 sql(get_user_items) ->
     ~"""
      SELECT node_id, item_id, publisher_domain, publisher_user, publisher_resource,

--- a/src/pubsub/mod_pubsub_backend_rdbms.erl
+++ b/src/pubsub/mod_pubsub_backend_rdbms.erl
@@ -11,7 +11,7 @@
          remove_user/2, remove_domain/2,
          set_subscription/2, delete_subscription/3, get_subscriptions/2,
          get_user_subscriptions/2, get_subscription/3,
-         set_item/2, delete_item/3, get_items/3, get_user_items/2,
+         set_item/3, delete_item/3, get_items/3, get_user_items/2,
          get_last_item/2, get_last_items/2]).
 
 -spec start(mongooseim:host_type()) -> ok.
@@ -23,7 +23,7 @@ start(HostType) ->
     ItemKey = NodeKey ++ [item_id],
     PublisherFullJid = [publisher_domain, publisher_user, publisher_resource],
     ItemUpdateFields = PublisherFullJid ++ [payload, published_at],
-    prepare_upsert(HostType, pubsub_node_upsert, pubsub_node, [access_model], NodeKey),
+    prepare_upsert(HostType, pubsub_node_upsert, pubsub_node, [access_model, max_items], NodeKey),
     mongoose_rdbms:prepare(pubsub_get_node, pubsub_node, NodeKey, sql(get_node)),
     mongoose_rdbms:prepare(pubsub_delete_node, pubsub_node, NodeKey, sql(delete_node)),
     mongoose_rdbms:prepare(pubsub_delete_nodes, pubsub_node, NodeJid, sql(delete_nodes)),
@@ -52,6 +52,10 @@ start(HostType) ->
     mongoose_rdbms:prepare(pubsub_get_last_item, pubsub_item, NodeKey, sql(get_last_item)),
     mongoose_rdbms:prepare(pubsub_get_last_items, pubsub_item, NodeJid, sql(get_last_items)),
     mongoose_rdbms:prepare(pubsub_delete_item, pubsub_item, ItemKey, sql(delete_item)),
+    mongoose_rdbms:prepare(pubsub_get_extra_item_published_at, pubsub_item,
+                           NodeKey ++ [offset], sql(get_extra_item_published_at)),
+    mongoose_rdbms:prepare(pubsub_delete_old_items, pubsub_item,
+                           NodeKey ++ [published_at], sql(delete_old_items)),
     ok.
 
 -spec prepare_upsert(mongooseim:host_type(), mongoose_rdbms:query_name(), atom(), [atom()],
@@ -68,11 +72,21 @@ stop(_HostType) ->
     ok.
 
 -spec set_node(mongooseim:host_type(), mod_pubsub:pubsub_node()) -> ok.
-set_node(HostType, #pubsub_node{node_key = {ServiceJid, NodeId},
-                                config = #{access_model := AccessModel}}) ->
-    Values = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, atom_to_binary(AccessModel)],
+set_node(HostType, Node) ->
+    F = fun() -> set_node_t(HostType, Node) end,
+    {atomic, ok} = mongoose_rdbms:sql_transaction(HostType, F),
+    ok.
+
+-spec set_node_t(mongooseim:host_type(), mod_pubsub:pubsub_node()) -> ok.
+set_node_t(HostType, #pubsub_node{node_key = NodeKey = {ServiceJid, NodeId},
+                                  config = #{access_model := AccessModel,
+                                             max_items := MaxItems}}) ->
+    MaxItemsValue = max_items_node_to_sql(MaxItems),
+    Values = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId,
+              atom_to_binary(AccessModel), MaxItemsValue],
     {updated, _} = rdbms_queries:execute_upsert(HostType, pubsub_node_upsert, Values,
-                                                [atom_to_binary(AccessModel)]),
+                                                [atom_to_binary(AccessModel), MaxItemsValue]),
+    delete_old_items(HostType, NodeKey, MaxItems),
     ok.
 
 -spec get_node(mongooseim:host_type(), mod_pubsub:node_key()) ->
@@ -82,18 +96,16 @@ get_node(HostType, {ServiceJid, NodeId} = NodeKey) ->
     case mongoose_rdbms:execute_successfully(HostType, pubsub_get_node, Args) of
         {selected, []} ->
             undefined;
-        {selected, [{AccessModelBin}]} ->
-            #pubsub_node{node_key = NodeKey,
-                         config = #{access_model => binary_to_existing_atom(AccessModelBin)}}
+        {selected, [{AccessModelBin, MaxItems}]} ->
+            row_to_node(NodeKey, AccessModelBin, MaxItems)
     end.
 
 -spec get_nodes(mongooseim:host_type(), jid:jid()) -> [mod_pubsub:pubsub_node()].
 get_nodes(HostType, ServiceJid) ->
     Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser],
     {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_nodes, Args),
-    [#pubsub_node{node_key = {ServiceJid, NodeId},
-                  config = #{access_model => binary_to_existing_atom(AccessModelBin)}}
-     || {NodeId, AccessModelBin} <- Rows].
+    [row_to_node({ServiceJid, NodeId}, AccessModelBin, MaxItems)
+     || {NodeId, AccessModelBin, MaxItems} <- Rows].
 
 -spec delete_node(mongooseim:host_type(), mod_pubsub:node_key()) -> ok.
 delete_node(HostType, {ServiceJid, NodeId}) ->
@@ -176,11 +188,18 @@ delete_subscription(HostType, {ServiceJid, NodeId}, SubscriberJid) ->
         {updated, 0} -> not_found
     end.
 
--spec set_item(mongooseim:host_type(), mod_pubsub:item()) -> ok.
-set_item(HostType, #item{node_key = {ServiceJid, NodeId},
-                         id = ItemId,
-                         publisher_jid = PublisherJid,
-                         payload = Payload}) ->
+-spec set_item(mongooseim:host_type(), mod_pubsub:item(), max | pos_integer()) -> ok.
+set_item(HostType, Item, MaxItems) ->
+    F = fun() -> set_item_t(HostType, Item, MaxItems) end,
+    {atomic, ok} = mongoose_rdbms:sql_transaction(HostType, F),
+    ok.
+
+-spec set_item_t(mongooseim:host_type(), mod_pubsub:item(), max | pos_integer()) -> ok.
+set_item_t(HostType, #item{node_key = NodeKey = {ServiceJid, NodeId},
+                           id = ItemId,
+                           publisher_jid = PublisherJid,
+                           payload = Payload},
+           MaxItems) ->
     PublishedAt = os:system_time(microsecond),
     PayloadBin = encode_payload(Payload),
     KeyValues = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, ItemId],
@@ -189,6 +208,7 @@ set_item(HostType, #item{node_key = {ServiceJid, NodeId},
     InsertValues = KeyValues ++ UpdateValues,
     {updated, _} = rdbms_queries:execute_upsert(HostType, pubsub_item_upsert,
                                                 InsertValues, UpdateValues),
+    delete_old_items(HostType, NodeKey, MaxItems),
     ok.
 
 -spec delete_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
@@ -313,23 +333,33 @@ max_items_node_from_sql(null) ->
 max_items_node_from_sql(MaxItems) ->
     MaxItems.
 
--spec delete_extra_item(mongooseim:host_type(), mod_pubsub:node_key(),
-                        max | pos_integer()) -> ok.
-delete_extra_item(_HostType, _NodeKey, max) ->
+-spec delete_old_items(mongooseim:host_type(), mod_pubsub:node_key(),
+                       mod_pubsub:max_items_node()) -> ok.
+delete_old_items(_HostType, _NodeKey, max) ->
     ok;
-delete_extra_item(HostType, NodeKey, MaxItems) ->
-    case get_extra_item_id(HostType, NodeKey, MaxItems) of
-        [ItemId] -> ok = delete_item(HostType, NodeKey, ItemId);
-        [] -> ok
+delete_old_items(HostType, NodeKey, MaxItems) ->
+    case get_extra_item_published_at(HostType, NodeKey, MaxItems) of
+        undefined -> ok;
+        PublishedAt -> delete_items_published_at_or_before(HostType, NodeKey, PublishedAt)
     end.
 
--spec get_extra_item_id(mongooseim:host_type(), mod_pubsub:node_key(),
-                        pos_integer()) -> [mod_pubsub:item_id()].
-get_extra_item_id(HostType, {ServiceJid, NodeId}, MaxItems) ->
+-spec get_extra_item_published_at(mongooseim:host_type(), mod_pubsub:node_key(),
+                                  non_neg_integer()) -> integer() | undefined.
+get_extra_item_published_at(HostType, {ServiceJid, NodeId}, MaxItems) ->
     Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, MaxItems],
-    {selected, Rows} = mongoose_rdbms:execute_successfully(HostType, pubsub_get_extra_item_id,
-                                                           Args),
-    [ItemId || {ItemId} <- Rows].
+    case mongoose_rdbms:execute_successfully(HostType, pubsub_get_extra_item_published_at,
+                                             Args) of
+        {selected, [{PublishedAt}]} -> PublishedAt;
+        {selected, []} -> undefined
+    end.
+
+-spec delete_items_published_at_or_before(mongooseim:host_type(), mod_pubsub:node_key(),
+                                          integer()) -> ok.
+delete_items_published_at_or_before(HostType, {ServiceJid, NodeId}, PublishedAt) ->
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, PublishedAt],
+    {updated, _} = mongoose_rdbms:execute_successfully(HostType, pubsub_delete_old_items,
+                                                       Args),
+    ok.
 
 %% SQL queries
 
@@ -365,7 +395,7 @@ sql(get_last_item) ->
      """;
 sql(get_nodes) ->
     ~"""
-     SELECT node_id, access_model
+     SELECT node_id, access_model, max_items
      FROM pubsub_node
      WHERE service_domain = ? AND service_user = ?
      """;
@@ -397,7 +427,7 @@ sql(delete_subscription) ->
      """;
 sql(get_node) ->
     ~"""
-     SELECT access_model
+     SELECT access_model, max_items
      FROM pubsub_node
      WHERE service_domain = ? AND service_user = ? AND node_id = ?
      """;
@@ -446,4 +476,17 @@ sql(delete_item) ->
     ~"""
      DELETE FROM pubsub_item
      WHERE service_domain = ? AND service_user = ? AND node_id = ? AND item_id = ?
+     """;
+sql(get_extra_item_published_at) ->
+    ~"""
+     SELECT published_at
+     FROM pubsub_item
+     WHERE service_domain = ? AND service_user = ? AND node_id = ?
+     ORDER BY published_at DESC
+     LIMIT 1 OFFSET ?
+     """;
+sql(delete_old_items) ->
+    ~"""
+     DELETE FROM pubsub_item
+     WHERE service_domain = ? AND service_user = ? AND node_id = ? AND published_at <= ?
      """.

--- a/src/pubsub/mod_pubsub_xml.erl
+++ b/src/pubsub/mod_pubsub_xml.erl
@@ -86,17 +86,40 @@ parse_retract_item(_) ->
     {error, bad_request}.
 
 -spec iq_pubsub_get([exml:element()]) -> mod_pubsub:iq_action() | mod_pubsub:error_result().
-iq_pubsub_get([#xmlel{name = ~"items", attrs = #{~"node" := NodeId}, children = []}]) ->
-    #{action => get_items, node_id => NodeId};
-iq_pubsub_get([#xmlel{name = ~"items", attrs = #{~"node" := NodeId}, children = Children}]) ->
-    case parse_item_ids(Children) of
-        ItemIds when length(ItemIds) =:= length(Children) ->
-            #{action => get_items, node_id => NodeId, item_ids => ItemIds};
-        _ ->
-            {error, bad_request}
+iq_pubsub_get([#xmlel{name = ~"items", attrs = #{~"node" := NodeId} = Attrs,
+                      children = Children}]) ->
+    maybe
+        {ok, Opts} ?= parse_get_items_opts(Attrs, Children),
+        #{action => get_items, node_id => NodeId, opts => Opts}
     end;
 iq_pubsub_get(_) ->
     {error, bad_request}.
+
+-spec parse_get_items_opts(exml:attrs(), [exml:child()]) ->
+          mod_pubsub:result(mod_pubsub:get_items_opts()).
+parse_get_items_opts(#{~"max_items" := MaxItemsBin}, []) ->
+    try binary_to_pos_integer(MaxItemsBin) of
+        MaxItems -> {ok, #{max_items => MaxItems}}
+    catch
+        _:_ -> {error, bad_request}
+    end;
+parse_get_items_opts(#{~"max_items" := _}, _Children) ->
+    {error, bad_request};
+parse_get_items_opts(#{}, []) ->
+    {ok, #{}};
+parse_get_items_opts(#{}, Children) ->
+    case parse_item_ids(Children) of
+        ItemIds when length(ItemIds) =:= length(Children) ->
+            {ok, #{item_ids => ItemIds}};
+        _ ->
+            {error, bad_request}
+    end.
+
+-spec binary_to_pos_integer(binary()) -> pos_integer().
+binary_to_pos_integer(BinValue) ->
+    IntValue = binary_to_integer(BinValue),
+    true = IntValue > 0,
+    IntValue.
 
 -spec iq_pubsub_owner_set([exml:element()]) -> mod_pubsub:iq_action() | mod_pubsub:error_result().
 iq_pubsub_owner_set([#xmlel{name = ~"delete", attrs = #{~"node" := NodeId}}]) ->
@@ -165,7 +188,7 @@ get_or_generate_item_id(#xmlel{attrs = #{~"id" := ItemId}}) ->
 get_or_generate_item_id(_) ->
     uuid:uuid_to_string(uuid:get_v4(), binary_standard).
 
--spec parse_payload([exml:child()]) -> {ok, exml:element()} | mod_pubsub:error_result().
+-spec parse_payload([exml:child()]) -> mod_pubsub:result(exml:element()).
 parse_payload([#xmlel{} = PayloadEl]) ->
     {ok, PayloadEl};
 parse_payload([]) ->
@@ -177,7 +200,7 @@ parse_payload(_) ->
 parse_item_ids(Elements) ->
     [ItemId || #xmlel{name = ~"item", attrs = #{~"id" := ItemId}} <- Elements].
 
--spec parse_flag(binary(), exml:attrs(), boolean()) -> {ok, boolean()} | mod_pubsub:error_result().
+-spec parse_flag(binary(), exml:attrs(), boolean()) -> mod_pubsub:result(boolean()).
 parse_flag(Key, Attrs, Default) ->
     case Attrs of
         #{Key := Value} when Value =:= ~"0"; Value =:= ~"false" -> {ok, false};

--- a/src/pubsub/mod_pubsub_xml.erl
+++ b/src/pubsub/mod_pubsub_xml.erl
@@ -16,7 +16,8 @@
 -include("mongoose_ns.hrl").
 -include("mod_pubsub.hrl").
 
--type node_config_field() :: {access_model, mod_pubsub:access_model()}.
+-type node_config_field() :: {access_model, mod_pubsub:access_model()} |
+                             {max_items, mod_pubsub:max_items_node()}.
 
 %% XML Parsing
 
@@ -239,6 +240,11 @@ parse_node_config_field(~"pubsub#access_model", Values) ->
         {ok, AccessModel} ?= parse_access_model(Values),
         {ok, {access_model, AccessModel}}
     end;
+parse_node_config_field(~"pubsub#max_items", Values) ->
+    maybe
+        {ok, MaxItems} ?= parse_max_items_node(Values),
+        {ok, {max_items, MaxItems}}
+    end;
 parse_node_config_field(_, _) ->
     {error, bad_request}.
 
@@ -247,6 +253,24 @@ parse_access_model([~"open"]) -> {ok, open};
 parse_access_model([~"presence"]) -> {ok, presence};
 parse_access_model([~"authorize"]) -> {error, {not_acceptable, ~"unsupported-access-model"}};
 parse_access_model(_) -> {error, bad_request}.
+
+-spec parse_max_items_node([binary()]) -> mod_pubsub:result(mod_pubsub:max_items_node()).
+parse_max_items_node([~"max"]) ->
+    {ok, max};
+parse_max_items_node([MaxItemsBin]) ->
+    try binary_to_non_neg_integer(MaxItemsBin) of
+        MaxItems -> {ok, MaxItems}
+    catch
+        _:_ -> {error, bad_request}
+    end;
+parse_max_items_node(_) ->
+    {error, bad_request}.
+
+-spec binary_to_non_neg_integer(binary()) -> non_neg_integer().
+binary_to_non_neg_integer(BinValue) ->
+    IntValue = binary_to_integer(BinValue),
+    true = IntValue >= 0,
+    IntValue.
 
 %% XML Construction
 
@@ -296,11 +320,20 @@ configure_el(Node = #pubsub_node{node_key = {_, NodeId}}) ->
     #xmlel{name = ~"configure", attrs = #{~"node" => NodeId}, children = [Form]}.
 
 -spec configure_fields(mod_pubsub:pubsub_node()) -> [mongoose_data_forms:field()].
-configure_fields(#pubsub_node{config = #{access_model := AccessModel}}) ->
+configure_fields(#pubsub_node{config = #{access_model := AccessModel, max_items := MaxItems}}) ->
     [#{var => ~"pubsub#access_model",
        type => ~"list-single",
        values => [atom_to_binary(AccessModel)],
-       options => [~"open", ~"presence"]}].
+       options => [~"open", ~"presence"]},
+     #{var => ~"pubsub#max_items",
+       type => ~"text-single",
+       values => [max_items_node_to_binary(MaxItems)]}].
+
+-spec max_items_node_to_binary(mod_pubsub:max_items_node()) -> binary().
+max_items_node_to_binary(max) ->
+    ~"max";
+max_items_node_to_binary(MaxItems) ->
+    integer_to_binary(MaxItems).
 
 -spec subscription_el(jid:jid(), mod_pubsub:node_id(), binary()) -> exml:element().
 subscription_el(SubscriberJid, NodeId, Subscription) ->


### PR DESCRIPTION
## Summary

Adds `max_items` support to the new `mod_pubsub`: both as an item retrieval option and as a node item persistence option.

## Changes

- Supports retrieval with `<items max_items='N'/>`.
- Adds `pubsub#max_items` as a node config and publish option.
- Stores `max_items` in `pubsub_node`.
- Enforces item retention limit on publish and node reconfiguration.
- Supports `max_items = 0` as “notify on publish, but do not persist items”.
- Updates `pep_SUITE` coverage for retrieval, persistence limits, pruning on reconfiguration, zero persistence, and invalid values.
- Updates `mod_pubsub` documentation.

## Retention Behavior

Old items are deleted by comparing `published_at` with the retention boundary timestamp.

If multiple items are published to the same node in the same microsecond, pruning may delete an extra boundary item unexpectedly. This race condition is unlikely and the impact is limited to retention precision.
