### PR TITLE
MIM-2785 Send push notifications for inactive users

### DIFF
--- a/big_tests/tests/push_integration_SUITE.erl
+++ b/big_tests/tests/push_integration_SUITE.erl
@@ -46,6 +46,8 @@ basic_groups() ->
      {group, failure_cases_v3},
      {group, failure_cases_v2},
      {group, integration_with_sm_and_offline_storage},
+     {group, notifications_with_csi_without_buffer},
+     {group, notifications_with_csi_and_buffer},
      {group, enhanced_integration_with_sm_and_filtering},
      {group, enhanced_integration_with_sm},
      {group, disco}
@@ -58,8 +60,22 @@ groups() ->
          {integration_with_sm_and_offline_storage,[],
           [
            no_duplicates_default_plugin,
-           negative_priority_session_gets_offline_push,
+           negative_priority_session_gets_push,
            sm_unack_messages_notified_default_plugin
+          ]},
+         {notifications_with_csi_without_buffer, [],
+          [
+           pm_msg_notify_on_apns_no_click_action,
+           pm_msg_notify_on_fcm_no_click_action,
+           muclight_msg_notify_on_apns_no_click_action,
+           negative_priority_session_gets_push,
+           default_active_session_gets_no_push,
+           inactive_session_gets_push
+          ]},
+         {notifications_with_csi_and_buffer, [],
+          [
+           default_active_session_gets_no_push,
+           inactive_session_gets_push_with_buffer
           ]},
          {enhanced_integration_with_sm,[],
           [
@@ -75,6 +91,8 @@ groups() ->
           ]},
          {pm_msg_notifications, [],
           [
+           default_active_session_gets_no_push,
+           negative_priority_session_gets_push,
            pm_msg_notify_on_apns_w_high_priority,
            pm_msg_notify_on_fcm_w_high_priority,
            pm_msg_notify_on_apns_w_high_priority_silent,
@@ -262,7 +280,7 @@ no_duplicates_default_plugin(Config) ->
 
     escalus_connection:stop(Bob).
 
-negative_priority_session_gets_offline_push(Config) ->
+negative_priority_session_gets_push(Config) ->
     escalus:fresh_story(
         Config, [{bob, 1}, {alice, 1}],
         fun(Bob, Alice) ->
@@ -275,9 +293,62 @@ negative_priority_session_gets_offline_push(Config) ->
             #{device_token := APNSDevice} = enable_push_for_user(Alice, <<"apns">>, [], Config),
 
             escalus_connection:send(Bob, escalus_stanza:chat_to(bare_jid(Alice), <<"msg-1">>)),
-            wait_helper:wait_until(fun() -> get_number_of_offline_msgs_for_client(Alice) end, 1),
             verify_notification(APNSDevice, <<"apns">>, [], BobJID, <<"msg-1">>),
             escalus_assert:has_no_stanzas(Alice)
+        end).
+
+default_active_session_gets_no_push(Config) ->
+    escalus:fresh_story(
+        Config, [{bob, 1}, {alice, 1}],
+        fun(Bob, Alice) ->
+            #{device_token := APNSDevice} = enable_push_for_user(Alice, <<"apns">>, [], Config),
+            escalus_connection:send(Bob, escalus_stanza:chat_to(bare_jid(Alice), <<"msg-1">>)),
+            escalus:assert(is_chat_message, [<<"msg-1">>], escalus_connection:get_stanza(Alice, msg)),
+            ?assertExit({test_case_failed, _}, wait_for_push_request(APNSDevice, 500))
+        end).
+
+inactive_session_gets_push(Config) ->
+    escalus:fresh_story(
+        Config, [{bob, 1}, {alice, 1}],
+        fun(Bob, Alice) ->
+            BobJID = bare_jid(Bob),
+            #{device_token := APNSDevice} = enable_push_for_user(Alice, <<"apns">>, [], Config),
+
+            %% 'inactive' client state should enable notifications
+            csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+            escalus_connection:send(Bob, escalus_stanza:chat_to(bare_jid(Alice), <<"msg-1">>)),
+            escalus:assert(is_chat_message, [<<"msg-1">>], escalus_connection:get_stanza(Alice, msg)),
+            verify_notification(APNSDevice, <<"apns">>, [], BobJID, <<"msg-1">>),
+
+            %% 'active' client state should disable notifications
+            csi_helper:given_client_is_active(Alice),
+            escalus_connection:send(Bob, escalus_stanza:chat_to(bare_jid(Alice), <<"msg-2">>)),
+            escalus:assert(is_chat_message, [<<"msg-2">>], escalus_connection:get_stanza(Alice, msg)),
+            ?assertExit({test_case_failed, _}, wait_for_push_request(APNSDevice, 500))
+        end).
+
+inactive_session_gets_push_with_buffer(Config) ->
+    escalus:fresh_story(
+        Config, [{bob, 1}, {alice, 1}],
+        fun(Bob, Alice) ->
+            BobJID = bare_jid(Bob),
+            #{device_token := APNSDevice} = enable_push_for_user(Alice, <<"apns">>, [], Config),
+
+            %% 'inactive' client state should enable notifications
+            csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+            escalus_connection:send(Bob, escalus_stanza:chat_to(bare_jid(Alice), <<"msg-1">>)),
+            csi_helper:then_client_does_not_receive_any_message(Alice),
+            verify_notification(APNSDevice, <<"apns">>, [], BobJID, <<"msg-1">>),
+
+            %% 'active' client state should disable notifications
+            csi_helper:given_client_is_active(Alice),
+
+            %% buffered message is delivered now
+            escalus:assert(is_chat_message, [<<"msg-1">>], escalus_connection:get_stanza(Alice, msg)),
+
+            escalus_connection:send(Bob, escalus_stanza:chat_to(bare_jid(Alice), <<"msg-2">>)),
+            escalus:assert(is_chat_message, [<<"msg-2">>], escalus_connection:get_stanza(Alice, msg)),
+            ?assertExit({test_case_failed, _}, wait_for_push_request(APNSDevice, 500))
         end).
 
 get_number_of_offline_msgs(Spec) ->
@@ -1143,6 +1214,13 @@ required_modules_for_group(integration_with_sm_and_offline_storage, API, PubSubH
                                                              #{ack_freq => never, resume_timeout => 1,
                                                                backend => MemBackend})},
      {mod_offline, config_parser_helper:mod_config(mod_offline, #{backend => Backend})} |
+     required_modules(API, PubSubHost)];
+required_modules_for_group(notifications_with_csi_without_buffer, API, PubSubHost) ->
+    [{mod_muc_light, muc_light_opts()},
+     {mod_csi, config_parser_helper:mod_config(mod_csi, #{})} |
+     required_modules(API, PubSubHost)];
+required_modules_for_group(notifications_with_csi_and_buffer, API, PubSubHost) ->
+    [{mod_csi, config_parser_helper:mod_config(mod_csi, #{buffer => #{max_size => 10}})} |
      required_modules(API, PubSubHost)];
 required_modules_for_group(enhanced_integration_with_sm, API, PubSubHost) ->
     MemBackend = ct_helper:get_internal_database(),

--- a/big_tests/tests/sasl2_helper.erl
+++ b/big_tests/tests/sasl2_helper.erl
@@ -18,7 +18,7 @@ load_all_sasl2_modules(HostType) ->
     SMOpts = #{ack_freq => never, backend => MemBackend},
     Modules = [{mod_bind2, default_mod_config(mod_bind2)},
                {mod_sasl2, default_mod_config(mod_sasl2)},
-               {mod_csi, default_mod_config(mod_csi)},
+               {mod_csi, mod_config(mod_csi, #{buffer => #{}})},
                {mod_carboncopy, default_mod_config(mod_carboncopy)},
                {mod_stream_management, mod_config(mod_stream_management, SMOpts)}]
         ++ rdbms_mods(),

--- a/big_tests/tests/xep_0352_csi_SUITE.erl
+++ b/big_tests/tests/xep_0352_csi_SUITE.erl
@@ -10,13 +10,15 @@
 -define(CSI_BUFFER_MAX, 10).
 
 all() ->
-    [{group, basic}].
+    [{group, with_buffer},
+     {group, without_buffer}].
 
 
 groups() ->
-    [{basic, [parallel], all_tests()}].
+    [{with_buffer, [parallel], buffer_tests()},
+     {without_buffer, [parallel], no_buffer_tests()}].
 
-all_tests() ->
+buffer_tests() ->
     [
      server_announces_csi,
      alice_is_inactive_and_no_stanza_arrived,
@@ -31,29 +33,42 @@ all_tests() ->
      invalid_csi_request_returns_error
     ].
 
+no_buffer_tests() ->
+    [
+     server_announces_csi,
+     alice_gets_msgs_while_inactive_without_buffer
+    ].
+
 suite() ->
     escalus:suite().
 
 init_per_suite(Config) ->
     instrument_helper:start(instrument_helper:declared_events(mod_csi)),
-    NewConfig = dynamic_modules:save_modules(host_type(), Config),
-    Backend = mongoose_helper:mnesia_or_rdbms_backend(),
-    dynamic_modules:ensure_modules(
-      host_type(), [{mod_offline, mod_config(mod_offline, #{backend => Backend})},
-                    {mod_csi, mod_config(mod_csi, #{buffer_max => ?CSI_BUFFER_MAX})}]),
-    [{escalus_user_db, {module, escalus_ejabberd}} | escalus:init_per_suite(NewConfig)].
+    [{escalus_user_db, {module, escalus_ejabberd}} | escalus:init_per_suite(Config)].
 
 end_per_suite(Config) ->
     escalus_fresh:clean(),
-    dynamic_modules:restore_modules(Config),
     escalus:end_per_suite(Config),
     instrument_helper:stop().
 
-init_per_group(_, Config) ->
-    escalus_users:update_userspec(Config, alice, stream_management, true).
+init_per_group(Group, Config) ->
+    Config1 = dynamic_modules:save_modules(host_type(), Config),
+    dynamic_modules:ensure_modules(host_type(), required_modules(Group)),
+    escalus_users:update_userspec(Config1, alice, stream_management, true).
 
 end_per_group(_Group, Config) ->
+    dynamic_modules:restore_modules(Config),
     Config.
+
+required_modules(Group) ->
+    Backend = mongoose_helper:mnesia_or_rdbms_backend(),
+    [{mod_offline, mod_config(mod_offline, #{backend => Backend})},
+     {mod_csi, mod_config(mod_csi, csi_options(Group))}].
+
+csi_options(with_buffer) ->
+    #{buffer => #{max_size => ?CSI_BUFFER_MAX}};
+csi_options(without_buffer) ->
+    #{}.
 
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
@@ -80,6 +95,15 @@ alice_is_inactive_and_no_stanza_arrived(Config) ->
         csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
         csi_helper:given_messages_are_sent(Alice, Bob, 1),
         csi_helper:then_client_does_not_receive_any_message(Alice)
+    end).
+
+alice_gets_msgs_while_inactive_without_buffer(Config) ->
+    escalus:fresh_story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
+        csi_helper:given_client_is_inactive_and_no_messages_arrive(Alice),
+        Msgs = csi_helper:given_messages_are_sent(Alice, Bob, 3),
+        csi_helper:then_client_receives_message(Alice, Msgs),
+        csi_helper:given_client_is_active(Alice),
+        csi_helper:then_client_does_not_receive_any_message(Alice) % no duplicates
     end).
 
 alice_gets_msgs_after_activate(Config) ->

--- a/doc/configuration/Modules.md
+++ b/doc/configuration/Modules.md
@@ -97,7 +97,7 @@ Allows sending online/offline notifications, chat and groupchat messages as even
 Allows sending presence changes (to available/unavailable), chat and groupchat messages as events to a RabbitMQ server.
 
 #### [mod_event_pusher_push](../modules/mod_event_pusher_push.md)
-Implements [XEP-0357: Push Notifications](https://xmpp.org/extensions/xep-0357.html) to provide push notifications to clients that are temporary unavailable.
+Implements [XEP-0357: Push Notifications](https://xmpp.org/extensions/xep-0357.html) to provide push notifications to clients that are temporarily unavailable or inactive.
 
 #### [mod_event_pusher_http](../modules/mod_event_pusher_http.md)
 Forward events to an external HTTP service.

--- a/doc/developers-guide/hooks_description.md
+++ b/doc/developers-guide/hooks_description.md
@@ -153,14 +153,30 @@ mongoose_hooks:message_routed(UserStatus, Acc)
 ```
 
 This hook is run after routing a message to an existing local user.
-The `UserStatus` argument is `online` if the message was routed to at least one online session (i.e. with an integer priority), and `offline` otherwise.
+The `UserStatus` argument is `{online, StatusMap}` if the message was routed to at least one online session (i.e. with an integer priority), and `offline` otherwise.
 For users with no selected C2S process, the hook is run before `offline_message` or `offline_groupchat_message`.
+The `StatusMap` is built with the `get_user_status` hook.
 
 ### Handler examples
 
 This hook is handled by the following module:
 
 * [`mod_event_pusher`](../modules/mod_event_pusher.md) - generates events e.g. for push notifications.
+
+## `get_user_status`
+
+```erlang
+mongoose_hooks:get_user_status(HostType, Sessions)
+```
+
+This hook is run by `ejabberd_sm` to collect extra status information for online sessions selected for message routing.
+It accumulates a map. If no handler is registered, the result is an empty map.
+
+### Handler examples
+
+This hook is handled by the following module:
+
+* [`mod_csi`](../modules/mod_csi.md) - adds `client_state`: `active` or `inactive`.
 
 ## `remove_user`
 
@@ -259,6 +275,7 @@ This is the perfect place to plug in custom security control.
 * get_mam_pm_gdpr_data
 * get_pep_recipients
 * get_personal_data
+* get_user_status
 * inbox_unread_count
 * invitation_sent
 * is_muc_room_owner

--- a/doc/migrations/6.8.1_6.x.x.md
+++ b/doc/migrations/6.8.1_6.x.x.md
@@ -2,10 +2,16 @@
 
 ## `mod_event_pusher` received message events
 
-`mod_event_pusher` no longer creates received-message events for non-user targets such as:
+[`mod_event_pusher`](../modules/mod_event_pusher.md) no longer creates received-message events for non-user targets such as:
 
 * A user-less JID (e.g. server).
 * A multi-user chat room.
 * A nonexistent user.
 
 These events were not valid user-delivery notifications and were unwanted for push-notification logic.
+
+## `mod_csi` buffering
+
+[`mod_csi`](../modules/mod_csi.md) no longer buffers stanzas by default.
+In order to keep buffering enabled, make sure the [`buffer`](../modules/mod_csi.md#modulesmod_csibuffer) section is present.
+If you used the `buffer_max` option, use [`buffer.max_size`](../modules/mod_csi.md#modulesmod_csibuffermax_size) instead.

--- a/doc/modules/mod_csi.md
+++ b/doc/modules/mod_csi.md
@@ -5,22 +5,42 @@
 Enables [XEP-0352: Client State Indication](http://xmpp.org/extensions/xep-0352.html) functionality.
 
 The XEP doesn't **require** any specific server behaviour in response to CSI stanzas, there are only some suggestions.
-The implementation in MongooseIM will simply buffer all packets (up to a configured limit) when the session is "inactive" and will flush the buffer when it becomes "active" again.
+MongooseIM stores the reported client state in the user's session. Other modules can use this information, for example to send push notifications for `inactive` sessions.
 
 ## Options
 
-### `modules.mod_csi.buffer_max`
+### `modules.mod_csi.buffer`
+
+By default, `mod_csi` does not buffer stanzas. To enable buffering, configure this section.
+When buffering is enabled, MongooseIM buffers packets up to the configured limit while the session is `inactive`, and flushes the buffer when it becomes `active` again.
+
+#### `modules.mod_csi.buffer.max_size`
 * **Syntax:** non-negative integer or the string `"infinity"`
 * **Default:** `20`
-* **Example:** `buffer_max = 40`
+* **Example:** `buffer.max_size = 40`
 
-Buffer size for messages queued when session was `inactive`.
+Maximum number of messages buffered while the session is `inactive`.
 
 ## Example Configuration
 
+CSI without buffering:
+
 ```toml
 [modules.mod_csi]
-  buffer_max = 40
+```
+
+CSI with default buffering:
+
+```toml
+[modules.mod_csi]
+  buffer = {}
+```
+
+CSI with buffering and a custom maximum buffer size:
+
+```toml
+[modules.mod_csi]
+  buffer.max_size = 40
 ```
 
 ## Metrics

--- a/doc/modules/mod_event_pusher_push.md
+++ b/doc/modules/mod_event_pusher_push.md
@@ -111,12 +111,11 @@ In order to achieve that, you need to create a plugin module that implements the
 `mod_event_pusher_push_plugin` behaviour and enable this plugin in the `plugin_module` section as
 above.
 
-A plugin module handles the dynamic configuration of push notifications. 
+A plugin module handles the dynamic configuration of push notifications.
 It contains the filtering and custom logic for notifying about messages.
 
 Two plugin implementations are provided.
 They offer different behaviour considering unacknowledged messages when using [XEP-0198: Stream Management][XEP-0198]:
-
 
 * `mod_event_pusher_push_plugin_defaults`, which implements an older behaviour. It does not notify
   the user of unacknowledged messages immediately after detecting a lost connection to the user.
@@ -131,6 +130,12 @@ notifications) should be uniquely identified. The only correct way to identify a
 XMPP standpoint is to use the data provided with the [enable stanza][enabling]. Because of that,
 each device should (re)enable the push notifications at the beginning of each and every connection.
 
+### Message notification rules
+
+For regular chat and groupchat messages, both provided plugins send push notifications if one of the following conditions occurs at the moment of routing:
+
+* Recipient has no online sessions selected for delivery.
+* Recipient has one or more online sessions selected for delivery, but [`mod_csi`](./mod_csi.md) is enabled, and all these sessions are in the `inactive` CSI state.
 ### Custom plugins
 
 A custom module implementing the optional callbacks of `mod_event_pusher_push_plugin`

--- a/doc/modules/mod_event_pusher_push.md
+++ b/doc/modules/mod_event_pusher_push.md
@@ -136,6 +136,7 @@ For regular chat and groupchat messages, both provided plugins send push notific
 
 * Recipient has no online sessions selected for delivery.
 * Recipient has one or more online sessions selected for delivery, but [`mod_csi`](./mod_csi.md) is enabled, and all these sessions are in the `inactive` CSI state.
+
 ### Custom plugins
 
 A custom module implementing the optional callbacks of `mod_event_pusher_push_plugin`

--- a/include/mod_event_pusher_events.hrl
+++ b/include/mod_event_pusher_events.hrl
@@ -1,6 +1,6 @@
 -include("jlib.hrl").
 
--record(user_status_event, {jid :: jid:jid(), status :: ejabberd_sm:user_status()}).
+-record(user_status_event, {jid :: jid:jid(), status :: online | offline}).
 -record(chat_event, {type :: headline | normal | chat | groupchat,
                      direction :: in | out,
                      from :: jid:jid(), to :: jid:jid(), packet :: exml:element(),

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -15,7 +15,7 @@
 %% utils
 -export([start_link/2, start/2, stop/2, exit/2, async/3, async_with_state/3, call/3, cast/3]).
 -export([create_data/1, get_host_type/1, get_lserver/1, get_sid/1, get_jid/1,
-         get_info/1, set_info/2,
+         get_info/1, set_info/2, get_session_priority/1,
          get_mod_state/2, get_listener_opts/1, merge_mod_state/2, remove_mod_state/2,
          get_ip/1, get_socket/1, get_lang/1, get_stream_id/1, hook_arg/5]).
 -export([get_auth_mechs/1, get_auth_mechs_to_announce/1,
@@ -39,7 +39,8 @@
           shaper :: undefined | mongoose_shaper:shaper(),
           listener_opts :: undefined | mongoose_listener:options(),
           state_mod = #{} :: #{module() => term()},
-          info = #{} :: info()
+          info = #{} :: info(),
+          session_priority = 0 :: ejabberd_sm:priority()
          }).
 -type data() :: #c2s_data{}.
 -type maybe_ok() :: ok | {error, atom()}.
@@ -866,17 +867,17 @@ handle_state_after_packet(StateData, C2SState, Acc) ->
                           state(),
                           undefined | mongoose_acc:t(),
                           mongoose_c2s_acc:t()) -> fsm_res().
-handle_state_result(StateData0, _, _, #{c2s_data := MaybeNewFsmData, hard_stop := Reason})
+handle_state_result(StateData0, _, _, #{c2s_data := MaybeNewFsmData, hard_stop := Reason} = C2SAcc)
   when Reason =/= undefined ->
     StateData1 = case MaybeNewFsmData of
                      undefined -> StateData0;
                      _ -> MaybeNewFsmData
                  end,
-    {stop, {shutdown, Reason}, StateData1};
+    {stop, {shutdown, Reason}, apply_session_priority(C2SAcc, StateData1)};
 handle_state_result(StateData0, C2SState, MaybeAcc,
                     #{state_mod := ModuleStates, actions := MaybeActions,
                       c2s_state := MaybeNewFsmState, c2s_data := MaybeNewFsmData,
-                      socket_send := MaybeSocketSend}) ->
+                      socket_send := MaybeSocketSend} = C2SAcc) ->
     NextFsmState = case MaybeNewFsmState of
                        undefined -> C2SState;
                        _ -> MaybeNewFsmState
@@ -885,12 +886,19 @@ handle_state_result(StateData0, C2SState, MaybeAcc,
                      undefined -> StateData0;
                      _ -> MaybeNewFsmData
                  end,
-    StateData2 = case map_size(ModuleStates) of
-                     0 -> StateData1;
-                     _ -> merge_mod_state(StateData1, ModuleStates)
+    StateData2 = apply_session_priority(C2SAcc, StateData1),
+    StateData3 = case map_size(ModuleStates) of
+                     0 -> StateData2;
+                     _ -> merge_mod_state(StateData2, ModuleStates)
                  end,
-    [maybe_send_xml(StateData2, MaybeAcc, Send) || Send <- MaybeSocketSend ],
-    {next_state, NextFsmState, StateData2, MaybeActions}.
+    [maybe_send_xml(StateData3, MaybeAcc, Send) || Send <- MaybeSocketSend ],
+    {next_state, NextFsmState, StateData3, MaybeActions}.
+
+-spec apply_session_priority(mongoose_c2s_acc:t(), data()) -> data().
+apply_session_priority(#{set_priority := Priority}, StateData) ->
+    StateData#c2s_data{session_priority = Priority};
+apply_session_priority(#{}, StateData) ->
+    StateData.
 
 %% @doc This function is executed when c2s receives a stanza from the TCP connection.
 -spec element_to_origin_accum(data(), exml:element()) -> mongoose_acc:t().
@@ -973,7 +981,7 @@ open_session(
                   conn => mongoose_xmpp_socket:get_conn_type(Socket)},
     Info2 = maps:merge(Info, NewFields),
     ReplacedPids = ejabberd_sm:open_session(HostType, Sid, Jid, 0, Info2),
-    {ReplacedPids, StateData#c2s_data{info = Info2}}.
+    {ReplacedPids, StateData#c2s_data{info = Info2, session_priority = 0}}.
 
 -spec close_session(data(), mongoose_acc:t(), term()) -> mongoose_acc:t().
 close_session(#c2s_data{sid = Sid, jid = Jid, info = Info}, Acc, Reason) ->
@@ -1200,6 +1208,10 @@ get_info(#c2s_data{info = Info}) ->
 set_info(StateData, Info) ->
     StateData#c2s_data{info = Info}.
 
+-spec get_session_priority(data()) -> ejabberd_sm:priority().
+get_session_priority(#c2s_data{session_priority = Priority}) ->
+    Priority.
+
 -spec get_lang(data()) -> ejabberd:lang().
 get_lang(#c2s_data{lang = Lang}) ->
     Lang.
@@ -1234,7 +1246,8 @@ merge_states(S0 = #c2s_data{}, S1 = #c2s_data{}) ->
       lserver = S0#c2s_data.lserver,
       jid = S0#c2s_data.jid,
       state_mod = S0#c2s_data.state_mod,
-      info = S0#c2s_data.info
+      info = S0#c2s_data.info,
+      session_priority = S0#c2s_data.session_priority
      }.
 
 %% Instrumentation helpers

--- a/src/c2s/mongoose_c2s_acc.erl
+++ b/src/c2s/mongoose_c2s_acc.erl
@@ -8,6 +8,7 @@
 %% - `actions': a list of valid `gen_statem:action()' to request the `mongoose_c2s' engine.
 %% - `c2s_state': a new state is requested for the state machine.
 %% - `c2s_data': a new state data is requested for the state machine.
+%% - `set_priority': a new session priority is requested for the state machine.
 %% - `stop': an action of type `{cast, {stop, Reason}}' is to be triggered.
 %% - `hard_stop': no other request is allowed, the state machine is immediatly triggered to stop.
 %% - `route': mongoose_acc elements to trigger the whole `handle_route' pipeline.
@@ -26,6 +27,7 @@
              | actions
              | c2s_state
              | c2s_data
+             | set_priority
              | stop
              | hard_stop
              | route
@@ -37,6 +39,7 @@
               | {actions, gen_statem:action()}
               | {c2s_state, mongoose_c2s:state()}
               | {c2s_data, mongoose_c2s:data()}
+              | {set_priority, ejabberd_sm:priority()}
               | {stop, term() | {shutdown, atom()}}
               | {hard_stop, term() | {shutdown, atom()}}
               | {route, mongoose_acc:t()}
@@ -49,6 +52,7 @@
         actions := [gen_statem:action()],
         c2s_state := undefined | mongoose_c2s:state(),
         c2s_data := undefined | mongoose_c2s:data(),
+        set_priority => ejabberd_sm:priority(),
         hard_stop := undefined | Reason :: term(),
         socket_send := [exml:element()]
        }.
@@ -58,6 +62,7 @@
         actions => [gen_statem:action()],
         c2s_state => mongoose_c2s:state(),
         c2s_data => mongoose_c2s:data(),
+        set_priority => ejabberd_sm:priority(),
         stop => Reason :: term(),
         hard_stop => Reason :: term(),
         route => [mongoose_acc:t()],
@@ -129,6 +134,7 @@ from_mongoose_acc(Acc, Key) ->
             (mongoose_acc:t(), actions, gen_statem:action() | [gen_statem:action()]) -> mongoose_acc:t();
             (mongoose_acc:t(), c2s_state, mongoose_c2s:state()) -> mongoose_acc:t();
             (mongoose_acc:t(), c2s_data, mongoose_c2s:data()) -> mongoose_acc:t();
+            (mongoose_acc:t(), set_priority, ejabberd_sm:priority()) -> mongoose_acc:t();
             (mongoose_acc:t(), hard_stop, atom()) -> mongoose_acc:t();
             (mongoose_acc:t(), stop, atom() | {shutdown, atom()}) -> mongoose_acc:t();
             (mongoose_acc:t(), route, mongoose_acc:t()) -> mongoose_acc:t();
@@ -169,6 +175,8 @@ to_c2s_acc(C2SAcc = #{actions := Actions}, {flush, Accs}) when is_list(Accs) ->
     C2SAcc#{actions := lists:reverse(Routes) ++ Actions};
 to_c2s_acc(C2SAcc = #{actions := Actions}, {flush, Acc}) ->
     C2SAcc#{actions := [{next_event, internal, {flush, Acc}} | Actions]};
+to_c2s_acc(C2SAcc, {set_priority, Priority}) ->
+    C2SAcc#{set_priority => Priority};
 to_c2s_acc(C2SAcc = #{socket_send := Stanzas}, {socket_send, NewStanzas}) when is_list(NewStanzas) ->
     C2SAcc#{socket_send := lists:reverse(NewStanzas) ++ Stanzas};
 to_c2s_acc(C2SAcc = #{socket_send := Stanzas}, {socket_send, Stanza}) ->

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -228,7 +228,7 @@ remove_info(JID, SID, Key) ->
 store_info_async(C2sData, SID, JID, Key, Value) ->
     Info = mongoose_c2s:get_info(C2sData),
     Info2 = update_info(Key, Value, Info),
-    Priority = mod_presence:get_old_priority(mod_presence:maybe_get_handler(C2sData)),
+    Priority = mongoose_c2s:get_session_priority(C2sData),
     set_session(SID, JID, Priority, Info2),
     mongoose_c2s:set_info(C2sData, Info2).
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -110,7 +110,7 @@
                       info     :: info()
                      }.
 -type info() :: #{info_key() => any()}.
--type user_status() :: online | offline.
+-type user_status() :: {online, map()} | offline.
 
 -type backend() :: ejabberd_sm_mnesia | ejabberd_sm_redis | ejabberd_sm_cets.
 -type close_reason() :: resumed | normal | {replaced, pid()}.
@@ -634,7 +634,7 @@ do_route(Acc, From, To, El) ->
 
 -spec notify_routed(session(), mongoose_acc:t(), binary()) -> mongoose_acc:t().
 notify_routed(Session, Acc, ~"message") ->
-    mongoose_hooks:message_routed(user_status([Session]), Acc);
+    mongoose_hooks:message_routed(user_status([Session], Acc), Acc);
 notify_routed(_Session, Acc, _) ->
     Acc.
 
@@ -780,7 +780,7 @@ route_message(From, To, Acc, Packet) ->
             route_message_fallback(From, To, Acc, Packet);
         Sessions ->
             [mongoose_c2s:route(Pid, Acc) || #session{sid = {_, Pid}} <- Sessions],
-            mongoose_hooks:message_routed(user_status(Sessions), Acc)
+            mongoose_hooks:message_routed(user_status(Sessions, Acc), Acc)
     end.
 
 -spec sessions_to_route([session()]) -> [session()].
@@ -828,11 +828,14 @@ route_message_by_type(_, From, To, Acc, Packet) ->
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec user_status([session()]) -> user_status().
-user_status(Sessions) ->
-    case lists:any(fun(#session{priority = Priority}) -> is_integer(Priority) end, Sessions) of
-        true -> online;
-        false -> offline
+-spec user_status([session()], mongoose_acc:t()) -> user_status().
+user_status(Sessions, Acc) ->
+    case lists:filter(fun(#session{priority = Priority}) -> is_integer(Priority) end, Sessions) of
+        [] ->
+            offline;
+        Sessions1 ->
+            HostType = mongoose_acc:host_type(Acc),
+            {online, mongoose_hooks:get_user_status(HostType, Sessions1)}
     end.
 
 -spec clean_session_list([#session{}]) -> [#session{}].

--- a/src/event_pusher/mod_event_pusher_hook_translator.erl
+++ b/src/event_pusher/mod_event_pusher_hook_translator.erl
@@ -67,7 +67,7 @@ user_send_message(Acc, _, _) ->
             {_, false} ->
                 Acc;
             {_, Type} ->
-                push_chat_event(Acc, Type, in, online)
+                push_chat_event(Acc, Type, in, {online, #{}})
         end,
     {ok, ResultAcc}.
 

--- a/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
+++ b/src/event_pusher/mod_event_pusher_push_plugin_defaults.erl
@@ -33,9 +33,9 @@
                         [mod_event_pusher_push:publish_service()].
 should_publish(Acc, #chat_event{user_status = UserStatus}, Services) ->
     PublishedServices = mongoose_acc:get(event_pusher, published_services, [], Acc),
-    case UserStatus of
-        online -> [];
-        offline -> Services -- PublishedServices
+    case should_publish(UserStatus) of
+        true -> Services -- PublishedServices;
+        false -> []
     end;
 should_publish(_Acc, _Event, _Services) -> [].
 
@@ -77,6 +77,14 @@ publish_notification(Acc, _, Payload, Services) ->
 %%--------------------------------------------------------------------
 %% local functions
 %%--------------------------------------------------------------------
+
+-spec should_publish(ejabberd_sm:user_status()) -> boolean().
+should_publish(offline) ->
+    true;
+should_publish({online, #{client_state := inactive}}) ->
+    true;
+should_publish({online, _}) ->
+    false.
 
 -spec get_unread_count(mongoose_acc:t(), jid:jid()) -> pos_integer().
 get_unread_count(Acc, To) ->

--- a/src/event_pusher/mod_event_pusher_rabbit.erl
+++ b/src/event_pusher/mod_event_pusher_rabbit.erl
@@ -191,7 +191,7 @@ user_topic_routing_key(JID, Topic) ->
     BinJID = jid:to_binary(jid:to_lus(JID)),
     <<BinJID/binary, ".", Topic/binary>>.
 
--spec is_user_online(ejabberd_sm:user_status()) -> boolean().
+-spec is_user_online(online | offline) -> boolean().
 is_user_online(online) -> true;
 is_user_online(offline) -> false.
 

--- a/src/hooks/mongoose_hooks.erl
+++ b/src/hooks/mongoose_hooks.erl
@@ -22,6 +22,7 @@
          get_key/2,
          packet_to_component/3,
          presence_probe/5,
+         get_user_status/2,
          push_notifications/4,
          register_subhost/2,
          register_user/3,
@@ -245,8 +246,8 @@ filter_local_packet(FilterAcc = {_From, _To, Acc, _Packet}) ->
     run_hook_for_host_type(filter_local_packet, HostType, FilterAcc, #{}).
 
 %%% @doc The `message_routed' hook is called after `ejabberd_sm' routes a message
-%%% to an existing local user. `UserStatus' is `online' when the message was
-%%% routed to at least one online session (i.e. with integer priority), and `offline' otherwise.
+%%% to an existing local user. `UserStatus' is `{online, StatusMap}' when the message
+%%% was routed to at least one online session (i.e. with integer priority), and `offline' otherwise.
 %%% It is called before `offline_message' or `offline_groupchat_message'.
 -spec message_routed(UserStatus, Acc) -> Result when
     UserStatus :: ejabberd_sm:user_status(),
@@ -311,6 +312,16 @@ packet_to_component(Acc, From, To) ->
 presence_probe(HostType, Acc, From, To, Pid) ->
     Params = #{from => From, to => To, pid => Pid},
     run_hook_for_host_type(presence_probe, HostType, Acc, Params).
+
+%%% @doc The `get_user_status' hook is used to collect extra user status information
+%%% for online sessions selected for message routing.
+-spec get_user_status(HostType, Sessions) -> Result when
+    HostType :: mongooseim:host_type(),
+    Sessions :: [ejabberd_sm:session()],
+    Result :: map().
+get_user_status(HostType, Sessions) ->
+    Params = #{sessions => Sessions},
+    run_hook_for_host_type(get_user_status, HostType, #{}, Params).
 
 %%% @doc The `push_notifications' hook is called to push notifications.
 -spec push_notifications(HostType, Acc, NotificationForms, Options) -> Result when

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -15,21 +15,19 @@
 -export([c2s_stream_features/3,
          bind2_stream_features/3,
          bind2_enable_features/3,
+         get_user_status/3,
          xmpp_presend_element/3,
          user_send_xmlel/3,
          handle_user_stopping/3,
          reroute_unacked_messages/3
         ]).
 
--record(csi_state, {
-          state = active :: state(),
-          buffer = [] :: [mongoose_acc:t()],
-          buffer_max = 20 :: non_neg_integer()
-         }).
+-record(csi_buffer_state, {buffer = [] :: [mongoose_acc:t()],
+                           buffer_max :: non_neg_integer() | infinity}).
 
 -type params() :: #{c2s_data := mongoose_c2s:data(), _ := _}.
 -type state() :: active | inactive.
--type csi_state() :: #csi_state{}.
+-type csi_buffer_state() :: #csi_buffer_state{}.
 
 -spec start(mongooseim:host_type(), gen_mod:module_opts()) -> ok.
 start(_HostType, _Opts) ->
@@ -39,18 +37,10 @@ start(_HostType, _Opts) ->
 stop(_HostType) ->
     ok.
 
+-spec hooks(mongooseim:host_type()) -> gen_hook:hook_list().
 hooks(HostType) ->
-    [
-     {c2s_stream_features, HostType, fun ?MODULE:c2s_stream_features/3, #{}, 60},
-     {bind2_stream_features, HostType, fun ?MODULE:bind2_stream_features/3, #{}, 50},
-     {bind2_enable_features, HostType, fun ?MODULE:bind2_enable_features/3, #{}, 50},
-     {xmpp_presend_element, HostType, fun ?MODULE:xmpp_presend_element/3, #{}, 45}, %% just before stream management!
-     {user_send_xmlel, HostType, fun ?MODULE:user_send_xmlel/3, #{}, 60},
-     {user_stop_request, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
-     {user_socket_closed, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
-     {user_socket_error, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
-     {reroute_unacked_messages, HostType, fun ?MODULE:reroute_unacked_messages/3, #{}, 70}
-    ].
+    Opts = gen_mod:get_module_opts(HostType, ?MODULE),
+    basic_hooks(HostType) ++ buffer_hooks(HostType, Opts).
 
 -spec instrumentation(mongooseim:host_type()) -> [mongoose_instrument:spec()].
 instrumentation(HostType) ->
@@ -62,15 +52,39 @@ instrumentation(HostType) ->
 -spec config_spec() -> mongoose_config_spec:config_section().
 config_spec() ->
     #section{
-       items = #{<<"buffer_max">> => #option{type = int_or_infinity,
-                                             validate = non_negative}},
-       defaults = #{<<"buffer_max">> => 20}
+       items = #{<<"buffer">> => buffer_config_spec()}
+    }.
+
+-spec buffer_config_spec() -> mongoose_config_spec:config_section().
+buffer_config_spec() ->
+    #section{
+       items = #{<<"max_size">> => #option{type = int_or_infinity,
+                                        validate = non_negative}},
+       defaults = #{<<"max_size">> => 20}
     }.
 
 -spec supported_features() -> [atom()].
 supported_features() ->
     [dynamic_domains].
 
+-spec basic_hooks(mongooseim:host_type()) -> gen_hook:hook_list().
+basic_hooks(HostType) ->
+    [{c2s_stream_features, HostType, fun ?MODULE:c2s_stream_features/3, #{}, 60},
+     {bind2_stream_features, HostType, fun ?MODULE:bind2_stream_features/3, #{}, 50},
+     {bind2_enable_features, HostType, fun ?MODULE:bind2_enable_features/3, #{}, 50},
+     {get_user_status, HostType, fun ?MODULE:get_user_status/3, #{}, 50},
+     {user_send_xmlel, HostType, fun ?MODULE:user_send_xmlel/3, #{}, 60}].
+
+% Note: xmpp_presend_element handler has to run before stream management
+-spec buffer_hooks(mongooseim:host_type(), gen_mod:module_opts()) -> gen_hook:hook_list().
+buffer_hooks(HostType, #{buffer := _}) ->
+    [{xmpp_presend_element, HostType, fun ?MODULE:xmpp_presend_element/3, #{}, 45},
+     {user_stop_request, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
+     {user_socket_closed, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
+     {user_socket_error, HostType, fun ?MODULE:handle_user_stopping/3, #{}, 95},
+     {reroute_unacked_messages, HostType, fun ?MODULE:reroute_unacked_messages/3, #{}, 70}];
+buffer_hooks(_, _) ->
+    [].
 
 %%% Hook handlers
 -spec c2s_stream_features(Acc, map(), gen_hook:extra()) -> {ok, Acc} when Acc :: [exml:element()].
@@ -98,6 +112,11 @@ bind2_enable_features(SaslAcc, Params, _) ->
             {ok, SaslAcc1}
     end.
 
+-spec get_user_status(map(), #{sessions := [ejabberd_sm:session()]}, gen_hook:extra()) ->
+          {ok, #{client_state := state(), _ => _}}.
+get_user_status(Acc, #{sessions := Sessions}, _) ->
+    {ok, Acc#{client_state => aggregate_client_state(Sessions)}}.
+
 %% The XEP doesn't require any specific server behaviour in response to CSI stanzas,
 %% there are only some suggestions. The implementation in MongooseIM will simply buffer
 %% all packets (up to a configured limit) when the session is "inactive" and will flush
@@ -106,30 +125,31 @@ bind2_enable_features(SaslAcc, Params, _) ->
     mongoose_c2s_hooks:result().
 xmpp_presend_element(Acc, #{c2s_data := C2SData}, _Extra) ->
     case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
-        {ok, Csi} ->
-            handle_presend_element(Acc, Csi);
-        _ ->
+        {ok, Csi = #csi_buffer_state{}} ->
+            handle_presend_element(Acc, Csi, get_client_state(C2SData));
+        {error, not_found} ->
             {ok, Acc}
     end.
 
--spec handle_presend_element(mongoose_acc:t(), csi_state()) -> mongoose_c2s_hooks:result().
-handle_presend_element(Acc, Csi = #csi_state{state = inactive, buffer = Buffer, buffer_max = BMax}) ->
+-spec handle_presend_element(mongoose_acc:t(), csi_buffer_state(), state()) ->
+    mongoose_c2s_hooks:result().
+handle_presend_element(Acc, Csi = #csi_buffer_state{buffer = Buffer, buffer_max = BMax}, inactive) ->
     case length(Buffer) + 1 > BMax of
         true ->
             NewBuffer = [mark_acc_as_buffered(Acc) | Buffer],
-            NewCsi = Csi#csi_state{buffer = []},
+            NewCsi = Csi#csi_buffer_state{buffer = []},
             ToAcc = [{state_mod, {?MODULE, NewCsi}}, {flush, lists:reverse(NewBuffer)}],
             {stop, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)};
         _ ->
             buffer_acc(Acc, Csi, is_acc_buffered(Acc))
     end;
-handle_presend_element(Acc, _) ->
+handle_presend_element(Acc, _, _) ->
     {ok, Acc}.
 
--spec buffer_acc(mongoose_acc:t(), csi_state(), boolean()) -> mongoose_c2s_hooks:result().
-buffer_acc(Acc, Csi = #csi_state{buffer = Buffer}, false) ->
+-spec buffer_acc(mongoose_acc:t(), csi_buffer_state(), boolean()) -> mongoose_c2s_hooks:result().
+buffer_acc(Acc, Csi = #csi_buffer_state{buffer = Buffer}, false) ->
     AccToBuffer = mark_acc_as_buffered(Acc),
-    NewCsi = Csi#csi_state{buffer = [AccToBuffer | Buffer]},
+    NewCsi = Csi#csi_buffer_state{buffer = [AccToBuffer | Buffer]},
     {stop, mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi})};
 buffer_acc(Acc, _, true) ->
     {ok, Acc}.
@@ -150,10 +170,11 @@ user_send_xmlel(Acc, Params, _Extra) ->
      mongoose_c2s_hooks:result().
 handle_user_stopping(Acc, #{c2s_data := C2SData}, _) ->
     case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
-        {ok, Csi = #csi_state{buffer = Buffer}} ->
-            NewCsi = Csi#csi_state{state = active, buffer = []},
-            ToAcc = [{state_mod, {?MODULE, NewCsi}}, {flush, lists:reverse(Buffer)}],
-            {ok, mongoose_c2s_acc:to_acc_many(Acc, ToAcc)};
+        {ok, Csi = #csi_buffer_state{buffer = Buffer}} ->
+            NewCsi = Csi#csi_buffer_state{buffer = []},
+            Acc1 = mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi}),
+            Acc2 = set_client_state(Acc1, C2SData, active),
+            {ok, mongoose_c2s_acc:to_acc(Acc2, flush, lists:reverse(Buffer))};
         _ ->
             {ok, Acc}
     end.
@@ -162,10 +183,11 @@ handle_user_stopping(Acc, #{c2s_data := C2SData}, _) ->
     mongoose_c2s_hooks:result().
 reroute_unacked_messages(Acc, #{c2s_data := C2SData}, _) ->
     case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
-        {ok, Csi = #csi_state{buffer = Buffer}} ->
+        {ok, Csi = #csi_buffer_state{buffer = Buffer}} ->
             mongoose_c2s:reroute_buffer(C2SData, Buffer),
-            NewCsi = Csi#csi_state{state = active, buffer = []},
-            {ok, mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi})};
+            NewCsi = Csi#csi_buffer_state{buffer = []},
+            Acc1 = mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi}),
+            {ok, set_client_state(Acc1, C2SData, active)};
         _ ->
             {ok, Acc}
     end.
@@ -187,14 +209,11 @@ handle_inactive_request(Acc, #{c2s_data := C2SData} = _Params) ->
     HostType = mongoose_c2s:get_host_type(C2SData),
     JID = mongoose_c2s:get_jid(C2SData),
     mongoose_instrument:execute(mod_csi_inactive, #{host_type => HostType}, #{count => 1, jid => JID}),
-    case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
-        {error, not_found} ->
-            BMax = gen_mod:get_module_opt(HostType, ?MODULE, buffer_max),
-            Csi = #csi_state{state = inactive, buffer_max = BMax},
-            mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, Csi});
-        {ok, Csi = #csi_state{}} ->
-            NewCsi = Csi#csi_state{state = inactive},
-            mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi})
+    case get_client_state(C2SData) of
+        active ->
+            set_client_state(maybe_init_buffer(Acc, C2SData, HostType), C2SData, inactive);
+        inactive ->
+            Acc
     end.
 
 -spec handle_active_request(mongoose_acc:t(), params()) -> mongoose_acc:t().
@@ -202,14 +221,60 @@ handle_active_request(Acc, #{c2s_data := C2SData}) ->
     HostType = mongoose_c2s:get_host_type(C2SData),
     JID = mongoose_c2s:get_jid(C2SData),
     mongoose_instrument:execute(mod_csi_active, #{host_type => HostType}, #{count => 1, jid => JID}),
+    case get_client_state(C2SData) of
+        active ->
+            Acc;
+        inactive ->
+            set_client_state(maybe_flush_buffer(Acc, C2SData), C2SData, active)
+    end.
+
+-spec maybe_init_buffer(mongoose_acc:t(), mongoose_c2s:data(), mongooseim:host_type()) ->
+          mongoose_acc:t().
+maybe_init_buffer(Acc, C2SData, HostType) ->
+    maybe
+        {error, not_found} ?= mongoose_c2s:get_mod_state(C2SData, ?MODULE),
+        #{buffer := #{max_size := BMax}} ?= gen_mod:get_module_opts(HostType, ?MODULE),
+        Csi = #csi_buffer_state{buffer_max = BMax},
+        mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, Csi})
+    else
+        _ -> Acc
+    end.
+
+-spec maybe_flush_buffer(mongoose_acc:t(), mongoose_c2s:data()) -> mongoose_acc:t().
+maybe_flush_buffer(Acc, C2SData) ->
     case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
-        {ok, Csi = #csi_state{state = inactive, buffer = Buffer}} ->
-            NewCsi = Csi#csi_state{state = active, buffer = []},
-            ToAcc = [{state_mod, {?MODULE, NewCsi}}, {flush, lists:reverse(Buffer)}],
-            mongoose_c2s_acc:to_acc_many(Acc, ToAcc);
+        {ok, Csi = #csi_buffer_state{buffer = Buffer}} ->
+            NewCsi = Csi#csi_buffer_state{buffer = []},
+            Acc1 = mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi}),
+            mongoose_c2s_acc:to_acc(Acc1, flush, lists:reverse(Buffer));
         _ ->
             Acc
     end.
+
+-spec get_client_state(mongoose_c2s:data()) -> state().
+get_client_state(C2SData) ->
+    case mongoose_c2s:get_info(C2SData) of
+        #{client_state := State} -> State;
+        _ -> active
+    end.
+
+-spec set_client_state(mongoose_acc:t(), mongoose_c2s:data(), state()) -> mongoose_acc:t().
+set_client_state(Acc, C2SData, State) ->
+    JID = mongoose_c2s:get_jid(C2SData),
+    SID = mongoose_c2s:get_sid(C2SData),
+    Info = mongoose_c2s:get_info(C2SData),
+    ejabberd_sm:store_info(JID, SID, client_state, State),
+    C2SData1 = mongoose_c2s:set_info(C2SData, Info#{client_state => State}),
+    mongoose_c2s_acc:to_acc(Acc, c2s_data, C2SData1).
+
+-spec aggregate_client_state([ejabberd_sm:session()]) -> state().
+aggregate_client_state([Session | Sessions]) ->
+    case mongoose_session:get_info(Session) of
+        #{client_state := inactive} -> aggregate_client_state(Sessions);
+        #{} -> active
+    end;
+aggregate_client_state([]) ->
+    inactive.
 
 -spec csi() -> exml:element().
 csi() ->

--- a/src/mod_csi.erl
+++ b/src/mod_csi.erl
@@ -59,7 +59,7 @@ config_spec() ->
 buffer_config_spec() ->
     #section{
        items = #{<<"max_size">> => #option{type = int_or_infinity,
-                                        validate = non_negative}},
+                                           validate = non_negative}},
        defaults = #{<<"max_size">> => 20}
     }.
 
@@ -245,8 +245,8 @@ maybe_flush_buffer(Acc, C2SData) ->
     case mongoose_c2s:get_mod_state(C2SData, ?MODULE) of
         {ok, Csi = #csi_buffer_state{buffer = Buffer}} ->
             NewCsi = Csi#csi_buffer_state{buffer = []},
-            Acc1 = mongoose_c2s_acc:to_acc(Acc, state_mod, {?MODULE, NewCsi}),
-            mongoose_c2s_acc:to_acc(Acc1, flush, lists:reverse(Buffer));
+            ToAcc = [{state_mod, {?MODULE, NewCsi}}, {flush, lists:reverse(Buffer)}],
+            mongoose_c2s_acc:to_acc_many(Acc, ToAcc);
         _ ->
             Acc
     end.

--- a/src/mod_presence.erl
+++ b/src/mod_presence.erl
@@ -55,7 +55,6 @@
          set_presence/2,
          get_presence_type/1,
          maybe_get_handler/1,
-         get_old_priority/1,
          is_subscribed/3,
          put_state_in_acc/2,
          get_state_from_acc/1
@@ -385,8 +384,9 @@ presence_update_to_unavailable(Acc, _FromJid, _ToJid, Packet, StateData, Presenc
     Acc1 = ejabberd_sm:unset_presence(Acc, Sid, Jid, Status, Info),
     presence_broadcast(Acc1, Presences),
     NewPresences = Presences#presences_state{pres_last = undefined,
-                                   pres_timestamp = undefined},
-    mongoose_c2s_acc:to_acc(Acc1, state_mod, {?MODULE, NewPresences}).
+                                             pres_timestamp = undefined},
+    mongoose_c2s_acc:to_acc_many(Acc1, [{state_mod, {?MODULE, NewPresences}},
+                                        {set_priority, undefined}]).
 
 %% @doc User sends a directed presence packet
 -spec presence_track(
@@ -687,7 +687,8 @@ update_priority(Acc, Priority, Packet, StateData) ->
     Sid = mongoose_c2s:get_sid(StateData),
     Jid = mongoose_c2s:get_jid(StateData),
     Info = mongoose_c2s:get_info(StateData),
-    ejabberd_sm:set_presence(Acc, Sid, Jid, Priority, Packet, Info).
+    Acc1 = ejabberd_sm:set_presence(Acc, Sid, Jid, Priority, Packet, Info),
+    mongoose_c2s_acc:to_acc(Acc1, set_priority, Priority).
 
 -spec am_i_subscribed_to_presence(jid:jid(), jid:jid(), state()) -> boolean().
 am_i_subscribed_to_presence(LJID, LBareJID, S) ->

--- a/test/common/config_parser_helper.erl
+++ b/test/common/config_parser_helper.erl
@@ -517,7 +517,7 @@ all_modules() ->
                           ttl => 3600, secret => <<"some secret">>},
                         #{host => <<"192.168.0.1">>, type => turn}]},
       mod_external_filter => mod_config(mod_external_filter, #{pool_tag => external_filter_http}),
-      mod_csi => mod_config(mod_csi, #{buffer_max => 40}),
+      mod_csi => mod_config(mod_csi, #{buffer => #{max_size => 40}}),
       mod_http_upload =>
           mod_config(
             mod_http_upload,
@@ -805,7 +805,7 @@ default_pool_conn_opts(_Type) ->
     #{}.
 
 mod_config(Module, ExtraOpts) ->
-    maps:merge(default_mod_config(Module), ExtraOpts).
+    config([modules, Module], ExtraOpts).
 
 %% Selects backend automatically depending on which databases are available
 mod_config_with_auto_backend(Module) ->
@@ -836,8 +836,6 @@ default_mod_config(mod_cache_users) ->
     #{strategy => fifo, time_to_live => 480, number_of_segments => 3};
 default_mod_config(mod_caps) ->
     #{backend => cets, iq_response_timeout => 5000, versions => [v1, v2]};
-default_mod_config(mod_csi) ->
-    #{buffer_max => 20};
 default_mod_config(mod_carboncopy) ->
     #{iqdisc => no_queue};
 default_mod_config(mod_disco) ->
@@ -1132,6 +1130,8 @@ default_config([listen, component, tls]) ->
     default_xmpp_tls_tls();
 default_config([modules, M]) ->
     default_mod_config(M);
+default_config([modules, mod_csi, buffer]) ->
+    #{max_size => 20};
 default_config([modules, mod_event_pusher, http]) ->
     #{handlers => []};
 default_config([modules, mod_event_pusher, push]) ->

--- a/test/config_parser_SUITE.erl
+++ b/test/config_parser_SUITE.erl
@@ -1610,9 +1610,11 @@ mod_csi(_Config) ->
     check_module_defaults(mod_csi),
     T = fun(K, V) -> #{<<"modules">> => #{<<"mod_csi">> => #{K => V}}} end,
     P = [modules, mod_csi],
-    ?cfgh(P ++ [buffer_max], 10, T(<<"buffer_max">>, 10)),
-    ?cfgh(P ++ [buffer_max], infinity, T(<<"buffer_max">>, <<"infinity">>)),
-    ?errh(T(<<"buffer_max">>, -1)).
+    ?cfgh(P ++ [buffer], config_parser_helper:default_config(P ++ [buffer]),
+          T(<<"buffer">>, #{})),
+    ?cfgh(P ++ [buffer, max_size], 10, T(<<"buffer">>, #{<<"max_size">> => 10})),
+    ?cfgh(P ++ [buffer, max_size], infinity, T(<<"buffer">>, #{<<"max_size">> => <<"infinity">>})),
+    ?errh(T(<<"buffer">>, #{<<"max_size">> => -1})).
 
 mod_disco(_Config) ->
     check_module_defaults(mod_disco),

--- a/test/config_parser_SUITE_data/modules.toml
+++ b/test/config_parser_SUITE_data/modules.toml
@@ -26,7 +26,7 @@
   iqdisc.type = "no_queue"
 
 [modules.mod_csi]
-  buffer_max = 40
+  buffer.max_size = 40
 
 [modules.mod_disco]
   iqdisc.type = "one_queue"

--- a/test/ejabberd_sm_SUITE.erl
+++ b/test/ejabberd_sm_SUITE.erl
@@ -495,6 +495,7 @@ do_meck_c2s(true) ->
     meck:expect(mongoose_c2s, async_with_state, fun async_with_state/3),
     meck:expect(mongoose_c2s, get_info, fun get_info/1),
     meck:expect(mongoose_c2s, set_info, fun set_info/2),
+    meck:expect(mongoose_c2s, get_session_priority, [{1, 0}]),
     %% Just return same thing all the time
     meck:expect(mongoose_c2s, get_mod_state, fun(_C2sState, _Mod) -> {error, not_found} end).
 


### PR DESCRIPTION
This PR lets push notifications use the CSI active/inactive state to decide whether a routed message should notify the recipient.

### Changes
* Fix session priority handling in `ejabberd_sm`.
* Extend `message_routed` with an extra status map for routed sessions.
* Keep general user presence status separate from message-routing status.
* Store CSI client state (active/inactive) in session info and expose it through `get_user_status`.
* Make CSI buffering optional with the new `mod_csi.buffer.max_size` section.
* Notify for regular chat/groupchat messages when the recipient is offline or routed sessions are CSI-inactive.
* Add coverage for CSI buffering modes, CSI-driven push notifications, default active sessions, and negative-priority sessions.
* Update module docs, hook docs, and migration notes.

### Known limitation
BIND2 inline CSI state is applied through the C2S process queue. In practice this means a newly bound session may be treated as active for a very short time before the inline CSI state is reflected in session info. We accept this for now because establishing the session is itself fresh client activity, and the simpler implementation avoids extra SASL2 state plumbing.