### PR TITLE
addr_list: Fix function signature in compare fun

### DIFF
--- a/src/mongoose_addr_list.erl
+++ b/src/mongoose_addr_list.erl
@@ -129,7 +129,7 @@ do_lookup_services(HostType, Domain, EnforceTls) ->
 %%    connection over the other.
 -spec order_and_prepare_addrs(mongooseim:host_type(), [srv_tls()]) -> [addr()].
 order_and_prepare_addrs(HostType, TlsTaggedSrvAddrLists) ->
-    OrderedByPriority = order_by_priority_and_weight(TlsTaggedSrvAddrLists),
+    OrderedByPriority = lists:sort(fun compare_priority_and_weight/2, TlsTaggedSrvAddrLists),
     WithIpAddresses = for_each_tagged_srv_get_ip_addresses(HostType, OrderedByPriority),
     lists:flatten(WithIpAddresses).
 
@@ -142,12 +142,10 @@ order_and_prepare_addrs(HostType, TlsTaggedSrvAddrLists) ->
 %%  Weight:
 %%      The weight field specifies a relative weight for entries with the same priority.
 %%      Larger weights SHOULD be given a proportionately higher probability of being selected.
--spec order_by_priority_and_weight([srv_tls()]) -> [srv_tls()].
-order_by_priority_and_weight(TlsTaggedSrvAddrLists) ->
-    Fun = fun({P1, _W1}, {P2, _W2}) when P1 < P2 -> true;
-             ({P1, _W1}, {P2, _W2}) when P1 > P2 -> false;
-             ({_P1, W1}, {_P2, W2}) -> W2 < W1 end,
-    lists:sort(Fun, TlsTaggedSrvAddrLists).
+-spec compare_priority_and_weight(srv_tls(), srv_tls()) -> boolean().
+compare_priority_and_weight({P1, _W1, _, _, _}, {P2, _W2, _, _, _}) when P1 < P2 -> true;
+compare_priority_and_weight({P1, _W1, _, _, _}, {P2, _W2, _, _, _}) when P1 > P2 -> false;
+compare_priority_and_weight({_P1, W1, _, _, _}, {_P2, W2, _, _, _}) -> W2 < W1.
 
 -spec for_each_tagged_srv_get_ip_addresses(mongooseim:host_type(), [srv_tls()]) -> [[[addr()]]].
 for_each_tagged_srv_get_ip_addresses(HostType, TlsTaggedSrvAddrLists) ->


### PR DESCRIPTION
This is what I got in production (indented for better readability and censored the real host names):

```erlang
{error,function_clause,[
   {mongoose_addr_list,'-order_by_priority_and_weight/1-fun-0-',
      [{30,0,5269,"somehost1",false},
       {31,0,5269,"somehost2",false}
      ],
      [{file,"/build/source/src/mongoose_addr_list.erl"},{line,147}]
   },
   {lists,sort,2,[{file,"lists.erl"},{line,1886}]},
   {mongoose_addr_list,order_and_prepare_addrs,2,
      [{file,"/build/source/src/mongoose_addr_list.erl"},{line,132}]},
   {mongoose_addr_list,do_lookup_services,3,
      [{file,"/build/source/src/mongoose_addr_list.erl"},{line,116}]},
   {mongoose_addr_list,get_addr_list,3,
      [{file,"/build/source/src/mongoose_addr_list.erl"},{line,47}]},
   {mongoose_s2s_out,open_socket,3,
      [{file,"/build/source/src/s2s/mongoose_s2s_out.erl"},{line,315}]},
   {mongoose_s2s_out,handle_event,4,
      [{file,"/build/source/src/s2s/mongoose_s2s_out.erl"},{line,140}]},
   {gen_statem,loop_state_callback,11,
      [{file,"gen_statem.erl"},{line,3743}]}
]}
```

Looking at the types of order_by_priority_and_weight/1, the input type is the following:

```erlang
-type srv_tls() :: {Prio :: integer(),
                    Weight :: integer(),
                    Port :: inet:port_number(),
                    DnsName :: hostname(),
                    Tls :: with_tls()}.
```

However, the function passed to lists:sort/2 only uses tuples of length 2, which leads to the error above.

To make sure that dialyzer detects this properly in the future, I moved the comparison function to a named function instead.