### PR TITLE
MIM-2750 Add max_items_per_node pubsub option

### DIFF
--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -8,7 +8,7 @@
 
 -compile([export_all, nowarn_export_all]).
 
--import(config_parser_helper, [default_mod_config/1]).
+-import(config_parser_helper, [default_mod_config/1, mod_config/2]).
 -import(distributed_helper, [require_rpc_nodes/1]).
 -import(domain_helper, [host_type/0]).
 -import(pubsub_tools, [check_item_notification/4,
@@ -61,11 +61,13 @@ end_per_testcase(TestName, Config) ->
 
 all() ->
     [{group, pep},
-     {group, pep_no_caps}].
+     {group, pep_no_caps},
+     {group, max_items_per_node}].
 
 groups() ->
     [{pep, [parallel], pep_tests()},
-     {pep_no_caps, [parallel], pep_no_caps_tests()}].
+     {pep_no_caps, [parallel], pep_no_caps_tests()},
+     {max_items_per_node, [parallel], max_items_per_node_tests()}].
 
 pep_tests() ->
     disco_tests() ++ protocol_tests() ++ protocol_tests_with_sm().
@@ -137,6 +139,11 @@ negative_tests() ->
 protocol_tests_with_sm() ->
     [send_last_item_on_implicit_sub_with_sm]. % check for regressions in a typical scenario
 
+-doc "Tests checking the max_items_per_node config option".
+max_items_per_node_tests() ->
+    [create_with_max_items_and_publish,
+     create_with_max_items_per_node_and_publish].
+
 %% Disco
 
 disco_info(Config) ->
@@ -198,6 +205,10 @@ create_and_configure_with_max_items(Config) ->
 
 create_with_max_items_and_publish(Config) ->
     escalus:fresh_story(Config, [{alice, 1}], fun create_with_max_items_and_publish_story/1).
+
+create_with_max_items_per_node_and_publish(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}],
+                        fun create_with_max_items_per_node_and_publish_story/1).
 
 create_with_max_items_zero_and_publish(Config) ->
     escalus:fresh_story_with_config(set_caps(Config), [{bob, 1}],
@@ -566,6 +577,14 @@ create_with_max_items_and_publish_story(Alice) ->
 
     %% XEP-0060 6.5 Request items: node stores only the configured number of items
     get_items(Alice, PepNode, [{expected_result, [~"item1", ~"item2"]}]).
+
+create_with_max_items_per_node_and_publish_story(Alice) ->
+    PepNode = pep_node(Alice, random_node_ns()),
+    create_node(Alice, PepNode, []),
+    [publish(Alice, ItemId, PepNode, []) || ItemId <- [~"item0", ~"item1", ~"item2", ~"item3"]],
+
+    %% XEP-0060 6.5 Request items: node stores only max_items_per_node items
+    get_items(Alice, PepNode, [{expected_result, [~"item1", ~"item2", ~"item3"]}]).
 
 create_with_max_items_zero_and_publish_story(Config, Bob) ->
     PepNode = pep_node(Bob, ?config(node_ns, Config)),
@@ -1066,7 +1085,9 @@ required_modules(pep) ->
     [{mod_caps, default_mod_config(mod_caps)},
      {mod_pubsub, default_mod_config(mod_pubsub)}];
 required_modules(pep_no_caps) ->
-    [{mod_pubsub, default_mod_config(mod_pubsub)}].
+    [{mod_pubsub, default_mod_config(mod_pubsub)}];
+required_modules(max_items_per_node) ->
+    [{mod_pubsub, mod_config(mod_pubsub, #{max_items_per_node => 3})}].
 
 set_caps(Config) ->
     set_caps(Config, random_node_ns()).

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -28,7 +28,7 @@ It handles same-server PEP requests addressed to users' bare JIDs and does not e
 `mod_pubsub` supports the following node configuration and publish options:
 
 * [`pubsub#access_model`](https://xmpp.org/extensions/xep-0060.html#accessmodels): controls who can access a node. Supported values are `open` and `presence`.
-* `pubsub#max_items`: controls how many published items are stored for later retrieval. It defaults to `max`, which stores all published items. A non-negative integer limits stored items for the node; when the limit is exceeded, the oldest stored item is removed. `0` allows publish notifications but does not persist items for later retrieval.
+* `pubsub#max_items`: controls how many published items are stored for later retrieval. It defaults to `max`, which stores all published items up to the server-wide [`max_items_per_node`](#modulesmod_pubsubmax_items_per_node) limit. A non-negative integer limits stored items for the node; when the limit is exceeded, the oldest stored item is removed. `0` allows publish notifications but does not persist items for later retrieval.
 
 ### Known omissions and limitations
 
@@ -49,6 +49,15 @@ Current intentional omissions and limitations are:
 
 Database backend used to store PEP nodes, subscriptions, and items.
 The `rdbms` backend requires a `default` RDBMS connection pool in [`outgoing_pools`](../configuration/outgoing-connections.md#rdbms-options).
+
+### `modules.mod_pubsub.max_items_per_node`
+* **Syntax:** non-negative integer or `"infinity"`
+* **Default:** `"infinity"`
+* **Example:** `max_items_per_node = 1000`
+
+Maximum number of items stored in a node.
+The effective limit is the lower of this value and `pubsub#max_items`.
+If you reduce this limit, excess items for each already existing node are removed when it is next configured or receives a published item.
 
 ### `modules.mod_pubsub.iqdisc.type`
 * **Syntax:** string, one of `"one_queue"`, `"no_queue"`, `"queues"`, `"parallel"`

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -101,9 +101,12 @@ config_spec() ->
     #section{
         items = #{~"backend" => #option{type = atom,
                                         validate = {module, mod_pubsub_backend}},
-                  ~"iqdisc" => mongoose_config_spec:iqdisc()},
+                  ~"iqdisc" => mongoose_config_spec:iqdisc(),
+                  ~"max_items_per_node" => #option{type = int_or_infinity,
+                                                   validate = non_negative}},
         defaults = #{~"backend" => rdbms,
-                     ~"iqdisc" => no_queue}
+                     ~"iqdisc" => no_queue,
+                     ~"max_items_per_node" => infinity}
     }.
 
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().

--- a/src/pubsub/mod_pubsub_backend_rdbms.erl
+++ b/src/pubsub/mod_pubsub_backend_rdbms.erl
@@ -334,23 +334,30 @@ max_items_node_from_sql(MaxItems) ->
     MaxItems.
 
 -spec delete_old_items(mongooseim:host_type(), mod_pubsub:node_key(),
-                       mod_pubsub:max_items_node()) -> ok.
-delete_old_items(_HostType, _NodeKey, max) ->
-    ok;
+                       mod_pubsub:max_items_node()) -> ok | no_limit | no_extra_items.
 delete_old_items(HostType, NodeKey, MaxItems) ->
-    case get_extra_item_published_at(HostType, NodeKey, MaxItems) of
-        undefined -> ok;
-        PublishedAt -> delete_items_published_at_or_before(HostType, NodeKey, PublishedAt)
+    maybe
+        {ok, Limit} ?= get_effective_max_items_limit(HostType, MaxItems),
+        {ok, PublishedAt} ?= get_extra_item_published_at(HostType, NodeKey, Limit),
+        delete_items_published_at_or_before(HostType, NodeKey, PublishedAt)
+    end.
+
+-spec get_effective_max_items_limit(mongooseim:host_type(), mod_pubsub:max_items_node()) ->
+          {ok, non_neg_integer()} | no_limit.
+get_effective_max_items_limit(HostType, MaxItems) ->
+    case min(MaxItems, gen_mod:get_module_opt(HostType, mod_pubsub, max_items_per_node)) of
+        Limit when is_integer(Limit) -> {ok, Limit};
+        _ -> no_limit % both were atoms: 'max', 'infinity'
     end.
 
 -spec get_extra_item_published_at(mongooseim:host_type(), mod_pubsub:node_key(),
-                                  non_neg_integer()) -> integer() | undefined.
-get_extra_item_published_at(HostType, {ServiceJid, NodeId}, MaxItems) ->
-    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, MaxItems],
+                                  non_neg_integer()) -> {ok, integer()} | no_extra_items.
+get_extra_item_published_at(HostType, {ServiceJid, NodeId}, Limit) ->
+    Args = [ServiceJid#jid.lserver, ServiceJid#jid.luser, NodeId, Limit],
     case mongoose_rdbms:execute_successfully(HostType, pubsub_get_extra_item_published_at,
                                              Args) of
-        {selected, [{PublishedAt}]} -> PublishedAt;
-        {selected, []} -> undefined
+        {selected, [{PublishedAt}]} -> {ok, PublishedAt};
+        {selected, []} -> no_extra_items
     end.
 
 -spec delete_items_published_at_or_before(mongooseim:host_type(), mod_pubsub:node_key(),

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -457,7 +457,8 @@ all_modules() ->
                                    })
                       }),
       mod_pubsub =>
-          mod_config(mod_pubsub, #{backend => rdbms, iqdisc => no_queue}),
+          mod_config(mod_pubsub, #{backend => rdbms, iqdisc => no_queue,
+                                   max_items_per_node => 100}),
       mod_pubsub_old =>
           mod_config(mod_pubsub_old, #{access_createnode => pubsub_createnode,
                                    backend => rdbms,
@@ -953,7 +954,7 @@ default_mod_config(mod_privacy) ->
 default_mod_config(mod_private) ->
     #{iqdisc => one_queue, backend => rdbms};
 default_mod_config(mod_pubsub) ->
-    #{backend => rdbms, iqdisc => no_queue};
+    #{backend => rdbms, iqdisc => no_queue, max_items_per_node => infinity};
 default_mod_config(mod_pubsub_old) ->
     #{iqdisc => one_queue, host => {prefix, <<"pubsub.">>}, backend => mnesia, access_createnode => all,
       max_items_node => 10, nodetree => nodetree_tree, ignore_pep_from_offline => true,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -2504,7 +2504,10 @@ mod_pubsub(_Config) ->
     P = [modules, mod_pubsub],
     ?cfgh(P ++ [backend], rdbms,
           T(#{<<"backend">> => <<"rdbms">>})),
-    ?errh(T(#{<<"backend">> => <<"mysql">>})).
+    ?cfgh(P ++ [max_items_per_node], 20,
+          T(#{<<"max_items_per_node">> => 20})),
+    ?errh(T(#{<<"backend">> => <<"mysql">>})),
+    ?errh(T(#{<<"max_items_per_node">> => -1})).
 
 mod_pubsub_old(_Config) ->
     check_iqdisc(mod_pubsub_old),

--- a/test/config_parser_SUITE_data/modules.toml
+++ b/test/config_parser_SUITE_data/modules.toml
@@ -231,6 +231,7 @@
 [modules.mod_pubsub]
   backend = "rdbms"
   iqdisc.type = "no_queue"
+  max_items_per_node = 100
 
 [modules.mod_push_service_mongoosepush]
   pool_name = "mongoose_push_http"


### PR DESCRIPTION
Add a configurable hard limit for the maximum items per PubSub node - effective even when `pubsub#max_items` is set to `max`. Such a limit is allowed by XEP-0060 (it is called a "server imposed maximum").
