### PR TITLE
MIM-2767 Classify errors logged during big tests

### DIFF
--- a/big_tests/src/cth_error_report.erl
+++ b/big_tests/src/cth_error_report.erl
@@ -40,6 +40,7 @@ Usage in tests:
 
 %% API for tests
 -export([expect/1, expect/2, max_unexpected_errors_logged/1]).
+-export([get_pattern_allowances/0]).
 
 -define(PATTERNS_TABLE, cth_error_report_patterns).
 -define(NODE_KEYS, [mim, mim2, mim3, fed, reg]).
@@ -278,7 +279,7 @@ is_parallel_group(Config) ->
 init_patterns_table() ->
     case ets:whereis(?PATTERNS_TABLE) of
         undefined ->
-            ets_helper:new(?PATTERNS_TABLE, [bag]);
+            ets_helper:new(?PATTERNS_TABLE, [duplicate_bag]);
         _Tid ->
             ets:delete_all_objects(?PATTERNS_TABLE)
     end.

--- a/big_tests/src/mim_helpers/acc_test_helper.erl
+++ b/big_tests/src/mim_helpers/acc_test_helper.erl
@@ -74,8 +74,36 @@ drop_if_jid_not_mine(Acc, _, _) ->
     {ok, Acc}.
 
 recreate_table() ->
+    stop_table_owner(),
+    Owner = spawn(?MODULE, table_owner, [self()]),
+    receive
+        {table_created, Owner} -> ok
+    after 5000 ->
+        exit(Owner, kill),
+        error(test_message_index_not_created)
+    end.
+
+table_owner(Caller) ->
+    register(test_message_index_owner, self()),
     try ets:delete(test_message_index) catch _:_ -> ok end,
-    ets:new(test_message_index, [named_table, public, {heir, whereis(mongoose_c2s_sup), none}]).
+    ets:new(test_message_index, [named_table, public]),
+    Caller ! {table_created, self()},
+    receive stop -> ok end.
+
+stop_table_owner() ->
+    case whereis(test_message_index_owner) of
+        undefined ->
+            ok;
+        Owner ->
+            MRef = erlang:monitor(process, Owner),
+            Owner ! stop,
+            receive
+                {'DOWN', MRef, process, Owner, _} -> ok
+            after 5000 ->
+                erlang:demonitor(MRef, [flush]),
+                exit(Owner, kill)
+            end
+    end.
 
 check_acc(#{ stanza := #{ type := <<"chat">> } } = Acc) ->
     Ref = mongoose_acc:ref(Acc),

--- a/big_tests/src/mim_helpers/acc_test_helper.erl
+++ b/big_tests/src/mim_helpers/acc_test_helper.erl
@@ -73,38 +73,6 @@ drop_if_jid_not_mine({F, T, #{ stanza := #{ type := <<"chat">> } } = Acc, P}, _,
 drop_if_jid_not_mine(Acc, _, _) ->
     {ok, Acc}.
 
-recreate_table() ->
-    stop_table_owner(),
-    Owner = spawn(?MODULE, table_owner, [self()]),
-    receive
-        {table_created, Owner} -> ok
-    after 5000 ->
-        exit(Owner, kill),
-        error(test_message_index_not_created)
-    end.
-
-table_owner(Caller) ->
-    register(test_message_index_owner, self()),
-    try ets:delete(test_message_index) catch _:_ -> ok end,
-    ets:new(test_message_index, [named_table, public]),
-    Caller ! {table_created, self()},
-    receive stop -> ok end.
-
-stop_table_owner() ->
-    case whereis(test_message_index_owner) of
-        undefined ->
-            ok;
-        Owner ->
-            MRef = erlang:monitor(process, Owner),
-            Owner ! stop,
-            receive
-                {'DOWN', MRef, process, Owner, _} -> ok
-            after 5000 ->
-                erlang:demonitor(MRef, [flush]),
-                exit(Owner, kill)
-            end
-    end.
-
 check_acc(#{ stanza := #{ type := <<"chat">> } } = Acc) ->
     Ref = mongoose_acc:ref(Acc),
     [Data] = ets:lookup(test_message_index, Ref),

--- a/big_tests/tests/acc_e2e_SUITE.erl
+++ b/big_tests/tests/acc_e2e_SUITE.erl
@@ -53,12 +53,13 @@ suite() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    {Module, Binary, Filename} = code:get_object_code(acc_test_helper) ,
-    rpc(mim(), code, load_binary, [Module, Filename, Binary]),
-    recreate_table(),
+    mongoose_helper:inject_module(mim(), acc_test_helper, reload),
+    mongoose_helper:inject_module(mim(), ets_helper, reload),
+    create_table(),
     escalus:init_per_suite(Config).
 
 end_per_suite(Config) ->
+    delete_table(),
     escalus_fresh:clean(),
     escalus:end_per_suite(Config).
 
@@ -138,6 +139,13 @@ filter_local_packet_uses_recipient_values(Config) ->
 handler(Hook, F, Seq) ->
     {Hook, domain_helper:host_type(mim), fun acc_test_helper:F/3, #{}, Seq}.
 
-%% creates a temporary ets table keeping refs and some attrs of accumulators created in c2s
-recreate_table() ->
-    rpc(mim(), acc_test_helper, recreate_table, []).
+%% a temporary ets table keeping refs and some attrs of accumulators created in c2s
+create_table() ->
+    delete_table(),
+    ok = rpc(mim(), ets_helper, new, [test_message_index]).
+
+delete_table() ->
+    case rpc(mim(), ets, whereis, [test_message_index]) of
+        undefined -> ok;
+        _Tid -> ok = rpc(mim(), ets_helper, delete, [test_message_index])
+    end.

--- a/big_tests/tests/accounts_SUITE.erl
+++ b/big_tests/tests/accounts_SUITE.erl
@@ -164,6 +164,9 @@ init_per_testcase(not_allowed_registration_cancelation, Config) ->
 init_per_testcase(registration_failure_timeout, Config) ->
     Config1 = deny_everyone_registration(Config),
     escalus:init_per_testcase(registration_failure_timeout, Config1);
+init_per_testcase(list_users_snapshot_invalid_params = CaseName, Config) ->
+    cth_error_report:expect({what, get_registered_users_snapshot_failed}, 2),
+    escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName, Config) when CaseName =:= list_selected_users;
                                          CaseName =:= count_selected_users ->
     case mongoose_helper:auth_modules() of

--- a/big_tests/tests/amp_big_SUITE.erl
+++ b/big_tests/tests/amp_big_SUITE.erl
@@ -143,6 +143,7 @@ init_per_group(GroupName, Config) ->
                       Config
               end,
     setup_meck(GroupName),
+    expect_errors(GroupName),
     save_offline_status(GroupName, Config1).
 
 setup_meck(suite) ->
@@ -153,6 +154,10 @@ setup_meck(mam_failure) ->
 setup_meck(offline_failure) ->
     ok = rpc(mim(), meck, expect, [mod_offline_backend_module(), write_messages, 4, {error, simulated}]);
 setup_meck(_) -> ok.
+
+expect_errors(offline_failure) ->
+    cth_error_report:expect({what, offline_write_failed});
+expect_errors(_) -> ok.
 
 save_offline_status(mam_success, Config) -> [{offline_storage, mam} | Config];
 save_offline_status(mam_failure, Config) -> [{offline_storage, mam_failure} | Config];
@@ -176,6 +181,11 @@ teardown_meck(suite) ->
     rpc(mim(), meck, unload, []);
 teardown_meck(_) -> ok.
 
+init_per_testcase(notify_deliver_to_unknown_domain_test = Name, C) ->
+    cth_error_report:expect({what, s2s_dns_lookup_failed}),
+    cth_error_report:expect({what, s2s_srv_lookup_failed}),
+    cth_error_report:expect({what, hook_failed}),
+    escalus:init_per_testcase(Name, C);
 init_per_testcase(Name, C) -> escalus:init_per_testcase(Name, C).
 end_per_testcase(Name, C) -> escalus:end_per_testcase(Name, C).
 

--- a/big_tests/tests/bosh_SUITE.erl
+++ b/big_tests/tests/bosh_SUITE.erl
@@ -151,6 +151,12 @@ end_per_group(_GroupName, Config) ->
     escalus:delete_users(Config, escalus:get_users([carol, carol_s, geralt, alice])),
     mongoose_helper:clear_last_activity(Config, carol).
 
+init_per_testcase(do_not_accept_0_hold_value = CaseName, Config) ->
+    cth_error_report:expect({what, bosh_stop}),
+    escalus:init_per_testcase(CaseName, Config);
+init_per_testcase(cant_send_invalid_rid = CaseName, Config) ->
+    cth_error_report:expect({what, bosh_socket_invalid_rid}),
+    escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 

--- a/big_tests/tests/cluster_commands_SUITE.erl
+++ b/big_tests/tests/cluster_commands_SUITE.erl
@@ -92,6 +92,7 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(clustered, Config) ->
+    expect_cluster_errors(),
     Node2 = mim2(),
     Config1 = add_node_to_cluster(Node2, Config),
     case is_sm_distributed() of
@@ -107,6 +108,7 @@ init_per_group(clustered, Config) ->
     end;
 
 init_per_group(Group, _Config) when Group == clustering_two orelse Group == clustering_three ->
+    expect_cluster_errors(),
     case is_sm_distributed() of
         true ->
             ok;
@@ -117,6 +119,11 @@ init_per_group(Group, _Config) when Group == clustering_two orelse Group == clus
 
 init_per_group(_GroupName, Config) ->
     escalus:create_users(Config).
+
+%% Every group joins and leaves the cluster, so CETS tasks waiting on RDBMS lose
+%% the process they monitor.
+expect_cluster_errors() ->
+    cth_error_report:expect({what, task_failed}).
 
 end_per_group(clustered, Config) ->
     escalus:delete_users(Config, escalus:get_users([alice, clusterguy])),

--- a/big_tests/tests/component_SUITE.erl
+++ b/big_tests/tests/component_SUITE.erl
@@ -84,6 +84,10 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(xep0114, Config) ->
+    %% The group registers conflicting components on purpose to check that the
+    %% second registration is rejected.
+    cth_error_report:expect({what, component_register_failed}),
+    cth_error_report:expect({what, comp_registration_conflict}),
     instrument_helper:start(events()),
     Config;
 init_per_group(check_from_disabled, Config) ->
@@ -94,6 +98,9 @@ init_per_group(subdomain, Config) ->
     setup_mim_config(Config, "true"),
     Config;
 init_per_group(distributed, Config) ->
+    %% Joining the cluster leaves CETS tasks waiting on RDBMS without the
+    %% process they monitor.
+    cth_error_report:expect({what, task_failed}),
     distributed_helper:add_node_to_cluster(Config);
 init_per_group(_GroupName, Config) ->
     Config.
@@ -710,6 +717,9 @@ verify_component(Config, Component, ComponentAddr) ->
         end).
 
 setup_mim_config(Config, CheckFrom) ->
+    %% Restarting the application leaves CETS tasks waiting on RDBMS without the
+    %% process they monitor.
+    cth_error_report:expect({what, task_failed}),
     Hosts = {hosts, "\"localhost\", \"sogndal\""},
     VarsToChange = [Hosts, {component_check_from, CheckFrom}],
     ejabberd_node_utils:backup_config_file(Config),

--- a/big_tests/tests/cth_error_report_SUITE.erl
+++ b/big_tests/tests/cth_error_report_SUITE.erl
@@ -44,6 +44,7 @@ groups() ->
      {counted_patterns, [],
       [expect_counted_exact,
        expect_counted_accumulate,
+       expect_counted_accumulate_same_count,
        expect_counted_overflow_is_unexpected,
        expect_counted_across_testcases]},
      {mixed_patterns, [],
@@ -179,6 +180,12 @@ expect_counted_accumulate(_Config) ->
     trigger_error(counted_accum, "three"),
     trigger_error(counted_accum, "four"),
     trigger_error(counted_accum, "five").
+
+expect_counted_accumulate_same_count(_Config) ->
+    cth_error_report:expect({what, counted_same}, 1),
+    cth_error_report:expect({what, counted_same}, 1),
+    Allowances = cth_error_report:get_pattern_allowances(),
+    ?assertEqual(2, maps:get({what, counted_same}, Allowances)).
 
 expect_counted_overflow_is_unexpected(_Config) ->
     %% Expect 2, trigger 4 -- 2 should be expected, 2 unexpected

--- a/big_tests/tests/domain_removal_SUITE.erl
+++ b/big_tests/tests/domain_removal_SUITE.erl
@@ -208,6 +208,9 @@ init_per_testcase(muc_removal, Config) ->
     muc_helper:load_muc(),
     mongoose_helper:ensure_muc_clean(),
     escalus:init_per_testcase(muc_removal, Config);
+init_per_testcase(removal_stops_if_handler_fails = TestCase, Config) ->
+    cth_error_report:expect({what, hook_failed}),
+    escalus:init_per_testcase(TestCase, Config);
 init_per_testcase(roster_removal, ConfigIn) ->
     Config = roster_helper:set_versioning(true, true, ConfigIn),
     escalus:init_per_testcase(roster_removal, Config);

--- a/big_tests/tests/dynamic_domains_SUITE.erl
+++ b/big_tests/tests/dynamic_domains_SUITE.erl
@@ -40,6 +40,9 @@ end_per_suite(Config0) ->
     instrument_helper:stop().
 
 init_per_group(with_mod_dynamic_domains_test, Config) ->
+    %% Routing is checked for domains and subdomains that have no S2S route.
+    cth_error_report:expect({what, s2s_dns_lookup_failed}),
+    cth_error_report:expect({what, s2s_srv_lookup_failed}),
     MockedModules = [mod_dynamic_domains_test, mongoose_router],
     [ok = rpc(mim(), meck, new, [Module, [passthrough, no_link]])
      || Module <- MockedModules],

--- a/big_tests/tests/external_filter_SUITE.erl
+++ b/big_tests/tests/external_filter_SUITE.erl
@@ -78,6 +78,11 @@ end_per_group(GN, Config) when GN =:= graphql_user; GN =:= graphql_admin ->
 end_per_group(_, Config) ->
     Config.
 
+init_per_testcase(CaseName, Config) when CaseName =:= allow_message_on_request_error;
+                                         CaseName =:= allow_message_on_request_error_muclight ->
+    %% These cases make the mocked filter service answer with a malformed body.
+    cth_error_report:expect({what, external_filter_bad_request}),
+    escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -249,7 +249,11 @@ is_backend_enabled(elasticsearch) -> mam_helper:is_elasticsearch_enabled(host_ty
 init_per_testcase(retrieve_logs = CN, Config) ->
     case is_mim2_started() of
         false -> {skip, not_running_in_distributed};
-        _ -> escalus:init_per_testcase(CN, Config)
+        _ ->
+            %% The test case writes a marker line at error level on mim2 and then
+            %% asserts that it can be retrieved from the logs.
+            cth_error_report:expect(<<"disturbance_in_the_force">>, 1),
+            escalus:init_per_testcase(CN, Config)
     end;
 init_per_testcase(CN, Config) when CN =:= remove_offline;
                                    CN =:= retrieve_offline ->

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -252,7 +252,7 @@ init_per_testcase(retrieve_logs = CN, Config) ->
         _ ->
             %% The test case writes a marker line at error level on mim2 and then
             %% asserts that it can be retrieved from the logs.
-            cth_error_report:expect(<<"disturbance_in_the_force">>, 1),
+            cth_error_report:expect(~"disturbance_in_the_force", 1),
             escalus:init_per_testcase(CN, Config)
     end;
 init_per_testcase(CN, Config) when CN =:= remove_offline;

--- a/big_tests/tests/graphql_broadcast_SUITE.erl
+++ b/big_tests/tests/graphql_broadcast_SUITE.erl
@@ -115,6 +115,13 @@ init_per_group(_Group, Config) ->
 end_per_group(_Group, _Config) ->
     graphql_helper:clean().
 
+init_per_testcase(admin_start_broadcast_manager_temporarily_unavailable = TestCase, Config) ->
+    cth_error_report:expect({what, broadcast_job_synchronization_failed}),
+    escalus:init_per_testcase(TestCase, Config);
+init_per_testcase(admin_get_broadcast_worker_killed = TestCase, Config) ->
+    cth_error_report:expect({what, broadcast_job_aborted_error}),
+    cth_error_report:expect(<<"reason,killed">>),
+    escalus:init_per_testcase(TestCase, Config);
 init_per_testcase(TestCase, Config) ->
     escalus:init_per_testcase(TestCase, Config).
 

--- a/big_tests/tests/graphql_broadcast_SUITE.erl
+++ b/big_tests/tests/graphql_broadcast_SUITE.erl
@@ -120,7 +120,7 @@ init_per_testcase(admin_start_broadcast_manager_temporarily_unavailable = TestCa
     escalus:init_per_testcase(TestCase, Config);
 init_per_testcase(admin_get_broadcast_worker_killed = TestCase, Config) ->
     cth_error_report:expect({what, broadcast_job_aborted_error}),
-    cth_error_report:expect(<<"reason,killed">>),
+    cth_error_report:expect(~"reason,killed"),
     escalus:init_per_testcase(TestCase, Config);
 init_per_testcase(TestCase, Config) ->
     escalus:init_per_testcase(TestCase, Config).

--- a/big_tests/tests/graphql_domain_SUITE.erl
+++ b/big_tests/tests/graphql_domain_SUITE.erl
@@ -103,9 +103,11 @@ end_per_group(_GroupName, _Config) ->
 init_per_testcase(get_all_domains_with_disabled, Config) ->
     disable_domain(?EXAMPLE_DOMAIN, Config),
     escalus:init_per_testcase(get_all_domains_with_disabled, Config);
-init_per_testcase(CaseName, Config)
-  when CaseName =:= create_domain_fails_if_db_transaction_fails_constantly;
-       CaseName =:= create_domain_succeeds_if_db_transaction_fails_once ->
+init_per_testcase(create_domain_fails_if_db_transaction_fails_constantly = CaseName, Config) ->
+    cth_error_report:expect({what, graphql_crash}, 1),
+    rpc(mim(), meck, new, [mongoose_rdbms, [no_link, passthrough]]),
+    escalus:init_per_testcase(CaseName, Config);
+init_per_testcase(create_domain_succeeds_if_db_transaction_fails_once = CaseName, Config) ->
     rpc(mim(), meck, new, [mongoose_rdbms, [no_link, passthrough]]),
     escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName, Config) ->

--- a/big_tests/tests/graphql_mnesia_SUITE.erl
+++ b/big_tests/tests/graphql_mnesia_SUITE.erl
@@ -109,6 +109,15 @@ end_per_group(_, _Config) ->
     graphql_helper:clean(),
     escalus_fresh:clean().
 
+init_per_testcase(backup_wrong_filename_test, Config) ->
+    cth_error_report:expect(<<"Failed to abort backup">>),
+    Config;
+init_per_testcase(backup_wrong_path_test, Config) ->
+    cth_error_report:expect(<<"Failed to abort backup">>),
+    Config;
+init_per_testcase(_CaseName, Config) ->
+    Config.
+
 skip_if_mnesia_not_configured(Config) ->
     case rpc_call(mongoose_config, lookup_opt, [[internal_databases, mnesia]]) of
         {error, not_found} ->

--- a/big_tests/tests/graphql_mnesia_SUITE.erl
+++ b/big_tests/tests/graphql_mnesia_SUITE.erl
@@ -110,10 +110,10 @@ end_per_group(_, _Config) ->
     escalus_fresh:clean().
 
 init_per_testcase(backup_wrong_filename_test, Config) ->
-    cth_error_report:expect(<<"Failed to abort backup">>),
+    cth_error_report:expect(~"Failed to abort backup"),
     Config;
 init_per_testcase(backup_wrong_path_test, Config) ->
-    cth_error_report:expect(<<"Failed to abort backup">>),
+    cth_error_report:expect(~"Failed to abort backup"),
     Config;
 init_per_testcase(_CaseName, Config) ->
     Config.

--- a/big_tests/tests/graphql_muc_SUITE.erl
+++ b/big_tests/tests/graphql_muc_SUITE.erl
@@ -216,6 +216,7 @@ domain_admin_muc_tests() ->
     ].
 
 init_per_suite(Config) ->
+    expect_unresolvable_domain_errors(),
     HostType = domain_helper:host_type(),
     SecondaryHostType = domain_helper:secondary_host_type(),
     Config2 = escalus:init_per_suite(Config),
@@ -278,6 +279,14 @@ maybe_enable_mam() ->
             dynamic_modules:ensure_modules(domain_helper:host_type(), [{mod_mam, MAMOpts}]),
             true
     end.
+
+%% Several cases address rooms or users on domains this node does not serve.
+%% Routing falls through to S2S, whose DNS and SRV lookups then fail - 4 DNS
+%% and 2 SRV in each of admin_muc_configured and user_muc_configured,
+%% 2 DNS and 1 SRV in domain_admin_muc.
+expect_unresolvable_domain_errors() ->
+    cth_error_report:expect({what, s2s_dns_lookup_failed}, 10),
+    cth_error_report:expect({what, s2s_srv_lookup_failed}, 5).
 
 ensure_muc_started() ->
     SecondaryHostType = domain_helper:secondary_host_type(),

--- a/big_tests/tests/graphql_muc_light_SUITE.erl
+++ b/big_tests/tests/graphql_muc_light_SUITE.erl
@@ -322,6 +322,12 @@ maybe_clear_db() ->
             ok
     end.
 
+init_per_testcase(TC, Config) when TC =:= admin_create_identified_room;
+                                   TC =:= user_create_identified_room ->
+    %% These cases create the same room twice, which the RDBMS backend resolves
+    %% by exhausting the transaction restarts.
+    cth_error_report:expect({what, rdbms_sql_transaction_restarts_exceeded}),
+    escalus:init_per_testcase(TC, Config);
 init_per_testcase(admin_list_rooms_schema_without_roomname = TC, Config) ->
     %% A config_schema may not define the roomname field at all
     NoRoomnameSchema = [{<<"subject">>, <<"Test">>, subject, binary}],

--- a/big_tests/tests/graphql_server_SUITE.erl
+++ b/big_tests/tests/graphql_server_SUITE.erl
@@ -85,6 +85,9 @@ init_per_group(admin_http, Config) ->
 init_per_group(admin_cli, Config) ->
     graphql_helper:init_admin_cli(Config);
 init_per_group(Group, Config) when Group =:= clustering_tests; Group =:= clustering_http_tests ->
+    %% These groups join and leave the cluster, so CETS tasks waiting on RDBMS
+    %% lose the process they monitor.
+    cth_error_report:expect({what, task_failed}),
     case is_sm_distributed() of
         true ->
             Config;

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -630,6 +630,12 @@ init_per_group(configurable_archiveid, Config) ->
 
 init_per_group(G, Config) when G =:= drop_msg;
                                G =:= muc_drop_msg ->
+    %% setup_meck/2 makes the archiving backend fail for every message. The
+    %% synchronous backends log the failure and re-raise, so gen_hook logs it a
+    %% second time.
+    cth_error_report:expect({what, archive_message_failed}),
+    cth_error_report:expect({what, archive_muc_single_message_failed}),
+    cth_error_report:expect({what, hook_failed}),
     setup_meck(G, ?config(configuration, Config)),
     Config;
 
@@ -845,7 +851,20 @@ init_per_testcase(CaseName, Config) ->
             {skip, Msg}
     end.
 
+maybe_setup(server_returns_item_not_found_for_after_filter_with_invalid_id, Config) ->
+    case ?config(muc_rsm, Config) of
+        true -> cth_error_report:expect({what, mam_muc_error});
+        _ -> cth_error_report:expect({what, mam_error})
+    end,
+    Config;
+maybe_setup(querying_with_invalid_mam_id_in_after, Config) ->
+    cth_error_report:expect({what, mam_error}),
+    Config;
+maybe_setup(text_search_query_fails_if_disabled, Config) ->
+    cth_error_report:expect({what, mam_error}),
+    Config;
 maybe_setup(muc_light_sql_query_failed, Config) ->
+    cth_error_report:expect({what, mam_muc_error}),
     ok = rpc(mim(), meck, new, [mongoose_rdbms, [no_link, passthrough]]),
     ok = rpc(mim(), meck, expect,
              [mongoose_rdbms, execute_successfully,
@@ -856,6 +875,7 @@ maybe_setup(muc_light_sql_query_failed, Config) ->
               end]),
     Config;
 maybe_setup(pm_sql_query_failed, Config) ->
+    cth_error_report:expect({what, mam_error}),
     ok = rpc(mim(), meck, new, [mongoose_rdbms, [no_link, passthrough]]),
     ok = rpc(mim(), meck, expect,
              [mongoose_rdbms, execute_successfully,
@@ -874,6 +894,11 @@ maybe_setup(async_pool_queue_lengths_are_updated, Config) ->
     PoolName = rpc(mim(), mongoose_async_pools, pool_name, [host_type(), PoolId]),
     Workers = rpc(mim(), wpool, get_workers, [PoolName]),
     [{pool_id, PoolId}, {workers, Workers} | Config];
+maybe_setup(CaseName, Config)
+  when CaseName =:= pm_failed_to_decode_message_in_database;
+       CaseName =:= muc_light_failed_to_decode_message_in_database ->
+    cth_error_report:expect({what, mam_failed_to_decode_message}),
+    Config;
 maybe_setup(_CaseName, Config) ->
     Config.
 

--- a/big_tests/tests/metrics_c2s_SUITE.erl
+++ b/big_tests/tests/metrics_c2s_SUITE.erl
@@ -79,6 +79,7 @@ end_per_suite(Config) ->
     instrument_helper:stop().
 
 init_per_group(invalid_cert, Config) ->
+    cth_error_report:expect({what, cert_parsing_failed}),
     #{tls := Tls} = Listener = proplists:get_value(c2s_listener_backup, Config),
     restart_listener(Listener#{tls => Tls#{certfile => <<"priv/ssl/fake_key.pem">>}}),
     Config;

--- a/big_tests/tests/mod_broadcast_SUITE.erl
+++ b/big_tests/tests/mod_broadcast_SUITE.erl
@@ -156,6 +156,8 @@ end_per_suite(Config) ->
     escalus:end_per_suite(Config).
 
 init_per_group(ownership, Config) ->
+    %% The group restarts the manager on the way in and on the way out.
+    cth_error_report:expect({regex, <<"reason,killed.*broadcast_manager">>}),
     ok = rpc(mim(), meck, new, [mod_broadcast, [no_link, passthrough]]),
     ok = rpc(mim(), meck, expect, [mod_broadcast, lease_time, 1, 1]),
     ok = rpc(mim(), meck, new, [mod_broadcast_backend, [no_link, passthrough]]),
@@ -187,6 +189,16 @@ init_per_testcase(take_expired_jobs_is_scoped_by_host_type = TestCase, Config) -
         false ->
             escalus:init_per_testcase(TestCase, Config)
     end;
+init_per_testcase(TestCase, Config)
+  when TestCase =:= manager_emergency_mode_pauses_workers_and_recovers;
+       TestCase =:= manager_repeated_emergency_failure_keeps_workers_paused ->
+    %% The case mecks renew_ownership into raising, to force emergency mode.
+    cth_error_report:expect({what, broadcast_job_synchronization_failed}),
+    escalus:init_per_testcase(TestCase, Config);
+init_per_testcase(manager_restart_is_idempotent_to_live_job_workers = TestCase, Config) ->
+    %% The case restarts the manager under live workers, which are killed with it.
+    cth_error_report:expect({regex, <<"reason,killed.*broadcast_manager">>}),
+    escalus:init_per_testcase(TestCase, Config);
 init_per_testcase(broadcast_job_delivers_message = TestCase, Config) ->
     accounts_helper:prepare_user_created_at(),
     escalus:init_per_testcase(TestCase, Config);

--- a/big_tests/tests/mod_broadcast_SUITE.erl
+++ b/big_tests/tests/mod_broadcast_SUITE.erl
@@ -157,7 +157,7 @@ end_per_suite(Config) ->
 
 init_per_group(ownership, Config) ->
     %% The group restarts the manager on the way in and on the way out.
-    cth_error_report:expect({regex, <<"reason,killed.*broadcast_manager">>}),
+    cth_error_report:expect({regex, ~"reason,killed.*broadcast_manager"}),
     ok = rpc(mim(), meck, new, [mod_broadcast, [no_link, passthrough]]),
     ok = rpc(mim(), meck, expect, [mod_broadcast, lease_time, 1, 1]),
     ok = rpc(mim(), meck, new, [mod_broadcast_backend, [no_link, passthrough]]),
@@ -197,7 +197,7 @@ init_per_testcase(TestCase, Config)
     escalus:init_per_testcase(TestCase, Config);
 init_per_testcase(manager_restart_is_idempotent_to_live_job_workers = TestCase, Config) ->
     %% The case restarts the manager under live workers, which are killed with it.
-    cth_error_report:expect({regex, <<"reason,killed.*broadcast_manager">>}),
+    cth_error_report:expect({regex, ~"reason,killed.*broadcast_manager"}),
     escalus:init_per_testcase(TestCase, Config);
 init_per_testcase(broadcast_job_delivers_message = TestCase, Config) ->
     accounts_helper:prepare_user_created_at(),

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -195,6 +195,12 @@ init_per_group(_, Config) ->
     init_per_group_generic(Config).
 
 init_per_group_generic(Config0) ->
+    %% Starting and stopping the listeners on every node makes receiver
+    %% processes come and go, and generic_end_per_testcase/2 drops every
+    %% outgoing connection after each case, so which case logs a gd_ error is a
+    %% matter of timing.
+    cth_error_report:expect({regex, <<"what => gd_">>}),
+    cth_error_report:expect(<<"mod_global_distrib_receiver">>),
     Config2 = lists:foldl(fun init_modules_per_node/2, Config0, get_hosts()),
     wait_for_listeners_to_appear(),
     {SomeNode, _, _} = hd(get_hosts()),
@@ -247,6 +253,10 @@ set_opts(_, Opts) ->
     Opts.
 
 end_per_group(advertised_endpoints, Config) ->
+    %% unmock_inet/1 removes the inet:getaddrs mock before restore_modules tears
+    %% the module down, so the teardown refresh resolves the advertised
+    %% "somefakedomain.com" for real and the server manager terminates.
+    cth_error_report:expect(<<"mod_global_distrib_server_mgr">>),
     Pids = ?config(meck_handlers, Config),
     unmock_inet(Pids),
     escalus_fresh:clean(),
@@ -289,6 +299,14 @@ init_per_testcase(CN, Config) when CN == test_pm_with_graceful_reconnection_to_d
                                    CN == test_pm_with_ungraceful_reconnection_to_different_server_with_asia_refreshes_first;
                                    CN == test_pm_with_ungraceful_reconnection_to_different_server_with_europe_refreshes_first ->
     escalus:init_per_testcase(CN, init_user_eve(Config));
+init_per_testcase(test_location_disconnect = CN, Config) ->
+    cth_error_report:expect({what, hook_failed}),
+    escalus:init_per_testcase(CN, Config);
+init_per_testcase(test_host_refreshing = CN, Config) ->
+    cth_error_report:expect(<<"mod_global_distrib_connection">>),
+    cth_error_report:expect(<<"mod_global_distrib_server_mgr">>),
+    cth_error_report:expect(<<"mod_global_distrib_server_sup">>),
+    escalus:init_per_testcase(CN, Config);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 

--- a/big_tests/tests/mod_global_distrib_SUITE.erl
+++ b/big_tests/tests/mod_global_distrib_SUITE.erl
@@ -199,8 +199,8 @@ init_per_group_generic(Config0) ->
     %% processes come and go, and generic_end_per_testcase/2 drops every
     %% outgoing connection after each case, so which case logs a gd_ error is a
     %% matter of timing.
-    cth_error_report:expect({regex, <<"what => gd_">>}),
-    cth_error_report:expect(<<"mod_global_distrib_receiver">>),
+    cth_error_report:expect({regex, ~"what => gd_"}),
+    cth_error_report:expect(~"mod_global_distrib_receiver"),
     Config2 = lists:foldl(fun init_modules_per_node/2, Config0, get_hosts()),
     wait_for_listeners_to_appear(),
     {SomeNode, _, _} = hd(get_hosts()),
@@ -256,7 +256,7 @@ end_per_group(advertised_endpoints, Config) ->
     %% unmock_inet/1 removes the inet:getaddrs mock before restore_modules tears
     %% the module down, so the teardown refresh resolves the advertised
     %% "somefakedomain.com" for real and the server manager terminates.
-    cth_error_report:expect(<<"mod_global_distrib_server_mgr">>),
+    cth_error_report:expect(~"mod_global_distrib_server_mgr"),
     Pids = ?config(meck_handlers, Config),
     unmock_inet(Pids),
     escalus_fresh:clean(),
@@ -303,9 +303,9 @@ init_per_testcase(test_location_disconnect = CN, Config) ->
     cth_error_report:expect({what, hook_failed}),
     escalus:init_per_testcase(CN, Config);
 init_per_testcase(test_host_refreshing = CN, Config) ->
-    cth_error_report:expect(<<"mod_global_distrib_connection">>),
-    cth_error_report:expect(<<"mod_global_distrib_server_mgr">>),
-    cth_error_report:expect(<<"mod_global_distrib_server_sup">>),
+    cth_error_report:expect(~"mod_global_distrib_connection"),
+    cth_error_report:expect(~"mod_global_distrib_server_mgr"),
+    cth_error_report:expect(~"mod_global_distrib_server_sup"),
     escalus:init_per_testcase(CN, Config);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).

--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -264,12 +264,17 @@ init_per_testcase(CaseName, Config) when CaseName =:= disco_features_with_mam;
             escalus:init_per_testcase(CaseName, Config)
     end;
 init_per_testcase(CaseName, Config) ->
+    expect_errors(CaseName),
     dynamic_modules:ensure_modules(host_type(), required_modules(CaseName)),
     case lists:member(CaseName, ?ROOM_LESS_CASES) of
         false -> create_room(?ROOM, ?MUCHOST, alice, [bob, kate], Config, ver(1));
         _ -> ok
     end,
     escalus:init_per_testcase(CaseName, Config).
+
+expect_errors(create_existing_room_deny) ->
+    cth_error_report:expect({what, rdbms_sql_transaction_restarts_exceeded});
+expect_errors(_) -> ok.
 
 end_per_testcase(CaseName, Config) ->
     muc_light_helper:clear_db(host_type()),

--- a/big_tests/tests/persistent_cluster_id_SUITE.erl
+++ b/big_tests/tests/persistent_cluster_id_SUITE.erl
@@ -70,7 +70,11 @@ group(_Groupname) ->
 
 init_per_group(rdbms, Config) ->
     case mongoose_helper:is_rdbms_enabled(host_type()) of
-        true -> Config;
+        true ->
+            %% The group wipes Mnesia to check the id is restored, so CETS tasks
+            %% waiting on RDBMS lose the process they monitor.
+            cth_error_report:expect({what, task_failed}),
+            Config;
         false -> {skip, require_rdbms}
     end;
 init_per_group(_, Config) ->

--- a/big_tests/tests/persistent_cluster_id_SUITE.erl
+++ b/big_tests/tests/persistent_cluster_id_SUITE.erl
@@ -71,8 +71,8 @@ group(_Groupname) ->
 init_per_group(rdbms, Config) ->
     case mongoose_helper:is_rdbms_enabled(host_type()) of
         true ->
-            %% The group wipes Mnesia to check the id is restored, so CETS tasks
-            %% waiting on RDBMS lose the process they monitor.
+            %% The group restarts the application, so CETS tasks waiting on
+            %% RDBMS lose the process they monitor.
             cth_error_report:expect({what, task_failed}),
             Config;
         false -> {skip, require_rdbms}

--- a/big_tests/tests/push_pubsub_SUITE.erl
+++ b/big_tests/tests/push_pubsub_SUITE.erl
@@ -73,6 +73,7 @@ end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(CaseName, Config) ->
+    expect_errors(CaseName),
     MongoosePushMockPort = setup_mock_rest(),
 
     %% Start HTTP pool
@@ -83,6 +84,10 @@ init_per_testcase(CaseName, Config) ->
                   #{opts => PoolOpts, conn_opts => ConnOpts}),
     [{ok, _Pid}] = rpc(mongoose_wpool, start_configured_pools, [[Pool]]),
     escalus:init_per_testcase(CaseName, Config).
+
+expect_errors(publish_fails_when_missing_mandatory_fields) ->
+    cth_error_report:expect({what, make_notification_failed}, 1);
+expect_errors(_) -> ok.
 
 end_per_testcase(CaseName, Config) ->
     rpc(mongoose_wpool, stop, [http, global, mongoose_push_http]),

--- a/big_tests/tests/rdbms_SUITE.erl
+++ b/big_tests/tests/rdbms_SUITE.erl
@@ -134,6 +134,18 @@ end_per_group(global_rdbms_queries, Config) ->
     instrument_helper:stop(),
     Config.
 
+init_per_testcase(Case = test_failed_wrapper_transaction, Config) ->
+    cth_error_report:expect({what, rdbms_outer_transaction_failed}),
+    escalus:init_per_testcase(Case, Config);
+init_per_testcase(Case = test_failed_wrapper, Config) ->
+    cth_error_report:expect({what, sql_execute_wrapped_failed}),
+    escalus:init_per_testcase(Case, Config);
+init_per_testcase(Case = test_failed_transaction_with_execute_wrapped, Config) ->
+    cth_error_report:expect({what, rdbms_sql_transaction_restarts_exceeded}),
+    escalus:init_per_testcase(Case, Config);
+init_per_testcase(Case = test_restart_transaction_with_execute, Config) ->
+    cth_error_report:expect({what, rdbms_sql_transaction_restarts_exceeded}),
+    escalus:init_per_testcase(Case, Config);
 init_per_testcase(test_incremental_upsert, Config) ->
     erase_inbox(Config),
     escalus:init_per_testcase(test_incremental_upsert, Config);

--- a/big_tests/tests/s2s_SUITE.erl
+++ b/big_tests/tests/s2s_SUITE.erl
@@ -128,16 +128,29 @@ init_per_group(both_tls_enforced, Config) ->
     Config1 = s2s_helper:configure_s2s(both_tls_enforced, Config),
     [{requires_tls, group_with_tls(both_tls_enforced)}, {group, both_tls_enforced} | Config1];
 init_per_group(start_stream_errors, Config) ->
+    expect_broken_stream_errors(),
     [{initial_steps, []} | Config];
 init_per_group(start_stream_errors_after_starttls, Config) ->
+    expect_broken_stream_errors(),
     [{initial_steps, [fun s2s_start_stream/2,
                       fun s2s_starttls/2]} | Config];
 init_per_group(start_stream_errors_after_auth, Config) ->
+    expect_broken_stream_errors(),
     [{initial_steps, [fun s2s_start_stream/2,
                       fun s2s_starttls/2,
                       fun s2s_start_stream/2,
                       fun s2s_external_auth/2]} | Config];
+init_per_group(node1_tls_required_trusted_node2_tls_optional = GroupName, Config) ->
+    %% Node1 only trusts its own CA, so it rejects node2's certificate.
+    cth_error_report:expect(<<"unknown_ca">>),
+    init_per_group_default(GroupName, Config);
 init_per_group(GroupName, Config) ->
+    init_per_group_default(GroupName, Config).
+
+expect_broken_stream_errors() ->
+    cth_error_report:expect(<<"s2s_sasl_failure">>).
+
+init_per_group_default(GroupName, Config) ->
     Config1 = s2s_helper:configure_s2s(GroupName, Config),
     [{requires_tls, group_with_tls(GroupName)}, {group, GroupName} | Config1].
 
@@ -155,6 +168,9 @@ init_per_testcase(dns_ip_discovery = CaseName, Config) ->
         true ->
             {skip, "Test skipped for GH Actions"};
         false ->
+            %% fed2 has no SRV record. The A record is mocked and resolves, so
+            %% no address lookup error is expected on top of it.
+            cth_error_report:expect({service, "_xmpp-server._tcp.fed2"}),
             meck_dns_srv_lookup("fed2", ip),
             Config1 = escalus_users:update_userspec(Config, alice2, server, <<"fed2">>),
             escalus:init_per_testcase(CaseName, Config1)
@@ -164,6 +180,8 @@ init_per_testcase(dns_discovery_fail = CaseName, Config) ->
         true ->
             {skip, "Test skipped for GH Actions"};
         false ->
+            cth_error_report:expect({service, "_xmpp-server._tcp.fed3"}),
+            cth_error_report:expect({server, "fed3"}),
             meck_dns_srv_lookup("fed3", none),
             escalus:init_per_testcase(CaseName, Config)
     end;
@@ -172,8 +190,13 @@ init_per_testcase(unknown_domain = CaseName, Config) ->
         true ->
             {skip, "Test skipped for GH Actions"};
         false ->
+            cth_error_report:expect({service, "_xmpp-server._tcp.somebogushost"}),
+            cth_error_report:expect({server, "somebogushost"}),
             escalus:init_per_testcase(CaseName, Config)
     end;
+init_per_testcase(malformed_jid = CaseName, Config) ->
+    cth_error_report:expect({server, "not a jid"}),
+    escalus:init_per_testcase(CaseName, Config);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 

--- a/big_tests/tests/s2s_SUITE.erl
+++ b/big_tests/tests/s2s_SUITE.erl
@@ -142,13 +142,13 @@ init_per_group(start_stream_errors_after_auth, Config) ->
                       fun s2s_external_auth/2]} | Config];
 init_per_group(node1_tls_required_trusted_node2_tls_optional = GroupName, Config) ->
     %% Node1 only trusts its own CA, so it rejects node2's certificate.
-    cth_error_report:expect(<<"unknown_ca">>),
+    cth_error_report:expect(~"unknown_ca"),
     init_per_group_default(GroupName, Config);
 init_per_group(GroupName, Config) ->
     init_per_group_default(GroupName, Config).
 
 expect_broken_stream_errors() ->
-    cth_error_report:expect(<<"s2s_sasl_failure">>).
+    cth_error_report:expect(~"s2s_sasl_failure").
 
 init_per_group_default(GroupName, Config) ->
     Config1 = s2s_helper:configure_s2s(GroupName, Config),

--- a/big_tests/tests/sasl_external_SUITE.erl
+++ b/big_tests/tests/sasl_external_SUITE.erl
@@ -121,6 +121,10 @@ init_per_group(standard_keep_auth = GroupName, Config) ->
         true ->
             Config1
     end;
+init_per_group(demo_verification_module = GroupName, Config) ->
+    %% The demo verification module rejects some of the presented credentials by design.
+    cth_error_report:expect({what, cyrsasl_external_verification_failed}),
+    configure(GroupName, Config);
 init_per_group(GroupName, Config) ->
     configure(GroupName, Config).
 

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -141,17 +141,38 @@ end_per_group(_GroupName, Config) ->
         per_testcase -> ok
     end.
 
-init_per_testcase(db_crash_on_initial_load_restarts_service, Config) ->
-    maybe_setup_meck(db_crash_on_initial_load_restarts_service),
+init_per_testcase(db_crash_on_initial_load_restarts_service = TestcaseName, Config) ->
+    expect_errors(TestcaseName),
+    maybe_setup_meck(TestcaseName),
     restart_domain_core(mim(), [], []),
     Config;
 init_per_testcase(TestcaseName, Config) ->
+    expect_errors(TestcaseName),
     maybe_setup_meck(TestcaseName),
     case ?config(service_setup, Config) of
         per_group -> ok;
         per_testcase -> setup_service(service_opts(TestcaseName), Config)
     end,
     init_per_testcase2(TestcaseName, Config).
+
+expect_errors(TC) when TC =:= db_cannot_delete_domain_with_unknown_host_type;
+                       TC =:= db_cannot_enable_domain_with_unknown_host_type;
+                       TC =:= db_cannot_disable_domain_with_unknown_host_type;
+                       TC =:= db_domains_with_unknown_host_type_are_ignored_by_core ->
+    cth_error_report:expect({what, ignore_domain_from_db_with_unknown_host_type});
+expect_errors(TC) when TC =:= db_gaps_are_getting_filled_automatically;
+                       TC =:= db_event_could_appear_with_lower_id ->
+    %% The case leaves a gap in the event ids and both nodes race to fill it,
+    %% so one of them hits a duplicate key on every id in the gap.
+    cth_error_report:expect({what, sql_execute_failed});
+expect_errors(db_record_is_ignored_if_domain_static) ->
+    cth_error_report:expect({what, domain_static_but_in_db});
+expect_errors(db_reinserted_from_one_node_while_service_disabled_on_another) ->
+    cth_error_report:expect({what, ignore_domain_from_db_with_different_host_type});
+expect_errors(db_restarts_properly) ->
+    %% The case restarts the service, so its supervisor reports the old one going down.
+    cth_error_report:expect({regex, <<"reason,shutdown.*service_domain_db">>});
+expect_errors(_) -> ok.
 
 service_opts(db_events_table_gets_truncated) ->
     #{event_cleaning_interval => 1, event_max_age => 3};

--- a/big_tests/tests/service_domain_db_SUITE.erl
+++ b/big_tests/tests/service_domain_db_SUITE.erl
@@ -171,7 +171,7 @@ expect_errors(db_reinserted_from_one_node_while_service_disabled_on_another) ->
     cth_error_report:expect({what, ignore_domain_from_db_with_different_host_type});
 expect_errors(db_restarts_properly) ->
     %% The case restarts the service, so its supervisor reports the old one going down.
-    cth_error_report:expect({regex, <<"reason,shutdown.*service_domain_db">>});
+    cth_error_report:expect({regex, ~"reason,shutdown.*service_domain_db"});
 expect_errors(_) -> ok.
 
 service_opts(db_events_table_gets_truncated) ->

--- a/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
+++ b/big_tests/tests/service_mongoose_system_metrics_SUITE.erl
@@ -116,6 +116,9 @@ init_per_testcase(system_metrics_are_not_reported_when_not_allowed, Config) ->
     delete_prev_client_id(mim()),
     Config;
 init_per_testcase(all_clustered_mongooses_report_the_same_client_id, Config) ->
+    %% Joining the cluster restarts CETS, so its tasks waiting for RDBMS lose
+    %% the process they monitor.
+    cth_error_report:expect({what, task_failed}),
     create_events_collection(),
     distributed_helper:add_node_to_cluster(mim2(), Config),
     enable_system_metrics(mim()),

--- a/src/cert_utils.erl
+++ b/src/cert_utils.erl
@@ -128,7 +128,7 @@ get_lserver_from_addr(_, _) -> [].
 
 
 log_exception(_Cert, Class, Exception, StackTrace) ->
-    ?LOG_ERROR(#{what => <<"cert_parsing_failed">>,
+    ?LOG_ERROR(#{what => cert_parsing_failed,
                  text => <<"failed to parse certificate">>,
                  class => Class, reason => Exception, stacktrace => StackTrace}).
 

--- a/test/common/mongoose_helper.erl
+++ b/test/common/mongoose_helper.erl
@@ -198,10 +198,20 @@ stop_online_rooms() ->
         true -> ok;
         false -> ct:fail({ejabberd_mod_muc_sup_not_found, Supervisor, HostType})
     end,
-    rpc(mim(), erlang, exit, [SupervisorPid, kill]),
+    %% Killing the supervisor instead logs a crash report per room. Rooms are
+    %% `brutal_kill' children, so terminate/3 does not run here.
+    [stop_online_room(SupervisorPid, RoomPid)
+     || {_, RoomPid, _, _} <- rpc(mim(), supervisor, which_children, [SupervisorPid]),
+        is_pid(RoomPid)],
     %% That's a pretty dirty way
     rpc(mim(), mod_muc_online_backend, clear_table, [HostType]),
     ok.
+
+stop_online_room(SupervisorPid, RoomPid) ->
+    case rpc(mim(), supervisor, terminate_child, [SupervisorPid, RoomPid]) of
+        ok -> ok;
+        {error, not_found} -> ok
+    end.
 
 forget_persistent_rooms() ->
     %% To avoid `binary_to_existing_atom(<<"maygetmemberlist">>, utf8)' failing


### PR DESCRIPTION
This PR classifies most errors that `cth_error_report` collects during a full big-test run, marking deliberately provoked ones as expected with `cth_error_report:expect/1,2`. In addition:

- Two noisy test helpers are fixed at the source rather than whitelisted: `mongoose_helper:stop_online_rooms/0` and `acc_test_helper:recreate_table/0`.
- `cth_error_report`'s patterns table becomes a `duplicate_bag` instead of a `bag`, so two identical `expect(Pattern, N)` calls accumulate instead of collapsing.
- One logging defect is fixed: `cert_utils:log_exception/4` logged `what` as a binary where the rest of the codebase uses an atom.