### PR TITLE
Preserve CETS stream mapping when a resumed session replaces its SID

### DIFF
--- a/big_tests/tests/sm_SUITE.erl
+++ b/big_tests/tests/sm_SUITE.erl
@@ -106,6 +106,7 @@ parallel_cases() ->
      resume_session_with_wrong_namespace_is_a_noop,
      resume_dead_session_results_in_item_not_found,
      resume_session_kills_old_C2S_gracefully,
+     resume_session_twice,
      carboncopy_works,
      carboncopy_works_after_resume,
      replies_are_processed_by_resumed_session,
@@ -1271,6 +1272,17 @@ resume_session_kills_old_C2S_gracefully(Config) ->
     %% C2S process should die gracefully with Reason=normal.
     sm_helper:wait_for_process_termination(MonitorRef),
     escalus_connection:stop(NewUser).
+
+resume_session_twice(Config) ->
+    User = connect_fresh(Config, ?config(user, Config), sr_presence, manual),
+    MonitorRef = sm_helper:monitor_session(User),
+    User1 = sm_helper:kill_and_connect_resume(User),
+    %% Cleanup of the old C2S must not unregister the resumed session's SMID.
+    sm_helper:wait_for_process_termination(MonitorRef),
+    SMID = sm_helper:client_to_smid(User1),
+    {sid, _} = sm_helper:get_sid_by_stream_id(host_type(), SMID),
+    User2 = sm_helper:kill_and_connect_resume(User1),
+    escalus_connection:stop(User2).
 
 carboncopy_works(Config) ->
     escalus:fresh_story(Config, [{?config(user, Config), 2}, {bob, 1}], fun(User1, User, Bob) ->

--- a/src/stream_management/mod_stream_management_cets.erl
+++ b/src/stream_management/mod_stream_management_cets.erl
@@ -51,7 +51,10 @@ unregister_smid(_HostType, SID) ->
         [] ->
             {error, smid_not_found};
         [{_, SMID}] ->
-            cets:delete_many(?TABLE, [{sid, SID}, {smid, SMID}]),
+            %% A resumed session may already have registered this SMID with a new SID.
+            %% Exact-object deletion preserves that mapping when the old session exits,
+            %% regardless of the order in which replicas apply registration and cleanup.
+            cets:delete_objects(?TABLE, [{{sid, SID}, SMID}, {{smid, SMID}, SID}]),
             {ok, SMID}
     end.
 

--- a/test/mod_stream_management_cets_SUITE.erl
+++ b/test/mod_stream_management_cets_SUITE.erl
@@ -1,0 +1,52 @@
+-module(mod_stream_management_cets_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TABLE, cets_stream_management_session).
+-define(HOST_TYPE, <<"localhost">>).
+
+all() ->
+    [old_session_cleanup_after_registration,
+     old_session_cleanup_before_registration].
+
+init_per_testcase(_, Config) ->
+    {ok, _} = cets:start(?TABLE, #{}),
+    Config.
+
+end_per_testcase(_, _Config) ->
+    cets:stop(?TABLE).
+
+old_session_cleanup_after_registration(_Config) ->
+    SMID = <<"resumed-stream">>,
+    OldSID = {1, self()},
+    NewSID = {2, self()},
+    ok = mod_stream_management_cets:register_smid(?HOST_TYPE, SMID, OldSID),
+    ok = mod_stream_management_cets:register_smid(?HOST_TYPE, SMID, NewSID),
+    %% Force the interleaving where the new C2S registers before the old C2S exits.
+    ?assertEqual({ok, SMID}, mod_stream_management_cets:unregister_smid(?HOST_TYPE, OldSID)),
+    assert_resumed_session(SMID, OldSID, NewSID),
+    assert_session_cleanup(SMID, NewSID).
+
+old_session_cleanup_before_registration(_Config) ->
+    SMID = <<"resumed-stream">>,
+    OldSID = {1, self()},
+    NewSID = {2, self()},
+    ok = mod_stream_management_cets:register_smid(?HOST_TYPE, SMID, OldSID),
+    ?assertEqual({ok, SMID}, mod_stream_management_cets:unregister_smid(?HOST_TYPE, OldSID)),
+    ok = mod_stream_management_cets:register_smid(?HOST_TYPE, SMID, NewSID),
+    assert_resumed_session(SMID, OldSID, NewSID),
+    assert_session_cleanup(SMID, NewSID).
+
+assert_resumed_session(SMID, OldSID, NewSID) ->
+    ?assertEqual({sid, NewSID}, mod_stream_management_cets:get_sid(?HOST_TYPE, SMID)),
+    ?assertEqual([], ets:lookup(?TABLE, {sid, OldSID})),
+    ?assertEqual([{{sid, NewSID}, SMID}], ets:lookup(?TABLE, {sid, NewSID})),
+    ?assertEqual({error, smid_not_found},
+                 mod_stream_management_cets:unregister_smid(?HOST_TYPE, OldSID)),
+    ?assertEqual({sid, NewSID}, mod_stream_management_cets:get_sid(?HOST_TYPE, SMID)).
+
+assert_session_cleanup(SMID, SID) ->
+    ?assertEqual({ok, SMID}, mod_stream_management_cets:unregister_smid(?HOST_TYPE, SID)),
+    ?assertEqual({error, smid_not_found}, mod_stream_management_cets:get_sid(?HOST_TYPE, SMID)),
+    ?assertEqual([], ets:tab2list(?TABLE)).


### PR DESCRIPTION
Fixes #4788.

A resumed C2S session registers the existing SMID with its new SID. If the previous C2S then unregisters its old SID, key-based deletion removes the replacement session's SMID mapping and the next resumption fails with `item-not-found`.

Use exact-object deletion in the CETS backend so cleanup removes the SMID mapping only if it still points to the SID being unregistered. This preserves the new mapping whichever registration/cleanup order a replica observes, without changing the table layout or wire protocol.

Tests added:
- A deterministic backend regression that registers the replacement SID before cleaning up the old SID, checks both mappings, retries old cleanup, and finally cleans up the replacement session.
- The reverse registration/cleanup ordering.
- A real-client `sm_SUITE` case that resumes the same SMID twice, waiting for the first C2S process to terminate between resumptions.

Validation on OTP 27:
- Deterministic CETS regression: original backend 1 passed / 1 failed; patched backend 2 passed. The failure is the new-registration-before-old-cleanup ordering.
- Full upstream `sm_SUITE`: 126 passed with `internal_mnesia`, and 126 passed with a local CETS preset. Both runs cover TCP and WebSocket, including `resume_session_twice` once per transport. These official-suite runs used one MongooseIM node; the CETS preset enables file discovery and retains Mnesia for internal authentication, without an external SQL dependency.
- Full small Common Test suite: 1008 passed, 4 failed. All four failures are `config_parser_SUITE` DNS/logging expectations (`mod_global_distrib`, `mod_global_distrib_connections_endpoints`, `no_warning_about_subdomain_patterns`, `no_warning_for_resolvable_domain`); rerunning those four with the unmodified upstream backend reproduces all four failures. They are not new test failures introduced by this patch.
- `./rebar3 xref`: passed.
- A separate downstream three-node TCP/XMPP comparison reproduced the original second-resumption failure and verified repeated resumption plus ACK/replay behavior on the downstream PR head. This supplements, and is distinct from, the upstream-only validation above.

The application BEAM was rebuilt and inspected to confirm that the tested release uses `delete_objects`, not a cached version of the original backend. GitHub CI results are not yet available.

This change is limited to session mapping ownership and regression coverage.
