### PR TITLE
MIM-1870 Add test for unavailable presence on websocket disconnect

### DIFF
--- a/big_tests/tests/websockets_SUITE.erl
+++ b/big_tests/tests/websockets_SUITE.erl
@@ -34,6 +34,7 @@
 
 all() ->
     [metrics_test,
+     unavailable_presence_on_ws_disconnect,
      {group, ws_chat},
      {group, wss_chat}].
 
@@ -120,6 +121,28 @@ metrics_test(Config) ->
 
         ok
         end).
+
+%% When a websocket client abruptly drops the connection, the associated c2s
+%% process must terminate.
+unavailable_presence_on_ws_disconnect(Config) ->
+    escalus:story(
+      Config, [{alice, 1}, {geralt, 1}],
+      fun(Alice, Geralt) ->
+              %% Geralt sends directed available presence to Alice
+              AliceJid = escalus_client:short_jid(Alice),
+              escalus:send(Geralt, escalus_stanza:presence_direct(AliceJid, <<"available">>)),
+              Received = escalus:wait_for_stanza(Alice),
+              escalus:assert(is_presence, Received),
+              escalus_assert:is_stanza_from(Geralt, Received),
+
+              %% Geralt's websocket connection dies abruptly
+              escalus_client:kill_connection(Config, Geralt),
+
+              %% Alice must receive unavailable presence from Geralt
+              Received2 = escalus:wait_for_stanza(Alice, timer:seconds(5)),
+              escalus:assert(is_presence_with_type, [<<"unavailable">>], Received2),
+              escalus_assert:is_stanza_from(Geralt, Received2)
+      end).
 
 too_big_stanza_is_rejected(Config) ->
     escalus:story(

--- a/big_tests/tests/websockets_SUITE.erl
+++ b/big_tests/tests/websockets_SUITE.erl
@@ -136,9 +136,13 @@ unavailable_presence_on_ws_disconnect(Config) ->
               escalus_assert:is_stanza_from(Geralt, Received),
 
               %% Geralt's websocket connection dies abruptly
+              C2SRef = sm_helper:monitor_session(Geralt),
               escalus_client:kill_connection(Config, Geralt),
 
-              %% Alice must receive unavailable presence from Geralt
+              %% the associated c2s process must terminate
+              ok = sm_helper:wait_for_process_termination(C2SRef),
+
+              %% and Alice must receive unavailable presence from Geralt
               Received2 = escalus:wait_for_stanza(Alice, timer:seconds(5)),
               escalus:assert(is_presence_with_type, [<<"unavailable">>], Received2),
               escalus_assert:is_stanza_from(Geralt, Received2)


### PR DESCRIPTION
This PR adds a big test verifying that when a websocket client abruptly drops its connection, its c2s process terminates and unavailable presence is broadcast so contacts stop seeing the user as available. It's the websocket counterpart of the existing TCP test (`presence_SUITE:available_direct_then_disconnect`).