### PR TITLE
MIM-2766 Fix mod ping intervals

### DIFF
--- a/big_tests/tests/mod_ping_SUITE.erl
+++ b/big_tests/tests/mod_ping_SUITE.erl
@@ -258,7 +258,7 @@ check_connection(_, Client) ->
     true = escalus_connection:is_connected(Client).
 
 wait_for_ping_req(Alice) ->
-    PingReq = escalus_client:wait_for_stanza(Alice, timer:seconds(10)),
+    PingReq = escalus_client:wait_for_stanza(Alice, ping_interval() + timer:seconds(1)),
     escalus:assert(is_iq_get, PingReq),
     <<"urn:xmpp:ping">> = exml_query:path(PingReq, [{element, <<"ping">>},
                                                     {attr, <<"xmlns">>}]),

--- a/big_tests/tests/mod_ping_SUITE.erl
+++ b/big_tests/tests/mod_ping_SUITE.erl
@@ -53,7 +53,6 @@ all_tests() ->
      ping,
      wrong_ping,
      active,
-     active_keep_alive,
      server_ping_pong,
      server_ping_pang,
      service_unavailable_response
@@ -201,19 +200,6 @@ active(Config) ->
                 wait_ping_interval(0.5),
                 % it shouldn't as the ping was sent
                 false = escalus_client:has_stanzas(Alice),
-                assert_no_event(mod_ping_response, Alice),
-                assert_no_event(mod_ping_response_timeout, Alice)
-        end).
-
-active_keep_alive(Config) ->
-    escalus:fresh_story(Config, [{alice, 1}],
-        fun(Alice) ->
-                wait_ping_interval(0.75),
-                escalus_tcp:send(Alice#client.rcv_pid, #xmlcdata{content = "\n"}),
-                wait_ping_interval(0.5),
-
-                false = escalus_client:has_stanzas(Alice),
-
                 assert_no_event(mod_ping_response, Alice),
                 assert_no_event(mod_ping_response_timeout, Alice)
         end).

--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -50,8 +50,8 @@ These hooks are handled by the following modules:
 * [`mod_event_pusher`](../modules/mod_event_pusher.md) - sends selected messages to an external service.
 * [`mod_inbox`](../modules/mod_inbox.md) - stores messages in the user's inbox.
 * [`mod_mam`](../modules/mod_mam.md) - stores outgoing messages in an archive.
-* [`mod_ping`](../modules/mod_ping.md) - upon reception of every message from the client, this module (re)starts a timer;
- if nothing more is received from the client within 60 seconds, it sends an IQ ping, to which the client should reply - which starts another timer.
+* [`mod_ping`](../modules/mod_ping.md) - upon reception of every stanza from the client, this module (re)starts a timer;
+ if no more stanzas are received from the client within `ping_interval`, it sends an IQ ping, to which the client should reply - which starts another timer.
 * [`mod_presence`](../modules/mod_presence.md) - handles presence stanzas, updating the user presence state and broadcasting presence updates.
 * [`mod_privacy`](../modules/mod_privacy.md) - filters sent stanzas according to privacy lists and handles privacy-related IQ requests.
 * [`mod_register`](../modules/mod_register.md) - registers a new user when a registration IQ is received. `user_send_xmlel` is used because the stanza is received while the session is not established.

--- a/doc/modules/mod_ping.md
+++ b/doc/modules/mod_ping.md
@@ -9,7 +9,7 @@ This module implements XMPP Ping functionality as described in [XEP-0199: XMPP P
 * **Default:** `false`
 * **Example:** `send_pings = true`
 
-If set to true, the server will send ping iqs to the client if they are not active for a `ping_interval`.
+If set to true, the server will send ping IQs to clients that send no XMPP stanzas for a `ping_interval`.
 
 ### `modules.mod_ping.ping_interval`
 * **Syntax:** positive integer (seconds)

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -173,15 +173,10 @@ determine_action(<<"error">>) ->
     mongoose_c2s_hooks:result().
 user_send_packet(Acc, _Params, #{host_type := HostType}) ->
     Interval = gen_mod:get_module_opt(HostType, ?MODULE, ping_interval),
-    Action = {{timeout, ping}, Interval, fun ping_c2s_handler/2},
+    Action = {{timeout, send_ping}, Interval, fun ping_c2s_handler/2},
     {ok, mongoose_c2s_acc:to_acc(Acc, actions, Action)}.
 
 -spec ping_c2s_handler(atom(), mongoose_c2s:data()) -> mongoose_c2s_acc:t().
-ping_c2s_handler(ping, StateData) ->
-    HostType = mongoose_c2s:get_host_type(StateData),
-    Interval = gen_mod:get_module_opt(HostType, ?MODULE, ping_req_timeout),
-    Actions = [{{timeout, send_ping}, Interval, fun ping_c2s_handler/2}],
-    mongoose_c2s_acc:new(#{actions => Actions});
 ping_c2s_handler(send_ping, StateData) ->
     PingId = mongoose_bin:gen_from_crypto(),
     IQ = ping_get(PingId),


### PR DESCRIPTION
Fix `mod_ping` so server-to-client pings are sent after the configured `ping_interval` with `ping_req_timeout` used only for waiting for the client response.

- The previous behaviour was buggy: there was one unnecessary wait, and timeout reset during the second wait was also missing.
- Remove the obsolete `active_keep_alive` test, since whitespace keepalive no longer resets the ping timer and is not part of XEP-0199 behavior. This test was passing only because of the bug. The tested functionality has been long gone from MIM (since `mongoose_c2s`).
- Remove ambiguity around `mod_ping` in docs.

