### PR TITLE
Fix the default host of mod_http_upload

### DIFF
--- a/src/http_upload/mod_http_upload.erl
+++ b/src/http_upload/mod_http_upload.erl
@@ -27,7 +27,7 @@
 
 -define(DEFAULT_TOKEN_BYTES, 32).
 -define(DEFAULT_MAX_FILE_SIZE, 10 * 1024 * 1024). % 10 MB
--define(DEFAULT_SUBHOST, <<"upload.@HOST@">>).
+-define(DEFAULT_SUBHOST, mongoose_subdomain_utils:make_subdomain_pattern(~"upload.@HOST@")).
 
 %% gen_mod callbacks
 -export([start/2,
@@ -103,10 +103,10 @@ config_spec() ->
                   <<"s3">> => s3_spec()
         },
         defaults = #{<<"iqdisc">> => one_queue,
-                     <<"host">> => <<"upload.@HOST@">>,
+                     <<"host">> => ?DEFAULT_SUBHOST,
                      <<"backend">> => s3,
                      <<"expiration_time">> => 60,
-                     <<"token_bytes">> => 32,
+                     <<"token_bytes">> => ?DEFAULT_TOKEN_BYTES,
                      <<"max_file_size">> => ?DEFAULT_MAX_FILE_SIZE
         },
         required = [<<"s3">>]

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -2003,11 +2003,7 @@ mod_http_upload(_Config) ->
     P = [modules, mod_http_upload],
     RequiredOpts = #{<<"s3">> => http_upload_s3_required_opts()},
     S3Cfg = http_upload_s3_expected_cfg(),
-    ?cfgh(P, mod_config(mod_http_upload,
-        #{host => <<"upload.@HOST@">>,
-          s3 => config_parser_helper:config([modules, mod_http_upload, s3], S3Cfg)
-         }),
-        T(RequiredOpts)),
+    ?cfgh(P, config(P, #{s3 => http_upload_s3_expected_cfg()}), T(RequiredOpts)),
     ?cfgh(P ++ [s3], S3Cfg#{add_acl => false}, T(RequiredOpts)),
     ?cfgh(P ++ [host], {prefix, <<"upload.">>},
           T(RequiredOpts#{<<"host">> => <<"upload.@HOST@">>})),


### PR DESCRIPTION
### Description

The default was not wired through `mongoose_subdomain_utils:make_subdomain_pattern/1`.
This PR fixes this issue and the related test.

### Notes

I checked that the updated test fails before the fix, and succeeds after the fix.

