### PR TITLE
MIM-2779 Use screen width more effectively in docs

### DIFF
--- a/doc/css/custom.css
+++ b/doc/css/custom.css
@@ -12,3 +12,41 @@ img#mim-readme-logo {
 [data-md-color-scheme="slate"] {
   --md-accent-fg-color: #7ab5ff;
 }
+
+/* Use more horizontal space on desktop docs pages. */
+@media screen and (min-width: 76.25em) {
+  .md-grid {
+    max-width: min(100%, 85rem);
+  }
+
+  .md-sidebar--primary {
+    width: 15rem;
+  }
+
+  .md-sidebar--secondary {
+    width: 20rem;
+  }
+
+  [dir="ltr"] .md-sidebar--primary .md-sidebar__inner {
+    padding-right: calc(100% - 14.4rem);
+  }
+
+  [dir="rtl"] .md-sidebar--primary .md-sidebar__inner {
+    padding-left: calc(100% - 14.4rem);
+  }
+
+  [dir="ltr"] .md-sidebar--secondary .md-sidebar__inner {
+    padding-right: calc(100% - 19.4rem);
+  }
+
+  [dir="rtl"] .md-sidebar--secondary .md-sidebar__inner {
+    padding-left: calc(100% - 19.4rem);
+  }
+}
+
+/* Don't scale the font up to 150% */
+@media screen and (min-width: 125em) {
+  html {
+    font-size: 137.5%;
+  }
+}


### PR DESCRIPTION
## Summary

- Scale the whole layout up to `85rem` (was: `61rem`)
- Increase desktop sidebar widths to reduce wrapping:
  - left navigation: `15rem` (was: `12.1rem`)
  - right table-of-contents sidebar: `20rem` (was: `12.1rem`)
- Scale font on wide screens to `137.5%` at most (was: `150%`)

## Verification

- Docs built successfully.
- Looks as expected on Firefox, Chrome and Safari.

Example of the widest layout before the changes:

<img width="4332" height="2332" alt="image" src="https://github.com/user-attachments/assets/f3a84bad-53e8-44cc-8c7b-b1afdcdd5ca7" />

After the changes:

<img width="4322" height="2362" alt="image" src="https://github.com/user-attachments/assets/183ed7bc-6eb8-43b3-95b5-be4f4007b627" />



