### PR TITLE
MIM-2749 muc_light: add `listRooms` admin GraphQL query

### DIFF
--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -134,6 +134,13 @@ admin_muc_light_tests() ->
      admin_list_user_rooms_non_existent_domain,
      admin_list_room_users,
      admin_list_room_users_non_existent_domain,
+     admin_list_rooms,
+     admin_list_rooms_pagination,
+     admin_list_rooms_filter,
+     admin_list_rooms_owner_absent,
+     admin_list_rooms_broken_config,
+     admin_list_rooms_schema_without_roomname,
+     admin_list_rooms_non_existent_domain,
      admin_get_room_config,
      admin_get_room_config_non_existent_domain,
      admin_blocking_list,
@@ -1487,6 +1494,231 @@ admin_list_room_users_non_existent_domain_story(Config, Alice) ->
     Res = list_room_users(make_bare_jid(RoomJID#jid.luser, ?UNKNOWN_DOMAIN), Config),
     ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
+admin_list_rooms(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}, {bob, 1}],
+                                    fun admin_list_rooms_story/3).
+
+admin_list_rooms_story(Config, Alice, Bob) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    BobBin = escalus_client:short_jid(Bob),
+    MUCServer = ?config(muc_light_host, Config),
+    %% Start from a clean slate so domain-wide counts are deterministic
+    %% (the admin group does not clear rooms between test cases).
+    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [domain_helper:host_type()]),
+    %% Empty domain
+    #{<<"rooms">> := [], <<"count">> := 0, <<"nextCursor">> := null} =
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
+    %% Create two rooms (Alice owns room1, Bob owns room2), invite Bob into room1
+    {ok, #{jid := RoomJID1}} = create_room(MUCServer, <<"Room A">>, <<"subjectA">>, AliceBin),
+    {ok, #{jid := RoomJID2}} = create_room(MUCServer, <<"Room B">>, <<"subjectB">>, BobBin),
+    invite_user(RoomJID1, AliceBin, BobBin),
+    #{<<"rooms">> := Rooms, <<"count">> := 2, <<"nextCursor">> := null} =
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
+    R1 = find_room_desc(jid:to_binary(RoomJID1), Rooms),
+    ?assertEqual(<<"Room A">>, maps:get(<<"name">>, R1)),
+    ?assertEqual(<<"subjectA">>, maps:get(<<"subject">>, R1)),
+    ?assertEqual(2, maps:get(<<"usersNumber">>, R1)),
+    ?assertEqual(escalus_utils:jid_to_lower(AliceBin), maps:get(<<"ownerJid">>, R1)),
+    R2 = find_room_desc(jid:to_binary(RoomJID2), Rooms),
+    ?assertEqual(1, maps:get(<<"usersNumber">>, R2)),
+    ?assertEqual(escalus_utils:jid_to_lower(BobBin), maps:get(<<"ownerJid">>, R2)).
+
+admin_list_rooms_pagination(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_list_rooms_pagination_story/2).
+
+admin_list_rooms_pagination_story(Config, Alice) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    MUCServer = ?config(muc_light_host, Config),
+    %% Start from a clean slate so pagination boundaries and counts are deterministic.
+    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [domain_helper:host_type()]),
+    [{ok, _} = create_room(MUCServer, Name, <<"s">>, AliceBin)
+     || Name <- [<<"R1">>, <<"R2">>, <<"R3">>]],
+    %% Full listing (limit defaults to 50), capture the global sort order
+    #{<<"rooms">> := All, <<"count">> := 3, <<"nextCursor">> := null} =
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
+    AllJids = [maps:get(<<"jid">>, R) || R <- All],
+    ?assertEqual(lists:sort(AllJids), AllJids),
+    %% First page: limit 2 -> first two rooms, cursor points at the second one
+    #{<<"rooms">> := Page1, <<"count">> := 3, <<"nextCursor">> := Cursor} =
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, 2, Config)),
+    ?assertEqual(lists:sublist(AllJids, 1, 2), [maps:get(<<"jid">>, R) || R <- Page1]),
+    ?assertEqual(lists:nth(2, AllJids), Cursor),
+    %% Second page: after the cursor -> last room only, no further pages
+    #{<<"rooms">> := Page2, <<"count">> := 3, <<"nextCursor">> := null} =
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, Cursor, 2, Config)),
+    ?assertEqual(lists:sublist(AllJids, 3, 1), [maps:get(<<"jid">>, R) || R <- Page2]),
+    %% An exactly-full last page also reports no further pages
+    #{<<"rooms">> := All, <<"count">> := 3, <<"nextCursor">> := null} =
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, 3, Config)),
+    %% After the last room -> empty page, count unchanged
+    #{<<"rooms">> := [], <<"count">> := 3, <<"nextCursor">> := null} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, null, lists:last(AllJids), 2, Config)).
+
+admin_list_rooms_filter(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_list_rooms_filter_story/2).
+
+admin_list_rooms_filter_story(Config, Alice) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    MUCServer = ?config(muc_light_host, Config),
+    %% Start from a clean slate so filtered counts are deterministic.
+    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [domain_helper:host_type()]),
+    [{ok, _} = create_identified_room(MUCServer, Name, <<"s">>, AliceBin, Id)
+     || {Id, Name} <- [{<<"apple-room">>, <<"Fruit HQ">>},
+                       {<<"banana-room">>, <<"Yellow">>},
+                       {<<"cherry-room">>, <<"fruit annex">>}]],
+    %% Filter by a substring of the room JID localpart
+    #{<<"rooms">> := [Apple], <<"count">> := 1, <<"nextCursor">> := null} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, <<"apple">>, null, null, Config)),
+    ?assertEqual(<<"apple-room@", MUCServer/binary>>, maps:get(<<"jid">>, Apple)),
+    %% Filter by room name, case-insensitively
+    #{<<"rooms">> := FruitRooms, <<"count">> := 2} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, <<"FRUIT">>, null, null, Config)),
+    ?assertEqual([<<"apple-room@", MUCServer/binary>>, <<"cherry-room@", MUCServer/binary>>],
+                 [maps:get(<<"jid">>, R) || R <- FruitRooms]),
+    %% Filter composes with cursor pagination
+    #{<<"rooms">> := [RoomA], <<"count">> := 3, <<"nextCursor">> := Cursor} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, <<"room">>, null, 1, Config)),
+    #{<<"rooms">> := [RoomB], <<"count">> := 3, <<"nextCursor">> := _} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, <<"room">>, Cursor, 1, Config)),
+    ?assertEqual([<<"apple-room@", MUCServer/binary>>, <<"banana-room@", MUCServer/binary>>],
+                 [maps:get(<<"jid">>, RoomA), maps:get(<<"jid">>, RoomB)]),
+    %% No match -> empty page and zero count
+    #{<<"rooms">> := [], <<"count">> := 0, <<"nextCursor">> := null} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, <<"does-not-match-anything">>, null, null, Config)),
+    %% An empty filter behaves like no filter
+    #{<<"count">> := 3} =
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, <<>>, null, null, Config)),
+    %% A room stored without any config (raw backend write) is matched by JID
+    %% but never by name
+    HostType = domain_helper:host_type(),
+    RawUS = {<<"rawroom">>, MUCServer},
+    MemberUS = {<<"bob">>, domain_helper:domain()},
+    {ok, _} = rpc(mim(), mod_muc_light_db_backend, create_room,
+                  [HostType, RawUS, [], [{MemberUS, member}], <<"v1">>]),
+    #{<<"count">> := 2} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, <<"FRUIT">>, null, null, Config)),
+    #{<<"rooms">> := [RawRoom], <<"count">> := 1} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, <<"rawroom">>, null, null, Config)),
+    ?assertEqual(<<"rawroom@", MUCServer/binary>>, maps:get(<<"jid">>, RawRoom)).
+
+admin_list_rooms_owner_absent(Config) ->
+    MUCServer = ?config(muc_light_host, Config),
+    HostType = domain_helper:host_type(),
+    Domain = domain_helper:domain(),
+    %% This test uses a fixed room name, so clear leftovers of an aborted
+    %% previous run that was killed before the cleanup in `after` could run.
+    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [HostType]),
+    Schema = rpc(mim(), mod_muc_light, config_schema, [MUCServer]),
+    {ok, RoomConfig} = rpc(mim(), mod_muc_light_room_config, from_binary_kv,
+                           [[{<<"roomname">>, <<"Orphan">>}], Schema]),
+    RoomU = <<"orphanroom">>,
+    RoomUS = {RoomU, MUCServer},
+    %% Write a member-only room straight to the backend (no owner affiliation) to
+    %% exercise ownerJid = null. The member account need not exist for a raw insert.
+    MemberUS = {<<"bob">>, Domain},
+    {ok, _} = rpc(mim(), mod_muc_light_db_backend, create_room,
+                  [HostType, RoomUS, RoomConfig, [{MemberUS, member}], <<"v1">>]),
+    try
+        #{<<"rooms">> := Rooms} =
+            get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
+        OrphanBin = jid:to_binary(jid:make_bare(RoomU, MUCServer)),
+        Orphan = find_room_desc(OrphanBin, Rooms),
+        ?assertEqual(null, maps:get(<<"ownerJid">>, Orphan)),
+        ?assertEqual(1, maps:get(<<"usersNumber">>, Orphan)),
+        ?assertEqual(<<"Orphan">>, maps:get(<<"name">>, Orphan))
+    after
+        rpc(mim(), mod_muc_light_db_backend, destroy_room, [HostType, RoomUS])
+    end.
+
+admin_list_rooms_broken_config(Config) ->
+    case {mongoose_helper:mnesia_or_rdbms_backend(), ?config(protocol, Config)} of
+        {mnesia, _} ->
+            {skip, "Only the RDBMS backend re-decodes stored configs when listing"};
+        {rdbms, cli} ->
+            {skip, "The decode warning is forwarded into the CLI output, breaking its JSON"};
+        {rdbms, http} ->
+            escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                            fun admin_list_rooms_broken_config_story/2)
+    end.
+
+admin_list_rooms_broken_config_story(Config, Alice) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    MUCServer = ?config(muc_light_host, Config),
+    HostType = domain_helper:host_type(),
+    %% Start from a clean slate so domain-wide counts are deterministic.
+    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [HostType]),
+    {ok, _} = create_identified_room(MUCServer, <<"Broken">>, <<"s">>, AliceBin,
+                                     <<"broken-room">>),
+    {ok, _} = create_identified_room(MUCServer, <<"Healthy">>, <<"s">>, AliceBin,
+                                     <<"healthy-room">>),
+    %% Corrupt the stored config: an option that no longer decodes against the
+    %% current config_schema (as after a schema change) must degrade that
+    %% room's config instead of failing the whole listing.
+    Insert = <<"INSERT INTO muc_light_config (room_id, opt, val) "
+               "SELECT id, 'bogus_option', 'x' FROM muc_light_rooms "
+               "WHERE luser = 'broken-room' AND lserver = '", MUCServer/binary, "'">>,
+    {updated, 1} = rpc(mim(), mongoose_rdbms, sql_query, [HostType, Insert]),
+    #{<<"rooms">> := Rooms, <<"count">> := 2} =
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
+    Broken = find_room_desc(<<"broken-room@", MUCServer/binary>>, Rooms),
+    ?assertEqual(null, maps:get(<<"name">>, Broken)),
+    Healthy = find_room_desc(<<"healthy-room@", MUCServer/binary>>, Rooms),
+    ?assertEqual(<<"Healthy">>, maps:get(<<"name">>, Healthy)).
+
+admin_list_rooms_schema_without_roomname(Config) ->
+    escalus:fresh_story_with_config(Config, [{alice, 1}],
+                                    fun admin_list_rooms_schema_without_roomname_story/2).
+
+admin_list_rooms_schema_without_roomname_story(Config, Alice) ->
+    AliceBin = escalus_client:short_jid(Alice),
+    MUCServer = ?config(muc_light_host, Config),
+    HostType = domain_helper:host_type(),
+    %% Start from a clean slate so domain-wide counts are deterministic.
+    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [HostType]),
+    %% A config_schema may not define the roomname field at all; the listing
+    %% must then report name = null and never match rooms by name
+    NoRoomnameSchema = [{<<"subject">>, <<"Test">>, subject, binary}],
+    Opts = config([modules, mod_muc_light],
+                  maps:merge(muc_light_opts(), #{config_schema => NoRoomnameSchema})),
+    dynamic_modules:ensure_modules(HostType, [{mod_muc_light, Opts}]),
+    try
+        CreatorJID = jid:from_binary(AliceBin),
+        {ok, _} = rpc(mim(), mod_muc_light_api, create_room,
+                      [MUCServer, <<"noname-room">>, CreatorJID, #{<<"subject">> => <<"s">>}]),
+        #{<<"rooms">> := [Room], <<"count">> := 1} =
+            get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
+        ?assertEqual(null, maps:get(<<"name">>, Room)),
+        ?assertEqual(<<"s">>, maps:get(<<"subject">>, Room)),
+        %% A filter can only match the JID, as there is no name to match
+        #{<<"rooms">> := [], <<"count">> := 0} =
+            get_ok_value(?USER_LIST_ROOMS_PATH,
+                         list_rooms(MUCServer, <<"qqq">>, null, null, Config)),
+        #{<<"count">> := 1} =
+            get_ok_value(?USER_LIST_ROOMS_PATH,
+                         list_rooms(MUCServer, <<"noname">>, null, null, Config))
+    after
+        dynamic_modules:ensure_modules(HostType, required_modules(suite))
+    end.
+
+admin_list_rooms_non_existent_domain(Config) ->
+    Res = list_rooms(<<"non-existent-muclight.example.com">>, null, null, null, Config),
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)),
+    %% A domain failing nameprep is reported the same way by the Erlang API
+    %% (the GraphQL DomainName scalar rejects such input before the resolver)
+    TooLong = binary:copy(<<"x">>, 2048),
+    {muc_server_not_found, _} = rpc(mim(), mod_muc_light_api, get_rooms,
+                                    [TooLong, undefined, undefined, 5]).
+
 admin_get_room_config(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_get_room_config_story/2).
 
@@ -1739,6 +1971,11 @@ create_room(Domain, Name, Subject, CreatorBin) ->
     Config = #{<<"roomname">> => Name, <<"subject">> => Subject},
     rpc(mim(), mod_muc_light_api, create_room, [Domain, CreatorJID, Config]).
 
+create_identified_room(Domain, Name, Subject, CreatorBin, Id) ->
+    CreatorJID = jid:from_binary(CreatorBin),
+    Config = #{<<"roomname">> => Name, <<"subject">> => Subject},
+    rpc(mim(), mod_muc_light_api, create_room, [Domain, Id, CreatorJID, Config]).
+
 invite_user(RoomJID, SenderBin, RecipientBin) ->
     SenderJID = jid:from_binary(SenderBin),
     RecipientJID = jid:from_binary(RecipientBin),
@@ -1798,6 +2035,11 @@ send_message_to_room(RoomJID, From, Body, Config) ->
 list_user_rooms(User, Config) ->
     Vars = #{<<"user">> => User},
     execute_command(<<"muc_light">>, <<"listUserRooms">>, Vars, Config).
+
+list_rooms(MUCDomain, Filter, After, Limit, Config) ->
+    Vars = #{<<"mucDomain">> => MUCDomain, <<"filter">> => Filter,
+             <<"after">> => After, <<"limit">> => Limit},
+    execute_command(<<"muc_light">>, <<"listRooms">>, Vars, Config).
 
 delete_room(RoomJID, Config) ->
     Vars = #{<<"room">> => RoomJID},
@@ -1904,3 +2146,7 @@ member_is_affiliated(Stanza, User) ->
     MemberJID = escalus_utils:jid_to_lower(escalus_utils:get_short_jid(User)),
     Data = exml_query:path(Stanza, [{element, <<"x">>}, {element, <<"user">>}, cdata]),
     MemberJID == Data.
+
+find_room_desc(JIDBin, Rooms) ->
+    [Room] = [R || #{<<"jid">> := J} = R <- Rooms, J =:= JIDBin],
+    Room.

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -137,8 +137,6 @@ admin_muc_light_tests() ->
      admin_list_rooms,
      admin_list_rooms_pagination,
      admin_list_rooms_filter,
-     admin_list_rooms_owner_absent,
-     admin_list_rooms_broken_config,
      admin_list_rooms_schema_without_roomname,
      admin_list_rooms_non_existent_domain,
      admin_get_room_config,
@@ -324,10 +322,20 @@ maybe_clear_db() ->
             ok
     end.
 
+init_per_testcase(admin_list_rooms_schema_without_roomname = TC, Config) ->
+    %% A config_schema may not define the roomname field at all
+    NoRoomnameSchema = [{<<"subject">>, <<"Test">>, subject, binary}],
+    Opts = config([modules, mod_muc_light],
+                  maps:merge(muc_light_opts(), #{config_schema => NoRoomnameSchema})),
+    dynamic_modules:ensure_modules(domain_helper:host_type(), [{mod_muc_light, Opts}]),
+    escalus:init_per_testcase(TC, Config);
 init_per_testcase(TC, Config) ->
     rest_helper:maybe_skip_mam_test_cases(TC, [user_get_room_messages,
                                                admin_get_room_messages], Config).
 
+end_per_testcase(admin_list_rooms_schema_without_roomname = TC, Config) ->
+    dynamic_modules:ensure_modules(domain_helper:host_type(), required_modules(suite)),
+    escalus:end_per_testcase(TC, Config);
 end_per_testcase(TC, Config) ->
     escalus:end_per_testcase(TC, Config).
 
@@ -1506,13 +1514,13 @@ admin_list_rooms_story(Config, Alice, Bob) ->
     %% (the admin group does not clear rooms between test cases).
     ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [domain_helper:host_type()]),
     %% Empty domain
-    #{<<"rooms">> := [], <<"count">> := 0, <<"nextCursor">> := null} =
+    #{<<"rooms">> := [], <<"count">> := 0, <<"nextPage">> := false} =
         get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
     %% Create two rooms (Alice owns room1, Bob owns room2), invite Bob into room1
     {ok, #{jid := RoomJID1}} = create_room(MUCServer, <<"Room A">>, <<"subjectA">>, AliceBin),
     {ok, #{jid := RoomJID2}} = create_room(MUCServer, <<"Room B">>, <<"subjectB">>, BobBin),
     invite_user(RoomJID1, AliceBin, BobBin),
-    #{<<"rooms">> := Rooms, <<"count">> := 2, <<"nextCursor">> := null} =
+    #{<<"rooms">> := Rooms, <<"count">> := 2, <<"nextPage">> := false} =
         get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
     R1 = find_room_desc(jid:to_binary(RoomJID1), Rooms),
     ?assertEqual(<<"Room A">>, maps:get(<<"name">>, R1)),
@@ -1535,24 +1543,25 @@ admin_list_rooms_pagination_story(Config, Alice) ->
     [{ok, _} = create_room(MUCServer, Name, <<"s">>, AliceBin)
      || Name <- [<<"R1">>, <<"R2">>, <<"R3">>]],
     %% Full listing (limit defaults to 50), capture the global sort order
-    #{<<"rooms">> := All, <<"count">> := 3, <<"nextCursor">> := null} =
+    #{<<"rooms">> := All, <<"count">> := 3, <<"nextPage">> := false} =
         get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
     AllJids = [maps:get(<<"jid">>, R) || R <- All],
     ?assertEqual(lists:sort(AllJids), AllJids),
-    %% First page: limit 2 -> first two rooms, cursor points at the second one
-    #{<<"rooms">> := Page1, <<"count">> := 3, <<"nextCursor">> := Cursor} =
+    %% First page: limit 2 -> first two rooms, more pages ahead
+    #{<<"rooms">> := Page1, <<"count">> := 3, <<"nextPage">> := true} =
         get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, 2, Config)),
-    ?assertEqual(lists:sublist(AllJids, 1, 2), [maps:get(<<"jid">>, R) || R <- Page1]),
-    ?assertEqual(lists:nth(2, AllJids), Cursor),
-    %% Second page: after the cursor -> last room only, no further pages
-    #{<<"rooms">> := Page2, <<"count">> := 3, <<"nextCursor">> := null} =
-        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, Cursor, 2, Config)),
+    Page1Jids = [maps:get(<<"jid">>, R) || R <- Page1],
+    ?assertEqual(lists:sublist(AllJids, 1, 2), Page1Jids),
+    %% Second page: after the last JID of the first page -> last room only
+    #{<<"rooms">> := Page2, <<"count">> := 3, <<"nextPage">> := false} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, null, lists:last(Page1Jids), 2, Config)),
     ?assertEqual(lists:sublist(AllJids, 3, 1), [maps:get(<<"jid">>, R) || R <- Page2]),
     %% An exactly-full last page also reports no further pages
-    #{<<"rooms">> := All, <<"count">> := 3, <<"nextCursor">> := null} =
+    #{<<"rooms">> := All, <<"count">> := 3, <<"nextPage">> := false} =
         get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, 3, Config)),
     %% After the last room -> empty page, count unchanged
-    #{<<"rooms">> := [], <<"count">> := 3, <<"nextCursor">> := null} =
+    #{<<"rooms">> := [], <<"count">> := 3, <<"nextPage">> := false} =
         get_ok_value(?USER_LIST_ROOMS_PATH,
                      list_rooms(MUCServer, null, lists:last(AllJids), 2, Config)).
 
@@ -1570,7 +1579,7 @@ admin_list_rooms_filter_story(Config, Alice) ->
                        {<<"banana-room">>, <<"Yellow">>},
                        {<<"cherry-room">>, <<"fruit annex">>}]],
     %% Filter by a substring of the room JID localpart
-    #{<<"rooms">> := [Apple], <<"count">> := 1, <<"nextCursor">> := null} =
+    #{<<"rooms">> := [Apple], <<"count">> := 1, <<"nextPage">> := false} =
         get_ok_value(?USER_LIST_ROOMS_PATH,
                      list_rooms(MUCServer, <<"apple">>, null, null, Config)),
     ?assertEqual(<<"apple-room@", MUCServer/binary>>, maps:get(<<"jid">>, Apple)),
@@ -1581,99 +1590,21 @@ admin_list_rooms_filter_story(Config, Alice) ->
     ?assertEqual([<<"apple-room@", MUCServer/binary>>, <<"cherry-room@", MUCServer/binary>>],
                  [maps:get(<<"jid">>, R) || R <- FruitRooms]),
     %% Filter composes with cursor pagination
-    #{<<"rooms">> := [RoomA], <<"count">> := 3, <<"nextCursor">> := Cursor} =
+    #{<<"rooms">> := [RoomA], <<"count">> := 3, <<"nextPage">> := true} =
         get_ok_value(?USER_LIST_ROOMS_PATH,
                      list_rooms(MUCServer, <<"room">>, null, 1, Config)),
-    #{<<"rooms">> := [RoomB], <<"count">> := 3, <<"nextCursor">> := _} =
+    #{<<"rooms">> := [RoomB], <<"count">> := 3, <<"nextPage">> := true} =
         get_ok_value(?USER_LIST_ROOMS_PATH,
-                     list_rooms(MUCServer, <<"room">>, Cursor, 1, Config)),
+                     list_rooms(MUCServer, <<"room">>, maps:get(<<"jid">>, RoomA), 1, Config)),
     ?assertEqual([<<"apple-room@", MUCServer/binary>>, <<"banana-room@", MUCServer/binary>>],
                  [maps:get(<<"jid">>, RoomA), maps:get(<<"jid">>, RoomB)]),
     %% No match -> empty page and zero count
-    #{<<"rooms">> := [], <<"count">> := 0, <<"nextCursor">> := null} =
+    #{<<"rooms">> := [], <<"count">> := 0, <<"nextPage">> := false} =
         get_ok_value(?USER_LIST_ROOMS_PATH,
                      list_rooms(MUCServer, <<"does-not-match-anything">>, null, null, Config)),
     %% An empty filter behaves like no filter
     #{<<"count">> := 3} =
-        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, <<>>, null, null, Config)),
-    %% A room stored without any config (raw backend write) is matched by JID
-    %% but never by name
-    HostType = domain_helper:host_type(),
-    RawUS = {<<"rawroom">>, MUCServer},
-    MemberUS = {<<"bob">>, domain_helper:domain()},
-    {ok, _} = rpc(mim(), mod_muc_light_db_backend, create_room,
-                  [HostType, RawUS, [], [{MemberUS, member}], <<"v1">>]),
-    #{<<"count">> := 2} =
-        get_ok_value(?USER_LIST_ROOMS_PATH,
-                     list_rooms(MUCServer, <<"FRUIT">>, null, null, Config)),
-    #{<<"rooms">> := [RawRoom], <<"count">> := 1} =
-        get_ok_value(?USER_LIST_ROOMS_PATH,
-                     list_rooms(MUCServer, <<"rawroom">>, null, null, Config)),
-    ?assertEqual(<<"rawroom@", MUCServer/binary>>, maps:get(<<"jid">>, RawRoom)).
-
-admin_list_rooms_owner_absent(Config) ->
-    MUCServer = ?config(muc_light_host, Config),
-    HostType = domain_helper:host_type(),
-    Domain = domain_helper:domain(),
-    %% This test uses a fixed room name, so clear leftovers of an aborted
-    %% previous run that was killed before the cleanup in `after` could run.
-    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [HostType]),
-    Schema = rpc(mim(), mod_muc_light, config_schema, [MUCServer]),
-    {ok, RoomConfig} = rpc(mim(), mod_muc_light_room_config, from_binary_kv,
-                           [[{<<"roomname">>, <<"Orphan">>}], Schema]),
-    RoomU = <<"orphanroom">>,
-    RoomUS = {RoomU, MUCServer},
-    %% Write a member-only room straight to the backend (no owner affiliation) to
-    %% exercise ownerJid = null. The member account need not exist for a raw insert.
-    MemberUS = {<<"bob">>, Domain},
-    {ok, _} = rpc(mim(), mod_muc_light_db_backend, create_room,
-                  [HostType, RoomUS, RoomConfig, [{MemberUS, member}], <<"v1">>]),
-    try
-        #{<<"rooms">> := Rooms} =
-            get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
-        OrphanBin = jid:to_binary(jid:make_bare(RoomU, MUCServer)),
-        Orphan = find_room_desc(OrphanBin, Rooms),
-        ?assertEqual(null, maps:get(<<"ownerJid">>, Orphan)),
-        ?assertEqual(1, maps:get(<<"usersNumber">>, Orphan)),
-        ?assertEqual(<<"Orphan">>, maps:get(<<"name">>, Orphan))
-    after
-        rpc(mim(), mod_muc_light_db_backend, destroy_room, [HostType, RoomUS])
-    end.
-
-admin_list_rooms_broken_config(Config) ->
-    case {mongoose_helper:mnesia_or_rdbms_backend(), ?config(protocol, Config)} of
-        {mnesia, _} ->
-            {skip, "Only the RDBMS backend re-decodes stored configs when listing"};
-        {rdbms, cli} ->
-            {skip, "The decode warning is forwarded into the CLI output, breaking its JSON"};
-        {rdbms, http} ->
-            escalus:fresh_story_with_config(Config, [{alice, 1}],
-                                            fun admin_list_rooms_broken_config_story/2)
-    end.
-
-admin_list_rooms_broken_config_story(Config, Alice) ->
-    AliceBin = escalus_client:short_jid(Alice),
-    MUCServer = ?config(muc_light_host, Config),
-    HostType = domain_helper:host_type(),
-    %% Start from a clean slate so domain-wide counts are deterministic.
-    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [HostType]),
-    {ok, _} = create_identified_room(MUCServer, <<"Broken">>, <<"s">>, AliceBin,
-                                     <<"broken-room">>),
-    {ok, _} = create_identified_room(MUCServer, <<"Healthy">>, <<"s">>, AliceBin,
-                                     <<"healthy-room">>),
-    %% Corrupt the stored config: an option that no longer decodes against the
-    %% current config_schema (as after a schema change) must degrade that
-    %% room's config instead of failing the whole listing.
-    Insert = <<"INSERT INTO muc_light_config (room_id, opt, val) "
-               "SELECT id, 'bogus_option', 'x' FROM muc_light_rooms "
-               "WHERE luser = 'broken-room' AND lserver = '", MUCServer/binary, "'">>,
-    {updated, 1} = rpc(mim(), mongoose_rdbms, sql_query, [HostType, Insert]),
-    #{<<"rooms">> := Rooms, <<"count">> := 2} =
-        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
-    Broken = find_room_desc(<<"broken-room@", MUCServer/binary>>, Rooms),
-    ?assertEqual(null, maps:get(<<"name">>, Broken)),
-    Healthy = find_room_desc(<<"healthy-room@", MUCServer/binary>>, Rooms),
-    ?assertEqual(<<"Healthy">>, maps:get(<<"name">>, Healthy)).
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, <<>>, null, null, Config)).
 
 admin_list_rooms_schema_without_roomname(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],
@@ -1682,42 +1613,26 @@ admin_list_rooms_schema_without_roomname(Config) ->
 admin_list_rooms_schema_without_roomname_story(Config, Alice) ->
     AliceBin = escalus_client:short_jid(Alice),
     MUCServer = ?config(muc_light_host, Config),
-    HostType = domain_helper:host_type(),
     %% Start from a clean slate so domain-wide counts are deterministic.
-    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [HostType]),
-    %% A config_schema may not define the roomname field at all; the listing
-    %% must then report name = null and never match rooms by name
-    NoRoomnameSchema = [{<<"subject">>, <<"Test">>, subject, binary}],
-    Opts = config([modules, mod_muc_light],
-                  maps:merge(muc_light_opts(), #{config_schema => NoRoomnameSchema})),
-    dynamic_modules:ensure_modules(HostType, [{mod_muc_light, Opts}]),
-    try
-        CreatorJID = jid:from_binary(AliceBin),
-        {ok, _} = rpc(mim(), mod_muc_light_api, create_room,
-                      [MUCServer, <<"noname-room">>, CreatorJID, #{<<"subject">> => <<"s">>}]),
-        #{<<"rooms">> := [Room], <<"count">> := 1} =
-            get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
-        ?assertEqual(null, maps:get(<<"name">>, Room)),
-        ?assertEqual(<<"s">>, maps:get(<<"subject">>, Room)),
-        %% A filter can only match the JID, as there is no name to match
-        #{<<"rooms">> := [], <<"count">> := 0} =
-            get_ok_value(?USER_LIST_ROOMS_PATH,
-                         list_rooms(MUCServer, <<"qqq">>, null, null, Config)),
-        #{<<"count">> := 1} =
-            get_ok_value(?USER_LIST_ROOMS_PATH,
-                         list_rooms(MUCServer, <<"noname">>, null, null, Config))
-    after
-        dynamic_modules:ensure_modules(HostType, required_modules(suite))
-    end.
+    ok = rpc(mim(), mod_muc_light_db_backend, force_clear, [domain_helper:host_type()]),
+    CreatorJID = jid:from_binary(AliceBin),
+    {ok, _} = rpc(mim(), mod_muc_light_api, create_room,
+                  [MUCServer, <<"noname-room">>, CreatorJID, #{<<"subject">> => <<"s">>}]),
+    #{<<"rooms">> := [Room], <<"count">> := 1} =
+        get_ok_value(?USER_LIST_ROOMS_PATH, list_rooms(MUCServer, null, null, null, Config)),
+    ?assertEqual(null, maps:get(<<"name">>, Room)),
+    ?assertEqual(<<"s">>, maps:get(<<"subject">>, Room)),
+    %% A filter can only match the JID, as there is no name to match
+    #{<<"rooms">> := [], <<"count">> := 0} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, <<"qqq">>, null, null, Config)),
+    #{<<"count">> := 1} =
+        get_ok_value(?USER_LIST_ROOMS_PATH,
+                     list_rooms(MUCServer, <<"noname">>, null, null, Config)).
 
 admin_list_rooms_non_existent_domain(Config) ->
     Res = list_rooms(<<"non-existent-muclight.example.com">>, null, null, null, Config),
-    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)),
-    %% A domain failing nameprep is reported the same way by the Erlang API
-    %% (the GraphQL DomainName scalar rejects such input before the resolver)
-    TooLong = binary:copy(<<"x">>, 2048),
-    {muc_server_not_found, _} = rpc(mim(), mod_muc_light_api, get_rooms,
-                                    [TooLong, undefined, undefined, 5]).
+    ?assertNotEqual(nomatch, binary:match(get_err_msg(Res), <<"not found">>)).
 
 admin_get_room_config(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}], fun admin_get_room_config_story/2).

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -1526,10 +1526,8 @@ admin_list_rooms_story(Config, Alice, Bob) ->
     ?assertEqual(<<"Room A">>, maps:get(<<"name">>, R1)),
     ?assertEqual(<<"subjectA">>, maps:get(<<"subject">>, R1)),
     ?assertEqual(2, maps:get(<<"usersNumber">>, R1)),
-    ?assertEqual(escalus_utils:jid_to_lower(AliceBin), maps:get(<<"ownerJid">>, R1)),
     R2 = find_room_desc(jid:to_binary(RoomJID2), Rooms),
-    ?assertEqual(1, maps:get(<<"usersNumber">>, R2)),
-    ?assertEqual(escalus_utils:jid_to_lower(BobBin), maps:get(<<"ownerJid">>, R2)).
+    ?assertEqual(1, maps:get(<<"usersNumber">>, R2)).
 
 admin_list_rooms_pagination(Config) ->
     escalus:fresh_story_with_config(Config, [{alice, 1}],

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -46,15 +46,7 @@ type MUCLightAdminQuery @protected @use(modules: ["mod_muc_light"]){
   "Get the user's list of blocked entities"
   getBlockingList(user: JID!): [BlockingItem!]
     @protected(type: DOMAIN, args: ["user"]) @use(args: ["user"])
-  "Get rooms under the given MUC Light domain, paginated by room JID"
-  listRooms(
-    mucDomain: DomainName!
-    "Return only rooms whose JID localpart or name contains this string (case-insensitive)"
-    filter: String
-    "JID of the last room from the previous page (see MUCLightRoomsPayload.nextCursor)"
-    after: BareJID
-    "Maximum number of rooms to return in one page"
-    limit: PosInt = 50
-  ): MUCLightRoomsPayload
+  "Get rooms of the given MUC Light domain, ordered by JID. To get the next page, pass the JID of the last room as 'after'. 'filter' matches a substring of the room JID or name"
+  listRooms(mucDomain: DomainName!, filter: String, after: BareJID, limit: PosInt = 50): MUCLightRoomsPayload
     @protected(type: DOMAIN, args: ["mucDomain"]) @use(args: ["mucDomain"])
 }

--- a/priv/graphql/schemas/admin/muc_light.gql
+++ b/priv/graphql/schemas/admin/muc_light.gql
@@ -46,4 +46,15 @@ type MUCLightAdminQuery @protected @use(modules: ["mod_muc_light"]){
   "Get the user's list of blocked entities"
   getBlockingList(user: JID!): [BlockingItem!]
     @protected(type: DOMAIN, args: ["user"]) @use(args: ["user"])
+  "Get rooms under the given MUC Light domain, paginated by room JID"
+  listRooms(
+    mucDomain: DomainName!
+    "Return only rooms whose JID localpart or name contains this string (case-insensitive)"
+    filter: String
+    "JID of the last room from the previous page (see MUCLightRoomsPayload.nextCursor)"
+    after: BareJID
+    "Maximum number of rooms to return in one page"
+    limit: PosInt = 50
+  ): MUCLightRoomsPayload
+    @protected(type: DOMAIN, args: ["mucDomain"]) @use(args: ["mucDomain"])
 }

--- a/priv/graphql/schemas/global/muc_light.gql
+++ b/priv/graphql/schemas/global/muc_light.gql
@@ -100,6 +100,4 @@ type MUCLightRoomDesc{
   subject: String
   "Number of room members"
   usersNumber: NonNegInt
-  "JID of one of the room's owners (there is normally exactly one); null if no owner can be resolved"
-  ownerJid: JID
 }

--- a/priv/graphql/schemas/global/muc_light.gql
+++ b/priv/graphql/schemas/global/muc_light.gql
@@ -86,8 +86,8 @@ type MUCLightRoomsPayload{
   rooms: [MUCLightRoomDesc!]
   "Total number of rooms in the domain matching the filter"
   count: NonNegInt
-  "JID of the last room in this page; pass it as 'after' to get the next page. Null when there are no more rooms"
-  nextCursor: BareJID
+  "Whether more rooms exist after this page"
+  nextPage: Boolean
 }
 
 "MUC Light room description"

--- a/priv/graphql/schemas/global/muc_light.gql
+++ b/priv/graphql/schemas/global/muc_light.gql
@@ -100,6 +100,6 @@ type MUCLightRoomDesc{
   subject: String
   "Number of room members"
   usersNumber: NonNegInt
-  "JID of the room's owner; null if no owner can be resolved"
+  "JID of one of the room's owners (there is normally exactly one); null if no owner can be resolved"
   ownerJid: JID
 }

--- a/priv/graphql/schemas/global/muc_light.gql
+++ b/priv/graphql/schemas/global/muc_light.gql
@@ -79,3 +79,27 @@ type RoomUser{
   "User's affiliation"
   affiliation: Affiliation!
 }
+
+"MUC Light rooms payload"
+type MUCLightRoomsPayload{
+  "List of room descriptions, ordered by room JID"
+  rooms: [MUCLightRoomDesc!]
+  "Total number of rooms in the domain matching the filter"
+  count: NonNegInt
+  "JID of the last room in this page; pass it as 'after' to get the next page. Null when there are no more rooms"
+  nextCursor: BareJID
+}
+
+"MUC Light room description"
+type MUCLightRoomDesc{
+  "Room's JID"
+  jid: BareJID!
+  "Room's display name (may be empty)"
+  name: String
+  "Room's subject (may be empty)"
+  subject: String
+  "Number of room members"
+  usersNumber: NonNegInt
+  "JID of the room's owner; null if no owner can be resolved"
+  ownerJid: JID
+}

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
@@ -87,8 +87,8 @@ list_rooms(#{<<"mucDomain">> := MUCDomain, <<"filter">> := Filter,
     After2 = after_to_luser(null_to_undefined(After)),
     Limit2 = null_to_default(Limit, ?DEFAULT_ROOMS_PAGE_SIZE),
     case mod_muc_light_api:get_rooms(MUCDomain, Filter2, After2, Limit2) of
-        {ok, {Rooms, Count, NextCursor}} ->
-            {ok, mongoose_graphql_muc_light_helper:make_rooms_payload(Rooms, Count, NextCursor)};
+        {ok, {Rooms, Count, HasNextPage}} ->
+            {ok, mongoose_graphql_muc_light_helper:make_rooms_payload(Rooms, Count, HasNextPage)};
         Err ->
             make_error(Err, #{mucDomain => MUCDomain})
     end.

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
@@ -10,7 +10,12 @@
 -import(mongoose_graphql_helper, [make_error/2, format_result/2, null_to_undefined/1]).
 -import(mongoose_graphql_muc_light_helper, [make_room/1,
                                             make_ok_user/1,
-                                            page_size_or_max_limit/2]).
+                                            page_size_or_max_limit/2,
+                                            null_to_default/2]).
+
+%% Matches the schema default of the listRooms limit argument; only needed
+%% when the client passes an explicit null.
+-define(DEFAULT_ROOMS_PAGE_SIZE, 50).
 
 execute(_Ctx, _Obj, <<"listUserRooms">>, Args) ->
     list_user_rooms(Args);
@@ -21,7 +26,9 @@ execute(_Ctx, _Obj, <<"getRoomConfig">>, Args) ->
 execute(_Ctx, _Obj, <<"getRoomMessages">>, Args) ->
     get_room_messages(Args);
 execute(_Ctx, _Obj, <<"getBlockingList">>, Args) ->
-    get_blocking_list(Args).
+    get_blocking_list(Args);
+execute(_Ctx, _Obj, <<"listRooms">>, Args) ->
+    list_rooms(Args).
 
 -spec list_user_rooms(map()) -> {ok, [{ok, binary()}]} | {error, resolver_error()}.
 list_user_rooms(#{<<"user">> := UserJID}) ->
@@ -72,3 +79,22 @@ get_blocking_list(#{<<"user">> := UserJID}) ->
         Err ->
             make_error(Err, #{user => jid:to_binary(UserJID)})
     end.
+
+-spec list_rooms(map()) -> {ok, map()} | {error, resolver_error()}.
+list_rooms(#{<<"mucDomain">> := MUCDomain, <<"filter">> := Filter,
+             <<"after">> := After, <<"limit">> := Limit}) ->
+    Filter2 = null_to_undefined(Filter),
+    After2 = after_to_luser(null_to_undefined(After)),
+    Limit2 = null_to_default(Limit, ?DEFAULT_ROOMS_PAGE_SIZE),
+    case mod_muc_light_api:get_rooms(MUCDomain, Filter2, After2, Limit2) of
+        {ok, {Rooms, Count, NextCursor}} ->
+            {ok, mongoose_graphql_muc_light_helper:make_rooms_payload(Rooms, Count, NextCursor)};
+        Err ->
+            make_error(Err, #{mucDomain => MUCDomain})
+    end.
+
+after_to_luser(undefined) ->
+    undefined;
+after_to_luser(JID) ->
+    {LUser, _} = jid:to_lus(JID),
+    LUser.

--- a/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
+++ b/src/graphql/admin/mongoose_graphql_muc_light_admin_query.erl
@@ -84,7 +84,7 @@ get_blocking_list(#{<<"user">> := UserJID}) ->
 list_rooms(#{<<"mucDomain">> := MUCDomain, <<"filter">> := Filter,
              <<"after">> := After, <<"limit">> := Limit}) ->
     Filter2 = null_to_undefined(Filter),
-    After2 = after_to_luser(null_to_undefined(After)),
+    After2 = after_to_luser(After),
     Limit2 = null_to_default(Limit, ?DEFAULT_ROOMS_PAGE_SIZE),
     case mod_muc_light_api:get_rooms(MUCDomain, Filter2, After2, Limit2) of
         {ok, {Rooms, Count, HasNextPage}} ->
@@ -93,7 +93,7 @@ list_rooms(#{<<"mucDomain">> := MUCDomain, <<"filter">> := Filter,
             make_error(Err, #{mucDomain => MUCDomain})
     end.
 
-after_to_luser(undefined) ->
+after_to_luser(null) ->
     undefined;
 after_to_luser(JID) ->
     {LUser, _} = jid:to_lus(JID),

--- a/src/graphql/mongoose_graphql_muc_light_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_light_helper.erl
@@ -60,9 +60,8 @@ make_rooms_payload(RoomDescs, Count, HasNextPage) ->
 
 -spec make_room_desc(mod_muc_light_api:room_desc()) -> map().
 make_room_desc(#{jid := JID, name := Name, subject := Subject,
-                 users_number := UsersNumber, owner := Owner}) ->
+                 users_number := UsersNumber}) ->
     #{<<"jid">> => jid:to_binary(JID),
       <<"name">> => undefined_to_null(Name),
       <<"subject">> => undefined_to_null(Subject),
-      <<"usersNumber">> => UsersNumber,
-      <<"ownerJid">> => undefined_to_null(Owner)}.
+      <<"usersNumber">> => UsersNumber}.

--- a/src/graphql/mongoose_graphql_muc_light_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_light_helper.erl
@@ -51,15 +51,12 @@ options_to_map(Options) ->
     maps:from_list([{K, V} || #{<<"key">> := K, <<"value">> := V} <- Options]).
 
 -spec make_rooms_payload([mod_muc_light_api:room_desc()], non_neg_integer(),
-                         jid:jid() | undefined) -> map().
-make_rooms_payload(RoomDescs, Count, NextCursor) ->
+                         boolean()) -> map().
+make_rooms_payload(RoomDescs, Count, HasNextPage) ->
     Rooms = [{ok, make_room_desc(D)} || D <- RoomDescs],
     #{<<"rooms">> => Rooms,
       <<"count">> => Count,
-      <<"nextCursor">> => next_cursor_value(NextCursor)}.
-
-next_cursor_value(undefined) -> null;
-next_cursor_value(JID) -> jid:to_binary(JID).
+      <<"nextPage">> => HasNextPage}.
 
 -spec make_room_desc(mod_muc_light_api:room_desc()) -> map().
 make_room_desc(#{jid := JID, name := Name, subject := Subject,

--- a/src/graphql/mongoose_graphql_muc_light_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_light_helper.erl
@@ -1,7 +1,10 @@
 -module(mongoose_graphql_muc_light_helper).
 
+-import(mongoose_graphql_helper, [undefined_to_null/1]).
+
 -export([make_room/1, make_ok_user/1, blocking_item_to_map/1, prepare_blocking_items/1,
-         page_size_or_max_limit/2, null_to_default/2, config_to_map/3]).
+         page_size_or_max_limit/2, null_to_default/2, config_to_map/3,
+         make_rooms_payload/3]).
 
 -spec page_size_or_max_limit(null | integer(), integer()) -> integer().
 page_size_or_max_limit(null, MaxLimit) ->
@@ -46,3 +49,23 @@ options_to_map(null) ->
     #{};
 options_to_map(Options) ->
     maps:from_list([{K, V} || #{<<"key">> := K, <<"value">> := V} <- Options]).
+
+-spec make_rooms_payload([mod_muc_light_api:room_desc()], non_neg_integer(),
+                         jid:jid() | undefined) -> map().
+make_rooms_payload(RoomDescs, Count, NextCursor) ->
+    Rooms = [{ok, make_room_desc(D)} || D <- RoomDescs],
+    #{<<"rooms">> => Rooms,
+      <<"count">> => Count,
+      <<"nextCursor">> => next_cursor_value(NextCursor)}.
+
+next_cursor_value(undefined) -> null;
+next_cursor_value(JID) -> jid:to_binary(JID).
+
+-spec make_room_desc(mod_muc_light_api:room_desc()) -> map().
+make_room_desc(#{jid := JID, name := Name, subject := Subject,
+                 users_number := UsersNumber, owner := Owner}) ->
+    #{<<"jid">> => jid:to_binary(JID),
+      <<"name">> => undefined_to_null(Name),
+      <<"subject">> => undefined_to_null(Subject),
+      <<"usersNumber">> => UsersNumber,
+      <<"ownerJid">> => undefined_to_null(Owner)}.

--- a/src/muc_light/mod_muc_light_api.erl
+++ b/src/muc_light/mod_muc_light_api.erl
@@ -209,7 +209,6 @@ check_muc_server(M = #{muc_server := MUCServer}) ->
         LServer ->
             case mongoose_domain_api:get_subdomain_host_type(LServer) of
                 {ok, HostType} ->
-                    %% Store the nameprepped value, as the backends match on it verbatim
                     M#{muc_server := LServer, muc_host_type => HostType};
                 {error, not_found} ->
                     ?MUC_SERVER_NOT_FOUND_RESULT
@@ -439,14 +438,12 @@ get_aff(UserUS, Affs) ->
 -spec raw_to_room_desc(mod_muc_light_db_backend:room_desc(),
                        mod_muc_light_room_config:schema()) -> room_desc().
 raw_to_room_desc(#{room := {RoomU, RoomS}, config := Config, aff_users := AffUsers}, Schema) ->
-    %% DB rows are already prepped; make_noprep cannot fail on a malformed row
     #{jid => jid:make_noprep(RoomU, RoomS, <<>>),
       name => config_field(<<"roomname">>, Config, Schema),
       subject => config_field(<<"subject">>, Config, Schema),
       users_number => length(AffUsers),
       owner => find_owner(AffUsers)}.
 
-%% Config kv() is keyed by the internal schema key, which may differ from the field name
 -spec config_field(binary(), mod_muc_light_room_config:kv(),
                    mod_muc_light_room_config:schema()) -> binary() | undefined.
 config_field(FieldName, Config, Schema) ->

--- a/src/muc_light/mod_muc_light_api.erl
+++ b/src/muc_light/mod_muc_light_api.erl
@@ -37,8 +37,7 @@
 -type room_desc() :: #{jid := jid:jid(),
                        name := binary() | undefined,
                        subject := binary() | undefined,
-                       users_number := non_neg_integer(),
-                       owner := jid:simple_bare_jid() | undefined}.
+                       users_number := non_neg_integer()}.
 
 -type list_rooms_result() :: {Rooms :: [room_desc()],
                               Count :: non_neg_integer(),
@@ -441,21 +440,13 @@ raw_to_room_desc(#{room := {RoomU, RoomS}, config := Config, aff_users := AffUse
     #{jid => jid:make_noprep(RoomU, RoomS, <<>>),
       name => config_field(<<"roomname">>, Config, Schema),
       subject => config_field(<<"subject">>, Config, Schema),
-      users_number => length(AffUsers),
-      owner => find_owner(AffUsers)}.
+      users_number => length(AffUsers)}.
 
 -spec config_field(binary(), mod_muc_light_room_config:kv(),
                    mod_muc_light_room_config:schema()) -> binary() | undefined.
 config_field(FieldName, Config, Schema) ->
     case lists:keyfind(FieldName, 1, Schema) of
         {FieldName, _Default, Key, _Type} -> proplists:get_value(Key, Config, undefined);
-        false -> undefined
-    end.
-
--spec find_owner(aff_users()) -> jid:simple_bare_jid() | undefined.
-find_owner(AffUsers) ->
-    case lists:keyfind(owner, 2, AffUsers) of
-        {OwnerUS, owner} -> OwnerUS;
         false -> undefined
     end.
 

--- a/src/muc_light/mod_muc_light_api.erl
+++ b/src/muc_light/mod_muc_light_api.erl
@@ -14,6 +14,7 @@
          get_room_messages/4,
          get_room_messages/5,
          get_user_rooms/1,
+         get_rooms/4,
          get_room_info/1,
          get_room_info/2,
          get_room_aff/1,
@@ -33,7 +34,17 @@
                   aff_users := aff_users(),
                   options := map()}.
 
--export_type([room/0]).
+-type room_desc() :: #{jid := jid:jid(),
+                       name := binary() | undefined,
+                       subject := binary() | undefined,
+                       users_number := non_neg_integer(),
+                       owner := jid:simple_bare_jid() | undefined}.
+
+-type list_rooms_result() :: {Rooms :: [room_desc()],
+                              Count :: non_neg_integer(),
+                              NextCursor :: jid:jid() | undefined}.
+
+-export_type([room/0, room_desc/0, list_rooms_result/0]).
 
 -define(ROOM_DELETED_SUCC_RESULT, {ok, "Room deleted successfully"}).
 -define(USER_NOT_ROOM_MEMBER_RESULT, {not_room_member, "Given user does not occupy this room"}).
@@ -151,6 +162,17 @@ get_room_aff(RoomJID) ->
 get_user_rooms(UserJID) ->
     fold(#{user => UserJID}, [fun check_user/1, fun do_get_user_rooms/1]).
 
+%% Filter is matched case-insensitively as a substring of the room localpart
+%% or the room name; After is the localpart of the last room of the previous
+%% page (keyset cursor).
+-spec get_rooms(jid:lserver(), binary() | undefined, jid:luser() | undefined,
+                pos_integer()) ->
+          {ok, list_rooms_result()} | {muc_server_not_found, iolist()}.
+get_rooms(MUCServer, Filter, After, Limit) ->
+    M = #{muc_server => MUCServer, filter => normalize_filter(Filter),
+          after_room => After, limit => Limit},
+    fold(M, [fun check_muc_domain/1, fun do_get_rooms/1]).
+
 -spec get_blocking_list(jid:jid()) -> {ok, [blocking_item()]} | {user_not_found, iolist()}.
 get_blocking_list(UserJID) ->
     fold(#{user => UserJID}, [fun check_user/1, fun do_get_blocking_list/1]).
@@ -173,6 +195,17 @@ check_user(M = #{user := UserJID = #jid{lserver = LServer}}) ->
     end.
 
 check_muc_domain(M = #{room := #jid{lserver = LServer}}) ->
+    check_muc_lserver(LServer, M);
+check_muc_domain(M = #{muc_server := MUCServer}) ->
+    case jid:nameprep(MUCServer) of
+        error ->
+            ?MUC_SERVER_NOT_FOUND_RESULT;
+        LServer ->
+            %% Store the nameprepped value, as the backends match on it verbatim
+            check_muc_lserver(LServer, M#{muc_server := LServer})
+    end.
+
+check_muc_lserver(LServer, M) ->
     case mongoose_domain_api:get_subdomain_host_type(LServer) of
         {ok, HostType} ->
             M#{muc_host_type => HostType};
@@ -345,6 +378,23 @@ do_get_user_rooms(#{user := UserJID, user_host_type := HostType}) ->
     MUCServer = mod_muc_light_utils:server_host_to_muc_host(HostType, UserJID#jid.lserver),
     {ok, mod_muc_light_db_backend:get_user_rooms(HostType, jid:to_lus(UserJID), MUCServer)}.
 
+do_get_rooms(#{muc_server := MUCServer, muc_host_type := HostType,
+               filter := Filter, after_room := After, limit := Limit}) ->
+    %% Fetch one extra room to learn whether a next page exists
+    {Raw, Count} =
+        mod_muc_light_db_backend:get_room_descs(HostType, MUCServer, Filter, After, Limit + 1),
+    Schema = mod_muc_light:config_schema(MUCServer),
+    Page = [raw_to_room_desc(R, Schema) || R <- lists:sublist(Raw, Limit)],
+    NextCursor = case length(Raw) > Limit of
+                     true -> maps:get(jid, lists:last(Page));
+                     false -> undefined
+                 end,
+    {ok, {Page, Count, NextCursor}}.
+
+normalize_filter(undefined) -> undefined;
+normalize_filter(<<>>) -> undefined;
+normalize_filter(Filter) -> string:lowercase(Filter).
+
 do_get_blocking_list(#{user := UserJID, user_host_type := HostType}) ->
     MUCServer = mod_muc_light_utils:server_host_to_muc_host(HostType, UserJID#jid.lserver),
     {ok, mod_muc_light_db_backend:get_blocking(HostType, jid:to_lus(UserJID), MUCServer)}.
@@ -385,6 +435,32 @@ get_aff(UserUS, Affs) ->
     case lists:keyfind(UserUS, 1, Affs) of
         {_, Aff} -> Aff;
         false -> none
+    end.
+
+-spec raw_to_room_desc(mod_muc_light_db_backend:room_desc(),
+                       mod_muc_light_room_config:schema()) -> room_desc().
+raw_to_room_desc(#{room := {RoomU, RoomS}, config := Config, aff_users := AffUsers}, Schema) ->
+    %% DB rows are already prepped; make_noprep cannot fail on a malformed row
+    #{jid => jid:make_noprep(RoomU, RoomS, <<>>),
+      name => config_field(<<"roomname">>, Config, Schema),
+      subject => config_field(<<"subject">>, Config, Schema),
+      users_number => length(AffUsers),
+      owner => find_owner(AffUsers)}.
+
+%% Config kv() is keyed by the internal schema key, which may differ from the field name
+-spec config_field(binary(), mod_muc_light_room_config:kv(),
+                   mod_muc_light_room_config:schema()) -> binary() | undefined.
+config_field(FieldName, Config, Schema) ->
+    case lists:keyfind(FieldName, 1, Schema) of
+        {FieldName, _Default, Key, _Type} -> proplists:get_value(Key, Config, undefined);
+        false -> undefined
+    end.
+
+-spec find_owner(aff_users()) -> jid:simple_bare_jid() | undefined.
+find_owner(AffUsers) ->
+    case lists:keyfind(owner, 2, AffUsers) of
+        {OwnerUS, owner} -> OwnerUS;
+        false -> undefined
     end.
 
 make_room(JID, #config{ raw_config = Options}, AffUsers) ->

--- a/src/muc_light/mod_muc_light_api.erl
+++ b/src/muc_light/mod_muc_light_api.erl
@@ -42,7 +42,7 @@
 
 -type list_rooms_result() :: {Rooms :: [room_desc()],
                               Count :: non_neg_integer(),
-                              NextCursor :: jid:jid() | undefined}.
+                              HasNextPage :: boolean()}.
 
 -export_type([room/0, room_desc/0, list_rooms_result/0]).
 
@@ -171,7 +171,7 @@ get_user_rooms(UserJID) ->
 get_rooms(MUCServer, Filter, After, Limit) ->
     M = #{muc_server => MUCServer, filter => normalize_filter(Filter),
           after_room => After, limit => Limit},
-    fold(M, [fun check_muc_domain/1, fun do_get_rooms/1]).
+    fold(M, [fun check_muc_server/1, fun do_get_rooms/1]).
 
 -spec get_blocking_list(jid:jid()) -> {ok, [blocking_item()]} | {user_not_found, iolist()}.
 get_blocking_list(UserJID) ->
@@ -195,22 +195,25 @@ check_user(M = #{user := UserJID = #jid{lserver = LServer}}) ->
     end.
 
 check_muc_domain(M = #{room := #jid{lserver = LServer}}) ->
-    check_muc_lserver(LServer, M);
-check_muc_domain(M = #{muc_server := MUCServer}) ->
-    case jid:nameprep(MUCServer) of
-        error ->
-            ?MUC_SERVER_NOT_FOUND_RESULT;
-        LServer ->
-            %% Store the nameprepped value, as the backends match on it verbatim
-            check_muc_lserver(LServer, M#{muc_server := LServer})
-    end.
-
-check_muc_lserver(LServer, M) ->
     case mongoose_domain_api:get_subdomain_host_type(LServer) of
         {ok, HostType} ->
             M#{muc_host_type => HostType};
         {error, not_found} ->
             ?MUC_SERVER_NOT_FOUND_RESULT
+    end.
+
+check_muc_server(M = #{muc_server := MUCServer}) ->
+    case jid:nameprep(MUCServer) of
+        error ->
+            ?MUC_SERVER_NOT_FOUND_RESULT;
+        LServer ->
+            case mongoose_domain_api:get_subdomain_host_type(LServer) of
+                {ok, HostType} ->
+                    %% Store the nameprepped value, as the backends match on it verbatim
+                    M#{muc_server := LServer, muc_host_type => HostType};
+                {error, not_found} ->
+                    ?MUC_SERVER_NOT_FOUND_RESULT
+            end
     end.
 
 check_room_member(M = #{user := UserJID, aff_users := AffUsers}) ->
@@ -385,11 +388,7 @@ do_get_rooms(#{muc_server := MUCServer, muc_host_type := HostType,
         mod_muc_light_db_backend:get_room_descs(HostType, MUCServer, Filter, After, Limit + 1),
     Schema = mod_muc_light:config_schema(MUCServer),
     Page = [raw_to_room_desc(R, Schema) || R <- lists:sublist(Raw, Limit)],
-    NextCursor = case length(Raw) > Limit of
-                     true -> maps:get(jid, lists:last(Page));
-                     false -> undefined
-                 end,
-    {ok, {Page, Count, NextCursor}}.
+    {ok, {Page, Count, length(Raw) > Limit}}.
 
 normalize_filter(undefined) -> undefined;
 normalize_filter(<<>>) -> undefined;

--- a/src/muc_light/mod_muc_light_db_backend.erl
+++ b/src/muc_light/mod_muc_light_db_backend.erl
@@ -21,8 +21,13 @@
 -type remove_user_return() :: [{RoomUS :: jid:simple_bare_jid(),
                                 modify_aff_users_return()}].
 
+-type room_desc() :: #{room := jid:simple_bare_jid(),
+                       config := mod_muc_light_room_config:kv(),
+                       aff_users := aff_users()}.
+
 -export_type([modify_aff_users_return/0,
-              remove_user_return/0]).
+              remove_user_return/0,
+              room_desc/0]).
 
 %% API
 -export([start/2]).
@@ -42,6 +47,7 @@
 -export([get_aff_users/2]).
 -export([modify_aff_users/5]).
 -export([get_info/2]).
+-export([get_room_descs/5]).
 
 %% For tests
 -export([force_clear/1]).
@@ -134,6 +140,19 @@
                    RoomUS :: jid:simple_bare_jid()) ->
     {ok, mod_muc_light_room_config:kv(), aff_users(), Version :: binary()}
     | {error, not_exists}.
+
+%% ------------------------ Listing rooms in a domain ------------------------
+%% Returns a page of at most Limit rooms sorted by the room localpart,
+%% positioned strictly after the After cursor (undefined starts from the
+%% beginning), together with the total number of rooms matching the filter.
+%% Filter is a lowercase substring matched case-insensitively against the room
+%% localpart and the room name; undefined matches every room.
+-callback get_room_descs(HostType :: mongooseim:host_type(),
+                         MUCServer :: jid:lserver(),
+                         Filter :: binary() | undefined,
+                         After :: jid:luser() | undefined,
+                         Limit :: pos_integer()) ->
+    {[room_desc()], Count :: non_neg_integer()}.
 
 %% ------------------------ API for tests ------------------------
 -callback force_clear() -> ok.
@@ -273,6 +292,13 @@ modify_aff_users(HostType, RoomUS, AffUsersChanges, ExternalCheck, Version) ->
     | {error, not_exists}.
 get_info(HostType, RoomUS) ->
     Args = [HostType, RoomUS],
+    mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
+
+-spec get_room_descs(mongooseim:host_type(), jid:lserver(), binary() | undefined,
+                     jid:luser() | undefined, pos_integer()) ->
+    {[room_desc()], Count :: non_neg_integer()}.
+get_room_descs(HostType, MUCServer, Filter, After, Limit) ->
+    Args = [HostType, MUCServer, Filter, After, Limit],
     mongoose_backend:call(HostType, ?MAIN_MODULE, ?FUNCTION_NAME, Args).
 
 -spec force_clear(HostType :: mongooseim:host_type()) -> ok.

--- a/src/muc_light/mod_muc_light_db_mnesia.erl
+++ b/src/muc_light/mod_muc_light_db_mnesia.erl
@@ -43,7 +43,8 @@
          set_blocking/4,
          get_aff_users/2,
          modify_aff_users/5,
-         get_info/2
+         get_info/2,
+         get_room_descs/5
         ]).
 
 %% Extra API for testing
@@ -51,6 +52,7 @@
 -ignore_xref([force_clear/0]).
 
 -include("mod_muc_light.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
 
 -record(muc_light_room, {
           room :: jid:simple_bare_jid(),
@@ -230,6 +232,46 @@ get_info(_HostType, RoomUS) ->
             {error, not_exists};
         [#muc_light_room{ config = Config, aff_users = AffUsers, version = Version }] ->
             {ok, Config, AffUsers, Version}
+    end.
+
+-spec get_room_descs(mongooseim:host_type(), jid:lserver(), binary() | undefined,
+                     jid:luser() | undefined, pos_integer()) ->
+    {[mod_muc_light_db_backend:room_desc()], non_neg_integer()}.
+get_room_descs(_HostType, MUCServer, Filter, After, Limit) ->
+    MS = ets:fun2ms(fun(#muc_light_room{room = {_, RoomS}} = Room)
+                          when RoomS =:= MUCServer -> Room end),
+    Rooms = mnesia:dirty_select(muc_light_room, MS),
+    Schema = mod_muc_light:config_schema(MUCServer),
+    Matching = lists:keysort(#muc_light_room.room,
+                             [R || R <- Rooms, room_matches_filter(R, Filter, Schema)]),
+    Page = lists:sublist(drop_up_to_cursor(Matching, After), Limit),
+    Descs = [#{room => RoomUS, config => Config, aff_users => AffUsers}
+             || #muc_light_room{room = RoomUS, config = Config, aff_users = AffUsers} <- Page],
+    {Descs, length(Matching)}.
+
+drop_up_to_cursor(Rooms, undefined) ->
+    Rooms;
+drop_up_to_cursor(Rooms, After) ->
+    lists:dropwhile(fun(#muc_light_room{room = {RoomU, _}}) -> RoomU =< After end, Rooms).
+
+room_matches_filter(_Room, undefined, _Schema) ->
+    true;
+room_matches_filter(#muc_light_room{room = {RoomU, _}, config = Config}, Filter, Schema) ->
+    binary:match(RoomU, Filter) =/= nomatch
+        orelse room_name_matches(Config, Filter, Schema).
+
+%% Config is keyed by the internal schema key, which may differ from the field name
+room_name_matches(Config, Filter, Schema) ->
+    case lists:keyfind(<<"roomname">>, 1, Schema) of
+        {_FieldName, _Default, Key, _Type} ->
+            case proplists:get_value(Key, Config) of
+                Name when is_binary(Name) ->
+                    binary:match(string:lowercase(Name), Filter) =/= nomatch;
+                _ ->
+                    false
+            end;
+        false ->
+            false
     end.
 
 %%====================================================================

--- a/src/muc_light/mod_muc_light_db_mnesia.erl
+++ b/src/muc_light/mod_muc_light_db_mnesia.erl
@@ -268,7 +268,6 @@ room_matches_filter(#muc_light_room{room = {RoomU, _}, config = Config}, Filter,
     binary:match(RoomU, Filter) =/= nomatch
         orelse room_name_matches(Config, Filter, Schema).
 
-%% The stored config is keyed by the internal key of the schema's roomname field
 room_name_matches(Config, Filter, Schema) ->
     case lists:keyfind(<<"roomname">>, 1, Schema) of
         {_FieldName, _Default, Key, _Type} ->

--- a/src/muc_light/mod_muc_light_db_mnesia.erl
+++ b/src/muc_light/mod_muc_light_db_mnesia.erl
@@ -238,29 +238,21 @@ get_info(_HostType, RoomUS) ->
                      jid:luser() | undefined, pos_integer()) ->
     {[mod_muc_light_db_backend:room_desc()], non_neg_integer()}.
 get_room_descs(_HostType, MUCServer, Filter, After, Limit) ->
-    %% The first page passes an empty cursor: every luser sorts after <<>>
-    AfterLUser = case After of undefined -> <<>>; _ -> After end,
-    MS = ets:fun2ms(fun(#muc_light_room{room = {RoomU, RoomS}} = Room)
-                          when RoomS =:= MUCServer, RoomU > AfterLUser -> Room end),
+    MS = ets:fun2ms(fun(#muc_light_room{room = {_, RoomS}} = Room)
+                          when RoomS =:= MUCServer -> Room end),
     Rooms = mnesia:dirty_select(muc_light_room, MS),
     Schema = mod_muc_light:config_schema(MUCServer),
     Matching = lists:keysort(#muc_light_room.room,
                              [R || R <- Rooms, room_matches_filter(R, Filter, Schema)]),
-    Page = lists:sublist(Matching, Limit),
+    Page = lists:sublist(drop_up_to_cursor(Matching, After), Limit),
     Descs = [#{room => RoomUS, config => Config, aff_users => AffUsers}
              || #muc_light_room{room = RoomUS, config = Config, aff_users = AffUsers} <- Page],
-    {Descs, count_rooms(MUCServer, Filter, Schema)}.
+    {Descs, length(Matching)}.
 
-%% The count covers the whole domain, so it cannot reuse the page cursor
-count_rooms(MUCServer, undefined, _Schema) ->
-    MS = ets:fun2ms(fun(#muc_light_room{room = {_, RoomS}})
-                          when RoomS =:= MUCServer -> true end),
-    length(mnesia:dirty_select(muc_light_room, MS));
-count_rooms(MUCServer, Filter, Schema) ->
-    MS = ets:fun2ms(fun(#muc_light_room{room = {_, RoomS}} = Room)
-                          when RoomS =:= MUCServer -> Room end),
-    length([R || R <- mnesia:dirty_select(muc_light_room, MS),
-                 room_matches_filter(R, Filter, Schema)]).
+drop_up_to_cursor(Rooms, undefined) ->
+    Rooms;
+drop_up_to_cursor(Rooms, After) ->
+    lists:dropwhile(fun(#muc_light_room{room = {RoomU, _}}) -> RoomU =< After end, Rooms).
 
 room_matches_filter(_Room, undefined, _Schema) ->
     true;

--- a/src/muc_light/mod_muc_light_db_mnesia.erl
+++ b/src/muc_light/mod_muc_light_db_mnesia.erl
@@ -238,21 +238,29 @@ get_info(_HostType, RoomUS) ->
                      jid:luser() | undefined, pos_integer()) ->
     {[mod_muc_light_db_backend:room_desc()], non_neg_integer()}.
 get_room_descs(_HostType, MUCServer, Filter, After, Limit) ->
-    MS = ets:fun2ms(fun(#muc_light_room{room = {_, RoomS}} = Room)
-                          when RoomS =:= MUCServer -> Room end),
+    %% The first page passes an empty cursor: every luser sorts after <<>>
+    AfterLUser = case After of undefined -> <<>>; _ -> After end,
+    MS = ets:fun2ms(fun(#muc_light_room{room = {RoomU, RoomS}} = Room)
+                          when RoomS =:= MUCServer, RoomU > AfterLUser -> Room end),
     Rooms = mnesia:dirty_select(muc_light_room, MS),
     Schema = mod_muc_light:config_schema(MUCServer),
     Matching = lists:keysort(#muc_light_room.room,
                              [R || R <- Rooms, room_matches_filter(R, Filter, Schema)]),
-    Page = lists:sublist(drop_up_to_cursor(Matching, After), Limit),
+    Page = lists:sublist(Matching, Limit),
     Descs = [#{room => RoomUS, config => Config, aff_users => AffUsers}
              || #muc_light_room{room = RoomUS, config = Config, aff_users = AffUsers} <- Page],
-    {Descs, length(Matching)}.
+    {Descs, count_rooms(MUCServer, Filter, Schema)}.
 
-drop_up_to_cursor(Rooms, undefined) ->
-    Rooms;
-drop_up_to_cursor(Rooms, After) ->
-    lists:dropwhile(fun(#muc_light_room{room = {RoomU, _}}) -> RoomU =< After end, Rooms).
+%% The count covers the whole domain, so it cannot reuse the page cursor
+count_rooms(MUCServer, undefined, _Schema) ->
+    MS = ets:fun2ms(fun(#muc_light_room{room = {_, RoomS}})
+                          when RoomS =:= MUCServer -> true end),
+    length(mnesia:dirty_select(muc_light_room, MS));
+count_rooms(MUCServer, Filter, Schema) ->
+    MS = ets:fun2ms(fun(#muc_light_room{room = {_, RoomS}} = Room)
+                          when RoomS =:= MUCServer -> Room end),
+    length([R || R <- mnesia:dirty_select(muc_light_room, MS),
+                 room_matches_filter(R, Filter, Schema)]).
 
 room_matches_filter(_Room, undefined, _Schema) ->
     true;
@@ -260,7 +268,7 @@ room_matches_filter(#muc_light_room{room = {RoomU, _}, config = Config}, Filter,
     binary:match(RoomU, Filter) =/= nomatch
         orelse room_name_matches(Config, Filter, Schema).
 
-%% Config is keyed by the internal schema key, which may differ from the field name
+%% The stored config is keyed by the internal key of the schema's roomname field
 room_name_matches(Config, Filter, Schema) ->
     case lists:keyfind(<<"roomname">>, 1, Schema) of
         {_FieldName, _Default, Key, _Type} ->

--- a/src/muc_light/mod_muc_light_db_rdbms.erl
+++ b/src/muc_light/mod_muc_light_db_rdbms.erl
@@ -674,22 +674,10 @@ room_desc(HostType, MUCServer, Schema, DbRoomID, RoomU) ->
             false;
         AffUsers ->
             {selected, ConfigRows} = select_config_by_room_id(HostType, RoomID),
+            {ok, Config} = mod_muc_light_room_config:from_binary_kv(ConfigRows, Schema),
             {true, #{room => {RoomU, MUCServer},
-                     config => decode_config_lenient(ConfigRows, RoomU, MUCServer, Schema),
+                     config => Config,
                      aff_users => AffUsers}}
-    end.
-
-%% A config that no longer decodes against the current schema (e.g. created
-%% before a config_schema change) must not break the room listing, so it
-%% degrades to an empty config instead of crashing.
-decode_config_lenient(ConfigRows, RoomU, MUCServer, Schema) ->
-    case mod_muc_light_room_config:from_binary_kv(ConfigRows, Schema) of
-        {ok, Config} ->
-            Config;
-        {error, Reason} ->
-            ?LOG_WARNING(#{what => muc_light_room_config_decode_failed,
-                           room => RoomU, sub_host => MUCServer, reason => Reason}),
-            []
     end.
 
 %% ------------------------ Conversions ------------------------

--- a/src/muc_light/mod_muc_light_db_rdbms.erl
+++ b/src/muc_light/mod_muc_light_db_rdbms.erl
@@ -43,7 +43,8 @@
          set_blocking/4,
          get_aff_users/2,
          modify_aff_users/5,
-         get_info/2
+         get_info/2,
+         get_room_descs/5
         ]).
 
 %% Extra API for testing
@@ -135,6 +136,37 @@ prepare_room_queries() ->
                              " FROM muc_light_occupants AS o "
                              " INNER JOIN muc_light_rooms AS r ON o.room_id = r.id"
                              " WHERE o.luser = ? AND o.lserver = ?">>),
+    %% Cursor-paginated room listing: keyset on luser, so the first page passes
+    %% an empty cursor (every luser sorts after <<>>).
+    LimitOffset = rdbms_queries:limit_offset(),
+    mongoose_rdbms:prepare(muc_light_select_rooms_page, muc_light_rooms,
+                           [lserver, luser, limit, offset],
+                           <<"SELECT r.id, r.luser FROM muc_light_rooms AS r "
+                             " WHERE r.lserver = ? AND r.luser > ?"
+                             " ORDER BY r.luser", LimitOffset/binary>>),
+    %% The filter matches a substring of the room localpart (stored lowercase)
+    %% or of the room name; 'roomname' is the schema field name under which
+    %% the name is persisted, regardless of any custom internal_key.
+    mongoose_rdbms:prepare(muc_light_select_rooms_page_filtered, muc_light_rooms,
+                           [lserver, luser, luser, val, limit, offset],
+                           <<"SELECT r.id, r.luser FROM muc_light_rooms AS r "
+                             " WHERE r.lserver = ? AND r.luser > ?"
+                             " AND (r.luser LIKE ? ESCAPE '$'"
+                             "      OR EXISTS (SELECT 1 FROM muc_light_config AS c"
+                             "                  WHERE c.room_id = r.id AND c.opt = 'roomname'"
+                             "                    AND LOWER(c.val) LIKE ? ESCAPE '$'))"
+                             " ORDER BY r.luser", LimitOffset/binary>>),
+    mongoose_rdbms:prepare(muc_light_count_rooms, muc_light_rooms,
+                           [lserver],
+                           <<"SELECT COUNT(*) FROM muc_light_rooms WHERE lserver = ?">>),
+    mongoose_rdbms:prepare(muc_light_count_rooms_filtered, muc_light_rooms,
+                           [lserver, luser, val],
+                           <<"SELECT COUNT(*) FROM muc_light_rooms AS r "
+                             " WHERE r.lserver = ?"
+                             " AND (r.luser LIKE ? ESCAPE '$'"
+                             "      OR EXISTS (SELECT 1 FROM muc_light_config AS c"
+                             "                  WHERE c.room_id = r.id AND c.opt = 'roomname'"
+                             "                    AND LOWER(c.val) LIKE ? ESCAPE '$'))">>),
     ok.
 
 prepare_affiliation_queries() ->
@@ -264,6 +296,27 @@ select_user_rooms(HostType, LUser, LServer) ->
 select_user_rooms_count(HostType, LUser, LServer) ->
     mongoose_rdbms:execute_successfully(
         HostType, muc_light_select_user_rooms_count, [LUser, LServer]).
+
+select_rooms_page(HostType, MUCServer, undefined, AfterLUser, Limit) ->
+    mongoose_rdbms:execute_successfully(
+        HostType, muc_light_select_rooms_page, [MUCServer, AfterLUser, Limit, 0]);
+select_rooms_page(HostType, MUCServer, Filter, AfterLUser, Limit) ->
+    Pattern = filter_to_like_pattern(Filter),
+    mongoose_rdbms:execute_successfully(
+        HostType, muc_light_select_rooms_page_filtered,
+        [MUCServer, AfterLUser, Pattern, Pattern, Limit, 0]).
+
+count_rooms(HostType, MUCServer, undefined) ->
+    mongoose_rdbms:execute_successfully(
+        HostType, muc_light_count_rooms, [MUCServer]);
+count_rooms(HostType, MUCServer, Filter) ->
+    Pattern = filter_to_like_pattern(Filter),
+    mongoose_rdbms:execute_successfully(
+        HostType, muc_light_count_rooms_filtered, [MUCServer, Pattern, Pattern]).
+
+filter_to_like_pattern(Filter) ->
+    Escaped = mongoose_rdbms:escape_prepared_like(Filter),
+    <<"%", Escaped/binary, "%">>.
 
 insert_room(HostType, RoomU, RoomS, Version) ->
     mongoose_rdbms:execute_successfully(
@@ -595,6 +648,48 @@ get_info(HostType, {RoomU, RoomS}) ->
             {ok, Config, AffUsers, Version};
         {selected, []} ->
             {error, not_exists}
+    end.
+
+-spec get_room_descs(mongooseim:host_type(), jid:lserver(), binary() | undefined,
+                     jid:luser() | undefined, pos_integer()) ->
+    {[mod_muc_light_db_backend:room_desc()], non_neg_integer()}.
+get_room_descs(HostType, MUCServer, Filter, After, Limit) ->
+    %% The first page passes an empty cursor: every luser sorts after <<>>
+    AfterLUser = case After of undefined -> <<>>; _ -> After end,
+    {selected, PageRows} = select_rooms_page(HostType, MUCServer, Filter, AfterLUser, Limit),
+    {selected, [{DbCount}]} = count_rooms(HostType, MUCServer, Filter),
+    Schema = mod_muc_light:config_schema(MUCServer),
+    Descs = lists:filtermap(fun({DbRoomID, RoomU}) ->
+                                room_desc(HostType, MUCServer, Schema, DbRoomID, RoomU)
+                            end, PageRows),
+    {Descs, mongoose_rdbms:result_to_integer(DbCount)}.
+
+room_desc(HostType, MUCServer, Schema, DbRoomID, RoomU) ->
+    RoomID = mongoose_rdbms:result_to_integer(DbRoomID),
+    {selected, AffRows} = select_affs_by_room_id(HostType, RoomID),
+    case decode_affs(AffRows) of
+        [] ->
+            %% The room was destroyed between the page select and this fetch;
+            %% a live room always has at least one occupant
+            false;
+        AffUsers ->
+            {selected, ConfigRows} = select_config_by_room_id(HostType, RoomID),
+            {true, #{room => {RoomU, MUCServer},
+                     config => decode_config_lenient(ConfigRows, RoomU, MUCServer, Schema),
+                     aff_users => AffUsers}}
+    end.
+
+%% A config that no longer decodes against the current schema (e.g. created
+%% before a config_schema change) must not break the room listing, so it
+%% degrades to an empty config instead of crashing.
+decode_config_lenient(ConfigRows, RoomU, MUCServer, Schema) ->
+    case mod_muc_light_room_config:from_binary_kv(ConfigRows, Schema) of
+        {ok, Config} ->
+            Config;
+        {error, Reason} ->
+            ?LOG_WARNING(#{what => muc_light_room_config_decode_failed,
+                           room => RoomU, sub_host => MUCServer, reason => Reason}),
+            []
     end.
 
 %% ------------------------ Conversions ------------------------


### PR DESCRIPTION
MIM-2749

## muc_light: add `listRooms` admin GraphQL query

The admin GraphQL API had no way to enumerate the MUC Light rooms of a domain — unlike classic MUC (`muc.listRooms`), rooms could only be discovered per user (`listUserRooms`) or per room JID (`getRoomConfig`). This PR adds a domain-wide, paginated room listing to the `muc_light` admin category.

### API

```graphql
type MUCLightAdminQuery {
  "Get rooms of the given MUC Light domain, ordered by JID. To get the next page, pass the JID of the last room as 'after'. 'filter' matches a substring of the room JID or name"
  listRooms(mucDomain: DomainName!, filter: String, after: BareJID, limit: PosInt = 50): MUCLightRoomsPayload
}

type MUCLightRoomsPayload {
  "List of room descriptions, ordered by room JID"
  rooms: [MUCLightRoomDesc!]
  "Total number of rooms in the domain matching the filter"
  count: NonNegInt
  "Whether more rooms exist after this page"
  nextPage: Boolean
}

type MUCLightRoomDesc {
  jid: BareJID!
  name: String
  subject: String
  usersNumber: NonNegInt
}
```

To iterate: call without `after`, then repeat passing the JID of the last room of each page until `nextPage` is `false`.

### Design notes

* **Keyset cursor instead of an index offset.** With offset pagination every page request would have to fetch, decode and sort *all* rooms of the domain just to slice one page out. The keyset cursor lets the RDBMS backend serve each page at O(page) cost using the existing `(lserver, luser)` primary key, and stays stable under concurrent room creation/deletion. Classic MUC can afford offset semantics because it lists *online* rooms from memory; MUC Light rooms live in the database — the same trade-off that gives MAM cursor-based paging.
* **Server-side `filter`** — case-insensitive substring match against the room JID localpart or the room name, applied in the backend (`LIKE` with proper escaping in RDBMS) so clients can search without loading the whole domain. It composes with pagination and is reflected in `count`.
* **`limit` defaults to 50**, so omitting it does not serialize an entire domain into one response.
* The room description carries the same kind of data as classic MUC's `MUCRoomDesc` (identity plus member count); configs are decoded strictly, exactly as `getRoomConfig` does.

### Implementation

* New backend callback `get_room_descs/5` (filter, cursor, limit → page + total count) with RDBMS and mnesia implementations. RDBMS pages room ids with a keyset select and a `COUNT(*)` query, then fetches config/affiliations per page room, reusing the existing row decoding. Mnesia serves both the page and the count from a single select.
* `mod_muc_light_api:get_rooms/4` validates and namepreps the domain, and fetches `limit + 1` rows to compute `nextPage` accurately (an exactly-full last page reports `false`).
* GraphQL schema, resolver and payload helper.

