### PR TITLE
[MIM-2794] - Print . when waiting for pipeline

### DIFF
--- a/tools/circleci-wait-pipeline.sh
+++ b/tools/circleci-wait-pipeline.sh
@@ -13,6 +13,7 @@ while true; do
 
   case "$status" in
     *running* | "")
+      echo "."
       sleep 10;;
 
     success)


### PR DESCRIPTION
> Too long with no output (exceeded 10m0s): context deadline exceeded

This should fix the above error received from the `packages` CircleCI job