### PR TITLE
MIM-2783 Use session state from routing in event_pusher

### DIFF
--- a/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
+++ b/big_tests/tests/mod_event_pusher_rabbit_SUITE.erl
@@ -95,13 +95,16 @@ chat_message_publish_tests() ->
     [chat_message_sent_event,
      chat_message_sent_event_properly_formatted,
      chat_message_received_event,
-     chat_message_received_event_properly_formatted].
+     chat_message_received_event_properly_formatted,
+     chat_message_to_nonexistent_user_is_skipped,
+     chat_message_to_server_is_skipped].
 
 group_chat_message_publish_tests() ->
     [group_chat_message_sent_event,
      group_chat_message_sent_event_properly_formatted,
      group_chat_message_received_event,
      group_chat_message_received_event_properly_formatted,
+     group_chat_message_to_room_is_skipped,
      group_chat_displayed_marker_is_skipped].
 
 instrumentation_tests() ->
@@ -408,6 +411,32 @@ chat_message_received_event_properly_formatted(Config) ->
                            get_decoded_message_from_rabbit(AliceChatMsgRecvRK))
       end).
 
+chat_message_to_nonexistent_user_is_skipped(Config) ->
+    escalus:story(
+      Config, [{bob, 1}],
+      fun(Bob) ->
+              %% GIVEN
+              NonexistentUserJID = <<"nonexistent_user@", (domain())/binary>>,
+              listen_to_chat_msg_recv_events_from_rabbit([NonexistentUserJID], Config),
+              %% WHEN user sends a chat message to a nonexistent local user
+              escalus:send(Bob, escalus_stanza:chat_to(NonexistentUserJID, ~"Hi stranger!")),
+              %% THEN there is no received-message event for the nonexistent user JID
+              assert_no_message_from_rabbit([chat_msg_recv_rk(NonexistentUserJID)])
+      end).
+
+chat_message_to_server_is_skipped(Config) ->
+    escalus:story(
+      Config, [{bob, 1}],
+      fun(Bob) ->
+              %% GIVEN
+              Server = domain(),
+              listen_to_chat_msg_recv_events_from_rabbit([Server], Config),
+              %% WHEN user sends a chat message to the local server JID
+              escalus:send(Bob, escalus_stanza:chat_to(Server, ~"Hi server!")),
+              %% THEN there is no received-message event for the server JID
+              assert_no_message_from_rabbit([chat_msg_recv_rk(Server)])
+      end).
+
 %%--------------------------------------------------------------------
 %% GROUP group_message_publish
 %%--------------------------------------------------------------------
@@ -515,6 +544,25 @@ group_chat_message_received_event_properly_formatted(Config) ->
                              <<"to_user_id">> := AliceFullJID,
                              <<"message">> := Message},
                            get_decoded_message_from_rabbit(AliceGroupChatMsgRecvRK))
+      end).
+
+group_chat_message_to_room_is_skipped(Config) ->
+    escalus:story(
+      Config, [{bob, 1}],
+      fun(Bob) ->
+              %% GIVEN basic variables
+              Room = ?config(room, Config),
+              RoomAddr = muc_helper:room_address(Room),
+              RoomGroupChatMsgRecvRK = group_chat_msg_recv_rk(RoomAddr),
+              %% GIVEN user in room
+              escalus:send(Bob, muc_helper:stanza_muc_enter_room(Room, nick(Bob))),
+              % wait for all room stanzas to be processed
+              escalus:wait_for_stanzas(Bob, 2),
+              listen_to_group_chat_msg_recv_events_from_rabbit([RoomAddr], Config),
+              %% WHEN user sends a groupchat message to the room
+              escalus:send(Bob, escalus_stanza:groupchat_to(RoomAddr, <<"Hi there!">>)),
+              %% THEN there is no received-message event for the room JID
+              assert_no_message_from_rabbit([RoomGroupChatMsgRecvRK])
       end).
 
 group_chat_displayed_marker_is_skipped(Config) ->

--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -58,6 +58,7 @@ groups() ->
          {integration_with_sm_and_offline_storage,[],
           [
            no_duplicates_default_plugin,
+           negative_priority_session_gets_offline_push,
            sm_unack_messages_notified_default_plugin
           ]},
          {enhanced_integration_with_sm,[],
@@ -261,9 +262,32 @@ no_duplicates_default_plugin(Config) ->
 
     escalus_connection:stop(Bob).
 
+negative_priority_session_gets_offline_push(Config) ->
+    escalus:fresh_story(
+        Config, [{bob, 1}, {alice, 1}],
+        fun(Bob, Alice) ->
+            BobJID = bare_jid(Bob),
+
+            Tags = escalus_stanza:tags([{<<"priority">>, <<"-10">>}]),
+            escalus_connection:send(Alice, escalus_stanza:presence(<<"available">>, Tags)),
+            escalus_connection:get_stanza(Alice, presence),
+
+            #{device_token := APNSDevice} = enable_push_for_user(Alice, <<"apns">>, [], Config),
+
+            escalus_connection:send(Bob, escalus_stanza:chat_to(bare_jid(Alice), <<"msg-1">>)),
+            wait_helper:wait_until(fun() -> get_number_of_offline_msgs_for_client(Alice) end, 1),
+            verify_notification(APNSDevice, <<"apns">>, [], BobJID, <<"msg-1">>),
+            escalus_assert:has_no_stanzas(Alice)
+        end).
+
 get_number_of_offline_msgs(Spec) ->
     Username = escalus_utils:jid_to_lower(proplists:get_value(username, Spec)),
     Server = proplists:get_value(server, Spec),
+    mongoose_helper:total_offline_messages({Username, Server}).
+
+get_number_of_offline_msgs_for_client(Client) ->
+    Username = escalus_utils:jid_to_lower(escalus_client:username(Client)),
+    Server = escalus_utils:jid_to_lower(escalus_client:server(Client)),
     mongoose_helper:total_offline_messages({Username, Server}).
 
 sm_unack_messages_notified_default_plugin(Config) ->

--- a/doc/developers-guide/Stanza-routing.md
+++ b/doc/developers-guide/Stanza-routing.md
@@ -57,7 +57,8 @@ If the check passes, the next step is to call the handler associated with the co
 
 `ejabberd_sm` determines the available resources of the recipient, takes into account their priorities and whether the message is addressed to a particular resource or a bare JID.
 It appropriately replicates (or not) the message and sends it to the recipient's C2S process(es) by calling `mongoose_c2s:route/2`.
-In case no resources are available for delivery (hence no C2S processes to pass the message to), the `offline_message` hook is run.
+Afterwards, the `message_routed` hook is run with the recipient status derived from local sessions.
+Then, in case no resources are available for delivery (hence no C2S processes to pass the message to), the `offline_message` hook is run.
 
 As Bob has one online session, the message is sent to the C2S process associated with that session.
 

--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -87,7 +87,6 @@ The stanza can be filtered out (in case the handler returns `drop`), left unchan
 These hooks are handled by the following modules:
 
 * [`mod_domain_isolation`](../modules/mod_domain_isolation.md) - filters out cross-domain stanzas.
-* [`mod_event_pusher`](../modules/mod_event_pusher.md) - sends out configured events (e.g. push notifications) for incoming stanzas.
 * [`mod_inbox`](../modules/mod_inbox.md) - stores incoming messages in the recipient's inbox.
 * [`mod_mam`](../modules/mod_mam.md) - stores incoming messages in the recipient's archive, and adds MAM-related elements to the message.
 * [`mod_pubsub_old`](../modules/mod_pubsub_old.md) - for each subscription authorization form sent by a node owner, the subscription state is updated, and the stanza is dropped.
@@ -146,6 +145,22 @@ This hook is handled by the following modules, listed in the order of execution:
 * [`mod_offline_stub`](../modules/mod_offline_stub.md) - returns `{stop, Acc}` for all messages, preventing further handlers from being called.
 
 * `ejabberd_sm` - calls `ejabberd_sm:bounce_offline_message`, which responds with the `<service-unavailable/>` stanza error. In the case of using `mod_mam` the message is actually stored, and no such error should be sent - that's why the module `mod_offline_stub` can be enabled.
+
+## `message_routed`
+
+```erlang
+mongoose_hooks:message_routed(UserStatus, Acc)
+```
+
+This hook is run after routing a message to an existing local user.
+The `UserStatus` argument is `online` if the message was routed to at least one online session (i.e. with an integer priority), and `offline` otherwise.
+For users with no selected C2S process, the hook is run before `offline_message` or `offline_groupchat_message`.
+
+### Handler examples
+
+This hook is handled by the following module:
+
+* [`mod_event_pusher`](../modules/mod_event_pusher.md) - generates events e.g. for push notifications.
 
 ## `remove_user`
 
@@ -271,6 +286,7 @@ This is the perfect place to plug in custom security control.
 * mam_remove_archive
 * mam_retraction
 * mam_set_prefs
+* message_routed
 * mod_global_distrib_known_recipient
 * mod_global_distrib_unknown_recipient
 * node_cleanup

--- a/doc/migrations/6.8.1_6.x.x.md
+++ b/doc/migrations/6.8.1_6.x.x.md
@@ -1,0 +1,11 @@
+# 6.8.1 to 6.x.x
+
+## `mod_event_pusher` received message events
+
+`mod_event_pusher` no longer creates received-message events for non-user targets such as:
+
+* A user-less JID (e.g. server).
+* A multi-user chat room.
+* A nonexistent user.
+
+These events were not valid user-delivery notifications and were unwanted for push-notification logic.

--- a/include/mod_event_pusher_events.hrl
+++ b/include/mod_event_pusher_events.hrl
@@ -1,8 +1,8 @@
 -include("jlib.hrl").
 
--record(user_status_event, {jid :: jid:jid(), status :: online | offline}).
+-record(user_status_event, {jid :: jid:jid(), status :: ejabberd_sm:user_status()}).
 -record(chat_event, {type :: headline | normal | chat | groupchat,
                      direction :: in | out,
-                     from :: jid:jid(), to :: jid:jid(), packet :: exml:element()}).
+                     from :: jid:jid(), to :: jid:jid(), packet :: exml:element(),
+                     user_status :: ejabberd_sm:user_status()}).
 -record(unack_msg_event, {to ::  jid:jid()}).
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -229,6 +229,7 @@ nav:
       - '6.6.0 to 6.7.0': 'migrations/6.6.0_6.7.0.md'
       - '6.7.0 to 6.8.0': 'migrations/6.7.0_6.8.0.md'
       - '6.8.0 to 6.8.1': 'migrations/6.8.0_6.8.1.md'
+      - '6.8.1 to 6.x.x': 'migrations/6.8.1_6.x.x.md'
       - 'MAM MUC migration helper': 'migrations/jid-from-mam-muc-script.md'
   - 'Contributions to the Ecosystem': 'Contributions.md'
   - 'MongooseIM History': 'History.md'

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -58,7 +58,6 @@
          get_session_ip/1,
          get_user_present_resources/1,
          get_raw_sessions/1,
-         is_offline/1,
          get_user_present_pids/2,
          get_user_present_resources_and_pids/1,
          sync/0,
@@ -111,6 +110,7 @@
                       info     :: info()
                      }.
 -type info() :: #{info_key() => any()}.
+-type user_status() :: online | offline.
 
 -type backend() :: ejabberd_sm_mnesia | ejabberd_sm_redis | ejabberd_sm_cets.
 -type close_reason() :: resumed | normal | {replaced, pid()}.
@@ -122,7 +122,8 @@
               backend/0,
               close_reason/0,
               info/0,
-              info_key/0
+              info_key/0,
+              user_status/0
              ]).
 
 %% default value for the maximum number of user connections
@@ -619,17 +620,23 @@ do_route(Acc, From, To, El) ->
         <<>> ->
             do_route_no_resource(Name, From, To, Acc, El);
         _ ->
-            case get_session_pid(To) of
-                none ->
+            case get_session(To) of
+                offline ->
                     do_route_offline(Name, mongoose_acc:stanza_type(Acc),
                                      From, To, Acc, El);
-                Pid when is_pid(Pid) ->
+                #session{sid = {_, Pid}} = Session ->
                     ?LOG_DEBUG(#{what => sm_route_to_pid, session_pid => Pid,
                                  session_node => node(Pid), acc => Acc}),
                     mongoose_c2s:route(Pid, Acc),
-                    Acc
+                    notify_routed(Session, Acc, Name)
             end
     end.
+
+-spec notify_routed(session(), mongoose_acc:t(), binary()) -> mongoose_acc:t().
+notify_routed(Session, Acc, ~"message") ->
+    mongoose_hooks:message_routed(user_status([Session]), Acc);
+notify_routed(_Session, Acc, _) ->
+    Acc.
 
 -spec do_route_no_resource_presence_prv(From, To, Acc, Packet, Type, Reason) -> boolean() when
       From :: jid:jid(),
@@ -768,29 +775,22 @@ is_privacy_allow(_From, To, Acc, _Packet, PrivacyList) ->
       Acc :: mongoose_acc:t(),
       Packet :: exml:element().
 route_message(From, To, Acc, Packet) ->
-    LUser = To#jid.luser,
-    LServer = To#jid.lserver,
-    case get_user_present_pids(LUser, LServer) of
+    case sessions_to_route(get_user_present_sessions(To#jid.luser, To#jid.lserver)) of
         [] ->
             route_message_fallback(From, To, Acc, Packet);
-        PrioPid ->
-            case lists:max(PrioPid) of
-                {Priority, _} when Priority >= 0 ->
-                    lists:foreach(
-                      %% Route messages to all priority that equals the max, if
-                      %% positive
-                      fun({Prio, Pid}) when Prio == Priority ->
-                         %% we will lose message if PID is not alive
-                              mongoose_c2s:route(Pid, Acc);
-                         %% Ignore other priority:
-                         ({_Prio, _Pid}) ->
-                              ok
-                      end,
-                      PrioPid),
-                      Acc;
-                _ ->
-                    route_message_fallback(From, To, Acc, Packet)
-            end
+        Sessions ->
+            [mongoose_c2s:route(Pid, Acc) || #session{sid = {_, Pid}} <- Sessions],
+            mongoose_hooks:message_routed(user_status(Sessions), Acc)
+    end.
+
+-spec sessions_to_route([session()]) -> [session()].
+sessions_to_route([]) -> [];
+sessions_to_route(Sessions) ->
+    case lists:max([Prio || #session{priority = Prio} <- Sessions]) of
+        MaxPrio when MaxPrio >= 0 ->
+            lists:filter(fun(#session{priority = Prio}) -> Prio =:= MaxPrio end, Sessions);
+        _ ->
+            []
     end.
 
 route_message_fallback(From, To, Acc, Packet) ->
@@ -800,7 +800,12 @@ route_message_fallback(From, To, Acc, Packet) ->
 route_message_by_type(<<"error">>, _From, _To, Acc, _Packet) ->
     Acc;
 route_message_by_type(<<"groupchat">>, From, To, Acc, Packet) ->
-    mongoose_hooks:offline_groupchat_message(Acc, From, To, Packet);
+    HostType = mongoose_acc:host_type(Acc),
+    Acc1 = case ejabberd_auth:does_user_exist(HostType, To, stored) of
+               true -> mongoose_hooks:message_routed(offline, Acc);
+               false -> Acc
+           end,
+    mongoose_hooks:offline_groupchat_message(Acc1, From, To, Packet);
 route_message_by_type(<<"headline">>, From, To, Acc, Packet) ->
     {stop, Acc1} = bounce_offline_message(Acc, #{from => From, to => To, packet => Packet}, #{}),
     Acc1;
@@ -808,11 +813,12 @@ route_message_by_type(_, From, To, Acc, Packet) ->
     HostType = mongoose_acc:host_type(Acc),
     case ejabberd_auth:does_user_exist(HostType, To, stored) of
         true ->
+            Acc1 = mongoose_hooks:message_routed(offline, Acc),
             case is_privacy_allow(From, To, Acc, Packet) of
                 true ->
-                    mongoose_hooks:offline_message(Acc, From, To, Packet);
+                    mongoose_hooks:offline_message(Acc1, From, To, Packet);
                 false ->
-                    mongoose_hooks:failed_to_store_message(Acc)
+                    mongoose_hooks:failed_to_store_message(Acc1)
             end;
         _ ->
             E = mongoose_xmpp_errors:service_unavailable(<<"User not found">>),
@@ -821,6 +827,13 @@ route_message_by_type(_, From, To, Acc, Packet) ->
     end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec user_status([session()]) -> user_status().
+user_status(Sessions) ->
+    case lists:any(fun(#session{priority = Priority}) -> is_integer(Priority) end, Sessions) of
+        true -> online;
+        false -> offline
+    end.
 
 -spec clean_session_list([#session{}]) -> [#session{}].
 clean_session_list(Ss) ->
@@ -843,7 +856,6 @@ clean_session_list([S1, S2 | Rest], Res) ->
             clean_session_list([S2 | Rest], [S1 | Res])
     end.
 
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 -spec get_user_present_pids(LUser, LServer) -> [{priority(), pid()}] when
@@ -853,6 +865,11 @@ get_user_present_pids(LUser, LServer) ->
     Ss = ejabberd_sm_backend:get_sessions(LUser, LServer),
     [{S#session.priority, element(2, S#session.sid)} ||
      S <- clean_session_list(Ss), is_integer(S#session.priority)].
+
+-spec get_user_present_sessions(jid:luser(), jid:lserver()) -> [session()].
+get_user_present_sessions(LUser, LServer) ->
+    Ss = ejabberd_sm_backend:get_sessions(LUser, LServer),
+    [S || S <- clean_session_list(Ss), is_integer(S#session.priority)].
 
 -spec get_user_present_resources_and_pids(jid:jid()) -> [{Resource :: binary(), pid()}].
 get_user_present_resources_and_pids(#jid{luser = LUser, lserver = LServer}) ->
@@ -866,20 +883,6 @@ get_user_present_resources(#jid{luser = LUser, lserver = LServer}) ->
     Ss = ejabberd_sm_backend:get_sessions(LUser, LServer),
     [{S#session.priority, element(3, S#session.usr)} ||
         S <- clean_session_list(Ss), is_integer(S#session.priority)].
-
--spec is_offline(jid:jid()) -> boolean().
-is_offline(#jid{luser = LUser, lserver = LServer}) ->
-    case get_user_present_pids(LUser, LServer) of
-        [] ->
-            true;
-        Pids ->
-            case lists:max(Pids) of
-                {Priority, _} when Priority >= 0 ->
-                    false;
-                _ ->
-                    true
-            end
-    end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -23,7 +23,7 @@
 -export([add_hooks/1, delete_hooks/1]).
 
 -export([user_send_message/3,
-         filter_local_packet/3,
+         message_routed/3,
          user_present/3,
          user_not_present/3,
          unacknowledged_message/3]).
@@ -43,16 +43,17 @@ delete_hooks(HostType) ->
 %%--------------------------------------------------------------------
 %% Hook callbacks
 %%--------------------------------------------------------------------
--spec filter_local_packet(Acc, Args, Extra) -> {ok, Acc} when
-      Acc :: mongoose_hooks:filter_packet_acc(),
-      Args :: map(),
+-spec message_routed(Acc, Args, Extra) -> {ok, Acc} when
+      Acc :: mongoose_acc:t(),
+      Args :: #{user_status := ejabberd_sm:user_status()},
       Extra :: gen_hook:extra().
-filter_local_packet({From, To, Acc0, Packet}, _, _) ->
-    Acc = case chat_type(Acc0) of
-              false -> Acc0;
-              Type -> push_chat_event(Acc0, Type, {From, To, Packet}, out)
-          end,
-    {ok, {From, To, Acc, Packet}}.
+message_routed(Acc, #{user_status := UserStatus}, _) ->
+    case chat_type(Acc) of
+        false ->
+            {ok, Acc};
+        Type ->
+            {ok, push_chat_event(Acc, Type, out, UserStatus)}
+    end.
 
 -spec user_send_message(mongoose_acc:t(), mongoose_c2s_hooks:params(), gen_hook:extra()) ->
     mongoose_c2s_hooks:result().
@@ -66,7 +67,7 @@ user_send_message(Acc, _, _) ->
             {_, false} ->
                 Acc;
             {_, Type} ->
-                push_chat_event(Acc, Type, Packet, in)
+                push_chat_event(Acc, Type, in, online)
         end,
     {ok, ResultAcc}.
 
@@ -101,16 +102,16 @@ unacknowledged_message(Acc, #{jid := Jid}, _) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
--spec push_chat_event(Acc, Type, {From, To, Packet}, Direction) -> Acc when
+-spec push_chat_event(Acc, Type, Direction, UserStatus) -> Acc when
       Acc :: mongoose_acc:t(),
       Type :: chat | groupchat | headline | normal | false,
-      From :: jid:jid(),
-      To :: jid:jid(),
-      Packet :: exml:element(),
-      Direction :: in | out.
-push_chat_event(Acc, Type, {From, To, Packet}, Direction) ->
+      Direction :: in | out,
+      UserStatus :: ejabberd_sm:user_status().
+push_chat_event(Acc, Type, Direction, UserStatus) ->
+    {From, To, Packet} = mongoose_acc:packet(Acc),
     Event = #chat_event{type = Type, direction = Direction,
-                        from = From, to = To, packet = Packet},
+                        from = From, to = To, packet = Packet,
+                        user_status = UserStatus},
     NewAcc = mod_event_pusher:push_event(Acc, Event),
     merge_acc(Acc, NewAcc).
 
@@ -133,7 +134,7 @@ merge_acc(Acc, EventPusherAcc) ->
 -spec hooks(mongooseim:host_type()) -> [gen_hook:hook_tuple()].
 hooks(HostType) ->
     [
-        {filter_local_packet, HostType, fun ?MODULE:filter_local_packet/3, #{}, 80},
+        {message_routed, HostType, fun ?MODULE:message_routed/3, #{}, 80},
         {unset_presence, HostType, fun ?MODULE:user_not_present/3, #{}, 90},
         {user_available, HostType, fun ?MODULE:user_present/3, #{}, 90},
         {user_send_message, HostType, fun ?MODULE:user_send_message/3, #{}, 90},

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -31,11 +31,11 @@
                      Event :: mod_event_pusher:event(),
                      Services :: [mod_event_pusher_push:publish_service()]) ->
                         [mod_event_pusher_push:publish_service()].
-should_publish(Acc, #chat_event{to = To}, Services) ->
+should_publish(Acc, #chat_event{user_status = UserStatus}, Services) ->
     PublishedServices = mongoose_acc:get(event_pusher, published_services, [], Acc),
-    case should_publish(Acc, To) of
-        true -> Services -- PublishedServices;
-        false -> []
+    case UserStatus of
+        online -> [];
+        offline -> Services -- PublishedServices
     end;
 should_publish(_Acc, _Event, _Services) -> [].
 
@@ -77,19 +77,6 @@ publish_notification(Acc, _, Payload, Services) ->
 %%--------------------------------------------------------------------
 %% local functions
 %%--------------------------------------------------------------------
-
--spec should_publish(Acc :: mongoose_acc:t(), To :: jid:jid()) -> boolean().
-should_publish(Acc, #jid{} = To) ->
-    HostType = mongoose_acc:host_type(Acc),
-    try ejabberd_auth:does_user_exist(HostType, To, stored) of
-        false ->
-            false;
-        true ->
-            ejabberd_sm:is_offline(To)
-    catch
-        _:_ ->
-            ejabberd_sm:is_offline(To)
-    end.
 
 -spec get_unread_count(mongoose_acc:t(), jid:jid()) -> pos_integer().
 get_unread_count(Acc, To) ->

--- a/src/event_pusher/mod_event_pusher_rabbit.erl
+++ b/src/event_pusher/mod_event_pusher_rabbit.erl
@@ -191,7 +191,7 @@ user_topic_routing_key(JID, Topic) ->
     BinJID = jid:to_binary(jid:to_lus(JID)),
     <<BinJID/binary, ".", Topic/binary>>.
 
--spec is_user_online(online | offline) -> boolean().
+-spec is_user_online(ejabberd_sm:user_status()) -> boolean().
 is_user_online(online) -> true;
 is_user_online(offline) -> false.
 

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -17,6 +17,7 @@
          filter_local_packet/1,
          filter_packet/1,
          inbox_unread_count/2,
+         message_routed/2,
          extend_inbox_result/3,
          get_key/2,
          packet_to_component/3,
@@ -242,6 +243,19 @@ failed_to_store_message(Acc) ->
 filter_local_packet(FilterAcc = {_From, _To, Acc, _Packet}) ->
     HostType = mongoose_acc:host_type(Acc),
     run_hook_for_host_type(filter_local_packet, HostType, FilterAcc, #{}).
+
+%%% @doc The `message_routed' hook is called after `ejabberd_sm' routes a message
+%%% to an existing local user. `UserStatus' is `online' when the message was
+%%% routed to at least one online session (i.e. with integer priority), and `offline' otherwise.
+%%% It is called before `offline_message' or `offline_groupchat_message'.
+-spec message_routed(UserStatus, Acc) -> Result when
+    UserStatus :: ejabberd_sm:user_status(),
+    Acc :: mongoose_acc:t(),
+    Result :: mongoose_acc:t().
+message_routed(UserStatus, Acc) ->
+    HostType = mongoose_acc:host_type(Acc),
+    Params = #{user_status => UserStatus},
+    run_hook_for_host_type(message_routed, HostType, Acc, Params).
 
 %%% @doc The `filter_packet' hook is called to filter out
 %%% stanzas routed with `mongoose_router_global'.

--- a/src/inbox/mod_inbox_rdbms.erl
+++ b/src/inbox/mod_inbox_rdbms.erl
@@ -123,9 +123,7 @@ get_inbox(HostType, LUser, LServer, Params) ->
 get_inbox_unread(HostType, {LUser, LServer, RemBareJID}) ->
     Res = execute_select_unread_count(HostType, LUser, LServer, RemBareJID),
     {ok, Val} = check_result(Res),
-    %% We read unread_count value when the message is sent and is not yet in receiver inbox
-    %% so we have to add +1
-    {ok, Val + 1}.
+    {ok, Val}.
 
 -spec set_inbox(HostType, InboxEntryKey, Packet, Count, MsgId, Timestamp) ->
     mod_inbox:write_res() when


### PR DESCRIPTION
The goal is to use the same user-session state for routing and for push notifications.
Several notification corner cases are fixed as a side-effect of such rework.

## Changes
- Add `message_routed` hook in `ejabberd_sm`.
- Move `mod_event_pusher` received-message handling from `filter_local_packet` to `message_routed`.
- Pass routed recipient status as `online` / `offline` so push logic uses routing-time session state.
- Run `message_routed` before offline hooks for offline messages, allowing push state to be stored with offline messages.
- Stop emitting received-message events for non-user targets such as server JIDs, room JIDs, and nonexistent users.
- Remove the old inbox unread-count `+1`, because push now runs after inbox updates.
- Add coverage for filtered-out event targets and negative-priority offline routing.
- Document the new hook and migration-visible event-pusher behavior.
