### PR TITLE
MIM-2723 Deprecate `mod_muc_light` legacy codec

### DIFF
--- a/doc/migrations/6.7.0_6.x.x.md
+++ b/doc/migrations/6.7.0_6.x.x.md
@@ -24,6 +24,10 @@ If your existing configuration uses the old PubSub module name, choose one of th
 
 * Use the new [`mod_pubsub`](../modules/mod_pubsub.md) for better performance if your deployment only needs the selected PEP features described in its module documentation.
 
+### `mod_muc_light` legacy mode deprecated
+
+The [`legacy_mode`](../modules/mod_muc_light.md#modulesmod_muc_lightlegacy_mode) option of `mod_muc_light`, which enables the legacy XEP-0045 compatibility codec, is now deprecated and will be removed in the next release.
+
 ## Metrics
 
 The changes to metrics and instrumentation are listed below.

--- a/doc/modules/mod_muc_light.md
+++ b/doc/modules/mod_muc_light.md
@@ -55,6 +55,9 @@ It means that every occupant will be a `member`, even the room creator.
 Enables XEP-0045 compatibility mode. 
 It allows using a subset of classic MUC stanzas with some MUC Light functions limited.
 
+!!! Warning
+    This option is **deprecated** and will be removed in the next release.
+
 ### `modules.mod_muc_light.rooms_per_user`
   * **Syntax:** positive integer or the string `"infinity"`
   * **Default:** `"infinity"`

--- a/src/muc_light/mod_muc_light.erl
+++ b/src/muc_light/mod_muc_light.erl
@@ -171,6 +171,7 @@ delete_room({_, RoomS} = RoomUS) ->
 -spec start(host_type(), gen_mod:module_opts()) -> ok.
 start(HostType, Opts) ->
     Codec = host_type_to_codec(HostType),
+    maybe_warn_about_legacy_mode(HostType, Codec),
     mod_muc_light_db_backend:start(HostType, Opts),
     mod_muc_light_codec_backend:start(HostType, #{backend => Codec}),
     %% Handler
@@ -207,6 +208,15 @@ host_type_to_codec(HostType) ->
         false ->
             modern
     end.
+
+-spec maybe_warn_about_legacy_mode(host_type(), legacy | modern) -> ok.
+maybe_warn_about_legacy_mode(HostType, legacy) ->
+    ?LOG_WARNING(#{what => muc_light_legacy_mode_deprecated,
+                   text => <<"The mod_muc_light 'legacy_mode' option is deprecated "
+                             "and will be removed in the next release.">>,
+                   host_type => HostType});
+maybe_warn_about_legacy_mode(_HostType, modern) ->
+    ok.
 
 %% Config callbacks
 -spec config_spec() -> mongoose_config_spec:config_section().


### PR DESCRIPTION
This PR deprecates the `legacy_mode` option in the `mod_muc_light` module. It updates documentation to warn users about the deprecation and adds a runtime warning when the legacy mode is used.