### PR TITLE
MIM-2793 Remove unsupported lang option from docs search

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,6 @@ extra:
 plugins:
   - search:
       separator: '[\s\-_,:!=\[\]()"/<>]+|\.(?!\d)|&[lg]t;'
-      lang: en
 extra_css: [css/custom.css]
 markdown_extensions:
   - pymdownx.snippets:


### PR DESCRIPTION
Unsupported in Zensical 0.0.60, this option started breaking our docs.

This legacy option is not needed anyway, because English is the default language.

For multilingual cases, there is `theme.language` but it defaults to `en` anyway.

