### PR TITLE
Add migration scripts for the next release 6.x.x

### DIFF
--- a/doc/migrations/6.7.0_6.x.x.md
+++ b/doc/migrations/6.7.0_6.x.x.md
@@ -28,6 +28,12 @@ If your existing configuration uses the old PubSub module name, choose one of th
 
 The [`legacy_mode`](../modules/mod_muc_light.md#modulesmod_muc_lightlegacy_mode) option of `mod_muc_light`, which enables the legacy XEP-0045 compatibility codec, is now deprecated and will be removed in the next release.
 
+## Database migration
+
+There are new tables in the database, which are used by the new [`mod_pubsub`](../modules/mod_pubsub.md) implementation and by [`mod_broadcast`](../modules/mod_broadcast.md). See the migrations in the [`priv/migrations`](https://github.com/esl/MongooseIM/tree/master/priv/migrations) directory. Although the new tables are only needed by these modules, we recommend applying the migration anyway to keep the database in sync with the latest schema.
+
+The deprecated [`mod_pubsub_old`](../modules/mod_pubsub_old.md) keeps using the existing `pubsub_*` tables, so no action is needed for the data stored there.
+
 ## Metrics
 
 The changes to metrics and instrumentation are listed below.

--- a/priv/migrations/cockroachdb_6.7.0_6.x.x.sql
+++ b/priv/migrations/cockroachdb_6.7.0_6.x.x.sql
@@ -1,0 +1,98 @@
+-- mod_pubsub
+
+CREATE TYPE pubsub_node_access_model AS ENUM('open', 'presence');
+
+CREATE TABLE pubsub_node (
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    access_model pubsub_node_access_model NOT NULL,
+    max_items BIGINT,
+    PRIMARY KEY (service_domain, service_user, node_id)
+);
+
+CREATE TABLE pubsub_item (
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    item_id VARCHAR(125) NOT NULL,
+    publisher_domain VARCHAR(125) NOT NULL,
+    publisher_user VARCHAR(125) NOT NULL,
+    publisher_resource VARCHAR(125) NOT NULL,
+    payload TEXT NOT NULL,
+    published_at BIGINT NOT NULL,
+    PRIMARY KEY (service_domain, service_user, node_id, item_id),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX i_pubsub_item_published_at ON pubsub_item USING btree
+    (service_domain, service_user, node_id, published_at);
+
+CREATE TABLE pubsub_subscription (
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    subscriber_domain VARCHAR(125) NOT NULL,
+    subscriber_user VARCHAR(125) NOT NULL,
+    subscriber_resource VARCHAR(125) NOT NULL,
+    PRIMARY KEY (service_domain, service_user, node_id,
+                 subscriber_domain, subscriber_user, subscriber_resource),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX i_pubsub_subscription_subscriber ON pubsub_subscription USING btree
+    (subscriber_domain, subscriber_user);
+
+-- mod_broadcast
+
+CREATE TYPE broadcast_state AS ENUM ('running', 'finished', 'abort_error', 'abort_admin');
+CREATE TYPE broadcast_recipient_group AS ENUM ('all_users_in_domain');
+
+CREATE SEQUENCE broadcast_jobs_id_sequence START 1 INCREMENT 1;
+
+CREATE TABLE broadcast_jobs (
+    id INTEGER NOT NULL DEFAULT nextval('broadcast_jobs_id_sequence') PRIMARY KEY,
+    name VARCHAR(250) NOT NULL,
+    server VARCHAR(250) NOT NULL,
+    host_type VARCHAR(250) NOT NULL,
+    from_jid VARCHAR(250) NOT NULL,
+    subject VARCHAR(1024) NOT NULL,
+    body TEXT NOT NULL,
+    rate INTEGER NOT NULL,
+    recipient_group broadcast_recipient_group NOT NULL,
+    recipient_count INTEGER NOT NULL,
+    execution_state broadcast_state NOT NULL DEFAULT 'running',
+    abortion_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    started_at TIMESTAMPTZ,
+    stopped_at TIMESTAMPTZ
+);
+
+CREATE INDEX i_broadcast_jobs_server ON broadcast_jobs USING btree (server, id);
+CREATE INDEX i_broadcast_jobs_host_state
+    ON broadcast_jobs USING btree (host_type, execution_state);
+CREATE INDEX i_broadcast_jobs_server_state
+    ON broadcast_jobs USING btree (server, execution_state);
+
+CREATE TABLE broadcast_jobs_ownership (
+    broadcast_id INTEGER NOT NULL REFERENCES broadcast_jobs(id) ON DELETE CASCADE,
+    owner_node VARCHAR(250) NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (broadcast_id)
+);
+
+CREATE INDEX i_broadcast_jobs_ownership_owner_node
+    ON broadcast_jobs_ownership USING btree (owner_node);
+CREATE INDEX i_broadcast_jobs_ownership_expires_at
+    ON broadcast_jobs_ownership USING btree (expires_at);
+
+CREATE TABLE broadcast_worker_state (
+    broadcast_id INTEGER NOT NULL REFERENCES broadcast_jobs(id) ON DELETE CASCADE,
+    cursor_user VARCHAR(250),
+    recipients_processed INTEGER NOT NULL DEFAULT 0,
+    finished BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (broadcast_id)
+);

--- a/priv/migrations/mysql_6.7.0_6.x.x.sql
+++ b/priv/migrations/mysql_6.7.0_6.x.x.sql
@@ -1,0 +1,93 @@
+-- mod_pubsub
+
+CREATE TABLE pubsub_node (
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    access_model ENUM('open', 'presence') NOT NULL,
+    max_items BIGINT,
+    PRIMARY KEY (service_domain, service_user, node_id)
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE pubsub_item (
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    item_id VARCHAR(125) NOT NULL,
+    publisher_domain VARCHAR(125) NOT NULL,
+    publisher_user VARCHAR(125) NOT NULL,
+    publisher_resource VARCHAR(125) NOT NULL,
+    payload TEXT NOT NULL,
+    published_at BIGINT NOT NULL,
+    PRIMARY KEY (service_domain, service_user, node_id, item_id),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE INDEX i_pubsub_item_published_at USING BTREE
+    ON pubsub_item(service_domain, service_user, node_id, published_at);
+
+CREATE TABLE pubsub_subscription (
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    subscriber_domain VARCHAR(125) NOT NULL,
+    subscriber_user VARCHAR(125) NOT NULL,
+    subscriber_resource VARCHAR(125) NOT NULL,
+    PRIMARY KEY (service_domain, service_user, node_id,
+                 subscriber_domain, subscriber_user, subscriber_resource),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE INDEX i_pubsub_subscription_subscriber USING BTREE
+    ON pubsub_subscription(subscriber_domain, subscriber_user);
+
+-- mod_broadcast
+
+CREATE TABLE broadcast_jobs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(250) NOT NULL,
+    server VARCHAR(250) NOT NULL,
+    host_type VARCHAR(250) NOT NULL,
+    from_jid VARCHAR(250) NOT NULL,
+    subject VARCHAR(1024) NOT NULL,
+    body TEXT NOT NULL,
+    rate INT NOT NULL,
+    recipient_group ENUM('all_users_in_domain') NOT NULL,
+    recipient_count INT NOT NULL,
+    execution_state ENUM('running', 'finished', 'abort_error', 'abort_admin') NOT NULL DEFAULT 'running',
+    abortion_reason TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    started_at TIMESTAMP NULL,
+    stopped_at TIMESTAMP NULL,
+    INDEX i_broadcast_jobs_server (server, id),
+    INDEX i_broadcast_jobs_host_state (host_type, execution_state),
+    INDEX i_broadcast_jobs_server_state (server, execution_state)
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE broadcast_jobs_ownership (
+    broadcast_id INT NOT NULL,
+    owner_node VARCHAR(250) NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (broadcast_id),
+    INDEX i_broadcast_jobs_ownership_owner_node (owner_node),
+    INDEX i_broadcast_jobs_ownership_expires_at (expires_at),
+    FOREIGN KEY (broadcast_id) REFERENCES broadcast_jobs(id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE broadcast_worker_state (
+    broadcast_id INT NOT NULL,
+    cursor_user VARCHAR(250),
+    recipients_processed INT NOT NULL DEFAULT 0,
+    finished BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (broadcast_id),
+    FOREIGN KEY (broadcast_id) REFERENCES broadcast_jobs(id) ON DELETE CASCADE
+) CHARACTER SET utf8mb4
+  ROW_FORMAT=DYNAMIC;

--- a/priv/migrations/pgsql_6.7.0_6.x.x.sql
+++ b/priv/migrations/pgsql_6.7.0_6.x.x.sql
@@ -1,0 +1,96 @@
+-- mod_pubsub
+
+CREATE TYPE pubsub_node_access_model AS ENUM('open', 'presence');
+
+CREATE TABLE pubsub_node (
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    access_model pubsub_node_access_model NOT NULL,
+    max_items BIGINT,
+    PRIMARY KEY (service_domain, service_user, node_id)
+);
+
+CREATE TABLE pubsub_item (
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    item_id VARCHAR(125) NOT NULL,
+    publisher_domain VARCHAR(125) NOT NULL,
+    publisher_user VARCHAR(125) NOT NULL,
+    publisher_resource VARCHAR(125) NOT NULL,
+    payload TEXT NOT NULL,
+    published_at BIGINT NOT NULL,
+    PRIMARY KEY (service_domain, service_user, node_id, item_id),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX i_pubsub_item_published_at ON pubsub_item USING btree
+    (service_domain, service_user, node_id, published_at);
+
+CREATE TABLE pubsub_subscription (
+    service_domain VARCHAR(125) NOT NULL,
+    service_user VARCHAR(125) NOT NULL,
+    node_id VARCHAR(125) NOT NULL,
+    subscriber_domain VARCHAR(125) NOT NULL,
+    subscriber_user VARCHAR(125) NOT NULL,
+    subscriber_resource VARCHAR(125) NOT NULL,
+    PRIMARY KEY (service_domain, service_user, node_id,
+                 subscriber_domain, subscriber_user, subscriber_resource),
+    FOREIGN KEY (service_domain, service_user, node_id)
+        REFERENCES pubsub_node(service_domain, service_user, node_id) ON DELETE CASCADE
+);
+
+CREATE INDEX i_pubsub_subscription_subscriber ON pubsub_subscription USING btree
+    (subscriber_domain, subscriber_user);
+
+-- mod_broadcast
+
+CREATE TYPE broadcast_state AS ENUM ('running', 'finished', 'abort_error', 'abort_admin');
+CREATE TYPE broadcast_recipient_group AS ENUM ('all_users_in_domain');
+
+CREATE TABLE broadcast_jobs (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(250) NOT NULL,
+    server VARCHAR(250) NOT NULL,
+    host_type VARCHAR(250) NOT NULL,
+    from_jid VARCHAR(250) NOT NULL,
+    subject VARCHAR(1024) NOT NULL,
+    body TEXT NOT NULL,
+    rate INTEGER NOT NULL,
+    recipient_group broadcast_recipient_group NOT NULL,
+    recipient_count INTEGER NOT NULL,
+    execution_state broadcast_state NOT NULL DEFAULT 'running',
+    abortion_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    started_at TIMESTAMPTZ,
+    stopped_at TIMESTAMPTZ
+);
+
+CREATE INDEX i_broadcast_jobs_server ON broadcast_jobs USING btree (server, id);
+CREATE INDEX i_broadcast_jobs_host_state
+    ON broadcast_jobs USING btree (host_type, execution_state);
+CREATE INDEX i_broadcast_jobs_server_state
+    ON broadcast_jobs USING btree (server, execution_state);
+
+CREATE TABLE broadcast_jobs_ownership (
+    broadcast_id INTEGER NOT NULL REFERENCES broadcast_jobs(id) ON DELETE CASCADE,
+    owner_node VARCHAR(250) NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (broadcast_id)
+);
+
+CREATE INDEX i_broadcast_jobs_ownership_owner_node
+    ON broadcast_jobs_ownership USING btree (owner_node);
+CREATE INDEX i_broadcast_jobs_ownership_expires_at
+    ON broadcast_jobs_ownership USING btree (expires_at);
+
+CREATE TABLE broadcast_worker_state (
+    broadcast_id INTEGER NOT NULL REFERENCES broadcast_jobs(id) ON DELETE CASCADE,
+    cursor_user VARCHAR(250),
+    recipients_processed INTEGER NOT NULL DEFAULT 0,
+    finished BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (broadcast_id)
+);


### PR DESCRIPTION
This PR addresses [MIM-2757](https://erlangsolutions.atlassian.net/browse/MIM-2757) and adds the migration scripts for the next release.

Proposed changes include:
* migration scripts for CRDB, pgsql and MySQL
* migration section in the next release documentation



[MIM-2757]: https://erlangsolutions.atlassian.net/browse/MIM-2757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ