### PR TITLE
[MIM-2775] - Fix auth http case_clause error

### DIFF
--- a/doc/authentication-methods/http.md
+++ b/doc/authentication-methods/http.md
@@ -73,6 +73,8 @@ For the best integration, the return code range should not exceed the list below
 * 200 - success, return value in response body
 
 Whenever the specification says "anything else", service should use one of the codes from the list above.
+Any other status code (e.g. 500 or 503) is logged and treated as a failure of the operation,
+i.e. authentication is rejected and registration or password change is not allowed.
 
 Some requests consider multiple return codes a "success".
 It is up to the server-side developer to pick one of the codes.

--- a/src/auth/ejabberd_auth_http.erl
+++ b/src/auth/ejabberd_auth_http.erl
@@ -31,7 +31,8 @@
 -include("mongoose.hrl").
 -include("mongoose_config_spec.hrl").
 
--type http_error_atom() :: conflict | not_found | not_authorized | not_allowed.
+-type http_error_atom() :: conflict | not_found | not_authorized | not_allowed
+                         | bad_request | unexpected_code.
 -type params() :: #{luser := jid:luser(),
                     lserver := jid:lserver(),
                     host_type := mongooseim:host_type(),
@@ -221,7 +222,13 @@ handle_result({ok, {Code, RespBody}}, Method, Path, LUser, HostType) ->
         <<"400">> -> {error, RespBody};
         <<"204">> -> {ok, <<>>};
         <<"201">> -> {ok, created};
-        <<"200">> -> {ok, RespBody}
+        <<"200">> -> {ok, RespBody};
+        _ ->
+            ?LOG_WARNING(#{what => http_auth_request_unexpected_code,
+                           text => <<"Unexpected HTTP status code received from the auth service">>,
+                           path => Path, method => Method, user => LUser, host_type => HostType,
+                           code => Code, result => RespBody}),
+            {error, unexpected_code}
     end;
 handle_result({error, Reason}, Method, Path, LUser, HostType) ->
     ?LOG_DEBUG(#{what => http_auth_request_failed, text => <<"HTTP request failed">>,

--- a/test/auth_http_SUITE.erl
+++ b/test/auth_http_SUITE.erl
@@ -47,7 +47,8 @@ all_tests() ->
      get_password,
      does_user_exist,
      remove_user,
-     supported_sasl_mechanisms
+     supported_sasl_mechanisms,
+     unexpected_http_code
     ].
 
 cert_auth() ->
@@ -217,6 +218,27 @@ supported_sasl_mechanisms(Config) ->
                       end,
     [true, DigestSupported, false, true, true, true, true, true] =
         [ejabberd_auth_http:supports_sasl_module(?HOST_TYPE, Mod) || Mod <- Modules].
+
+unexpected_http_code(_Config) ->
+    lists:foreach(fun check_unexpected_http_code/1, [500, 502, 503, 504, 429]).
+
+check_unexpected_http_code(Code) ->
+    mim_ct_rest:fail(Code),
+    false = ejabberd_auth_http:get_password(?HOST_TYPE, <<"alice">>, ?DOMAIN),
+    mim_ct_rest:fail(Code),
+    <<>> = ejabberd_auth_http:get_password_s(?HOST_TYPE, <<"alice">>, ?DOMAIN),
+    mim_ct_rest:fail(Code),
+    false = ejabberd_auth_http:check_password(?HOST_TYPE, <<"alice">>, ?DOMAIN, <<"makota">>),
+    mim_ct_rest:fail(Code),
+    false = ejabberd_auth_http:does_user_exist(?HOST_TYPE, <<"alice">>, ?DOMAIN),
+    mim_ct_rest:fail(Code),
+    {error, not_allowed} = ejabberd_auth_http:set_password(?HOST_TYPE, <<"alice">>,
+                                                           ?DOMAIN, <<"makota">>),
+    mim_ct_rest:fail(Code),
+    {error, not_allowed} = ejabberd_auth_http:try_register(?HOST_TYPE, <<"alice">>,
+                                                           ?DOMAIN, <<"makota">>),
+    mim_ct_rest:fail(Code),
+    {error, not_allowed} = ejabberd_auth_http:remove_user(?HOST_TYPE, <<"alice">>, ?DOMAIN).
 
 cert_auth_fail(Config) ->
     Creds = creds_with_cert(Config, <<"cert_user">>),

--- a/test/mim_ct_rest.erl
+++ b/test/mim_ct_rest.erl
@@ -14,7 +14,7 @@
 
 %% API
 -export([start/2, stop/0]).
--export([listen/0, verify/1, cancel_listen/0, fail/0]).
+-export([listen/0, verify/1, cancel_listen/0, fail/0, fail/1]).
 -export([op/1, consume_fail/0, get_basic_auth/0]).
 -export([check_password/3, get_password/2, user_exists/2, set_password/3,
          remove_user/2, remove_user_validate/3, register/3]).
@@ -31,7 +31,7 @@
           basic_auth = <<>> :: binary(),
           users = [] :: [user()],
           rest_listeners = [] :: [pid()],
-          fail_once = false :: boolean() | middle
+          fail_once = false :: boolean() | middle | pos_integer()
          }).
 
 %%% -------------------------------------
@@ -73,6 +73,9 @@ cancel_listen() ->
 
 fail() ->
     gen_server:call(mim_ct_rest_server, {fail, true}).
+
+fail(Code) when is_integer(Code) ->
+    gen_server:call(mim_ct_rest_server, {fail, Code}).
 
 op(Op) ->
     gen_server:call(mim_ct_rest_server, {op, Op}).

--- a/test/mim_ct_rest_handler.erl
+++ b/test/mim_ct_rest_handler.erl
@@ -45,6 +45,8 @@ handle(Req, {_, _, _, _, _, false} = State) ->
     reply(Req1, State, 401, "401 Unauthorized");
 handle(Req, {_, _, _, _, true, _} = State) ->
     reply(Req, State, 404, "");
+handle(Req, {_, _, _, _, Code, _} = State) when is_integer(Code) ->
+    reply(Req, State, Code, <<>>);
 handle(Req, {<<"GET">>, <<"/auth/", _/binary>>, <<"check_password">>, {U, S, P}, _, _} = State) ->
     Result = mim_ct_rest:check_password(U, S, P),
     reply(Req, State, 200, atom_to_binary(Result));


### PR DESCRIPTION
This PR addresses [MIM-2775](https://erlangsolutions.atlassian.net/browse/MIM-2775). It fixes the runtime error when the HTTP auth server returns an unexpected code, e.g. 503. 


[MIM-2775]: https://erlangsolutions.atlassian.net/browse/MIM-2775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ