### PR TITLE
Fix replaced-session diagnostics after remote node shutdown

### DIFF
--- a/big_tests/tests/connect_SUITE.erl
+++ b/big_tests/tests/connect_SUITE.erl
@@ -29,6 +29,11 @@
     [ct:fail("ASSERT EQUAL~n\tExpected ~p~n\tValue ~p~n", [(E), (V)])
      || (E) =/= (V)])).
 -define(SECURE_USER, secure_joe).
+%% The replaced_wait_timeout used by replaced_session_survives_remote_node_shutdown.
+%% It has to outlast a real `mongooseimctl stop' of the other node, because the
+%% whole point of the test is that the node is already gone when the timer fires.
+%% The case asserts that ordering instead of assuming it.
+-define(REMOTE_SHUTDOWN_WAIT, 30000).
 -define(CACERT_FILE, "priv/ssl/cacert.pem").
 -define(CERT_FILE, "priv/ssl/fake_cert.pem").
 -define(KEY_FILE, "priv/ssl/fake_key.pem").
@@ -86,7 +91,8 @@ groups() ->
                                    same_resource_replaces_session_with_colon,
                                    clean_close_of_replaced_session,
                                    replaced_session_cannot_terminate,
-                                   replaced_session_cannot_terminate_different_nodes]},
+                                   replaced_session_cannot_terminate_different_nodes,
+                                   replaced_session_survives_remote_node_shutdown]},
         {security, [], [return_proper_stream_error_if_service_is_not_hidden,
                         close_connection_if_service_type_is_hidden]},
         {incorrect_behaviors, [parallel], [close_connection_if_start_stream_duplicated,
@@ -216,9 +222,27 @@ init_per_testcase(replaced_session_cannot_terminate_different_nodes = CN, Config
     Config2 = distributed_helper:add_node_to_cluster(mim2(), Config1),
     logger_ct_backend:start(mim2()),
     escalus:init_per_testcase(CN, Config2);
+init_per_testcase(replaced_session_survives_remote_node_shutdown = CN, Config) ->
+    S = escalus_users:get_server(Config, alice),
+    OptKey = {replaced_wait_timeout, S},
+    Config1 = mongoose_helper:backup_and_set_config_option(Config, OptKey, ?REMOTE_SHUTDOWN_WAIT),
+    Config2 = distributed_helper:add_node_to_cluster(mim2(), Config1),
+    %% distributed_helper:stop_node/2 and start_node/2 need mim2's release path
+    Config3 = ejabberd_node_utils:init(mim2(), Config2),
+    escalus:init_per_testcase(CN, Config3);
 init_per_testcase(CaseName, Config) ->
     escalus:init_per_testcase(CaseName, Config).
 
+end_per_testcase(replaced_session_survives_remote_node_shutdown = CaseName, Config) ->
+    %% The case stops mim2 on purpose; put it back before anything else runs.
+    #{node := Mim2Node} = mim2(),
+    case is_node_running(Mim2Node) of
+        true -> ok;
+        false -> distributed_helper:start_node(Mim2Node, Config)
+    end,
+    distributed_helper:remove_node_from_cluster(mim2(), Config),
+    mongoose_helper:restore_config(Config),
+    escalus:end_per_testcase(CaseName, Config);
 end_per_testcase(replaced_session_cannot_terminate_different_nodes = CaseName, Config) ->
     logger_ct_backend:stop(mim2()),
     distributed_helper:remove_node_from_cluster(mim2(), Config),
@@ -688,6 +712,10 @@ replaced_session_cannot_terminate(Config) ->
     rpc(mim(), sys, resume, [C2SPid]),
     logger_ct_backend:stop_capture(),
 
+    %% The diagnostic reported a frozen old session - and left the new one alone
+    assert_connection_still_usable(Alice2),
+    assert_message_processed(),
+
     escalus_connection:stop(Alice2).
 
 replaced_session_cannot_terminate_different_nodes(Config) ->
@@ -712,7 +740,92 @@ replaced_session_cannot_terminate_different_nodes(Config) ->
     rpc(mim(), sys, resume, [C2SPid]),
     logger_ct_backend:stop_capture(),
 
+    %% Same, with the frozen old session on another node: the remote check
+    %% answered `true' and the new connection carried on regardless.
+    assert_connection_still_usable(Alice2),
+
     escalus_connection:stop(Alice2).
+
+%% Regression test for the rolling restart outage: the node that hosted the
+%% replaced session disappears between "capture the replaced pids" and "check
+%% whether they exited". The check then used to raise
+%% {case_clause, {badrpc, nodedown}} inside the new connection's own gen_statem
+%% callback and take that brand new, fully authenticated connection down with it.
+%%
+%% The assertion is deliberately on the ORIGINAL c2s process and the ORIGINAL
+%% socket. Checking that a client can reconnect afterwards would hide the bug.
+replaced_session_survives_remote_node_shutdown(Config) ->
+    logger_ct_backend:capture(error),
+    UserSpec = [{resource, <<"conflict">>} | escalus_users:get_userspec(Config, alice)],
+
+    %% GIVEN a session on the other node
+    {ok, Alice1, _} = escalus_connection:start([{port, 5232} | UserSpec]),
+
+    %% WHEN it is replaced by a new session on this node, which captures the
+    %% remote pid and arms replaced_wait_timeout with it
+    ArmedAt = erlang:monotonic_time(millisecond),
+    {ok, Alice2, _} = escalus_connection:start(UserSpec),
+
+    %% Barrier 1: the old session really was replaced, so the pid list was not
+    %% empty and the timer really is armed.
+    escalus:assert(is_stream_error, [<<"conflict">>, <<>>],
+                   escalus:wait_for_stanza(Alice1, timer:seconds(5))),
+    ReplacementConfirmedAt = erlang:monotonic_time(millisecond),
+    C2SPid = mongoose_helper:get_session_pid(Alice2, mim()),
+    ?assert(is_pid(C2SPid)),
+
+    %% Barrier 2: the other node is really gone, and this node knows it, before
+    %% the timer fires. No sleeping until "probably down".
+    #{node := Mim2Node} = mim2(),
+    distributed_helper:stop_node(Mim2Node, Config),
+    wait_helper:wait_until(
+      fun() -> lists:member(Mim2Node, rpc(mim(), erlang, nodes, [connected])) end, false,
+      #{name => remote_node_down, time_left => timer:seconds(60)}),
+    Elapsed = erlang:monotonic_time(millisecond) - ArmedAt,
+    Elapsed < ?REMOTE_SHUTDOWN_WAIT orelse
+        ct:fail("Stopping ~p took ~pms, which is not less than the armed "
+                "replaced_wait_timeout of ~pms - raise ?REMOTE_SHUTDOWN_WAIT",
+                [Mim2Node, Elapsed, ?REMOTE_SHUTDOWN_WAIT]),
+
+    %% Barrier 3: start from an upper bound on when the timer was armed.
+    %% Login may take longer than the margin, so ArmedAt alone could let the
+    %% assertions run before the timer fires and hide the original crash.
+    SinceReplacement = erlang:monotonic_time(millisecond) - ReplacementConfirmedAt,
+    timer:sleep(max(0, ?REMOTE_SHUTDOWN_WAIT - SinceReplacement) + timer:seconds(2)),
+
+    %% THEN the very same c2s process is still serving the very same socket
+    ?assert(rpc(mim(), erlang, is_process_alive, [C2SPid])),
+    ?assert_equal(C2SPid, mongoose_helper:get_session_pid(Alice2, mim())),
+    assert_connection_still_usable(Alice2),
+    assert_message_processed(),
+
+    %% ... and the diagnostic did not crash anything on the way
+    logger_ct_backend:stop_capture(),
+    FilterFun = fun(_, Msg) ->
+                        re:run(Msg, "case_clause|verify_process_alive") /= nomatch
+                end,
+    [] = logger_ct_backend:recv(FilterFun),
+
+    escalus_connection:stop(Alice2).
+
+%% Round trip an IQ and a message on the very same socket.
+assert_connection_still_usable(Client) ->
+    escalus:send(Client, escalus_stanza:roster_get()),
+    escalus:assert(is_roster_result, escalus:wait_for_stanza(Client, timer:seconds(5))),
+    Jid = escalus_client:full_jid(Client),
+    escalus:send(Client, escalus_stanza:chat_to(Jid, <<"still connected">>)),
+    escalus:assert(is_chat_message, [<<"still connected">>],
+                   escalus:wait_for_stanza(Client, timer:seconds(5))).
+
+%% The event collector observes mim(), so assert this for round trips on that node.
+assert_message_processed() ->
+    instrument_helper:wait_and_assert(c2s_message_processed,
+                                     #{host_type => domain_helper:host_type()},
+                                     fun(#{time := Time}) -> is_integer(Time) andalso Time >= 0 end).
+
+%% distributed_helper:rpc/4 raises on a dead node, so ask erlang directly.
+is_node_running(Node) ->
+    rpc:call(Node, erlang, node, [], timer:seconds(5)) =:= Node.
 
 return_proper_stream_error_if_service_is_not_hidden(_Config) ->
     % GIVEN MongooseIM is running default configuration

--- a/doc/configuration/general.md
+++ b/doc/configuration/general.md
@@ -120,6 +120,8 @@ See the section about [redis connection setup](./outgoing-connections.md#redis-s
 
 When a user's session is replaced (due to a full JID conflict) by a new one, this parameter specifies the time MongooseIM waits for the old sessions to close. The default value is sufficient in most cases. If you observe `replaced_wait_timeout` warning in logs, then most probably the old sessions are frozen for some reason and it should be investigated.
 
+The check that produces that warning is diagnostic only. Diagnostic failures are caught and do not request termination of the new connection. Remote RPC waits share a 1000 ms timeout budget across the batch; this is not a hard wall-clock latency guarantee. When the old session lived on a node that is no longer reachable - a rolling restart, for instance - the check cannot confirm anything either way. That outcome is reported as `c2s_replaced_probe_inconclusive` at debug level (so a rolling restart does not flood the logs when debug logging is disabled) and, for a node that is still connected but does not answer within the probe's budget, at info level. Neither is an error, and neither disconnects anybody.
+
 ## XMPP federation (S2S)
 
 ### `general.s2s_backend`

--- a/src/c2s/mongoose_c2s.erl
+++ b/src/c2s/mongoose_c2s.erl
@@ -674,8 +674,11 @@ handle_info(StateData, C2SState, Info) ->
 handle_timeout(StateData, _C2SState, activate_socket, activate_socket) ->
     activate_socket(StateData),
     keep_state_and_data;
-handle_timeout(StateData, C2SState, replaced_wait_timeout, ReplacedPids) ->
-    [ verify_process_alive(StateData, C2SState, Pid) || Pid <- ReplacedPids ],
+handle_timeout(_StateData, C2SState, replaced_wait_timeout, ReplacedPids) ->
+    %% Diagnostics only, see mongoose_c2s_replaced_probe. Whatever the replaced
+    %% sessions did - or whether their node is still reachable at all - this
+    %% connection keeps running.
+    mongoose_c2s_replaced_probe:verify(ReplacedPids, C2SState),
     keep_state_and_data;
 handle_timeout(StateData, C2SState, Name, Handler) when is_atom(Name), is_function(Handler, 2) ->
     C2sAcc = Handler(Name, StateData),
@@ -687,19 +690,6 @@ handle_timeout(StateData, _C2SState, state_timeout, state_timeout_termination) -
     {stop, {shutdown, state_timeout}};
 handle_timeout(StateData, C2SState, Name, Payload) ->
     handle_foreign_event(StateData, C2SState, {timeout, Name}, Payload).
-
-verify_process_alive(StateData, C2SState, Pid) ->
-    IsAlive = case node(Pid) =:= node() of
-                  true -> erlang:is_process_alive(Pid);
-                  false -> rpc:call(node(Pid), erlang, is_process_alive, [Pid])
-              end,
-    case IsAlive of
-        false -> ok;
-        true ->
-            ?LOG_WARNING(#{what => c2s_replaced_wait_timeout,
-                           text => <<"Some processes are not responding when handling replace messages">>,
-                           replaced_pid => Pid, state_name => C2SState, c2s_data => StateData})
-    end.
 
 -spec maybe_retry_state(state()) -> state() | {stop, term()}.
 maybe_retry_state(connect) -> connect;

--- a/src/c2s/mongoose_c2s_replaced_probe.erl
+++ b/src/c2s/mongoose_c2s_replaced_probe.erl
@@ -1,0 +1,219 @@
+%%% @doc Diagnostics for sessions that were replaced by a new connection.
+%%%
+%%% When a new session replaces older ones, {@link ejabberd_sm} asks the old
+%%% processes to exit and returns their pids. `mongoose_c2s' arms a
+%%% `replaced_wait_timeout' timer with that list and, once it fires, checks
+%%% whether those processes really went away. That check exists only to tell an
+%%% operator that some old session is frozen - it is not part of authentication,
+%%% authorisation or session replacement, and it must never influence the new
+%%% connection in any way.
+%%%
+%%% It used to be `rpc:call(node(Pid), erlang, is_process_alive, [Pid])' matched
+%%% against `true' and `false' only. During a rolling shutdown the node hosting
+%%% the old session is already gone by the time the timer fires, the call
+%%% answers `{badrpc, nodedown}', and the missing clause raised `case_clause'
+%%% inside the `gen_statem' callback - killing a brand new, fully authenticated
+%%% connection that had nothing to do with the old node.
+%%%
+%%% Rules this module keeps:
+%%% <ul>
+%%%  <li>every answer is classified, there is no unmatched clause;</li>
+%%%  <li>"the node cannot be reached" means "unknown", never "the process is
+%%%      dead" and never "the process is alive";</li>
+%%%  <li>remote RPC waits share one timeout budget (`?BATCH_BUDGET_MS'),
+%%%      rather than a fresh timeout per pid; disconnected nodes are not called;</li>
+%%%  <li>nothing escapes: {@link verify/2} catches its own errors, so a bug here
+%%%      can never take a connection down;</li>
+%%%  <li>logs carry the event, the remote nodes, the outcome categories and the
+%%%      counts - never `c2s_data', acc, packets, tokens or any other runtime
+%%%      payload - and the outcome that a mass shutdown produces (`unreachable')
+%%%      is logged at debug level, avoiding per-session info or warning logs
+%%%      during a rolling deploy when debug logging is disabled.</li>
+%%% </ul>
+-module(mongoose_c2s_replaced_probe).
+
+-include("mongoose_logger.hrl").
+
+-export([verify/2, probe/1, probe/2]).
+
+-ignore_xref([probe/1, probe/2]).
+
+%% Shared timeout budget for remote RPC waits in one batch. As with erpc
+%% timeouts generally, scheduling and distribution backpressure can delay the
+%% return; this is not a hard wall-clock limit on the calling process.
+-define(BATCH_BUDGET_MS, 1000).
+%% Replacement normally yields a single pid. Cap the batch anyway so that a
+%% pathological session table can never turn one timer into unbounded work.
+-define(MAX_REMOTE_PIDS, 16).
+
+-type status() :: alive        % confirmed still running
+                | dead         % confirmed gone, the expected outcome
+                | unreachable  % node is not connected or dropped: unknown
+                | timeout      % node did not answer within the budget: unknown
+                | error        % unexpected answer or remote exception: unknown
+                | skipped.     % batch cap reached, deliberately not asked
+-type result() :: {pid(), status()}.
+-type opts() :: #{budget => non_neg_integer(), max_remote => non_neg_integer()}.
+
+-export_type([status/0, result/0, opts/0]).
+
+%% @doc Probe the replaced pids and log the outcome. Always returns `ok'.
+-spec verify([pid()], mongoose_c2s:state()) -> ok.
+verify([], _C2SState) ->
+    ok;
+verify(ReplacedPids, C2SState) ->
+    try
+        log_results(probe(ReplacedPids), C2SState)
+    catch
+        Class:Reason:Stacktrace ->
+            %% This is a diagnostic path: if the diagnostic itself is broken we
+            %% report it and carry on. The connection is never affected.
+            ?LOG_INFO(#{what => c2s_replaced_probe_failed,
+                        text => <<"Failed to verify replaced sessions">>,
+                        class => Class, reason => Reason, stacktrace => Stacktrace})
+    end,
+    ok.
+
+%% @doc Classify replaced pids, sharing one timeout budget across remote RPCs.
+%% Invalid input or internal failures are contained by verify/2. Only explicit
+%% remote answers are classified as alive or dead.
+-spec probe([pid()]) -> [result()].
+probe(Pids) ->
+    probe(Pids, #{}).
+
+-spec probe([pid()], opts()) -> [result()].
+probe(Pids, Opts) ->
+    Budget = maps:get(budget, Opts, ?BATCH_BUDGET_MS),
+    MaxRemote = maps:get(max_remote, Opts, ?MAX_REMOTE_PIDS),
+    {Local, Remote} = lists:partition(fun(Pid) -> node(Pid) =:= node() end, lists:usort(Pids)),
+    [{Pid, local_status(Pid)} || Pid <- Local] ++ probe_remote(Remote, Budget, MaxRemote).
+
+-spec local_status(pid()) -> alive | dead.
+local_status(Pid) ->
+    case erlang:is_process_alive(Pid) of
+        true -> alive;
+        false -> dead
+    end.
+
+-spec probe_remote([pid()], non_neg_integer(), non_neg_integer()) -> [result()].
+probe_remote([], _Budget, _MaxRemote) ->
+    [];
+probe_remote(Pids, Budget, MaxRemote) ->
+    {Probed, Skipped} = lists:split(min(MaxRemote, length(Pids)), Pids),
+    Deadline = erlang:monotonic_time(millisecond) + Budget,
+    ByNode = maps:to_list(maps:groups_from_list(fun erlang:node/1, Probed)),
+    probe_nodes(ByNode, Deadline, [{Pid, skipped} || Pid <- Skipped]).
+
+-spec probe_nodes([{node(), [pid()]}], integer(), [result()]) -> [result()].
+probe_nodes([], _Deadline, Acc) ->
+    Acc;
+probe_nodes([{Node, Pids} | Rest], Deadline, Acc) ->
+    TimeLeft = Deadline - erlang:monotonic_time(millisecond),
+    probe_nodes(Rest, Deadline, probe_node(Node, Pids, TimeLeft) ++ Acc).
+
+-spec probe_node(node(), [pid()], integer()) -> [result()].
+probe_node(_Node, Pids, TimeLeft) when TimeLeft =< 0 ->
+    %% The batch budget is spent. We do not know, and we will not block to find out.
+    [{Pid, timeout} || Pid <- Pids];
+probe_node(Node, Pids, TimeLeft) when TimeLeft > 0 ->
+    case lists:member(Node, nodes(connected)) of
+        false ->
+            %% The common case during a rolling shutdown: the node that hosted the
+            %% old session is already gone. Skipping the call keeps this free and
+            %% keeps a c2s event loop out of distribution connection setup, and
+            %% "not connected" is not evidence about the process either way.
+            [{Pid, unreachable} || Pid <- Pids];
+        true ->
+            %% One round trip per node, one shared deadline, results in pid order.
+            %% `fun erlang:is_process_alive/1' is an external fun, so it resolves
+            %% on the remote node and works across mixed code versions.
+            %% One node in, so one answer out - but even that is matched, not assumed.
+            case erpc:multicall([Node], lists, map,
+                                [fun erlang:is_process_alive/1, Pids], TimeLeft) of
+                [Answer] -> interpret(Answer, Pids);
+                Unexpected -> interpret(Unexpected, Pids)
+            end
+    end.
+
+%% Total by construction: anything that is not a well formed answer is `error'.
+-spec interpret(term(), [pid()]) -> [result()].
+interpret({ok, Alive}, Pids) when is_list(Alive), length(Alive) =:= length(Pids) ->
+    lists:zipwith(fun(Pid, true) -> {Pid, alive};
+                     (Pid, false) -> {Pid, dead};
+                     (Pid, _) -> {Pid, error}
+                  end, Pids, Alive);
+interpret({error, {erpc, noconnection}}, Pids) ->
+    [{Pid, unreachable} || Pid <- Pids];
+interpret({error, {erpc, timeout}}, Pids) ->
+    [{Pid, timeout} || Pid <- Pids];
+interpret(_Other, Pids) ->
+    %% Remote exception, remote exit, an erpc reason we do not know, or a badly
+    %% shaped answer. Unknown is unknown - it is never reported as dead.
+    [{Pid, error} || Pid <- Pids].
+
+-spec log_results([result()], mongoose_c2s:state()) -> ok.
+log_results(Results, C2SState) ->
+    Counts = log_counts(Results),
+    log_alive(pids_with_status(alive, Results), Counts, C2SState),
+    log_unknown(unknown_results(Results), Counts, C2SState).
+
+%% The original diagnostic: some old session did not react to being replaced.
+%% Rare, and `replaced_wait_timeout' is the phrase documented for operators.
+-spec log_alive([pid()], map(), mongoose_c2s:state()) -> ok.
+log_alive([], _Counts, _C2SState) ->
+    ok;
+log_alive(AlivePids, Counts, C2SState) ->
+    ?LOG_WARNING(Counts#{what => c2s_replaced_wait_timeout,
+                         text => <<"Some processes are not responding when handling replace messages">>,
+                         replaced_pids => AlivePids,
+                         replaced_nodes => nodes_of(AlivePids),
+                         state_name => C2SState}),
+    ok.
+
+%% We asked but got no answer. `unreachable' is the expected outcome of a rolling
+%% shutdown, so it stays at debug level and cannot storm the logs; a connected
+%% node that times out or misbehaves is rare and worth an info line.
+-spec log_unknown([result()], map(), mongoose_c2s:state()) -> ok.
+log_unknown([], _Counts, _C2SState) ->
+    ok;
+log_unknown(Unknown, Counts, C2SState) ->
+    Report = Counts#{what => c2s_replaced_probe_inconclusive,
+                     text => <<"Could not confirm whether replaced sessions exited">>,
+                     replaced_nodes => nodes_of([Pid || {Pid, _} <- Unknown]),
+                     state_name => C2SState},
+    case [Pid || {Pid, Status} <- Unknown, Status =/= unreachable] of
+        [] -> ?LOG_DEBUG(Report);
+        _ -> ?LOG_INFO(Report)
+    end,
+    ok.
+
+%% Everything we could not confirm one way or the other.
+-spec unknown_results([result()]) -> [result()].
+unknown_results(Results) ->
+    [R || {_Pid, Status} = R <- Results, Status =/= alive, Status =/= dead].
+
+-spec pids_with_status(status(), [result()]) -> [pid()].
+pids_with_status(Status, Results) ->
+    [Pid || {Pid, S} <- Results, S =:= Status].
+
+-spec nodes_of([pid()]) -> [node()].
+nodes_of(Pids) ->
+    lists:usort([node(Pid) || Pid <- Pids]).
+
+%% Fixed set of keys, so the shape of the log line never depends on the outcome.
+-spec log_counts([result()]) -> map().
+log_counts(Results) ->
+    Zeroes = #{alive_count => 0, dead_count => 0, unreachable_count => 0,
+               timeout_count => 0, error_count => 0, skipped_count => 0},
+    lists:foldl(fun({_Pid, Status}, Acc) ->
+                        Key = count_key(Status),
+                        maps:update_with(Key, fun(N) -> N + 1 end, 1, Acc)
+                end, Zeroes, Results).
+
+-spec count_key(status()) -> atom().
+count_key(alive) -> alive_count;
+count_key(dead) -> dead_count;
+count_key(unreachable) -> unreachable_count;
+count_key(timeout) -> timeout_count;
+count_key(error) -> error_count;
+count_key(skipped) -> skipped_count.

--- a/test/mongoose_c2s_replaced_probe_SUITE.erl
+++ b/test/mongoose_c2s_replaced_probe_SUITE.erl
@@ -1,0 +1,417 @@
+%%% @doc Regression tests for the replaced-session diagnostic.
+%%%
+%%% The production incident: during a rolling restart the node that hosted
+%%% a replaced session disappeared between "capture the replaced pids" and "check
+%%% whether they exited". `rpc:call/4' then answered `{badrpc, nodedown}', which
+%%% the old `mongoose_c2s:verify_process_alive/3' had no clause for, so a
+%%% `case_clause' killed the brand new connection from inside the `gen_statem'
+%%% timeout callback.
+%%%
+%%% These tests use real Erlang nodes (`peer'), started and stopped for real, so
+%%% the cross-node cases exercise actual distribution rather than a mock. The
+%%% barrier in each node-shutdown case is explicit: capture the pid while the node
+%%% is up, wait for a real `nodedown', only then run the check.
+-module(mongoose_c2s_replaced_probe_SUITE).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("log_helper.hrl").
+
+-define(HOST_TYPE, <<"localhost">>).
+-define(PROBE, mongoose_c2s_replaced_probe).
+
+%% Everything the sanitised warning is allowed to carry. The old warning dumped
+%% the whole #c2s_data{} record; nothing connection-scoped may come back.
+-define(ALLOWED_WARNING_KEYS,
+        [what, text, state_name, replaced_pids, replaced_nodes,
+         alive_count, dead_count, unreachable_count, timeout_count,
+         error_count, skipped_count]).
+
+all() ->
+    [{group, same_node},
+     {group, cross_node}].
+
+groups() ->
+    [{same_node, [], [alive_local_process_is_reported_alive,
+                      exited_local_process_is_reported_dead,
+                      warning_is_sanitised_and_carries_counts,
+                      confirmed_exit_is_not_logged,
+                      broken_input_cannot_take_the_connection_down]},
+     {cross_node, [], [alive_remote_process_is_reported_alive,
+                       exited_remote_process_is_reported_dead,
+                       node_down_after_capture_is_unreachable_not_dead,
+                       node_down_after_capture_does_not_stop_the_c2s_callback,
+                       node_down_after_capture_does_not_storm_the_logs,
+                       node_restarted_after_capture_is_answered_by_the_new_node,
+                       unresponsive_node_times_out_within_the_budget,
+                       mixed_batch_shares_one_budget,
+                       oversized_batch_is_capped,
+                       probe_leaves_no_background_work_behind]}].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(jid),
+    mongoose_config:set_opts(#{default_server_name => <<"localhost">>,
+                               default_server_domain => <<"localhost">>,
+                               language => <<"en">>}),
+    ensure_distributed(),
+    LoggerConfig = logger:get_primary_config(),
+    logger:set_primary_config(level, warning),
+    %% Only this module talks at debug level, so the assertions below see the
+    %% quiet branch without the rest of the system flooding the handler.
+    ok = logger:set_module_level(?PROBE, debug),
+    log_helper:set_up(),
+    [{logger_primary_config, LoggerConfig} | Config].
+
+end_per_suite(Config) ->
+    log_helper:tear_down(),
+    mongoose_config:erase_opts(),
+    logger:unset_module_level(?PROBE),
+    logger:set_primary_config(?config(logger_primary_config, Config)),
+    ok.
+
+init_per_testcase(_CaseName, Config) ->
+    flush_logs(),
+    log_helper:subscribe(),
+    Config.
+
+end_per_testcase(_CaseName, _Config) ->
+    log_helper:unsubscribe(),
+    flush_logs(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Same node
+%%--------------------------------------------------------------------
+
+%% A replaced session that is still running is the whole point of the diagnostic.
+alive_local_process_is_reported_alive(_Config) ->
+    Pid = alive_pid(),
+    ?assertEqual([{Pid, alive}], ?PROBE:probe([Pid])).
+
+exited_local_process_is_reported_dead(_Config) ->
+    Pid = exited_pid(),
+    ?assertEqual([{Pid, dead}], ?PROBE:probe([Pid])).
+
+warning_is_sanitised_and_carries_counts(_Config) ->
+    Pid = alive_pid(),
+
+    ok = ?PROBE:verify([Pid], session_established),
+
+    {warning, Log} = ?receiveLog(warning, #{what := c2s_replaced_wait_timeout}),
+    ?assertMatch(#{alive_count := 1, dead_count := 0, unreachable_count := 0,
+                   timeout_count := 0, error_count := 0, skipped_count := 0,
+                   state_name := session_established}, Log),
+    ?assertEqual([Pid], maps:get(replaced_pids, Log)),
+    ?assertEqual([node()], maps:get(replaced_nodes, Log)),
+    %% No connection state, no acc, no packets - and nothing else we did not plan.
+    ?assertEqual([], lists:sort(maps:keys(Log)) -- lists:sort(?ALLOWED_WARNING_KEYS)).
+
+%% Old sessions that exited on time are the normal case and stay silent.
+confirmed_exit_is_not_logged(_Config) ->
+    ok = ?PROBE:verify([exited_pid()], session_established),
+    ?assertNoLog(warning, #{what := _}),
+    ?assertNoLog(info, #{what := _}),
+    ?assertNoLog(debug, #{what := _}).
+
+%% The diagnostic is wrapped: even a bug inside it cannot reach the state machine.
+broken_input_cannot_take_the_connection_down(_Config) ->
+    NotAPid = list_to_atom("definitely_not_a_pid"),
+
+    ?assertEqual(ok, ?PROBE:verify([NotAPid], session_established)),
+
+    {info, Log} = ?receiveLog(info, #{what := c2s_replaced_probe_failed}),
+    ?assertMatch(#{class := error, reason := badarg}, Log).
+
+%%--------------------------------------------------------------------
+%% Cross node - real Erlang nodes, started and stopped for real
+%%--------------------------------------------------------------------
+
+alive_remote_process_is_reported_alive(_Config) ->
+    {Peer, Node} = start_peer(),
+    try
+        Pid = remote_alive_pid(Node),
+        ?assertEqual([{Pid, alive}], ?PROBE:probe([Pid])),
+        ok = ?PROBE:verify([Pid], session_established),
+        {warning, Log} = ?receiveLog(warning, #{what := c2s_replaced_wait_timeout}),
+        ?assertEqual([Node], maps:get(replaced_nodes, Log))
+    after
+        stop_peer(Peer, Node)
+    end.
+
+exited_remote_process_is_reported_dead(_Config) ->
+    {Peer, Node} = start_peer(),
+    try
+        Pid = remote_exited_pid(Node),
+        ?assertEqual([{Pid, dead}], ?PROBE:probe([Pid]))
+    after
+        stop_peer(Peer, Node)
+    end.
+
+%% THE incident. Capture the pid while the node is up, shut the node down, then
+%% run the check - the exact order that used to raise case_clause.
+node_down_after_capture_is_unreachable_not_dead(_Config) ->
+    {Peer, Node} = start_peer(),
+    Pid = remote_alive_pid(Node),
+    %% Barrier 1: the pid was captured while the node was still serving it.
+    ?assertEqual([{Pid, alive}], ?PROBE:probe([Pid])),
+    %% Barrier 2: the node is really gone before the check runs.
+    stop_peer(Peer, Node),
+
+    %% This is literally what the old code fed into a case with two clauses.
+    ?assertEqual({badrpc, nodedown}, rpc:call(Node, erlang, is_process_alive, [Pid])),
+
+    %% Unreachable is not evidence of death, and it is not an error either.
+    ?assertEqual([{Pid, unreachable}], ?PROBE:probe([Pid])).
+
+%% The production stack frame: gen_statem callback -> handle_timeout -> the check.
+node_down_after_capture_does_not_stop_the_c2s_callback(_Config) ->
+    {Peer, Node} = start_peer(),
+    Pid = remote_alive_pid(Node),
+    stop_peer(Peer, Node),
+
+    Data = mongoose_c2s:create_data(#{host_type => ?HOST_TYPE,
+                                      jid => jid:from_binary(<<"alice@localhost/res">>)}),
+    ?assertEqual(keep_state_and_data,
+                 mongoose_c2s:handle_event({timeout, replaced_wait_timeout}, [Pid],
+                                           session_established, Data)).
+
+%% A rolling shutdown replaces thousands of sessions at once. The expected
+%% outcome must not produce a warning or an info line for every one of them.
+node_down_after_capture_does_not_storm_the_logs(_Config) ->
+    {Peer, Node} = start_peer(),
+    Pid = remote_alive_pid(Node),
+    stop_peer(Peer, Node),
+
+    ok = ?PROBE:verify([Pid], session_established),
+
+    ?assertNoLog(warning, #{what := _}),
+    ?assertNoLog(info, #{what := _}),
+    {debug, Log} = ?receiveLog(debug, #{what := c2s_replaced_probe_inconclusive}),
+    ?assertMatch(#{alive_count := 0, dead_count := 0, unreachable_count := 1,
+                   timeout_count := 0, error_count := 0}, Log),
+    ?assertEqual([Node], maps:get(replaced_nodes, Log)).
+
+%% A node that comes back under the same name answers for itself: the old
+%% incarnation's process is genuinely gone, and nothing crashes on the way.
+node_restarted_after_capture_is_answered_by_the_new_node(_Config) ->
+    Name = list_to_atom("mongoose_probe_restart_" ++ os:getpid()),
+    {Peer1, Node} = start_peer(#{name => Name}),
+    Pid = remote_alive_pid(Node),
+    stop_peer(Peer1, Node),
+    {Peer2, Node} = start_peer(#{name => Name}),
+    try
+        pong = net_adm:ping(Node),
+        ?assertEqual([{Pid, dead}], ?PROBE:probe([Pid]))
+    after
+        stop_peer(Peer2, Node)
+    end.
+
+%% A node that is connected but does not answer must cost one bounded wait, and
+%% must never be reported as "the process is gone".
+unresponsive_node_times_out_within_the_budget(_Config) ->
+    Budget = 300,
+    StarveMs = 2000,
+    {Peer, Node} = start_peer(#{args => ["+S", "1"]}),
+    try
+        Pid = remote_alive_pid(Node),
+        starve(Node, StarveMs),
+
+        {Elapsed, Results} = timed(fun() -> ?PROBE:probe([Pid], #{budget => Budget}) end),
+
+        ?assertEqual([{Pid, timeout}], Results),
+        ?assert(Elapsed >= Budget),
+        ?assert(Elapsed < Budget + 1000),
+        timer:sleep(StarveMs)
+    after
+        stop_peer(Peer, Node)
+    end.
+
+%% One budget for the whole batch. Two unresponsive nodes must not cost two
+%% timeouts, and the local pids must still be classified correctly.
+mixed_batch_shares_one_budget(_Config) ->
+    Budget = 400,
+    StarveMs = 3000,
+    {Peer1, Node1} = start_peer(#{args => ["+S", "1"]}),
+    {Peer2, Node2} = start_peer(#{args => ["+S", "1"]}),
+    try
+        Local = alive_pid(),
+        Gone = exited_pid(),
+        Remote1 = remote_alive_pid(Node1),
+        Remote2 = remote_alive_pid(Node2),
+        starve(Node1, StarveMs),
+        starve(Node2, StarveMs),
+
+        {Elapsed, Results} =
+            timed(fun() -> ?PROBE:probe([Local, Gone, Remote1, Remote2], #{budget => Budget}) end),
+
+        ?assertEqual(alive, status_of(Local, Results)),
+        ?assertEqual(dead, status_of(Gone, Results)),
+        ?assertEqual(timeout, status_of(Remote1, Results)),
+        ?assertEqual(timeout, status_of(Remote2, Results)),
+        %% The point of the budget: not Budget per pid, not Budget per node.
+        ?assert(Elapsed < 2 * Budget),
+        timer:sleep(StarveMs)
+    after
+        stop_peer(Peer1, Node1),
+        stop_peer(Peer2, Node2)
+    end.
+
+oversized_batch_is_capped(_Config) ->
+    {Peer, Node} = start_peer(),
+    try
+        Pids = [remote_alive_pid(Node) || _ <- lists:seq(1, 3)],
+
+        Results = ?PROBE:probe(Pids, #{max_remote => 1}),
+
+        ?assertEqual(3, length(Results)),
+        ?assertEqual(1, count_status(alive, Results)),
+        ?assertEqual(2, count_status(skipped, Results))
+    after
+        stop_peer(Peer, Node)
+    end.
+
+%% "The connection closed while the diagnostic was running": killing the caller
+%% must leave nothing behind - no spawned worker, no lingering remote process.
+probe_leaves_no_background_work_behind(_Config) ->
+    StarveMs = 2000,
+    {Peer, Node} = start_peer(#{args => ["+S", "1"]}),
+    try
+        Pid = remote_alive_pid(Node),
+        starve(Node, StarveMs),
+        Caller = spawn(fun() -> ?PROBE:verify([Pid], session_established) end),
+        Ref = erlang:monitor(process, Caller),
+        timer:sleep(100),
+        %% The diagnostic is still in flight - this is the "connection closed
+        %% while we were probing" case.
+        ?assert(erlang:is_process_alive(Caller)),
+
+        exit(Caller, kill),
+
+        receive {'DOWN', Ref, process, Caller, _Reason} -> ok
+        after 5000 -> ct:fail(caller_did_not_die) end,
+        timer:sleep(100),
+        ?assertEqual([], probe_processes(node())),
+        %% Let the remote node recover and check it kept nothing either.
+        timer:sleep(StarveMs),
+        ?assertEqual([], erpc:call(Node, ?MODULE, probe_processes, [Node], 5000)),
+        ?assertEqual([], erpc:call(Node, ?MODULE, map_processes, [], 5000))
+    after
+        stop_peer(Peer, Node)
+    end.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+ensure_distributed() ->
+    case is_alive() of
+        true ->
+            ok;
+        false ->
+            Name = list_to_atom("mongoose_c2s_probe_ct_" ++ os:getpid()),
+            {ok, _} = net_kernel:start(Name, #{name_domain => shortnames}),
+            ok
+    end.
+
+start_peer() ->
+    start_peer(#{}).
+
+start_peer(Opts) ->
+    Name = maps:get(name, Opts, peer:random_name(?MODULE)),
+    %% The CT node runs with an explicit cookie (see rebar.config), which a peer
+    %% would not pick up from ~/.erlang.cookie.
+    Args = maps:get(args, Opts, []) ++
+        ["-setcookie", atom_to_list(erlang:get_cookie()), "-pa", suite_code_dir()],
+    {ok, Peer, Node} = peer:start_link(#{name => Name, args => Args, wait_boot => 30000}),
+    {Peer, Node}.
+
+%% Stop for real and wait for the real nodedown - no sleeps, no polling.
+stop_peer(Peer, Node) ->
+    monitor_node(Node, true),
+    catch peer:stop(Peer),
+    receive {nodedown, Node} -> ok
+    after 30000 -> ct:fail({node_did_not_go_down, Node}) end,
+    monitor_node(Node, false),
+    ok.
+
+%% code:which/1 answers `cover_compiled' under coverage, so ask the code path.
+suite_code_dir() ->
+    filename:dirname(code:where_is_file(atom_to_list(?MODULE) ++ ".beam")).
+
+alive_pid() ->
+    spawn(fun() -> receive stop -> ok end end).
+
+exited_pid() ->
+    Pid = spawn(fun() -> ok end),
+    wait_until_dead(Pid),
+    Pid.
+
+remote_alive_pid(Node) ->
+    erpc:call(Node, erlang, spawn, [timer, sleep, [infinity]], 30000).
+
+remote_exited_pid(Node) ->
+    Pid = erpc:call(Node, erlang, spawn, [erlang, self, []], 30000),
+    wait_until_dead(Pid),
+    Pid.
+
+wait_until_dead(Pid) ->
+    Ref = erlang:monitor(process, Pid),
+    receive {'DOWN', Ref, process, Pid, _} -> ok
+    after 30000 -> ct:fail({process_still_alive, Pid}) end.
+
+%% Occupy the peer's only scheduler at max priority: it stays connected but
+%% cannot run the process erpc spawns there, which is a real rpc timeout.
+starve(Node, Ms) ->
+    {module, ?MODULE} = erpc:call(Node, code, ensure_loaded, [?MODULE], 30000),
+    ?assertEqual(1, erpc:call(Node, erlang, system_info, [schedulers_online], 30000)),
+    Busy = spawn_opt(Node, ?MODULE, busy, [self(), Ms], [{priority, max}]),
+    %% Barrier: the probe below must meet a node that is already busy.
+    receive {busy_started, Busy} -> ok
+    after 30000 -> ct:fail({peer_not_busy, Node}) end,
+    Busy.
+
+busy(ReportTo, Ms) ->
+    ReportTo ! {busy_started, self()},
+    busy_until(erlang:monotonic_time(millisecond) + Ms).
+
+busy_until(Deadline) ->
+    case erlang:monotonic_time(millisecond) < Deadline of
+        true -> busy_until(Deadline);
+        false -> ok
+    end.
+
+timed(Fun) ->
+    T0 = erlang:monotonic_time(millisecond),
+    Result = Fun(),
+    {erlang:monotonic_time(millisecond) - T0, Result}.
+
+status_of(Pid, Results) ->
+    proplists:get_value(Pid, Results).
+
+count_status(Status, Results) ->
+    length([Pid || {Pid, S} <- Results, S =:= Status]).
+
+%% Called both locally and on the peer node.
+probe_processes(_Node) ->
+    [Pid || Pid <- erlang:processes(), runs_module(Pid, mongoose_c2s_replaced_probe)].
+
+map_processes() ->
+    [Pid || Pid <- erlang:processes(), runs_function(Pid, {lists, map, 2})].
+
+runs_module(Pid, Module) ->
+    case erlang:process_info(Pid, [initial_call, current_function]) of
+        [{initial_call, {Module, _, _}}, _] -> true;
+        [_, {current_function, {Module, _, _}}] -> true;
+        _ -> false
+    end.
+
+runs_function(Pid, MFA) ->
+    case erlang:process_info(Pid, current_function) of
+        {current_function, MFA} -> true;
+        _ -> false
+    end.
+
+flush_logs() ->
+    receive {log, _} -> flush_logs()
+    after 0 -> ok end.


### PR DESCRIPTION
This PR addresses #4786.

When a new C2S session replaces a remote session and the old node stops before `replaced_wait_timeout`, the existing diagnostic receives `{badrpc, nodedown}` and raises `case_clause` inside the new connection's state machine. This change keeps the replacement connection alive and records the old process status as unknown.

Proposed changes include:

* Move replaced-session diagnostics into `mongoose_c2s_replaced_probe`, classify alive/dead/unreachable/timeout/error/skipped outcomes, and catch diagnostic exceptions in `verify/2`.
* Skip disconnected nodes, group remote checks by node, cap remote PIDs at 16, and share a 1000 ms RPC timeout budget across the batch. This is a shared RPC wait budget, not a hard wall-clock guarantee under scheduler or distribution delays.
* Preserve the existing warning for confirmed live old sessions, keep unreachable-only results at debug level, and omit connection state from normal diagnostic reports.
* Add 15 real-peer regression tests and a real-node shutdown case in `connect_SUITE`. Verify the original C2S PID and TCP connection using IQ and chat round trips. Assert the resulting message instrumentation and wait from an upper bound on timer arming, so slow login cannot make the regression test pass prematurely.
* Document the diagnostic behavior and timeout semantics.

## Test record

Patch revision: `8685ed85350b9a18f60d2a86c519a09723158282`. Tested on upstream `bc461ddfa94163741e99d6a08c5af97baac3b352` with the patch, on Linux/aarch64 in Docker, Erlang/OTP 27 / ERTS 15.2.7.9.

| Check | Result |
| --- | --- |
| Upstream callback before/after | Unmodified callback raises `error:{case_clause,{badrpc,nodedown}}` at `verify_process_alive/3:696`; patched callback returns `keep_state_and_data`. A real peer is stopped before each check. |
| `./rebar3 ct --dir test` | 996 passed, 4 failed, 25 skipped. All 15 new probe cases passed. The four failures and the skipped cases are detailed below. |
| `./rebar3 xref` | Passed; no warnings. |
| Elvis lint for changed Erlang files | Passed for all four files; the configured test rules were also applied to `connect_SUITE`. |
| `big_tests` compilation and three development releases | Passed. |
| Upstream session-replacement integration | 7/7 passed: all six `session_replacement` cases plus the existing `metrics_test`; suite teardown passed, 0 failures and 0 skips. |
| Redis-dependent small tests | `ejabberd_sm_SUITE`: 73/73 passed, 0 skips, after starting Redis with TLS. |

### Existing configuration-parser failures

The four failed cases were:

* `modules.mod_global_distrib_connections_endpoints`
* `modules.mod_global_distrib`
* `logs.no_warning_about_subdomain_patterns`
* `logs.no_warning_for_resolvable_domain`

An independent pristine source checkout of the same upstream revision, with the application build artifacts removed and no new probe files present, ran `./rebar3 ct --dir test --suite config_parser_SUITE`: **182 passed, the same 4 failed, 0 skipped**. This environment's DNS returns synthetic `198.18.0.x` addresses for `nohost`, `something.invalid`, and `vjud.test`, while these cases expect failed resolution. The failures therefore do not require this patch. This is a targeted pristine comparison, not a claim that the entire pristine suite was run.

The 25 initial skips were the existing Redis-backed session-manager cases because Redis was not running during the first full-suite run. After starting Redis with the expected TLS configuration, `./rebar3 ct --dir test --suite ejabberd_sm_SUITE` passed all 73 cases without skips. The complete full-suite run was not repeated; the initial result remains reported above.

### Real-node and same-socket checks

The upstream integration run used three development releases (`mim1`, `mim2`, `mim3`), the original `internal_mnesia` preset, Redis with TLS, and the existing Common Test hooks. A temporary testspec selected the complete `session_replacement` group and the existing `metrics_test` so the generic TCP instrumentation was also checked. The real node-shutdown testcase stopped and restarted `mim2`. The underlying `suite.log` confirmed all testcase results, `end_per_group`, and `end_per_suite` were successful; the runner exit status was not used as the sole success criterion.

An additional, separate downstream CETS integration fixture used three real MongooseIM nodes and synthetic clients, keeping the default 2000 ms replacement timeout. It passed all three scenarios:

1. Normal cross-node replacement: the old connection received a conflict error.
2. Suspended old session: the diagnostic recorded a confirmed live old process.
3. Old node stopped before the timer fired: the diagnostic recorded an unreachable node.

Each scenario observed the armed timer, traced the diagnostic call and return on the new C2S PID, then checked the same PID and TCP connection, an IQ result, and cross-node messages in both directions.

For a negative control, only the real pre-fix C2S module was loaded into that same fixture. The new C2S died with `{case_clause,{badrpc,nodedown}}`, its original socket failed, and the session lookup returned `none`. Restoring the patched module made the shutdown scenario pass. The other fixture components were unchanged; this was a controlled module comparison, not a complete pre-fix release test. The downstream fixture is separate evidence from the upstream Common Test results above.

Only OTP 27 was executed locally. The upstream CI matrix and other backends remain for CI/maintainer validation.
