### PR TITLE
Fix listener pattern matching in mongoose_listener

### DIFF
--- a/src/listeners/mongoose_listener.erl
+++ b/src/listeners/mongoose_listener.erl
@@ -179,7 +179,7 @@ get_typed_listeners() ->
     Listeners1 = [{cowboy, ejabberd_cowboy:ref(Listener)}
                   || {Listener, _, _, [ejabberd_cowboy]} <- Children],
     Listeners2 = [{ranch, Ref}
-                  || {Ref, _, _, [mongoose_c2s_listener]} <- Children],
+                  || {Ref, _, _, [mongoose_c2s_listener | _]} <- Children],
     Listeners1 ++ Listeners2.
 
 -spec broadcast_c2s_shutdown_sup() -> StoppedCount :: non_neg_integer().


### PR DESCRIPTION
This PR addresses a bugfix on mongoose_listener.erl

Proposed changes include:
* describe the functionality changes: mongoose_listener.erl:182 uses a strict pattern match [mongoose_c2s_listener] but the actual child spec at line 277 sets modules => [mongoose_c2s_listener, ranch_embedded_sup]. So get_typed_listeners() always returns an empty list for Ranch listeners.
* describe new or updated tests
* describe changes to the documentation

