### PR TITLE
Prepare mim_ct_rest before dialyzer

### DIFF
--- a/big_tests/Makefile
+++ b/big_tests/Makefile
@@ -41,7 +41,7 @@ else
 SED := gsed
 endif
 
-dialyzer:
+dialyzer: mim_ct_rest
 	ERL_LIBS=../_build/default/lib ../rebar3 dialyzer
 
 test_clean: get-deps


### PR DESCRIPTION
This should fix the `dialyzer` failing in master because `mim_ct_rest` module isn't available