### PR TITLE
MIM-2776 Configurable pubsub node config defaults

### DIFF
--- a/big_tests/tests/pep_SUITE.erl
+++ b/big_tests/tests/pep_SUITE.erl
@@ -62,11 +62,13 @@ end_per_testcase(TestName, Config) ->
 all() ->
     [{group, pep},
      {group, pep_no_caps},
+     {group, default_node_config},
      {group, max_items_per_node}].
 
 groups() ->
     [{pep, [parallel], pep_tests()},
      {pep_no_caps, [parallel], pep_no_caps_tests()},
+     {default_node_config, [parallel], default_node_config_tests()},
      {max_items_per_node, [parallel], max_items_per_node_tests()}].
 
 pep_tests() ->
@@ -144,6 +146,11 @@ max_items_per_node_tests() ->
     [create_with_max_items_and_publish,
      create_with_max_items_per_node_and_publish].
 
+-doc "Tests checking the default_node_config option".
+default_node_config_tests() ->
+    [create_uses_default_node_config,
+     autocreate_uses_default_node_config].
+
 %% Disco
 
 disco_info(Config) ->
@@ -209,6 +216,12 @@ create_with_max_items_and_publish(Config) ->
 create_with_max_items_per_node_and_publish(Config) ->
     escalus:fresh_story(Config, [{alice, 1}],
                         fun create_with_max_items_per_node_and_publish_story/1).
+
+create_uses_default_node_config(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun create_uses_default_node_config_story/1).
+
+autocreate_uses_default_node_config(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}], fun autocreate_uses_default_node_config_story/1).
 
 create_with_max_items_zero_and_publish(Config) ->
     escalus:fresh_story_with_config(set_caps(Config), [{bob, 1}],
@@ -425,6 +438,18 @@ create_with_empty_config_story(Alice) ->
     create_node(Alice, PepNode, [{config, []}]),
     get_configuration(Alice, PepNode, [{expected_result, [{~"pubsub#access_model", ~"presence"},
                                                           {~"pubsub#max_items", ~"max"}]}]).
+
+create_uses_default_node_config_story(Alice) ->
+    PepNode = pep_node(Alice, random_node_ns()),
+    create_node(Alice, PepNode, []),
+    get_configuration(Alice, PepNode, [{expected_result, [{~"pubsub#access_model", ~"open"},
+                                                          {~"pubsub#max_items", ~"1"}]}]).
+
+autocreate_uses_default_node_config_story(Alice) ->
+    PepNode = pep_node(Alice, random_node_ns()),
+    publish(Alice, ~"item0", PepNode, []),
+    get_configuration(Alice, PepNode, [{expected_result, [{~"pubsub#access_model", ~"open"},
+                                                          {~"pubsub#max_items", ~"1"}]}]).
 
 create_and_configure_story(Alice) ->
     PepNode = pep_node(Alice),
@@ -1086,6 +1111,9 @@ required_modules(pep) ->
      {mod_pubsub, default_mod_config(mod_pubsub)}];
 required_modules(pep_no_caps) ->
     [{mod_pubsub, default_mod_config(mod_pubsub)}];
+required_modules(default_node_config) ->
+    [{mod_pubsub, mod_config(mod_pubsub,
+                             #{default_node_config => #{access_model => open, max_items => 1}})}];
 required_modules(max_items_per_node) ->
     [{mod_pubsub, mod_config(mod_pubsub, #{max_items_per_node => 3})}].
 

--- a/doc/modules/mod_pubsub.md
+++ b/doc/modules/mod_pubsub.md
@@ -27,8 +27,8 @@ It handles same-server PEP requests addressed to users' bare JIDs and does not e
 
 `mod_pubsub` supports the following node configuration and publish options:
 
-* [`pubsub#access_model`](https://xmpp.org/extensions/xep-0060.html#accessmodels): controls who can access a node. Supported values are `open` and `presence`.
-* `pubsub#max_items`: controls how many published items are stored for later retrieval. It defaults to `max`, which stores all published items up to the server-wide [`max_items_per_node`](#modulesmod_pubsubmax_items_per_node) limit. A non-negative integer limits stored items for the node; when the limit is exceeded, the oldest stored item is removed. `0` allows publish notifications but does not persist items for later retrieval.
+* [`pubsub#access_model`](https://xmpp.org/extensions/xep-0060.html#accessmodels): controls who can access a node. Supported values are `open` and `presence`. It defaults to [`default_node_config.access_model`](#modulesmod_pubsubdefault_node_configaccess_model).
+* `pubsub#max_items`: controls how many published items are stored for later retrieval. It defaults to [`default_node_config.max_items`](#modulesmod_pubsubdefault_node_configmax_items). A non-negative integer limits stored items for the node; when the limit is exceeded, the oldest stored item is removed. `0` allows publish notifications but does not persist items for later retrieval.
 
 ### Known omissions and limitations
 
@@ -59,6 +59,26 @@ Maximum number of items stored in a node.
 The effective limit is the lower of this value and `pubsub#max_items`.
 If you reduce this limit, excess items for each already existing node are removed when it is next configured or receives a published item.
 
+### `modules.mod_pubsub.default_node_config`
+Default configuration applied to newly created PEP nodes, including nodes auto-created on publish.
+Request-level node configuration and publish options override these values.
+
+#### `modules.mod_pubsub.default_node_config.access_model`
+* **Syntax:** string, one of `"presence"`, `"open"`
+* **Default:** `"presence"`
+* **Example:** `default_node_config.access_model = "open"`
+
+Default value of `pubsub#access_model` for newly created nodes.
+The default `presence` as required for [PEP](https://xmpp.org/extensions/xep-0163.html#approach-presence).
+
+#### `modules.mod_pubsub.default_node_config.max_items`
+* **Syntax:** non-negative integer or `"infinity"`
+* **Default:** `"infinity"`
+* **Example:** `default_node_config.max_items = 100`
+
+Default value of `pubsub#max_items` for newly created nodes.
+The `"infinity"` value is exposed in node configuration forms as `max`, and stores all published items up to the [`max_items_per_node`](#modulesmod_pubsubmax_items_per_node) limit.
+
 ### `modules.mod_pubsub.iqdisc.type`
 * **Syntax:** string, one of `"one_queue"`, `"no_queue"`, `"queues"`, `"parallel"`
 * **Default:** `"no_queue"`
@@ -83,4 +103,12 @@ The example below shows a different configuration where IQ requests are handled 
 [modules.mod_pubsub]
   iqdisc.type = "queues"
   iqdisc.workers = 50
+```
+
+The example below makes newly created PEP nodes open by default and stores only the most recent item per node, unless the create request or publish options override these values:
+
+```toml
+[modules.mod_pubsub]
+  default_node_config.access_model = "open"
+  default_node_config.max_items = 1
 ```

--- a/include/mod_pubsub.hrl
+++ b/include/mod_pubsub.hrl
@@ -1,6 +1,5 @@
 -record(pubsub_node, {node_key :: mod_pubsub:node_key(),
-                      config = #{access_model => presence,
-                                 max_items => max} :: mod_pubsub:node_config()}).
+                      config :: mod_pubsub:node_config()}).
 
 -record(subscription, {node_key :: mod_pubsub:node_key(),
                        jid :: jid:jid()}).

--- a/src/pubsub/mod_pubsub.erl
+++ b/src/pubsub/mod_pubsub.erl
@@ -37,7 +37,7 @@
 -type item_id() :: binary().
 -type get_items_opts() :: #{} | #{max_items := max_items()} | #{item_ids := [item_id()]}.
 -type max_items() :: pos_integer().
--type max_items_node() :: max | non_neg_integer().
+-type max_items_node() :: infinity | non_neg_integer().
 -type item_payload() :: exml:element().
 -type access_model() :: open | presence.
 -type node_config() :: #{access_model => access_model(), max_items => max_items_node()}.
@@ -103,11 +103,22 @@ config_spec() ->
                                         validate = {module, mod_pubsub_backend}},
                   ~"iqdisc" => mongoose_config_spec:iqdisc(),
                   ~"max_items_per_node" => #option{type = int_or_infinity,
-                                                   validate = non_negative}},
+                                                   validate = non_negative},
+                  ~"default_node_config" => default_node_config_spec()},
         defaults = #{~"backend" => rdbms,
                      ~"iqdisc" => no_queue,
                      ~"max_items_per_node" => infinity}
     }.
+
+-spec default_node_config_spec() -> mongoose_config_spec:config_section().
+default_node_config_spec() ->
+    #section{items = #{~"access_model" => #option{type = atom,
+                                                  validate = {enum, [open, presence]}},
+                       ~"max_items" => #option{type = int_or_infinity,
+                                               validate = non_negative}},
+             defaults = #{~"access_model" => presence,
+                          ~"max_items" => infinity},
+             include = always}.
 
 -spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
@@ -302,8 +313,8 @@ perform_action(Request, Action = #{action := create}) ->
         HostType = mongoose_acc:host_type(Acc),
         NodeKey = {ServiceJid, NodeId},
         ok ?= assert_node_does_not_exist(HostType, NodeKey),
-        Node = #pubsub_node{node_key = NodeKey},
-        mod_pubsub_backend:set_node(HostType, apply_node_config(Node, Config)),
+        Node = apply_node_config(new_node(HostType, NodeKey), Config),
+        mod_pubsub_backend:set_node(HostType, Node),
         Action#{result => ok}
     end;
 perform_action(Request, Action = #{action := get_configuration}) ->
@@ -449,10 +460,6 @@ is_owner(#{from_jid := FromJid, service_jid := ServiceJid}) ->
 is_open(#pubsub_node{config = #{access_model := AccessModel}}) ->
     AccessModel =:= open.
 
--spec apply_node_config(pubsub_node(), node_config()) -> pubsub_node().
-apply_node_config(Node, Config) ->
-    Node#pubsub_node{config = maps:merge(Node#pubsub_node.config, Config)}.
-
 -spec get_node(mongooseim:host_type(), node_key()) -> result(pubsub_node()).
 get_node(HostType, NodeKey) ->
     case mod_pubsub_backend:get_node(HostType, NodeKey) of
@@ -500,8 +507,7 @@ delete_item(HostType, NodeKey, ItemId) ->
 get_or_create_node(HostType, NodeKey, Config) ->
     case mod_pubsub_backend:get_node(HostType, NodeKey) of
         undefined ->
-            Node = #pubsub_node{node_key = NodeKey},
-            ConfiguredNode = apply_node_config(Node, Config),
+            ConfiguredNode = apply_node_config(new_node(HostType, NodeKey), Config),
             mod_pubsub_backend:set_node(HostType, ConfiguredNode),
             {ok, ConfiguredNode};
         Node = #pubsub_node{config = ExistingConfig} ->
@@ -510,6 +516,15 @@ get_or_create_node(HostType, NodeKey, Config) ->
                 _ -> {error, {conflict, ~"precondition-not-met"}}
             end
     end.
+
+-spec new_node(mongooseim:host_type(), node_key()) -> pubsub_node().
+new_node(HostType, NodeKey) ->
+    Config = gen_mod:get_module_opt(HostType, ?MODULE, default_node_config),
+    #pubsub_node{node_key = NodeKey, config = Config}.
+
+-spec apply_node_config(pubsub_node(), node_config()) -> pubsub_node().
+apply_node_config(Node, Config) ->
+    Node#pubsub_node{config = maps:merge(Node#pubsub_node.config, Config)}.
 
 %% Notification helpers
 

--- a/src/pubsub/mod_pubsub_backend.erl
+++ b/src/pubsub/mod_pubsub_backend.erl
@@ -27,7 +27,7 @@
     [mod_pubsub:subscription()].
 -callback get_subscription(mongooseim:host_type(), mod_pubsub:node_key(), jid:jid()) ->
     mod_pubsub:subscription() | undefined.
--callback set_item(mongooseim:host_type(), mod_pubsub:item(), mod_pubsub:max_items_node()) -> ok.
+-callback set_item(mongooseim:host_type(), mod_pubsub:item(), infinity | pos_integer()) -> ok.
 -callback delete_item(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:item_id()) ->
     ok | not_found.
 -callback get_items(mongooseim:host_type(), mod_pubsub:node_key(), mod_pubsub:get_items_opts()) ->
@@ -106,7 +106,7 @@ delete_subscription(HostType, NodeKey, SubscriberJid) ->
 get_subscription(HostType, NodeKey, SubscriberJid) ->
     mongoose_backend:call(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, NodeKey, SubscriberJid]).
 
--spec set_item(mongooseim:host_type(), mod_pubsub:item(), mod_pubsub:max_items_node()) -> ok.
+-spec set_item(mongooseim:host_type(), mod_pubsub:item(), infinity | pos_integer()) -> ok.
 set_item(HostType, Item, MaxItems) ->
     mongoose_backend:call_tracked(HostType, ?MODULE, ?FUNCTION_NAME, [HostType, Item, MaxItems]).
 

--- a/src/pubsub/mod_pubsub_backend_rdbms.erl
+++ b/src/pubsub/mod_pubsub_backend_rdbms.erl
@@ -188,13 +188,13 @@ delete_subscription(HostType, {ServiceJid, NodeId}, SubscriberJid) ->
         {updated, 0} -> not_found
     end.
 
--spec set_item(mongooseim:host_type(), mod_pubsub:item(), max | pos_integer()) -> ok.
+-spec set_item(mongooseim:host_type(), mod_pubsub:item(), infinity | pos_integer()) -> ok.
 set_item(HostType, Item, MaxItems) ->
     F = fun() -> set_item_t(HostType, Item, MaxItems) end,
     {atomic, ok} = mongoose_rdbms:sql_transaction(HostType, F),
     ok.
 
--spec set_item_t(mongooseim:host_type(), mod_pubsub:item(), max | pos_integer()) -> ok.
+-spec set_item_t(mongooseim:host_type(), mod_pubsub:item(), infinity | pos_integer()) -> ok.
 set_item_t(HostType, #item{node_key = NodeKey = {ServiceJid, NodeId},
                            id = ItemId,
                            publisher_jid = PublisherJid,
@@ -322,14 +322,14 @@ row_to_node(NodeKey, AccessModelBin, MaxItems) ->
                             max_items => max_items_node_from_sql(MaxItems)}}.
 
 -spec max_items_node_to_sql(mod_pubsub:max_items_node()) -> null | non_neg_integer().
-max_items_node_to_sql(max) ->
+max_items_node_to_sql(infinity) ->
     null;
 max_items_node_to_sql(MaxItems) ->
     MaxItems.
 
 -spec max_items_node_from_sql(null | non_neg_integer()) -> mod_pubsub:max_items_node().
 max_items_node_from_sql(null) ->
-    max;
+    infinity;
 max_items_node_from_sql(MaxItems) ->
     MaxItems.
 
@@ -347,7 +347,7 @@ delete_old_items(HostType, NodeKey, MaxItems) ->
 get_effective_max_items_limit(HostType, MaxItems) ->
     case min(MaxItems, gen_mod:get_module_opt(HostType, mod_pubsub, max_items_per_node)) of
         Limit when is_integer(Limit) -> {ok, Limit};
-        _ -> no_limit % both were atoms: 'max', 'infinity'
+        _ -> no_limit % both values were 'infinity'
     end.
 
 -spec get_extra_item_published_at(mongooseim:host_type(), mod_pubsub:node_key(),

--- a/src/pubsub/mod_pubsub_xml.erl
+++ b/src/pubsub/mod_pubsub_xml.erl
@@ -148,7 +148,7 @@ iq_pubsub_owner_get(_) ->
 parse_create_config([ConfigureEl = #xmlel{name = ~"configure"}]) ->
     parse_configure_config(ConfigureEl);
 parse_create_config([]) ->
-    {ok, #{access_model => presence}};
+    {ok, #{}};
 parse_create_config(_) ->
     {error, bad_request}.
 
@@ -256,7 +256,7 @@ parse_access_model(_) -> {error, bad_request}.
 
 -spec parse_max_items_node([binary()]) -> mod_pubsub:result(mod_pubsub:max_items_node()).
 parse_max_items_node([~"max"]) ->
-    {ok, max};
+    {ok, infinity};
 parse_max_items_node([MaxItemsBin]) ->
     try binary_to_non_neg_integer(MaxItemsBin) of
         MaxItems -> {ok, MaxItems}
@@ -330,7 +330,7 @@ configure_fields(#pubsub_node{config = #{access_model := AccessModel, max_items 
        values => [max_items_node_to_binary(MaxItems)]}].
 
 -spec max_items_node_to_binary(mod_pubsub:max_items_node()) -> binary().
-max_items_node_to_binary(max) ->
+max_items_node_to_binary(infinity) ->
     ~"max";
 max_items_node_to_binary(MaxItems) ->
     integer_to_binary(MaxItems).

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -954,7 +954,9 @@ default_mod_config(mod_privacy) ->
 default_mod_config(mod_private) ->
     #{iqdisc => one_queue, backend => rdbms};
 default_mod_config(mod_pubsub) ->
-    #{backend => rdbms, iqdisc => no_queue, max_items_per_node => infinity};
+    #{backend => rdbms,
+      default_node_config => #{access_model => presence, max_items => infinity},
+      iqdisc => no_queue, max_items_per_node => infinity};
 default_mod_config(mod_pubsub_old) ->
     #{iqdisc => one_queue, host => {prefix, <<"pubsub.">>}, backend => mnesia, access_createnode => all,
       max_items_node => 10, nodetree => nodetree_tree, ignore_pep_from_offline => true,

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -2508,8 +2508,16 @@ mod_pubsub(_Config) ->
           T(#{<<"backend">> => <<"rdbms">>})),
     ?cfgh(P ++ [max_items_per_node], 20,
           T(#{<<"max_items_per_node">> => 20})),
+    ?cfgh(P ++ [default_node_config, access_model], open,
+          T(#{<<"default_node_config">> => #{<<"access_model">> => <<"open">>}})),
+    ?cfgh(P ++ [default_node_config, max_items], 20,
+          T(#{<<"default_node_config">> => #{<<"max_items">> => 20}})),
+    ?cfgh(P ++ [default_node_config, max_items], infinity,
+          T(#{<<"default_node_config">> => #{<<"max_items">> => <<"infinity">>}})),
     ?errh(T(#{<<"backend">> => <<"mysql">>})),
-    ?errh(T(#{<<"max_items_per_node">> => -1})).
+    ?errh(T(#{<<"max_items_per_node">> => -1})),
+    ?errh(T(#{<<"default_node_config">> => #{<<"access_model">> => <<"authorize">>}})),
+    ?errh(T(#{<<"default_node_config">> => #{<<"max_items">> => -1}})).
 
 mod_pubsub_old(_Config) ->
     check_iqdisc(mod_pubsub_old),


### PR DESCRIPTION
Add `modules.mod_pubsub.default_node_config` for configuring the default node options used when creating PEP nodes. The new section supports:
- `access_model`, defaulting to `presence` (as before)
- `max_items`, defaulting to `infinity` (meaning: `max` as before)

### Secondary changes

- Move default node config from `mod_pubsub.hrl` into the module config spec.
- Use `infinity` internally instead of `max` for consistency.
- Narrow the PubSub backend `set_item/3` type specs for consistency.
- Add tests and docs for the new options.

