### PR TITLE
Fix last admin leaving with promotion disabled

### DIFF
--- a/big_tests/tests/muc_light_SUITE.erl
+++ b/big_tests/tests/muc_light_SUITE.erl
@@ -60,7 +60,9 @@
          explicit_owner_change/1,
          explicit_owner_handover/1,
          implicit_owner_change/1,
-         implicit_owner_change_disabled/1,
+         implicit_owner_change_no_promotion/1,
+         implicit_destroy_room/1,
+         implicit_destroy_room_no_promotion/1,
          edge_case_owner_change/1,
          adding_wrongly_named_user_triggers_infinite_loop/1
         ]).
@@ -190,7 +192,9 @@ groups() ->
                               explicit_owner_handover,
                               multiple_owner_change,
                               implicit_owner_change,
-                              implicit_owner_change_disabled,
+                              implicit_owner_change_no_promotion,
+                              implicit_destroy_room,
+                              implicit_destroy_room_no_promotion,
                               edge_case_owner_change,
                               adding_wrongly_named_user_triggers_infinite_loop
                              ]},
@@ -321,7 +325,8 @@ muc_light_opts(blocking_disabled) ->
     #{blocking => false};
 muc_light_opts(multiple_owner_change) ->
     #{allow_multiple_owners => true};
-muc_light_opts(implicit_owner_change_disabled) ->
+muc_light_opts(CaseName) when CaseName =:= implicit_owner_change_no_promotion;
+                              CaseName =:= implicit_destroy_room_no_promotion ->
     #{promote_on_last_owner_leave => false};
 muc_light_opts(_) ->
     #{}.
@@ -907,13 +912,31 @@ implicit_owner_change(Config) ->
             escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice))
         end).
 
-implicit_owner_change_disabled(Config) ->
+implicit_owner_change_no_promotion(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}], fun(Alice, Bob) ->
             AffUsersChanges1 = [{Bob, none}, {Alice, member}],
             escalus:send(Alice, stanza_aff_set(?ROOM, AffUsersChanges1)),
             escalus:assert(is_error, [<<"modify">>, <<"bad-request">>],
                            escalus:wait_for_stanza(Alice))
         end).
+
+implicit_destroy_room(Config) ->
+    escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->
+            AffUsersChanges1 = [{Bob, none}, {Kate, none}],
+            escalus:send(Alice, stanza_aff_set(?ROOM, AffUsersChanges1)),
+            verify_aff_bcast([{Alice, owner}], AffUsersChanges1),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+            AffUsersChanges2 = [{Alice, none}],
+            escalus:send(Alice, stanza_aff_set(?ROOM, AffUsersChanges2)),
+            verify_aff_bcast([], AffUsersChanges2, []),
+            escalus:assert(is_iq_result, escalus:wait_for_stanza(Alice)),
+
+            {error, not_exists} = rpc(mim(), mod_muc_light_db_backend, get_info,
+                                      [host_type(), {?ROOM, ?MUCHOST}])
+        end).
+
+implicit_destroy_room_no_promotion(Config) ->
+    implicit_destroy_room(Config).
 
 edge_case_owner_change(Config) ->
     escalus:story(Config, [{alice, 1}, {bob, 1}, {kate, 1}], fun(Alice, Bob, Kate) ->

--- a/doc/modules/mod_muc_light.md
+++ b/doc/modules/mod_muc_light.md
@@ -114,17 +114,13 @@ This option may be useful for creating a subset of users with admin rights, inst
 which can be done with the [all_can_configure](#modulesmod_muc_lightall_can_configure) and
 [all_can_invite](#modulesmod_muc_lightall_can_invite) options.
 
-!!! Warning
-    This is a custom option, not compatible with our [MUC Light XEP](../open-extensions/muc_light.md).
-    If a client is adhering to the XEP, its behaviour may be unexpected, and this option should not be enabled.
-
 ### `modules.mod_muc_light.promote_on_last_owner_leave`
 * **Syntax**: boolean
 * **Default**: `true`
 * **Example**: `promote_on_last_owner_leave = false`
 
-When enabled, one of the group members is promoted to owner when the last owner leaves the room.
-Otherwise, leaving the room is rejected.
+When enabled, if the last owner leaves the room, another user is promoted to owner.
+When disabled, if the last owner leaves the room while other members are still present, the operation fails.
 
 ### `modules.mod_muc_light.config_schema`
   * **Syntax:** an array of `config_schema` items, as described below

--- a/src/muc_light/mod_muc_light_utils.erl
+++ b/src/muc_light/mod_muc_light_utils.erl
@@ -203,6 +203,8 @@ is_new_owner_needed(AU) ->
 
 -spec find_new_owner(CanPromote :: boolean(), aff_users(), aff_users(), [jid:simple_bare_jid()]) ->
     {jid:simple_bare_jid(), promotion_type()} | false | disabled.
+find_new_owner(false, [], _AUC, _JoiningUsers) ->
+    false;
 find_new_owner(false, _AU, _AUC, _JoiningUsers) ->
     disabled;
 find_new_owner(true, AU, AUC, JoiningUsers) ->


### PR DESCRIPTION
This PR fixes a bug introduced in PR #4749 that prevents the last admin from leaving the room by removing themselves from the affiliation list when `promote_on_last_owner_leave` is disabled.

Steps to reproduce:
1. Set `promote_on_last_owner_leave = false` in `mod_muc_light`
2. Create a room with a single occupant (the admin)
3. Send an IQ request to set owner's affiliation to `none`

MIM-2786