### PR TITLE
MIM-2792 Do not crash when the SSE handler terminates without a state

### DIFF
--- a/src/graphql/mongoose_graphql_sse_handler.erl
+++ b/src/graphql/mongoose_graphql_sse_handler.erl
@@ -104,12 +104,12 @@ handle_error(Msg, Reason, _State) ->
     ?LOG_ERROR(#{what => mongoose_graphql_sse_handler_failed,
                  reason => Reason, text => Msg}).
 
--spec terminate(term(), req(), state()) -> ok.
+-spec terminate(term(), req(), state() | undefined) -> ok.
 terminate(_Reason, _Req, #{ep := Ep, req := Req = #{ctx := Ctx}}) ->
     Ctx1 = Ctx#{event => terminate},
     {ok, #{aux := [{stream, closed}]}} = mongoose_graphql:execute(Ep, Req#{ctx := Ctx1}),
     ok;
-terminate(_Reason, _Req, #{}) ->
+terminate(_Reason, _Req, _State) ->
     ok.
 
 make_error(Phase, Term) ->


### PR DESCRIPTION
This PR widens the last clause of `mongoose_graphql_sse_handler:terminate/3` to accept any state. `lasse_handler` passes `undefined` when it rejects a request before `init/3` returned a state - a `POST` to the SSE endpoint, answered with 405 - which crashed the request process with a `function_clause`.

The `graphql_sse` suite logged 3 unexpected errors before this change and none after.