### PR TITLE
MIM-2762 Add missing output conversion for BareJID

### DIFF
--- a/src/graphql/mongoose_graphql_muc_light_helper.erl
+++ b/src/graphql/mongoose_graphql_muc_light_helper.erl
@@ -19,7 +19,7 @@ make_room(#{jid := JID, aff_users := Users, options := Options}) ->
     Participants = lists:map(fun make_ok_user/1, Users),
     Name = maps:get(<<"roomname">>, Options, null),
     Subject = maps:get(<<"subject">>, Options, null),
-    #{<<"jid">> => jid:to_binary(JID), <<"name">> => Name, <<"subject">> => Subject,
+    #{<<"jid">> => JID, <<"name">> => Name, <<"subject">> => Subject,
       <<"participants">> => Participants, <<"options">> => make_options(Options)}.
 
 make_ok_user({JID, Aff}) ->
@@ -61,7 +61,7 @@ make_rooms_payload(RoomDescs, Count, HasNextPage) ->
 -spec make_room_desc(mod_muc_light_api:room_desc()) -> map().
 make_room_desc(#{jid := JID, name := Name, subject := Subject,
                  users_number := UsersNumber}) ->
-    #{<<"jid">> => jid:to_binary(JID),
+    #{<<"jid">> => JID,
       <<"name">> => undefined_to_null(Name),
       <<"subject">> => undefined_to_null(Subject),
       <<"usersNumber">> => UsersNumber}.

--- a/src/graphql/mongoose_graphql_scalar.erl
+++ b/src/graphql/mongoose_graphql_scalar.erl
@@ -36,6 +36,7 @@ input(Ty, V) ->
 output(<<"DateTime">>, DT) -> {ok, encode_datetime(DT)};
 output(<<"XmlElement">>, Elem) -> {ok, exml:to_binary(Elem)};
 output(<<"JID">>, Jid) -> {ok, jid:to_binary(Jid)};
+output(<<"BareJID">>, Jid) -> {ok, jid:to_bare_binary(Jid)};
 output(<<"UserName">>, User) -> {ok, User};
 output(<<"DomainName">>, Domain) -> {ok, Domain};
 output(<<"ResourceName">>, Res) -> {ok, Res};


### PR DESCRIPTION
This PR replaces manual conversion of BareJID for GraphQL output types, thus eliminating unncessary `notice` logs from `mongoose_graphql_scalar:output/2`.

The conversion function used is `jid:to_bare_binary/1` - maybe a bit too permissive, but for output types it is convenient, and we have control over what is passed to that function, so it's not an issue for me.

I checked other scalar types that only have `input` conversions, and they are never used for `output`, so no changes were needed for them.